### PR TITLE
Harden Claude Code settings and rework user-wide git hooks

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -63,7 +63,6 @@ packages:
         - git-crypt
         - git-delta
         - git-filter-repo
-        - git-lfs
         - git-sizer
         - gitleaks
         - glow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ drift freely without forcing a chezmoi resync.
   (`permission_prompt` matcher) fires alerter, `PreToolUse` (`Bash` matcher) writes to
   `~/.claude/audit.log`.
 - `statusLine`, `enabledPlugins`, `cleanupPeriodDays` (= 36525, effectively disables session cleanup),
-  `autoUpdatesChannel` (= `stable`, pins the release channel so updates lag `latest`).
+  `autoUpdatesChannel` (= `stable`, pins the release channel so updates lag `latest`),
+  `remoteControlAtStartup` (= `true`, starts the Remote Control bridge every session).
 
 **Free-drift (Claude Code owns):** `alwaysThinkingEnabled`, `useAutoModeDuringPlan`, `voiceEnabled`,
 `skipDangerousModePermissionPrompt`, and any future setting `/config` adds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ See https://www.chezmoi.io/user-guide/manage-different-types-of-file/ for the `m
 Both hooks live in the **user-wide** hooks dir — `core.hooksPath = ~/.config/git/hooks` (set in
 `dot_gitconfig.tmpl`), so they apply to every repo:
 
-- **`prepare-commit-msg` — user-wide AI commit messages.** Prepopulates a conventional message via Claude
-  haiku (internals under **AI Commit Messages** below). Bails on `-m`/merge/rebase; bypass with
-  `SKIP_AI_COMMIT=1`.
+- **`prepare-commit-msg` — user-wide AI commit messages.** Prepopulates a Conventional Commits message
+  via Claude Sonnet (internals under **AI Commit Messages** below). Bails on `-m`/merge/rebase; bypass
+  with `SKIP_AI_COMMIT=1`.
 - **`pre-commit` — per-repo lint, via a dispatcher.** `dot_config/git/hooks/executable_pre-commit` runs
   in every repo but only acts when the repository tracks an executable `.githooks/pre-commit`, which it
   then `exec`s. This repo's `.githooks/pre-commit` runs `just lint-check` (check-only — reports drift,
@@ -296,11 +296,12 @@ logged in — it is not a "is the daemon working" check; use `atuin daemon statu
 ### AI Commit Messages
 
 The user-wide `prepare-commit-msg` hook (`dot_config/git/hooks/executable_prepare-commit-msg`, activated
-by `core.hooksPath = ~/.config/git/hooks`) truncates the staged diff to 5 KB, pipes it to
-`claude -p --model=haiku` with a 10-second timeout, and prepopulates the commit editor with the returned
-conventional message. Bails on `-m`/`-F`/merge/rebase/cherry-pick and on `SKIP_AI_COMMIT=1`. Chains to a
-repo-local `.git/hooks/prepare-commit-msg` if present. Never blocks a commit — worst case the editor
-opens with an empty message.
+by `core.hooksPath = ~/.config/git/hooks`) pipes the full staged diff (no truncation) to
+`claude -p --model=sonnet` with a 30-second timeout, and prepopulates the commit editor with the returned
+Conventional Commits message (subject, optional body, optional footers). Bails on
+`-m`/`-F`/merge/rebase/cherry-pick and on `SKIP_AI_COMMIT=1`. Chains to a repo-local
+`.git/hooks/prepare-commit-msg` if present. Never blocks a commit — worst case the editor opens with an
+empty message.
 
 A per-repo `core.hooksPath` override (e.g. what `git lfs install` writes) would shadow this hook; that is
 why the per-repo pre-commit lint uses the dispatcher described under Git Hooks rather than an override.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ just y          # yq (YAML) only
 ```
 
 These invoke `nix develop .#run --command ./scripts/lint.sh` with the appropriate flag. The lint script
-auto-formats in place and reports diffs. The pre-commit hook runs `just l` — install it with `just h`.
+auto-formats in place and reports diffs. On commit, the per-repo `.githooks/pre-commit` hook runs
+`just lint-check` (check-only) — auto-wired via the user-wide dispatcher, no install step. See Git Hooks.
 
 To enter an interactive dev shell with all tools: `nix develop`.
 
