### PR TITLE
feat(happy): keep the Happy daemon always running via launchd

### DIFF
--- a/.chezmoiscripts/run_onchange_after_62-load-happy-daemon-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_62-load-happy-daemon-launchagent.sh.tmpl
@@ -1,0 +1,28 @@
+#!/bin/bash
+# run_onchange_after_62-load-happy-daemon-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl" | sha256sum }}
+
+{{- if eq .chezmoi.os "darwin" }}
+set -euo pipefail
+
+mkdir -p "$HOME/.local/log"
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.happy-daemon.plist"
+TARGET="gui/$(id -u)/com.webdavis.happy-daemon"
+
+# Re-bootstrap the LaunchAgent so a changed plist takes effect. launchd's
+# user-domain registry sometimes still holds the previous registration when
+# bootstrap fires right after bootout — the call returns EIO. Retry silently
+# up to 3 times before surfacing the real error on the final attempt. (Same
+# rationale as the atuin-daemon loader.)
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,33 @@ stale code, silently breaking recording via gRPC schema drift (now self-healing 
 logged in — it is not a "is the daemon working" check; use `atuin daemon status` (reports `Version`,
 `Protocol`, `Healthy`) for daemon health.
 
+### Happy Daemon (Remote Agent Control)
+
+[happy](https://happy.engineering/) bridges Claude Code sessions to the Happy mobile and web apps for
+remote control; the local daemon is that bridge. Its lifecycle is managed by
+`~/Library/LaunchAgents/com.webdavis.happy-daemon.plist` (`KeepAlive=true`, `RunAtLoad=true`), loaded on
+every `chezmoi apply` by `.chezmoiscripts/run_onchange_after_62-load-happy-daemon-launchagent.sh.tmpl`
+(`bootout` + `bootstrap` with a 3-try retry loop, mirroring the atuin loader). `happy` itself is an npm
+global tracked under `npm:` in `.chezmoidata/system_packages_autoinstall.yaml`, and logs go to
+`~/.local/log/happy-daemon.log`.
+
+**The one gotcha — use `start-sync`, not `start`.** The plist runs `happy daemon start-sync`, which keeps
+the daemon in the foreground. The documented command, `happy daemon start`, detaches (forks, then
+returns), which under `KeepAlive` looks like an instant exit and restart-loops — orphaning a daemon each
+cycle. `start-sync` is the foreground entry point that `start` spawns internally; it is NOT listed in
+`happy daemon --help`, so the plist comment is the only record of why it is used. launchd then supervises
+a two-process tree: the `start-sync` process it keeps alive, which in turn manages the real daemon.
+
+**Diagnostic ladder** when remote control stops connecting:
+
+```bash
+happy daemon status                        # 'Daemon is running' + PID, port, version
+launchctl list | grep happy                # col 1 = live PID, col 2 = last exit status
+ps aux | grep '[h]appy daemon'             # supervised start-sync process + the daemon it spawns
+tail ~/.local/log/happy-daemon.log         # crash messages
+happy doctor                               # full diagnostics ('happy doctor clean' kills runaways)
+```
+
 ### AI Commit Messages
 
 The user-wide `prepare-commit-msg` hook (`dot_config/git/hooks/executable_prepare-commit-msg`, activated

--- a/Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.happy-daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/happy</string>
+    <string>daemon</string>
+    <!-- start-sync runs the daemon in the FOREGROUND so launchd can supervise
+         and KeepAlive it. `happy daemon start` detaches (forks, then returns),
+         which under KeepAlive looks like an instant exit and restart-loops.
+         start-sync is the same foreground entry point that `happy daemon start`
+         spawns internally; happy ships no documented --foreground flag. -->
+    <string>start-sync</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/happy-daemon.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/happy-daemon.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{ .chezmoi.homeDir }}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## What

Keeps the [Happy](https://happy.engineering/) daemon — the bridge that exposes Claude Code sessions to the Happy mobile/web apps for remote control — running continuously via a launchd LaunchAgent.

## Changes

- **`Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl`** — `KeepAlive` + `RunAtLoad` agent that runs `happy daemon start-sync` (foreground) so launchd can supervise it. Logs to `~/.local/log/happy-daemon.log`.
- **`.chezmoiscripts/run_onchange_after_62-load-happy-daemon-launchagent.sh.tmpl`** — `bootout` + `bootstrap` loader with a 3-try retry loop, mirroring the atuin-daemon loader. Darwin-only.
- **`CLAUDE.md`** — new "Happy Daemon" subsection documenting the architecture and the non-obvious `start-sync`-vs-`start` gotcha (the documented `start` detaches and restart-loops under `KeepAlive`; `start-sync` is the undocumented foreground entry point).

## Verification

- Daemon confirmed running under launchd (stable PID, live heartbeat).
- `happy` is already tracked under `npm:` in `system_packages_autoinstall.yaml`, so fresh machines get the binary.
- Lint green (7/7 tools); per-repo pre-commit hook passed.