### PR TITLE
chore(brew): trust all declared third-party taps up front

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -17,13 +17,29 @@ packages:
         - vjeantet/tap
         - xdevplatform/tap
         - yakitrak/yakitrak
-      # Third-party taps whose formulae/casks must be trusted before `brew bundle`
-      # will load them under the HOMEBREW_REQUIRE_TAP_TRUST gate. The pre-bundle
-      # loop in run_onchange_before_10-system-packages.sh.tmpl runs `brew trust`
-      # for each. Add a tap here when `brew bundle` reports it as untrusted.
+      # Every third-party tap declared above is trusted up front so Homebrew can
+      # load its formulae, casks, or commands under the HOMEBREW_REQUIRE_TAP_TRUST
+      # gate. The pre-bundle loop in run_onchange_before_10-system-packages.sh.tmpl
+      # runs `brew trust --tap` for each (covers command taps too). The gate is a
+      # load-time check, so an untrusted tap only fails when brew must (re)load it
+      # — on a fresh install or an upgrade — which is why trusting all of them up
+      # front is what keeps `brew bundle` from tripping. Keep in sync with `taps:`.
       trusted_taps:
+        - antoniorodr/memo
+        - buo/cask-upgrade
+        - cirruslabs/cli
+        - domt4/autoupdate
         - eugene1g/safehouse
+        - felixkratz/formulae
+        - mediosz/tap
+        - nikitabobko/tap
+        - openhue/cli
+        - oven-sh/bun
+        - owenthereal/upterm
         - steipete/tap
+        - vjeantet/tap
+        - xdevplatform/tap
+        - yakitrak/yakitrak
       formulae:
         - act
         - actionlint


### PR DESCRIPTION
## Summary

`HOMEBREW_REQUIRE_TAP_TRUST` is a **load-time** gate — an untrusted non-official tap only fails when `brew` must (re)load it to install or upgrade its formulae/casks/commands. So failures appear one tap at a time (whack-a-mole): `eugene1g/safehouse` and `steipete/tap` first, then `domt4/autoupdate` (a command tap) broke `brew autoupdate` in the system-packages script.

Expand `trusted_taps` from those two to the **full `taps:` list** (15 declared taps) so a fresh `chezmoi apply` and every upgrade are covered up front. `openclaw/tap` is intentionally excluded (tapped but undeclared; separate workstream).

## Verified

- [x] `brew trust --tap` covers command taps (trusting `domt4/autoupdate` made `brew autoupdate` load, rc 0)
- [x] Rendered trust loop emits all 15 `brew trust --tap` lines
- [x] `just l` green