### PR TITLE
chore(worktrunk): tune user config + relocate wt shell wrapper

### DIFF
--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -137,6 +137,16 @@ complete -F _just -o bashdefault -o default j
 # OpenClaw Completion
 [[ -s "$HOME/.openclaw/completions/openclaw.bash" ]] && . "$HOME/.openclaw/completions/openclaw.bash"
 
+# Worktrunk: https://worktrunk.dev/
+# Defines a `wt` shell function wrapping the binary so `wt switch`/`wt merge`
+# can change the parent shell's directory (a subprocess can't cd its caller —
+# the function reads a directive temp file and runs the cd itself). Without it,
+# `wt switch` finds the worktree but cannot move you there. The init output is
+# self-guarding (`if command -v wt`) and uses `builtin cd`, so it is inert when
+# wt is absent and unaffected by zoxide's later `cd` alias. No PROMPT_COMMAND
+# mutation, so placement here (before zoxide/atuin) is safe.
+eval "$(wt config shell init bash)"
+
 # Nix: https://github.com/NixOS/nix-installer
 nix_daemon='/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 [[ -e $nix_daemon ]] && . "$nix_daemon"

--- a/dot_config/worktrunk/config.toml
+++ b/dot_config/worktrunk/config.toml
@@ -3,17 +3,26 @@
 
 worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
 
+# MAX_THINKING_TOKENS is the effort knob (0 = thinking off). Raised to give
+# haiku a real thinking budget for branch summaries — but this command is shared
+# with commit-message generation, so wt commit messages also think now.
 [commit.generation]
-command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+command = "CLAUDECODE= MAX_THINKING_TOKENS=16000 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 
 [commit]
-stage = "all"
+stage = "tracked"
 
 [merge]
 squash = true
 rebase = true
 remove = true
 verify = true
+
+# Keep the branch ref after merge (worktree is still removed). Squash writes a
+# backup ref at refs/wt-backup/<branch>, but retaining the branch leaves an
+# obvious recovery/audit handle without digging through reflog.
+[remove]
+delete-branch = false
 
 [list]
 summary = false
@@ -25,13 +34,5 @@ pager = "delta --paging=never"
 [post-start]
 copy = "wt step copy-ignored"
 
-# Pre-merge validation gate (sequential, fast checks first).
-# Array-of-tables form per worktrunk docs — [pre-merge] table form is deprecated.
-[[pre-merge]]
-lint = "just l 2>/dev/null || true"
-
-[[pre-merge]]
-test = "just test 2>/dev/null || true"
-
 [aliases]
-up = "git fetch --all --prune && wt step for-each -- 'git rev-parse --verify -q @{u} >/dev/null || exit 0; g=$(git rev-parse --git-dir); test -d \"$g/rebase-merge\" -o -d \"$g/rebase-apply\" && exit 0; git rebase @{u} --no-autostash || git rebase --abort'"
+up = "git fetch --all --prune && wt step for-each -- 'git rev-parse --verify -q @{u} >/dev/null || exit 0; g=$(git rev-parse --git-dir); test -d \"$g/rebase-merge\" -o -d \"$g/rebase-apply\" && exit 0; git rebase @{u} --no-autostash || { git rebase --abort; echo \"wt up: rebase failed for $(git branch --show-current); left unchanged\" >&2; }'"


### PR DESCRIPTION
Tunes the worktrunk **user** config and moves the `wt` shell-init wrapper here from `add-paseo-cli` (it fits with the worktrunk work, not that branch).

## `dot_config/worktrunk/config.toml`
- `stage = "tracked"` (was `"all"`) — don't sweep untracked files into commits.
- Removed user-level `[[pre-merge]]` hooks — wrong scope for a user config (they'd run in *every* repo), and the `|| true` meant they never actually blocked a merge. Per-repo gating belongs in each repo's `.config/wt.toml`.
- `[remove] delete-branch = false` — keep the branch ref after merge for recovery/audit; the worktree is still removed.
- `up` alias — emit a stderr message on rebase failure instead of silently aborting and leaving the branch behind with no signal.
- `MAX_THINKING_TOKENS` `0 → 16000` — higher-effort branch summaries (kept on haiku). Note: shared with commit-message generation, so `wt` commit messages now think too.

## `dot_bashrc.tmpl`
- Add `eval "$(wt config shell init bash)"` so the `wt` function is defined and `wt switch`/`wt merge` can cd the parent shell. Self-guarding and uses `builtin cd`; placed before zoxide/atuin.

## Verification
- `just l` (all linters incl. shellcheck on the rendered template): pass
- `nix flake check --all-systems`: pass
- `wt config shell init bash | bash -n`: valid