@@ -101,18 +102,32 @@ See https://www.chezmoi.io/user-guide/manage-different-types-of-file/ for the `m
 
 ### Git Hooks
 
-Install pre-commit hook (runs full lint): `just h`. Commits also trigger a global `prepare-commit-msg`
-hook at `~/.config/git/hooks/` that prepopulates conventional commit messages via Claude haiku.
+Both hooks live in the **user-wide** hooks dir — `core.hooksPath = ~/.config/git/hooks` (set in
+`dot_gitconfig.tmpl`), so they apply to every repo:
 
-Bypass the AI commit hook: `SKIP_AI_COMMIT=1 git commit ...`.
+- **`prepare-commit-msg` — user-wide AI commit messages.** Prepopulates a conventional message via Claude
+  haiku (internals under **AI Commit Messages** below). Bails on `-m`/merge/rebase; bypass with
+  `SKIP_AI_COMMIT=1`.
+- **`pre-commit` — per-repo lint, via a dispatcher.** `dot_config/git/hooks/executable_pre-commit` runs
+  in every repo but only acts when the repository tracks an executable `.githooks/pre-commit`, which it
+  then `exec`s. This repo's `.githooks/pre-commit` runs `just lint-check` (check-only — reports drift,
+  never mutates the tree or index). No install step: the dispatcher is user-wide and the repo hook is
+  committed with its executable bit.
+
+**Why a dispatcher, not `git config core.hooksPath .githooks`?** `core.hooksPath` is single-valued, so a
+per-repo override shadows the user-wide `prepare-commit-msg`. The dispatcher keeps the global hook
+authoritative while letting any repo opt into pre-commit checks. **Do not reintroduce Git LFS here** —
+`git lfs install` writes exactly such an override, and this repo tracks no LFS files.
+
+Bypass all hooks for one commit: `git commit --no-verify`.
 
 ## Architecture
 
 ### Source-Only Files
 
 Some files are dev/CI only and are excluded from `$HOME` via `.chezmoiignore`: `justfile`, `scripts/`,
-`flake.nix`, `flake.lock`, `.envrc`, `.shellcheckrc`, `.editorconfig`, `.mdformat.toml`, `assets/`,
-`docs/`, `private/`, `README.md`, `LICENSE`, `.gitignore`, `.worktrees/`, `**/.DS_Store`. Only
+`.githooks/`, `flake.nix`, `flake.lock`, `.envrc`, `.shellcheckrc`, `.editorconfig`, `.mdformat.toml`,
+`assets/`, `docs/`, `private/`, `README.md`, `LICENSE`, `.gitignore`, `.worktrees/`, `**/.DS_Store`. Only
 chezmoi-managed files (`dot_`, `private_`, `run_`, etc. prefixes) reach the target state.
 
 ### Minimum Chezmoi Version
