### PR TITLE
fix(osquery): correctly detect FileVault-off without false positives (#18)

### DIFF
--- a/dot_config/osquery/packs/security-policy-regression.conf
+++ b/dot_config/osquery/packs/security-policy-regression.conf
@@ -59,10 +59,9 @@
     },
     "filevault_off": {
       "query": "SELECT 'filevault' AS protection WHERE NOT EXISTS (SELECT 1 FROM disk_encryption WHERE type = 'APFS Encryption' AND filevault_status = 'on');",
-      "interval": 86400,
-      "snapshot": true,
+      "interval": 3600,
       "platform": "darwin",
-      "description": "Absolute-state floor (snapshot): a row here means NO APFS volume is FileVault-encrypted, i.e. FileVault is OFF right now. Empty (silent) when on."
+      "description": "FileVault off-detector. Returns one constant row only when NO APFS volume is FileVault-encrypted (FileVault OFF), empty otherwise. Differential (NOT snapshot) on purpose: snapshot results are written to osqueryd.snapshots.log, which the alerter does not read, so as a snapshot this never reached #priority (issue #18). As a differential query the off-row is logged 'added' to osqueryd.results.log when FileVault goes off (or is already off at first run), exactly like firewall_state. The row is constant, so APFS volume identity churn cannot trigger it; it fires only on genuine FileVault-off."
     }
   }
 }

--- a/dot_local/bin/executable_osquery-results-alerter.sh
+++ b/dot_local/bin/executable_osquery-results-alerter.sh
@@ -73,17 +73,31 @@ raw_findings=$(printf '%s\n' "$new_lines" | jq -rR '
   . as $line | (try ($line | fromjson) catch empty) |
   # A security-policy row is CRITICAL only when the protection turned OFF, not
   # on every change. For the boolean states that is an "added" row carrying the
-  # off value; for filevault (the query returns only encrypted volumes) it is a
-  # "removed" row — a volume left the encrypted set. Re-enables, version bumps,
-  # sharing changes, and the paired "removed" old-value rows fall through to
-  # NOTICE. (sharing cannot be direction-classified from a single row, so it is
-  # always NOTICE; the poller covers firewall/Gatekeeper transitions too.)
+  # off value. Re-enables, version bumps, sharing changes, and the paired
+  # "removed" old-value rows fall through to NOTICE. (sharing cannot be
+  # direction-classified from a single row, so it is always NOTICE; the poller
+  # covers firewall/Gatekeeper transitions too.)
+  #
+  # FileVault is NOT detected via filevault_state. That query emits one row per
+  # FileVault-on APFS volume, and on sealed-system-volume macOS a single row can
+  # leave the differential set (a base system volume unmounting, a snapshot
+  # replacing it, APFS identity churn) while the data-bearing volume stays
+  # encrypted — so "one filevault_state row removed" does NOT mean FileVault is
+  # off (issue #18). A removed filevault_state row falls through to NOTICE.
+  #
+  # Genuine FileVault-off is detected by the filevault_off query, which emits a
+  # single constant row only when NO APFS volume is encrypted. It is a
+  # DIFFERENTIAL query (not snapshot): snapshot output goes to
+  # osqueryd.snapshots.log, which this alerter does not read, so the earlier
+  # snapshot form never reached here (the false-negative half of issue #18). As
+  # a differential query its off-row is logged "added" to results.log, matched
+  # below. The constant row is immune to APFS churn, so no false positive.
   def protection_off:
     (.name == "pack_security-policy-regression_firewall_state" and .action == "added" and (.columns.global_state // "") == "0")
     or (.name == "pack_security-policy-regression_gatekeeper_state" and .action == "added" and (.columns.assessments_enabled // "") == "0")
     or (.name == "pack_security-policy-regression_sip_state" and .action == "added" and (.columns.enabled // "") == "0")
     or (.name == "pack_security-policy-regression_screenlock_state" and .action == "added" and (.columns.enabled // "") == "0")
-    or (.name == "pack_security-policy-regression_filevault_state" and .action == "removed")
+    or (.name == "pack_security-policy-regression_filevault_off" and .action == "added")
     or (.action == "currently-off" and (.name | startswith("pack_security-policy-regression_")));
   def sev:
     if protection_off


### PR DESCRIPTION
Closes #18.

## The bug (two-sided)

**False positive.** The alerter flagged *any* removed `filevault_state` row as a protection-off event → a CRITICAL "FileVault turned OFF" in #priority. But `filevault_state` lists one row per FileVault-on APFS volume, and APFS volume identity churn (a base/system volume unmounting, a snapshot replacing it) drops a single row from the differential set while the data-bearing volume stays encrypted. The 2026-06-02 incident: removed `/dev/disk3s1` still reported `filevault_status: on`, `encrypted: 1` — FileVault was on.

**False negative (found while fixing the above).** Just removing the bad clause and leaning on `filevault_off` to still catch a genuine off — as both the issue and the first patch assumed — does **not** work: `filevault_off` was a **snapshot** query, and osquery writes snapshot results to `osqueryd.snapshots.log`, which the alerter never reads (it consumes `osqueryd.results.log`). So a real FileVault-off had **no path to #priority at all** — we'd have traded a false positive for a false negative on a protection turning off.

## The fix

- Drop the brittle `filevault_state … removed` clause. A removed row now falls through to a NOTICE in #osquery (breadcrumb without paging).
- Convert `filevault_off` from **snapshot** to a **differential** query (1h interval). It returns one constant row only when no APFS volume is encrypted, so its off-row is logged `added` to `results.log` when FileVault goes off (or is already off at first run) — exactly like `firewall_state`. The constant row is immune to APFS churn, so it cannot false-positive. Add the matching `protection_off` clause.

## Corrections to earlier analysis (for the record)

- The **issue description** states: *"`filevault_off` already exists as an absolute-state snapshot query and is probably closer to the right signal."* The instinct (judge absolute state, not a vanished row) was correct — but as a **snapshot** its output goes to a log the alerter never reads, so relying on it as-is is exactly what produced the false negative. This fix keeps the query's logic and changes its **mode** (snapshot → differential) so the answer lands where the consumer reads.
- An intermediate fix's commit message claimed *"genuine FileVault-off remains CRITICAL via the existing filevault_off snapshot floor … the snapshot-explode path turns that into a currently-off row"* — wrong for the same reason; that path never fires from `results.log`.

## Verification

- #18 incident row (`filevault_state` removed, `filevault_status: on`) → NOTICE in #osquery, **not** CRITICAL ✅
- `filevault_off` `added` row → CRITICAL "FileVault turned OFF" in #priority ✅
- Firewall-off and other protections → unaffected ✅
- `just l` green

## Known follow-up (separate issue)

The same snapshot-logging gap means the rest of the `*_off` "snapshot floor" (`firewall_off`, `gatekeeper_off`, `screenlock_off`) also never reaches the alerter, and the alerter's `action == "snapshot"` handling is consequently dead. Those protections are still covered by their `*_state` differential checks (and firewall/Gatekeeper by the 60s poller), so the practical gap was FileVault-only — but reviving or removing the dead snapshot floor deserves its own issue.
