### PR TITLE
test(lint): validate osquery config/packs + shellcheck the setup script

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -148,12 +148,15 @@ find_shell_templates() {
     -type d \( -name ".git" -o -name ".worktrees" -o -name ".direnv" -o -regex ".*/\.?vendor" \) -prune \
     -o -type f \( \
     -name "dot_bashrc.tmpl" \
+    -o -name "run_onchange_before_50-setup-osquery.sh.tmpl" \
     \) -print0
 }
 
 shellcheck_rendered_template_runner() {
   local template_file="$1"
-  CI=1 chezmoi execute-template --no-tty <"$template_file" | shellcheck - || return "$?"
+  # --source "$PWD" so includeTemplate (used by the osquery setup script to pull
+  # in osquery.conf) resolves against this checkout's .chezmoitemplates.
+  CI=1 chezmoi --source "$PWD" execute-template --no-tty <"$template_file" | shellcheck - || return "$?"
 }
 
 run_11_shellcheck_templates() {
@@ -290,6 +293,27 @@ run_70_jq() {
   execute_runner find_json_files jq_runner || return "$?"
 }
 
+find_osquery_config_templates() {
+  # osquery's config and packs are JSON-bodied .conf templates assembled by
+  # run_onchange_before_50-setup-osquery.sh.tmpl via includeTemplate. The plain
+  # *.json jq runner never sees them, and a broken config silently stops the
+  # daemon from loading. Render each (osquery.conf carries {{ .chezmoi.homeDir }}
+  # directives) and jq-validate the result.
+  find .chezmoitemplates/osquery -type f -name "*.conf" -print0
+}
+
+jq_osquery_runner() {
+  local file="$1"
+  # Source path -> includeTemplate name (drop the .chezmoitemplates/ prefix).
+  local tmpl="${file#./}"
+  tmpl="${tmpl#.chezmoitemplates/}"
+  CI=1 chezmoi --source "$PWD" execute-template --no-tty "{{ includeTemplate \"${tmpl}\" . }}" | jq empty || return "$?"
+}
+
+run_72_osquery_config() {
+  execute_runner find_osquery_config_templates jq_osquery_runner || return "$?"
+}
+
 find_yaml_files() {
   find .chezmoidata -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 2>/dev/null
 }
@@ -319,7 +343,7 @@ parse_cli_options() {
       m) pco_runners+=("run_40_mdformat") ;;
       n) pco_runners+=("run_50_nixfmt") ;;
       t) pco_runners+=("run_60_taplo") ;;
-      j) pco_runners+=("run_70_jq") ;;
+      j) pco_runners+=("run_70_jq" "run_72_osquery_config") ;;
       y) pco_runners+=("run_80_yq") ;;
       *)
         printf "%s\n" "Error: invalid option '$OPTARG'" >&2


### PR DESCRIPTION
## Why

CI never functionally validated the osquery monitoring config — which is how PR #21's osquery work merged without it:

- The jq runner matches only `*.json`, so the JSON-bodied `.conf` config and packs (assembled by `run_onchange_before_50-setup-osquery.sh.tmpl` via `includeTemplate`) were **never validated**. A broken config silently stops osqueryd from loading.
- `.chezmoiscripts/*.sh.tmpl` are **never shell-linted** (only `dot_bashrc.tmpl` is rendered for shellcheck), so the setup script could ship a shell bug.

## What

- `run_72_osquery_config`: renders `osquery.conf` + the three packs via `includeTemplate` (`--source` so it resolves in CI) and jq-validates each. Folds into the jq summary line and the `j` CLI option.
- Adds the osquery setup script to the shellcheck-template finder; passes `--source` to the renderer so its `includeTemplate` resolves.

## Verification

- Positive: lint now processes all 4 osquery JSON templates with jq and shellchecks the rendered setup script.
- Negative: injecting invalid JSON into a pack makes the runner exit non-zero (5); reverting restores exit 0.
- `shellcheck scripts/lint.sh` clean; full `just l` green.