@@ -280,10 +295,15 @@ logged in — it is not a "is the daemon working" check; use `atuin daemon statu
 
 ### AI Commit Messages
 
-Global `core.hooksPath = ~/.config/git/hooks` activates a `prepare-commit-msg` hook that: truncates the
-staged diff to 5 KB, pipes it to `claude -p --model=haiku` with a 4-second timeout, and prepopulates the
-commit editor with the returned conventional message. Bails on merge/rebase/cherry-pick. Set
-`SKIP_AI_COMMIT=1` to bypass. Chains to repo-local `.git/hooks/prepare-commit-msg` if present.
+The user-wide `prepare-commit-msg` hook (`dot_config/git/hooks/executable_prepare-commit-msg`, activated
+by `core.hooksPath = ~/.config/git/hooks`) truncates the staged diff to 5 KB, pipes it to
+`claude -p --model=haiku` with a 10-second timeout, and prepopulates the commit editor with the returned
+conventional message. Bails on `-m`/`-F`/merge/rebase/cherry-pick and on `SKIP_AI_COMMIT=1`. Chains to a
+repo-local `.git/hooks/prepare-commit-msg` if present. Never blocks a commit — worst case the editor
+opens with an empty message.
+
+A per-repo `core.hooksPath` override (e.g. what `git lfs install` writes) would shadow this hook; that is
+why the per-repo pre-commit lint uses the dispatcher described under Git Hooks rather than an override.
 
 ### Long-running Command Notifier
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ data and runs `brew bundle --cleanup` whenever the data changes. Prerequisites:
 1. Install the package immediately: `brew install <formula>` or `brew install --cask <cask>`.
 1. On success, add it to `.chezmoidata/system_packages_autoinstall.yaml` in the appropriate list
    (formulae, casks, taps, mas), maintaining alphabetical order.
-1. Remind the user to run `chezmoi apply` at 22:00 local time (America/Denver) that day.
+1. Remind the user to run `chezmoi apply` when appropriate.
 
 Do **not** run `chezmoi apply` directly — see the KeePassXC constraint above.
 
@@ -204,13 +204,9 @@ the design spec in the chezmoi source tree at
 
 ### Template Files
 
-Template files use chezmoi Go templates (`.tmpl` suffix) and live alongside their target files. Notable
-templates: `.chezmoi.toml.tmpl`, `dot_bashrc.tmpl`, `dot_gitconfig.tmpl`, `dot_aws/credentials.tmpl`,
-`dot_config/gh/private_hosts.yml.tmpl`, `dot_config/atuin/config.toml.tmpl`,
-`dot_config/himalaya/config.toml.tmpl`, `dot_config/osquery/osquery.conf.tmpl`,
-`Library/LaunchAgents/*.plist.tmpl`, `Library/Application Support/espanso/match/identity.yml.tmpl`,
-`Library/Application Support/gogcli/credentials.json.tmpl`, and scripts in `.chezmoiscripts/`. Templates
-conditionally branch on `.chezmoi.os` and, where they pull secrets, call `keepassxc`.
+Template files use chezmoi Go templates (`.tmpl` suffix) and live alongside their target files (e.g.
+`.chezmoi.toml.tmpl`, `dot_bashrc.tmpl`, `dot_gitconfig.tmpl`, and scripts in `.chezmoiscripts/`).
+Templates conditionally branch on `.chezmoi.os` and, where they pull secrets, call `keepassxc`.
 
 ### Template Shellcheck Workaround
 
@@ -242,18 +238,17 @@ GitHub Actions (`.github/workflows/lint.yml`) runs on `macos-latest`. Runs
 ### Tmux Session Management
 
 Sessions are managed by [sesh](https://github.com/joshmedeski/sesh). Named sessions live in
-`dot_config/sesh/sesh.toml` (13 configured: uriel, openclaw, homelab, ivy, casually-concerned, dotfiles,
-nvim-config, essential-feed, webdavis-profile, job-hunting, justdavis-ansible, maeve, dresden).
-`~/.local/bin/sesh-bootstrap.sh` creates the three default sessions (uriel/openclaw/homelab) and is
-invoked from bashrc, `tmux-refresh.sh`, and the Claude Code LaunchAgent. `prefix + o` opens the fuzzy
-picker; `prefix + C-o <letter>` jumps to a named session via the SESH key table; `prefix + \\` toggles
-last session; `prefix + R` reloads `~/.tmux.conf`.
+`dot_config/sesh/sesh.toml`. `~/.local/bin/sesh-bootstrap.sh` creates the three default sessions
+(uriel/openclaw/homelab) and is invoked from bashrc, `tmux-refresh.sh`, and the Claude Code LaunchAgent.
+`prefix + o` opens the fuzzy picker; `prefix + C-o <letter>` jumps to a named session via the SESH key
+table; `prefix + \\` toggles last session; `prefix + R` reloads `~/.tmux.conf`.
 
 ### Git Worktrees (Worktrunk)
 
 Git worktrees are managed by [worktrunk](https://worktrunk.dev/). Config in
-`dot_config/worktrunk/config.toml`: squash+rebase+remove merges; array-of-tables `[[pre-merge]]` hooks
-run `just l` and `just test` before merge. `wt up` rebases every worktree against upstream safely.
+`dot_config/worktrunk/config.toml`: squash+rebase+remove merges with `verify = true`, and
+`delete-branch = false` keeps the branch ref after merge. `wt up` rebases every worktree against upstream
+safely.
 
 ### Bashrc Init Ordering
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ drift freely without forcing a chezmoi resync.
 - `hooks`: `UserPromptSubmit` marks session start, `Stop` pulses Hue lights, `Notification`
   (`permission_prompt` matcher) fires alerter, `PreToolUse` (`Bash` matcher) writes to
   `~/.claude/audit.log`.
-- `statusLine`, `enabledPlugins`, `cleanupPeriodDays` (= 36525, effectively disables session cleanup).
+- `statusLine`, `enabledPlugins`, `cleanupPeriodDays` (= 36525, effectively disables session cleanup),
+  `autoUpdatesChannel` (= `stable`, pins the release channel so updates lag `latest`).
 
 **Free-drift (Claude Code owns):** `alwaysThinkingEnabled`, `useAutoModeDuringPlan`, `voiceEnabled`,
 `skipDangerousModePermissionPrompt`, and any future setting `/config` adds.

--- a/dot_config/git/hooks/executable_pre-commit
+++ b/dot_config/git/hooks/executable_pre-commit
@@ -11,6 +11,6 @@
 # Repos without `.githooks/pre-commit` get a no-op.
 
 toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-repo_hook="$toplevel/.githooks/pre-commit"
+repo_hook="${toplevel}/.githooks/pre-commit"
 [[ -x $repo_hook ]] && exec "$repo_hook" "$@"
 exit 0

--- a/dot_config/git/hooks/executable_pre-commit
+++ b/dot_config/git/hooks/executable_pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Global pre-commit dispatcher — runs a repository's own pre-commit checks.
+# Activated by core.hooksPath in dot_gitconfig.tmpl, so it runs in every repo.
+#
+# The user-wide hooks dir must stay authoritative so the global
+# prepare-commit-msg AI hook runs everywhere. A per-repo `core.hooksPath`
+# override (e.g. what `git lfs install` writes) would shadow it. To keep
+# pre-commit checks per-repo without that override, each repo opts in by
+# tracking an executable `.githooks/pre-commit`; this dispatcher runs it.
+#
+# Repos without `.githooks/pre-commit` get a no-op.
+
+toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+repo_hook="$toplevel/.githooks/pre-commit"
+[[ -x $repo_hook ]] && exec "$repo_hook" "$@"
+exit 0

--- a/dot_config/git/hooks/executable_prepare-commit-msg
+++ b/dot_config/git/hooks/executable_prepare-commit-msg
@@ -24,20 +24,19 @@ GIT_DIR="$(git rev-parse --git-dir)"
 [[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]] && exit 0
 [[ -d "$GIT_DIR/rebase-merge" || -d "$GIT_DIR/rebase-apply" ]] && exit 0
 
-# Truncate the diff to 5 KB — huge diffs slow haiku and hurt message quality.
-diff="$(git diff --cached --diff-algorithm=histogram 2>/dev/null | head -c 5000)"
+# Full staged diff — no truncation (Sonnet handles large diffs).
+diff="$(git diff --cached --diff-algorithm=histogram 2>/dev/null)"
 [[ -z $diff ]] && exit 0
 
-# 10-second timeout on the model call. timeout(1) is provided by Homebrew
+# 30-second timeout on the model call. timeout(1) is provided by Homebrew
 # coreutils (in the manifest). On failure/timeout, msg stays empty and the
-# editor opens with an empty first line. Bumped from 4s after observing
-# claude haiku consistently lands at ~4.0s in this environment, causing the
-# hook to truncate 100% of calls and produce empty messages.
-msg="$(printf '%s' "$diff" | timeout 10 \
+# editor opens with an empty first line. Larger than the old 10s because
+# Sonnet is slower than haiku and the diff is no longer truncated.
+msg="$(printf '%s' "$diff" | timeout 30 \
   env CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p \
-  --no-session-persistence --model=haiku --tools='' \
+  --no-session-persistence --model=sonnet --tools='' \
   --disable-slash-commands --setting-sources='' \
-  --system-prompt='Write a conventional commit message (type: subject). One line, under 72 chars. No explanation.' \
+  --system-prompt='Write a Conventional Commits message for the staged diff piped on stdin. Subject line "<type>[optional scope]: <description>" in imperative mood, lowercase description, no trailing period. Optionally add a blank line then a body explaining what and why, then a blank line and footer(s). Use only standard types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Output only the raw commit message with no markdown, no code fences, no preamble, and no Co-Authored-By or tool attribution.' \
   2>/dev/null)"
 
 [[ -n $msg ]] && printf '%s\n\n' "$msg" >"$1"

--- a/dot_config/git/hooks/executable_prepare-commit-msg
+++ b/dot_config/git/hooks/executable_prepare-commit-msg
@@ -20,9 +20,9 @@
 GIT_DIR="$(git rev-parse --git-dir)"
 
 # Bail during in-progress merges, rebases, cherry-picks.
-[[ -f "$GIT_DIR/MERGE_HEAD" ]] && exit 0
-[[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]] && exit 0
-[[ -d "$GIT_DIR/rebase-merge" || -d "$GIT_DIR/rebase-apply" ]] && exit 0
+[[ -f "${GIT_DIR}/MERGE_HEAD" ]] && exit 0
+[[ -f "${GIT_DIR}/CHERRY_PICK_HEAD" ]] && exit 0
+[[ -d "${GIT_DIR}/rebase-merge" || -d "${GIT_DIR}/rebase-apply" ]] && exit 0
 
 # Full staged diff — no truncation (Sonnet handles large diffs).
 diff="$(git diff --cached --diff-algorithm=histogram 2>/dev/null)"
@@ -42,7 +42,7 @@ msg="$(printf '%s' "$diff" | timeout 30 \
 [[ -n $msg ]] && printf '%s\n\n' "$msg" >"$1"
 
 # Chain to repo-local hook if present.
-local_hook="$GIT_DIR/hooks/prepare-commit-msg"
+local_hook="${GIT_DIR}/hooks/prepare-commit-msg"
 [[ -x $local_hook ]] && exec "$local_hook" "$@"
 
 exit 0

--- a/justfile
+++ b/justfile
@@ -3,7 +3,6 @@ set shell := ["bash", "-c", "source /nix/var/nix/profiles/default/etc/profile.d/
 default:
   @just --choose
 
-alias h := install-hooks
 alias l := lint
 alias L := lint-check
 alias s := lint-shell
@@ -53,12 +52,6 @@ apply-no-auth:
 
 check:
   nix develop .#run --command nix flake check --all-systems
-
-install-hooks:
-  @echo "Installing Git pre-commit hooks..."
-  git config core.hooksPath .githooks
-  chmod +x .githooks/pre-commit
-  @echo "✓ Git hooks installed. Pre-commit will run lint.sh"
 
 # macOS Defaults: drift, apply, capture
 

--- a/private_dot_claude/modify_settings.json
+++ b/private_dot_claude/modify_settings.json
@@ -30,6 +30,7 @@
 {{- /* --- stable: scalars and policy --- */ -}}
 {{- $merged = setValueAtPath "cleanupPeriodDays" 36525 $merged -}}
 {{- $merged = setValueAtPath "autoUpdatesChannel" "stable" $merged -}}
