### PR TITLE
feat(brew): pre-trust taps that require it before brew bundle

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -17,6 +17,13 @@ packages:
         - vjeantet/tap
         - xdevplatform/tap
         - yakitrak/yakitrak
+      # Third-party taps whose formulae/casks must be trusted before `brew bundle`
+      # will load them under the HOMEBREW_REQUIRE_TAP_TRUST gate. The pre-bundle
+      # loop in run_onchange_before_10-system-packages.sh.tmpl runs `brew trust`
+      # for each. Add a tap here when `brew bundle` reports it as untrusted.
+      trusted_taps:
+        - eugene1g/safehouse
+        - steipete/tap
       formulae:
         - act
         - actionlint

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -3,6 +3,14 @@
 
 set -euo pipefail
 
+# Pre-trust taps that require it. `brew tap` first (no-op if already tapped) so
+# `brew trust` has a target to operate on, then trust. Both idempotent and safe
+# to re-run. Required because `brew bundle` will refuse to install formulae from
+# untrusted taps when HOMEBREW_REQUIRE_TAP_TRUST is set.
+{{ range .packages.macos.homebrew.trusted_taps -}}
+/opt/homebrew/bin/brew tap {{ . | quote }} 2>/dev/null || true
+/opt/homebrew/bin/brew trust --tap {{ . | quote }} 2>/dev/null || true
+{{ end }}
 # Use `brew bundle ...` to install all taps, formulae, casks, and macOS App Store apps.
 /opt/homebrew/bin/brew bundle --cleanup --file=/dev/stdin <<EOF
 {{ range .packages.macos.homebrew.taps -}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,11 @@ keys: `taps`, `formulae`, `casks`, `mas`. The
 data and runs `brew bundle --cleanup` whenever the data changes. Prerequisites:
 `run_once_before_00-install-homebrew.sh.tmpl` ensures `/opt/homebrew/bin/brew` exists on fresh machines.
 
+Third-party taps whose formulae or casks must be trusted under Homebrew's `HOMEBREW_REQUIRE_TAP_TRUST`
+gate are listed under a `trusted_taps` key in the same data file. A pre-bundle loop in
+`run_onchange_before_10-system-packages.sh.tmpl` runs `brew trust --tap` for each before `brew bundle`,
+so the bundle does not refuse to load them. Add a tap there when `brew bundle` reports it as untrusted.
+
 **Homebrew install workflow (for AI agents):**
 
 1. Install the package immediately: `brew install <formula>` or `brew install --cask <cask>`.


### PR DESCRIPTION
## Summary

Homebrew's `HOMEBREW_REQUIRE_TAP_TRUST` gate makes `brew bundle` refuse to load formulae or casks from untrusted third-party taps, which aborts the system-package sync (`run_onchange_before_10-system-packages.sh.tmpl`).

This adds a general trust mechanism:
- A new `trusted_taps` key in `.chezmoidata/system_packages_autoinstall.yaml`.
- A pre-bundle loop that runs `brew tap` then `brew trust --tap` for each entry (both idempotent) before `brew bundle`.

Seeded with the two taps that demonstrably require trust on this setup:
- `eugene1g/safehouse` → `agent-safehouse`
- `steipete/tap` → `peekaboo`, `remindctl`, `sag`

The mechanism is abstract — add a tap to `trusted_taps` whenever `brew bundle` reports it as untrusted.

## Test plan

- [x] `just l` green (shellcheck, shfmt, mdformat, nixfmt, taplo, jq, yq)
- [x] Rendered script emits `brew trust --tap` for both seeded taps
- [x] `brew trust --tap eugene1g/safehouse` verified to succeed (exit 0)