### PR TITLE
Aerospace window manager configuration

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -4,7 +4,10 @@ packages:
       taps:
         - buo/cask-upgrade
         - domt4/autoupdate # Automatic Upgrades.
+        - FelixKratz/formulae
+        - mediosz/tap
         - morantron/tmux-fingers
+        - nikitabobko/tap
         - owenthereal/upterm
         - oven-sh/bun
       formulae:
@@ -29,6 +32,7 @@ packages:
         - dust
         - eza
         - fd
+        - FelixKratz/formulae/borders
         - ffmpeg
         - fzf
         - gawk
@@ -74,6 +78,7 @@ packages:
         - swiftlint
         - switchaudio-osx
         - tealdeer
+        - terminal-notifier
         - tmux
         - tmuxinator
         - tokei
@@ -107,9 +112,11 @@ packages:
         - karabiner-elements
         - keepassxc
         - lunar
+        - mediosz/tap/swipeaerospace
         - microsoft-auto-update
         - microsoft-office
         - mitmproxy
+        - nikitabobko/tap/aerospace
         - obs
         - obsidian
         - openemu

--- a/dot_aerospace.toml
+++ b/dot_aerospace.toml
@@ -1,0 +1,377 @@
+##
+# Aerospace config
+# ================
+# Inspired by my previous i3 setup: https://github.com/webdavis/dotfiles/blob/master/config/i3/config
+#
+# Aerospace Docs
+# --------------
+# Guide:    https://nikitabobko.github.io/AeroSpace/guide
+# Commands: https://nikitabobko.github.io/AeroSpace/commands
+# Goodies:  https://nikitabobko.github.io/AeroSpace/goodies
+##
+
+# Config version for compatibility and deprecations.
+# Fallback value (if you omit the key): config-version = 1
+config-version = 2
+
+# You can use it to add commands that run after AeroSpace startup.
+# Available commands : https://nikitabobko.github.io/AeroSpace/commands
+after-startup-command = [
+  # JankyBorders has a built-in detection of already running process, so it won't be run twice on AeroSpace restart.
+  # See: https://github.com/FelixKratz/JankyBorders
+  # 'exec-and-forget borders active_color=0xffe1e3e4 inactive_color=0xff494d64 width=5.0'
+  'exec-and-forget borders active_color=0xffe61a52 inactive_color=0xff494d64 width=7.0'
+]
+
+# Start AeroSpace at login.
+start-at-login = true
+
+# Normalizations, see: https://nikitabobko.github.io/AeroSpace/guide#normalization
+enable-normalization-flatten-containers = false
+enable-normalization-opposite-orientation-for-nested-containers = true
+
+# The 'accordion-padding' specifies the size of accordion padding. You can set 0 to disable the padding feature.
+# See: https://nikitabobko.github.io/AeroSpace/guide#layouts
+accordion-padding = 30
+
+# Possible values: tiles|accordion
+default-root-container-layout = 'tiles'
+
+# Possible values: horizontal|vertical|auto
+# 'auto' means: wide monitor (anything wider than high) gets horizontal orientation,
+#               tall monitor (anything higher than wide) gets vertical orientation
+default-root-container-orientation = 'auto'
+
+# Mouse follows focus when focused monitor changes. Drop it from your config, if you don't like this behavior.
+# See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks
+# See https://nikitabobko.github.io/AeroSpace/commands#move-mouse
+# Fallback value (if you omit the key): on-focused-monitor-changed = []
+on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
+
+# You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag.
+# Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key.
+# Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
+automatically-unhide-macos-hidden-apps = false
+
+# List of workspaces that should stay alive even when they contain no windows, even when they are invisible.
+# This config version is only available since 'config-version = 2'
+# Fallback value (if you omit the key): persistent-workspaces = []
+persistent-workspaces = [
+  "1:Main",
+  "2:Work",
+  "3:Finances",
+  "4:Relax",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10"
+]
+
+# A callback that runs every time binding mode changes.
+# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+# See: https://nikitabobko.github.io/AeroSpace/commands#mode
+on-mode-changed = []
+
+# Possible values: (qwerty|dvorak|colemak)
+# See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
+[key-mapping]
+    preset = 'qwerty'
+
+##
+# Gaps Configuration
+# ------------------
+#
+# Controls the spacing between windows (inner-*) and the space
+# between windows and monitor edges (outer-*).
+#
+# Possible values:
+#
+# 1. Constant values (applies to all monitors):
+#
+#       gaps.outer.top = 8
+#
+# 2. Per-monitor values:
+#
+#       gaps.outer.top = [
+#         { monitor.main = 16 },
+#         { monitor."some-pattern" = 32 },
+#         24
+#       ]
+#
+#    Notes:
+#       - In this example, 24 is a default value when there is no match.
+#       - Monitor pattern is the same as for 'workspace-to-monitor-force-assignment'.
+#       - See full guide: https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
+##
+[gaps]
+    inner.horizontal = 7
+    inner.vertical =   7
+    outer.left =       7
+    outer.bottom =     7
+    outer.top =        7
+    outer.right =      7
+
+# 'main' binding mode declaration. (This mode must be always presented.)
+# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+# Fallback value (if you omit the key): mode.main.binding = {}
+[mode.main.binding]
+    ##
+    # Key Reference
+    # =============
+    #
+    # Modifiers
+    # -------------------
+    #   cmd, alt, ctrl, shift
+    #
+    # Letters
+    # -------------------
+    #   a, b, c, ..., z
+    #
+    # Numbers
+    # -------------------
+    #   0, 1, 2, ..., 9
+    #
+    # Function keys
+    # --------------
+    #   f1, f2, ..., f20
+    #
+    # Keypad numbers
+    # -------------------
+    #   keypad0, keypad1, keypad2, ..., keypad9
+    #
+    # Arrows
+    # -------------------
+    #   left, down, up, right
+    #
+    # Special keys
+    # -------------------
+    #   minus, equal, period, comma, slash, backslash, quote, semicolon,
+    #   backtick, leftSquareBracket, rightSquareBracket, space, enter, esc,
+    #   backspace, tab, pageUp, pageDown, home, end, forwardDelete,
+    #   sectionSign (ISO/european keyboards only)
+    #
+    # Keypad special keys
+    # -------------------
+    #   keypadClear, keypadDecimalMark, keypadDivide, keypadEnter,
+    #   keypadEqual, keypadMinus, keypadMultiply, keypadPlus
+    #
+    # For all possible commands, see: https://nikitabobko.github.io/AeroSpace/commands
+    ##
+
+    cmd-h = [] # Disable "hide application"
+    cmd-alt-h = [] # Disable "hide others"
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#exec-and-forget
+    ctrl-cmd-comma = 'exec-and-forget ~/.local/bin/aerospace_toggle_app_focus.sh "Strongbox"'
+    ctrl-cmd-period = 'exec-and-forget ~/.local/bin/aerospace_toggle_app_focus.sh "KeePassXC"'
+    alt-ctrl-cmd-shift-backtick = 'exec-and-forget open -na Brave\ Browser --args --incognito'
+    alt-ctrl-cmd-shift-semicolon = 'exec-and-forget open -a Ghostty'
+    alt-ctrl-cmd-shift-enter = 'exec-and-forget open -na Ghostty'
+    alt-ctrl-cmd-shift-minus = 'exec-and-forget open -a Cardhop'
+    alt-ctrl-cmd-shift-quote = 'exec-and-forget open -a Mail'
+    alt-ctrl-cmd-shift-equal = 'exec-and-forget ~/.local/bin/aerospace_toggle_app_focus.sh "Session"'
+    alt-ctrl-cmd-shift-up = [
+      'exec-and-forget /opt/homebrew/bin/espanso restart',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Restarted Espanso" -group aerospace-config'
+    ]
+    alt-ctrl-cmd-shift-a = 'exec-and-forget open -a "Activity Monitor"'
+    alt-ctrl-cmd-shift-b = 'exec-and-forget open -a Arc'
+    # alt-ctrl-cmd-shift-b = 'exec-and-forget open -a Zen'
+    # alt-ctrl-cmd-shift-n = 'exec-and-forget /Applications/Zen.app/Contents/MacOS/zen --new-window'
+    alt-ctrl-cmd-shift-c = 'exec-and-forget ~/.local/bin/aerospace_toggle_app_focus.sh "Fantastical"'
+    alt-ctrl-cmd-shift-d = 'exec-and-forget open -a Docker'
+    alt-ctrl-cmd-shift-g = 'exec-and-forget open -a ChatGPT'
+    alt-ctrl-cmd-shift-m = 'exec-and-forget open -a Messages'
+    alt-ctrl-cmd-shift-o = 'exec-and-forget open -a Obsidian'
+    alt-ctrl-cmd-shift-p = 'exec-and-forget open -a Phone'
+    alt-ctrl-cmd-shift-v = 'exec-and-forget open -a System\ Settings'
+    alt-ctrl-cmd-shift-x = 'exec-and-forget open -a Xcode'
+    alt-ctrl-cmd-shift-y = 'exec-and-forget open -a Microsoft\ Excel'
+
+    # Hide focused application (this is a replacement for macOS Cmd+h).
+    alt-ctrl-cmd-shift-down = "exec-and-forget osascript -e 'tell application \"System Events\" to set visible of first process whose frontmost is true to false'"
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#focus
+    alt-ctrl-cmd-shift-h = 'focus --boundaries-action wrap-around-the-workspace left'
+    alt-ctrl-cmd-shift-j = 'focus --boundaries-action wrap-around-the-workspace down'
+    alt-ctrl-cmd-shift-k = 'focus --boundaries-action wrap-around-the-workspace up'
+    alt-ctrl-cmd-shift-l = 'focus --boundaries-action wrap-around-the-workspace right'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move
+    cmd-ctrl-h = 'move left'
+    cmd-ctrl-j = 'move down'
+    cmd-ctrl-k = 'move up'
+    cmd-ctrl-l = 'move right'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#fullscreen
+    # Alternatively, there is: https://nikitabobko.github.io/AeroSpace/commands#macos-native-fullscreen
+    alt-ctrl-cmd-shift-f = 'fullscreen'
+    # alt-ctrl-cmd-shift-f = 'macos-native-fullscreen'
+
+    # Consider using 'join-with' command as a 'split' replacement, if you want to enable normalizations.
+    alt-ctrl-cmd-shift-u = 'split vertical'
+    alt-ctrl-cmd-shift-i = 'split horizontal'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#layout
+    alt-ctrl-cmd-shift-s = 'layout v_accordion' # 'layout stacking' in i3
+    alt-ctrl-cmd-shift-t = 'layout h_accordion' # 'layout tabbed' in i3
+    alt-ctrl-cmd-shift-e = 'layout tiles horizontal vertical' # 'layout toggle split' in i3
+    alt-ctrl-cmd-shift-w = 'layout accordion horizontal vertical' # 'layout toggle tabbed' in i3
+    alt-ctrl-cmd-shift-space = 'layout floating tiling' # 'floating toggle' in i3
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#workspace
+    alt-ctrl-cmd-shift-1 = 'workspace "1:Main"'
+    alt-ctrl-cmd-shift-2 = 'workspace "2:Work"'
+    alt-ctrl-cmd-shift-3 = 'workspace "3:Finances"'
+    alt-ctrl-cmd-shift-4 = 'workspace "4:Relax"'
+    alt-ctrl-cmd-shift-5 = 'workspace 5'
+    alt-ctrl-cmd-shift-6 = 'workspace 6'
+    alt-ctrl-cmd-shift-7 = 'workspace 7'
+    alt-ctrl-cmd-shift-8 = 'workspace 8'
+    alt-ctrl-cmd-shift-9 = 'workspace 9'
+    alt-ctrl-cmd-shift-0 = 'workspace "scratchpad"'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move-node-to-workspace
+    cmd-ctrl-1 = 'move-node-to-workspace "1:Main"'
+    cmd-ctrl-2 = 'move-node-to-workspace "2:Work"'
+    cmd-ctrl-3 = 'move-node-to-workspace "3:Finances"'
+    cmd-ctrl-4 = 'move-node-to-workspace "4:Relax"'
+    cmd-ctrl-5 = 'move-node-to-workspace 5'
+    cmd-ctrl-6 = 'move-node-to-workspace 6'
+    cmd-ctrl-7 = 'move-node-to-workspace 7'
+    cmd-ctrl-8 = 'move-node-to-workspace 8'
+    cmd-ctrl-9 = 'move-node-to-workspace 9'
+    cmd-ctrl-0 = 'move-node-to-workspace "scratchpad"'
+
+    alt-ctrl-cmd-shift-rightSquareBracket = 'workspace next'
+    alt-ctrl-cmd-shift-leftSquareBracket = 'workspace prev'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#workspace-back-and-forth
+    alt-ctrl-cmd-shift-backslash = 'workspace-back-and-forth'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move-workspace-to-monitor
+    # alt-shift-tab = 'move-workspace-to-monitor --wrap-around next'
+
+    alt-ctrl-cmd-shift-home = [
+      'reload-config',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Config reloaded" -group aerospace-config'
+    ]
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#mode
+    alt-ctrl-cmd-shift-q = [
+      'mode service',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"service\" mode" -group aerospace-config'
+    ]
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#resize
+    alt-ctrl-cmd-shift-r = [
+      'mode resize',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"resize\" mode" -group aerospace-config'
+    ]
+
+# 'service' binding mode declaration, see: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+[mode.service.binding]
+    esc = [
+      'reload-config',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+    # Reset layout.
+    r = [
+      'flatten-workspace-tree',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+    # Toggle between floating and tiling layout.
+    f = [
+      'layout floating tiling',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+    backspace = [
+      'close-all-windows-but-current',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+    # 'sticky' is not yet supported, see: https://github.com/nikitabobko/AeroSpace/issues/2
+    # s = [
+    #   'layout sticky tiling',
+    #   'mode main',
+    #   'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    # ]
+
+    alt-shift-h = [
+      'join-with left',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+    alt-shift-j = [
+      'join-with up',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+    alt-shift-k = [
+      'join-with down',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+    alt-shift-l = [
+      'join-with right',
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+[mode.resize.binding]
+    b = 'balance-sizes'
+    h = 'resize width -50'
+    j = 'resize height +50'
+    k = 'resize height -50'
+    l = 'resize width +50'
+    enter = [
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+    esc = [
+      'mode main',
+      'exec-and-forget /opt/homebrew/bin/terminal-notifier -title "Aerospace" -message "Entered \"main\" mode" -group aerospace-config'
+    ]
+
+# You can use on-window-detected callback to set application defaults.
+# See: https://nikitabobko.github.io/AeroSpace/guide#on-window-detected-callback
+
+[[on-window-detected]]
+    if.app-id = 'com.apple.systempreferences'
+    check-further-callbacks = true
+    run = ['layout floating']
+
+[[on-window-detected]]
+    if.app-id = 'com.flexibits.fantastical2.mac'
+    check-further-callbacks = true
+    run = ['layout floating']
+
+[[on-window-detected]]
+    if.app-id = 'com.philipyoungg.session'
+    check-further-callbacks = true
+    run = ['layout floating']
+
+[[on-window-detected]]
+    if.app-id = 'org.keepassxc.keepassxc'
+    check-further-callbacks = true
+    run = ['layout floating']
+
+[[on-window-detected]]
+    if.app-id = 'com.markmcguill.strongbox'
+    check-further-callbacks = true
+    run = ['layout floating']
+
+# [[on-window-detected]]
+#     if.app-id = 'com.flexibits.cardhop.mac'
+#     check-further-callbacks = true
+#     run = ['layout floating']
+

--- a/dot_config/private_karabiner/private_karabiner.json
+++ b/dot_config/private_karabiner/private_karabiner.json
@@ -1,92 +1,67 @@
 {
-    "profiles": [
-        {
-            "complex_modifications": {
-                "parameters": {
-                    "basic.simultaneous_threshold_milliseconds": 30,
-                    "basic.to_delayed_action_delay_milliseconds": 200,
-                    "basic.to_if_alone_timeout_milliseconds": 200,
-                    "basic.to_if_held_down_threshold_milliseconds": 100
+  "profiles": [
+    {
+      "complex_modifications": {
+        "parameters": {
+          "basic.simultaneous_threshold_milliseconds": 30,
+          "basic.to_delayed_action_delay_milliseconds": 200,
+          "basic.to_if_alone_timeout_milliseconds": 200,
+          "basic.to_if_held_down_threshold_milliseconds": 100
+        },
+        "rules": [
+          {
+            "description": "Change tab to hyper (⌥⌃⌘⇧) when held, and tab when tapped.",
+            "manipulators": [
+              {
+                "from": {
+                  "key_code": "tab",
+                  "modifiers": { "optional": ["any"] }
                 },
-                "rules": [
-                    {
-                        "description": "Mac OSX: disable cmd + option + h + m to prevent minimising all windows",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "h",
-                                    "modifiers": {
-                                        "mandatory": ["command", "option"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "m",
-                                    "modifiers": {
-                                        "mandatory": ["command", "option"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Change caps_lock to escape when tapped, and control when held.",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "left_control",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "left_control",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "escape" }],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Change tab to hyper (⌥⌃⌘⇧) when held, and tab when tapped.",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "tab",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "to_if_alone": [{ "key_code": "tab" }],
-                                "to_if_held_down": [
-                                    {
-                                        "key_code": "left_shift",
-                                        "lazy": true,
-                                        "modifiers": ["left_command", "left_control", "left_option"]
-                                    }
-                                ],
-                                "type": "basic"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "name": "Default profile",
-            "selected": true,
-            "simple_modifications": [
-                {
-                    "from": { "key_code": "caps_lock" },
-                    "to": [{ "key_code": "left_control" }]
-                }
-            ],
-            "virtual_hid_keyboard": {
-                "country_code": 0,
-                "keyboard_type_v2": "ansi"
-            }
+                "to_if_alone": [{ "key_code": "tab" }],
+                "to_if_held_down": [
+                  {
+                    "key_code": "left_shift",
+                    "lazy": true,
+                    "modifiers": ["left_command", "left_control", "left_option"]
+                  }
+                ],
+                "type": "basic"
+              }
+            ]
+          },
+          {
+            "description": "Change caps_lock to escape when tapped, and control when held.",
+            "manipulators": [
+              {
+                "from": {
+                  "key_code": "left_control",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "key_code": "left_control",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [{ "key_code": "escape" }],
+                "type": "basic"
+              }
+            ]
+          }
+        ]
+      },
+      "name": "Default profile",
+      "selected": true,
+      "simple_modifications": [
+        {
+          "from": { "key_code": "caps_lock" },
+          "to": [{ "key_code": "left_control" }]
         }
-    ]
+      ],
+      "virtual_hid_keyboard": {
+        "country_code": 0,
+        "keyboard_type_v2": "ansi"
+      }
+    }
+  ]
 }

--- a/dot_local/bin/executable_aerospace_toggle_app_focus.sh
+++ b/dot_local/bin/executable_aerospace_toggle_app_focus.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+##
+# Description: Toggles an app managed by AeroSpace between focused and scratchpad (hide).
+# Credit: https://github.com/nikitabobko/AeroSpace/issues/296#issuecomment-2326103392
+#
+# Example usage:
+#
+#   $ ./aerospace_toggle_app_focus.sh fantastical
+##
+
+# Exit immediately if any command fails or if any variable is unset.
+set -euo pipefail
+
+get_current_workspace() {
+  aerospace list-workspaces --focused
+}
+
+get_app_window_id() {
+  aerospace list-windows --all --format "%{window-id}%{right-padding} | %{app-name}" | grep -m 1 -i "$1" | cut -d' ' -f1 | sed '1p;d'
+}
+
+focus_app() {
+  local app_name="$1"
+
+  local current_workspace
+  current_workspace="$(get_current_workspace)"
+
+  local app_window_id
+  app_window_id="$(get_app_window_id "$app_name")"
+
+  aerospace focus --window-id "$app_window_id"
+  aerospace move-node-to-workspace "$current_workspace"
+  aerospace workspace "$current_workspace"
+  aerospace move-mouse window-lazy-center
+}
+
+app_closed() {
+  local app_name="$1"
+
+  if aerospace list-windows --all --format '%{app-name}' | grep -iq -- "$app_name"; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+get_focused_app_bundle_id() {
+  aerospace list-windows --focused --format "%{app-bundle-id}"
+}
+
+get_target_app_bundle_id() {
+  local app_name="$1"
+  aerospace list-windows --all --format "%{app-bundle-id}" | grep -m 1 -i "$app_name"
+}
+
+app_focused() {
+  local app_name="$1"
+
+  local focused_bundle_id
+  focused_bundle_id="$(get_focused_app_bundle_id)"
+
+  local target_bundle_id
+  target_bundle_id="$(get_target_app_bundle_id "$app_name")"
+
+  [[ $focused_bundle_id == "$target_bundle_id" ]]
+}
+
+unfocus_app() {
+  aerospace move-node-to-workspace scratchpad
+}
+
+main() {
+  local app_name="$1"
+
+  if app_closed "$app_name"; then
+    open -a "$app_name"
+    sleep 0.5
+  else
+    if app_focused "$app_name"; then
+      unfocus_app
+    else
+      focus_app "$app_name"
+    fi
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This PR does the following:

- [x] Closes #14
- [x] Closes #6
- [x] Adds support for Aerospace, which is an i3-like window manager for macOS.
- [x] Manages Aerospace keyboard bindings through:
  - Primary: A custom "hyper" key (`cmd + ctrl + option + shift`)
  - Secondary: `cmd + ctrl`
- [x] Adds window border highlighting via [JankyBorders](https://github.com/FelixKratz/JankyBorders).
- [x] Removes Karabiner Elements modification that turns-off builtin macOS hide application keyboard
  shortcut (this is now managed by Aerospace).
- [x] Adds a `aerospace_toggle_app_focus.sh` script to mimic i3 scratchpad behavior, which basically just
  toggles the app between the foreground and background.