+{{- $merged = setValueAtPath "remoteControlAtStartup" true $merged -}}
 
 {{- $permissions := dict
     "allow" (list

--- a/private_dot_claude/modify_settings.json
+++ b/private_dot_claude/modify_settings.json
@@ -29,6 +29,7 @@
 
 {{- /* --- stable: scalars and policy --- */ -}}
 {{- $merged = setValueAtPath "cleanupPeriodDays" 36525 $merged -}}
+{{- $merged = setValueAtPath "autoUpdatesChannel" "stable" $merged -}}
 
 {{- $permissions := dict
     "allow" (list


### PR DESCRIPTION
## Summary
- **Claude settings (chezmoi modify-template):** pin `autoUpdatesChannel=stable` and `remoteControlAtStartup=true` as enforced stable fields.
- **User-wide git hooks:** add a `pre-commit` dispatcher so a repo's own `.githooks/pre-commit` runs without setting a per-repo `core.hooksPath` (which would shadow the user-wide AI `prepare-commit-msg`); retire `just h`. Upgrade the AI commit-message hook to Sonnet with the full untruncated diff and full Conventional Commits output (subject + body + footers).
- **Git LFS:** drop `git-lfs` from the package manifest — unused here, and `git lfs install` writes exactly the kind of per-repo `core.hooksPath` override that was shadowing the user-wide hooks.
- **Docs/style:** trim drift-prone lists in CLAUDE.md, correct the worktrunk merge note (no `[[pre-merge]]` hooks exist), and brace-quote hook variable expansions.

## Test plan
- [x] `just l` green (shellcheck, shfmt, mdformat, nixfmt, taplo, jq, yq)
- [x] modify-template renders valid JSON; live `chezmoi cat` preserves free-drift fields
- [x] dispatcher verified firing per-repo; Sonnet hook generates a full conventional commit
- [x] hooks + settings applied via chezmoi (live == source)
- [ ] CI: `nix flake check --all-systems`