### PR TITLE
feat(claude): track installed plugins in the settings modify-template

### DIFF
--- a/private_dot_claude/modify_settings.json
+++ b/private_dot_claude/modify_settings.json
@@ -89,7 +89,11 @@
 {{- /* --- stable: plugins enabled by default --- */ -}}
 {{- $enabledPlugins := dict
     "superpowers@claude-plugins-official" true
-    "document-skills@anthropic-agent-skills" true -}}
+    "document-skills@anthropic-agent-skills" true
+    "frontend-design@claude-plugins-official" true
+    "playwright@claude-plugins-official" true
+    "security-guidance@claude-plugins-official" true
+    "swift-lsp@claude-plugins-official" true -}}
 {{- $merged = setValueAtPath "enabledPlugins" $enabledPlugins $merged -}}
 
 {{ $merged | toPrettyJson }}


### PR DESCRIPTION
## What

Adds the four `/plugin`-installed plugins to the chezmoi modify-template's enforced `enabledPlugins` set so a `chezmoi apply` no longer strips them from `~/.claude/settings.json`.

## Why

`private_dot_claude/modify_settings.json` force-overwrites `enabledPlugins` to exactly the dict it declares on every apply. Anything installed via `/plugin` but absent from that dict gets removed on the next sync. These four were installed interactively and would silently disappear.

## Changes

`private_dot_claude/modify_settings.json` — add to the stable `enabledPlugins` dict:

- `frontend-design@claude-plugins-official`
- `playwright@claude-plugins-official`
- `security-guidance@claude-plugins-official`
- `swift-lsp@claude-plugins-official`

(joining the existing `superpowers` + `document-skills`).

## Verification

Rebased onto current main; lint green. Once merged, `chezmoi apply` will preserve all six plugins instead of pruning the four.