### PR TITLE
Harden the tmux-to-herdr migration machinery (Wave 3b)

### DIFF
--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -1,0 +1,66 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+set -euo pipefail
+
+# Live-migration ordering safety: this writes the herdr-verified stamp that
+# run_onchange_before_10 consults before it lets `brew bundle --cleanup` remove
+# the old multiplexer (tmux/sesh). The teardown must not happen until herdr is
+# proven usable as a multiplexer, so the stamp is written ONLY when ALL of these
+# hold, and removed otherwise:
+#   1. the herdr binary is present and runnable
+#   2. its config.toml is present
+#   3. BOTH vendored plugins are registered (exact plugin id, via the JSON API)
+#   4. the herdr session server is reachable and reports a running session
+# A full "spawn AND attach a second session" needs an interactive TTY the apply
+# does not have, so (4) — the session server answering over its socket with a
+# running session — is the strongest safe non-interactive proof a second session
+# can be hosted. This runs every apply (a run_ script, no run_onchange) so the
+# stamp always reflects current herdr health; it never aborts the apply (a down
+# herdr just means "not yet verified") and is idempotent.
+#
+# ROLLBACK: this only WRITES the stamp; it removes nothing else. If herdr never
+# verifies, the stamp stays absent, before_10 keeps tmux/sesh installed, and the
+# machine keeps a working multiplexer. Force a re-gate by deleting the stamp:
+# rm -f "$HOME/.cache/herdr-migration/verified".
+
+stamp="$HOME/.cache/herdr-migration/verified"
+config="$HOME/.config/herdr/config.toml"
+plugins=(herdr-last-workspace herdr-smart-nav)
+
+# Not verified: drop the stamp so before_10 stays conservative, note why, and
+# exit 0 (never abort the apply).
+not_verified() {
+  rm -f "$stamp"
+  printf 'herdr not yet verified as a multiplexer (%s); before_10 will keep tmux/sesh until it is.\n' "$1" >&2
+  exit 0
+}
+
+command -v herdr >/dev/null 2>&1 || not_verified "binary not found"
+herdr --version >/dev/null 2>&1 || not_verified "binary does not run"
+[[ -f $config ]] || not_verified "config.toml missing"
+
+# Both plugins must be registered, matched by EXACT plugin id (never a substring).
+for plugin_id in "${plugins[@]}"; do
+  response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)" ||
+    not_verified "plugin query failed for $plugin_id"
+  if printf '%s' "$response" | jq -e '.error' >/dev/null 2>&1; then
+    not_verified "herdr error envelope querying $plugin_id"
+  fi
+  count="$(printf '%s' "$response" |
+    jq --arg id "$plugin_id" '[.result.plugins[]? | select(.plugin_id == $id)] | length' 2>/dev/null ||
+    printf '0')"
+  [[ $count == "1" ]] || not_verified "plugin $plugin_id not registered"
+done
+
+# The session server must be reachable and report at least one running session.
+session_response="$(herdr session list --json 2>/dev/null)" ||
+  not_verified "session server unreachable"
+running="$(printf '%s' "$session_response" |
+  jq '[.sessions[]? | select(.running == true)] | length' 2>/dev/null || printf '0')"
+[[ $running =~ ^[0-9]+$ && $running -ge 1 ]] || not_verified "no running session"
+
+mkdir -p "$(dirname "$stamp")"
+: >"$stamp"
+printf 'herdr verified as a multiplexer; %s written (before_10 may now remove tmux/sesh).\n' "$stamp"
+{{ end -}}

--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -3,53 +3,83 @@
 
 set -euo pipefail
 
-# Live-migration ordering safety: this writes the herdr-verified stamp that
-# run_onchange_before_10 consults before it lets `brew bundle --cleanup` remove
-# the old multiplexer (tmux/sesh). The stamp is the TRIGGER half of the gate
-# (its presence is interpolated into before_10's rendered body, so writing it
-# here re-fires before_10 on the next apply); the AUTHORITY half is the live
-# health check before_10 re-runs itself immediately before enabling --cleanup.
-# Both sites share one predicate, herdr_health_check, included from
-# .chezmoitemplates/herdr-health-check.sh.tmpl so they cannot drift.
+# Post-target-update migration verify + deferred cleanup. Chezmoi runs all
+# before_ scripts, then updates target files, then runs after_ scripts, so THIS
+# script (after_58) is the first place the CURRENT revision's herdr is on disk.
+# before_10 withholds `--cleanup` while tmux/sesh is installed; this script owns
+# the teardown: it verifies the just-installed herdr LIVE and, only on success,
+# performs the same removal before_10 withheld (regenerate the Brewfile from the
+# same package data and run `brew bundle cleanup --force`).
 #
-# A full "spawn AND attach a second session" needs an interactive TTY the
-# apply does not have, so the session server answering over its socket with a
-# running session is the strongest safe non-interactive proof a second session
-# can be hosted. This runs every apply (a run_ script, not run_onchange) so
-# the stamp always reflects current herdr health; it never aborts the apply (a
-# down herdr just means "not yet verified") and is idempotent.
+# True migration sequence (do NOT start the server from here): plugin
+# registration and the session server need a RUNNING herdr server, which only an
+# interactive bashrc starts. So an unattended apply on a serverless host can
+# never verify: it defers forever (loud warning naming the activation step) and
+# retries naturally on the next apply. Sequence: apply (installs herdr, cleanup
+# deferred) -> open an interactive terminal so the server starts -> apply again
+# (this script verifies and cleans).
 #
-# ROLLBACK: this only WRITES or REMOVES the stamp; it touches nothing else. If
-# herdr never verifies, the stamp stays absent, before_10 keeps tmux/sesh
-# installed, and the machine keeps a working multiplexer. Force a re-gate by
-# deleting the stamp: rm -f "$HOME/.cache/herdr-migration/verified".
+# Fail-closed and abort-proof: set -e is active, but a not-verified herdr or a
+# failed cleanup only means the migration stays deferred (tmux/sesh survive),
+# which is the safe direction; no path aborts the apply. This script holds no
+# stamp -- it re-derives everything from live state on every apply.
 
-stamp="$HOME/.cache/herdr-migration/verified"
+brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
+brew_bin="$brew_prefix/bin/brew"
+
+# Short-circuit FIRST: if neither tmux nor sesh is installed there is nothing to
+# migrate. Make NO herdr contact at all (this also avoids the routine
+# reload-config side effect on already-migrated machines) and exit.
+multiplexer_present=false
+for multiplexer in tmux sesh; do
+  if "$brew_bin" list "$multiplexer" &>/dev/null; then
+    multiplexer_present=true
+    break
+  fi
+done
+if [[ $multiplexer_present == false ]]; then
+  exit 0
+fi
 
 {{ includeTemplate "herdr-health-check.sh.tmpl" }}
-# Every filesystem operation below is guarded: this script must NEVER abort
-# the apply (set -e is active, so an unguarded mkdir/truncate/rm failure, for
-# example a directory squatting on the stamp path or a read-only ~/.cache,
-# would kill the whole chezmoi apply). A failed stamp write only means the
-# migration stays deferred, which is the safe direction.
-if reason="$(herdr_health_check)"; then
-  if ! mkdir -p "$(dirname "$stamp")" 2>/dev/null; then
-    printf 'WARNING: herdr is healthy but %s could not be created; stamp not written (before_10 keeps tmux/sesh). Fix the directory permissions and re-apply.\n' "$(dirname "$stamp")" >&2
-    exit 0
-  fi
-  if ! : >"$stamp" 2>/dev/null; then
-    printf 'WARNING: herdr is healthy but the stamp %s could not be written (is a directory squatting on that path?); before_10 keeps tmux/sesh. Clear the path and re-apply.\n' "$stamp" >&2
-    exit 0
-  fi
-  printf 'herdr verified as a multiplexer; %s written (before_10 may now remove tmux/sesh).\n' "$stamp"
+
+# A legacy multiplexer is still installed: verify the CURRENT herdr before
+# removing it. On any failure, defer with a warning that names the interactive
+# activation step, and exit 0 so the next apply retries.
+if ! reason="$(herdr_health_check)"; then
+  printf 'herdr not yet verified as a multiplexer (%s); keeping tmux/sesh installed.\n' "$reason" >&2
+  printf 'Plugin registration and the session server need a RUNNING herdr server, which only an interactive terminal starts (a chezmoiscript must not start it). Complete the migration: open an interactive terminal (bashrc auto-attaches and starts the server), then run chezmoi apply again so this script verifies herdr and removes tmux/sesh.\n' >&2
+  exit 0
+fi
+
+# Verified: perform the deferred cleanup. Regenerate the Brewfile from the SAME
+# package data before_10 uses, then `brew bundle cleanup --force` removes every
+# installed formula/cask/tap absent from it (tmux/sesh among them) -- the exact
+# removal before_10 withheld. Guard mktemp so an unwritable TMPDIR defers the
+# cleanup rather than aborting the apply (set -e is active).
+if ! brewfile="$(mktemp 2>/dev/null)"; then
+  printf 'WARNING: herdr verified but a temporary Brewfile could not be created; cleanup deferred to the next apply.\n' >&2
+  exit 0
+fi
+trap 'rm -f "$brewfile"' EXIT
+cat >"$brewfile" <<EOF
+{{ range .packages.macos.homebrew.taps -}}
+tap {{ . | quote }}
+{{ end -}}
+{{ range .packages.macos.homebrew.formulae -}}
+brew {{ . | quote }}
+{{ end -}}
+{{ range .packages.macos.homebrew.casks -}}
+cask {{ . | quote }}
+{{ end -}}
+{{ range .packages.macos.homebrew.mas -}}
+mas {{ .name | quote }}, id: {{ .id }}
+{{ end -}}
+EOF
+if "$brew_bin" bundle cleanup --force --file="$brewfile"; then
+  printf 'herdr verified as a multiplexer; removed tmux/sesh via brew bundle cleanup (migration complete).\n'
 else
-  # Not verified: drop the stamp so before_10 stays conservative, note why,
-  # and finish cleanly.
-  if ! rm -f "$stamp" 2>/dev/null; then
-    printf 'WARNING: could not remove the stale stamp %s (is a directory squatting on that path?). Remove it by hand; until then before_10 treats the migration as unverified anyway (the stamp must be a regular file).\n' "$stamp" >&2
-    exit 0
-  fi
-  printf 'herdr not yet verified as a multiplexer (%s); before_10 will keep tmux/sesh until it is.\n' "$reason" >&2
+  printf 'WARNING: herdr verified but brew bundle cleanup failed; tmux/sesh may still be installed. Re-run chezmoi apply to retry.\n' >&2
 fi
 exit 0
 {{ end -}}

--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -27,14 +27,28 @@ set -euo pipefail
 stamp="$HOME/.cache/herdr-migration/verified"
 
 {{ includeTemplate "herdr-health-check.sh.tmpl" }}
+# Every filesystem operation below is guarded: this script must NEVER abort
+# the apply (set -e is active, so an unguarded mkdir/truncate/rm failure, for
+# example a directory squatting on the stamp path or a read-only ~/.cache,
+# would kill the whole chezmoi apply). A failed stamp write only means the
+# migration stays deferred, which is the safe direction.
 if reason="$(herdr_health_check)"; then
-  mkdir -p "$(dirname "$stamp")"
-  : >"$stamp"
+  if ! mkdir -p "$(dirname "$stamp")" 2>/dev/null; then
+    printf 'WARNING: herdr is healthy but %s could not be created; stamp not written (before_10 keeps tmux/sesh). Fix the directory permissions and re-apply.\n' "$(dirname "$stamp")" >&2
+    exit 0
+  fi
+  if ! : >"$stamp" 2>/dev/null; then
+    printf 'WARNING: herdr is healthy but the stamp %s could not be written (is a directory squatting on that path?); before_10 keeps tmux/sesh. Clear the path and re-apply.\n' "$stamp" >&2
+    exit 0
+  fi
   printf 'herdr verified as a multiplexer; %s written (before_10 may now remove tmux/sesh).\n' "$stamp"
 else
   # Not verified: drop the stamp so before_10 stays conservative, note why,
-  # and finish cleanly (never abort the apply).
-  rm -f "$stamp"
+  # and finish cleanly.
+  if ! rm -f "$stamp" 2>/dev/null; then
+    printf 'WARNING: could not remove the stale stamp %s (is a directory squatting on that path?). Remove it by hand; until then before_10 treats the migration as unverified anyway (the stamp must be a regular file).\n' "$stamp" >&2
+    exit 0
+  fi
   printf 'herdr not yet verified as a multiplexer (%s); before_10 will keep tmux/sesh until it is.\n' "$reason" >&2
 fi
 exit 0

--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -5,62 +5,37 @@ set -euo pipefail
 
 # Live-migration ordering safety: this writes the herdr-verified stamp that
 # run_onchange_before_10 consults before it lets `brew bundle --cleanup` remove
-# the old multiplexer (tmux/sesh). The teardown must not happen until herdr is
-# proven usable as a multiplexer, so the stamp is written ONLY when ALL of these
-# hold, and removed otherwise:
-#   1. the herdr binary is present and runnable
-#   2. its config.toml is present
-#   3. BOTH vendored plugins are registered (exact plugin id, via the JSON API)
-#   4. the herdr session server is reachable and reports a running session
-# A full "spawn AND attach a second session" needs an interactive TTY the apply
-# does not have, so (4) — the session server answering over its socket with a
-# running session — is the strongest safe non-interactive proof a second session
-# can be hosted. This runs every apply (a run_ script, no run_onchange) so the
-# stamp always reflects current herdr health; it never aborts the apply (a down
-# herdr just means "not yet verified") and is idempotent.
+# the old multiplexer (tmux/sesh). The stamp is the TRIGGER half of the gate
+# (its presence is interpolated into before_10's rendered body, so writing it
+# here re-fires before_10 on the next apply); the AUTHORITY half is the live
+# health check before_10 re-runs itself immediately before enabling --cleanup.
+# Both sites share one predicate, herdr_health_check, included from
+# .chezmoitemplates/herdr-health-check.sh.tmpl so they cannot drift.
 #
-# ROLLBACK: this only WRITES the stamp; it removes nothing else. If herdr never
-# verifies, the stamp stays absent, before_10 keeps tmux/sesh installed, and the
-# machine keeps a working multiplexer. Force a re-gate by deleting the stamp:
-# rm -f "$HOME/.cache/herdr-migration/verified".
+# A full "spawn AND attach a second session" needs an interactive TTY the
+# apply does not have, so the session server answering over its socket with a
+# running session is the strongest safe non-interactive proof a second session
+# can be hosted. This runs every apply (a run_ script, not run_onchange) so
+# the stamp always reflects current herdr health; it never aborts the apply (a
+# down herdr just means "not yet verified") and is idempotent.
+#
+# ROLLBACK: this only WRITES or REMOVES the stamp; it touches nothing else. If
+# herdr never verifies, the stamp stays absent, before_10 keeps tmux/sesh
+# installed, and the machine keeps a working multiplexer. Force a re-gate by
+# deleting the stamp: rm -f "$HOME/.cache/herdr-migration/verified".
 
 stamp="$HOME/.cache/herdr-migration/verified"
-config="$HOME/.config/herdr/config.toml"
-plugins=(herdr-last-workspace herdr-smart-nav)
 
-# Not verified: drop the stamp so before_10 stays conservative, note why, and
-# exit 0 (never abort the apply).
-not_verified() {
+{{ includeTemplate "herdr-health-check.sh.tmpl" }}
+if reason="$(herdr_health_check)"; then
+  mkdir -p "$(dirname "$stamp")"
+  : >"$stamp"
+  printf 'herdr verified as a multiplexer; %s written (before_10 may now remove tmux/sesh).\n' "$stamp"
+else
+  # Not verified: drop the stamp so before_10 stays conservative, note why,
+  # and finish cleanly (never abort the apply).
   rm -f "$stamp"
-  printf 'herdr not yet verified as a multiplexer (%s); before_10 will keep tmux/sesh until it is.\n' "$1" >&2
-  exit 0
-}
-
-command -v herdr >/dev/null 2>&1 || not_verified "binary not found"
-herdr --version >/dev/null 2>&1 || not_verified "binary does not run"
-[[ -f $config ]] || not_verified "config.toml missing"
-
-# Both plugins must be registered, matched by EXACT plugin id (never a substring).
-for plugin_id in "${plugins[@]}"; do
-  response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)" ||
-    not_verified "plugin query failed for $plugin_id"
-  if printf '%s' "$response" | jq -e '.error' >/dev/null 2>&1; then
-    not_verified "herdr error envelope querying $plugin_id"
-  fi
-  count="$(printf '%s' "$response" |
-    jq --arg id "$plugin_id" '[.result.plugins[]? | select(.plugin_id == $id)] | length' 2>/dev/null ||
-    printf '0')"
-  [[ $count == "1" ]] || not_verified "plugin $plugin_id not registered"
-done
-
-# The session server must be reachable and report at least one running session.
-session_response="$(herdr session list --json 2>/dev/null)" ||
-  not_verified "session server unreachable"
-running="$(printf '%s' "$session_response" |
-  jq '[.sessions[]? | select(.running == true)] | length' 2>/dev/null || printf '0')"
-[[ $running =~ ^[0-9]+$ && $running -ge 1 ]] || not_verified "no running session"
-
-mkdir -p "$(dirname "$stamp")"
-: >"$stamp"
-printf 'herdr verified as a multiplexer; %s written (before_10 may now remove tmux/sesh).\n' "$stamp"
+  printf 'herdr not yet verified as a multiplexer (%s); before_10 will keep tmux/sesh until it is.\n' "$reason" >&2
+fi
+exit 0
 {{ end -}}

--- a/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
@@ -13,32 +13,53 @@ set -euo pipefail
 #
 # Honesty contract: run_once records this script as done after ANY exit 0 and
 # never retries it, so no failure may masquerade as success. The retired
-# message is printed ONLY after a re-probe confirms the service is gone; a
-# bootout that leaves the service loaded prints a loud warning naming the
-# exact manual command instead. And no path may abort the apply: every
+# message is printed ONLY after a re-probe CONFIRMS the service is gone; a
+# bootout that leaves the service loaded, or a probe that cannot determine the
+# state, prints a loud warning instead. And no path may abort the apply: every
 # command that can fail (id, launchctl, rm) is guarded, because a retirement
 # hiccup must never block the rest of a chezmoi apply.
 
 label="com.claude.code"
 plist="$HOME/Library/LaunchAgents/$label.plist"
+# `launchctl print <service>` exits 0 when the service is loaded and with a
+# known not-found status when it is absent. That status, verified live on this
+# host, is 113. Treat the probe as TRI-STATE: 0 = loaded, 113 = confirmed
+# absent, anything else = an operational error whose result we must not
+# interpret as either state (an nonzero-but-not-113 was previously misread as
+# not-loaded, which let an operational error after bootout print the success
+# message). Only a CONFIRMED absence prints success.
+not_found_status=113
 
 if uid="$(id -u 2>/dev/null)" && [[ $uid =~ ^[0-9]+$ ]]; then
   domain_target="gui/$uid/$label"
-  # Probe first: `launchctl print <service>` exits non-zero for an unknown
-  # service, so it is the load probe. A failing probe reads as not-loaded
-  # (it is the only visibility launchd offers here), which keeps the
-  # not-loaded path a clean no-op.
-  if launchctl print "$domain_target" >/dev/null 2>&1; then
+  # Capture the probe status without tripping set -e (a nonzero print is
+  # expected when the service is absent).
+  probe_status=0
+  launchctl print "$domain_target" >/dev/null 2>&1 || probe_status=$?
+  if [[ $probe_status -eq 0 ]]; then
+    # Loaded: boot it out, then re-probe. Only a CONFIRMED absence
+    # (not_found_status) earns the success message. run_once will not retry, so
+    # a survivor -- or a re-probe we cannot interpret -- demands the operator's
+    # attention NOW.
     launchctl bootout "$domain_target" 2>/dev/null || true
-    # Re-probe: only a confirmed absence earns the success message. run_once
-    # will not retry, so a survivor demands the operator's attention NOW,
-    # with the exact command to run.
-    if launchctl print "$domain_target" >/dev/null 2>&1; then
+    reprobe_status=0
+    launchctl print "$domain_target" >/dev/null 2>&1 || reprobe_status=$?
+    if [[ $reprobe_status -eq $not_found_status ]]; then
+      printf 'retired LaunchAgent %s (booted out of %s)\n' "$label" "$domain_target"
+    elif [[ $reprobe_status -eq 0 ]]; then
       printf 'WARNING: LaunchAgent %s is STILL loaded after bootout; this run_once script will not retry.\n' "$label" >&2
       printf 'Retire it by hand:  launchctl bootout %s\n' "$domain_target" >&2
     else
-      printf 'retired LaunchAgent %s (booted out of %s)\n' "$label" "$domain_target"
+      printf 'WARNING: could not confirm %s is unloaded after bootout (launchctl print returned an unexpected status %s, neither loaded=0 nor not-found=%s); this run_once script will not retry.\n' "$label" "$reprobe_status" "$not_found_status" >&2
+      printf 'Verify by hand:  launchctl print %s   (and bootout if it is still loaded)\n' "$domain_target" >&2
     fi
+  elif [[ $probe_status -eq $not_found_status ]]; then
+    : # Confirmed absent: nothing to unload, a clean no-op.
+  else
+    # Operational error: the load state is unknown. Make no change and do not
+    # claim success; run_once will not retry, so surface it now.
+    printf 'WARNING: could not determine whether %s is loaded (launchctl print returned an unexpected status %s, neither loaded=0 nor not-found=%s); leaving it untouched. This run_once script will not retry.\n' "$label" "$probe_status" "$not_found_status" >&2
+    printf 'Check by hand:  launchctl print %s\n' "$domain_target" >&2
   fi
 else
   printf 'WARNING: id -u failed; cannot address the gui launchd domain, skipping the unload probe.\n' >&2

--- a/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
@@ -3,32 +3,55 @@
 
 set -euo pipefail
 
-# One-time retirement of the old com.claude.code LaunchAgent — the tmux-coupled
+# One-time retirement of the old com.claude.code LaunchAgent, the tmux-coupled
 # claude-restart.sh supervisor that the herdr migration (S4) removed. Deleting
-# the plist SOURCE from the repo does NOT unload an already-running LaunchAgent,
-# so this is the live-side complement: boot the service out of the GUI domain if
-# it is loaded, and delete a leftover deployed plist if one is present. It is a
-# silent no-op once both are already gone (the state on this machine), idempotent
-# on a re-run, and never aborts the apply — a missing service or plist is the
-# expected end state, not an error.
+# the plist SOURCE from the repo does NOT unload an already-running
+# LaunchAgent, so this is the live-side complement: boot the service out of
+# the GUI domain if it is loaded, and delete a leftover deployed plist if one
+# is present. It is a silent no-op once both are already gone (the state on
+# this machine) and idempotent on a re-run.
+#
+# Honesty contract: run_once records this script as done after ANY exit 0 and
+# never retries it, so no failure may masquerade as success. The retired
+# message is printed ONLY after a re-probe confirms the service is gone; a
+# bootout that leaves the service loaded prints a loud warning naming the
+# exact manual command instead. And no path may abort the apply: every
+# command that can fail (id, launchctl, rm) is guarded, because a retirement
+# hiccup must never block the rest of a chezmoi apply.
 
 label="com.claude.code"
 plist="$HOME/Library/LaunchAgents/$label.plist"
-domain_target="gui/$(id -u)/$label"
 
-# Unload only when actually loaded: `launchctl print <service>` exits non-zero
-# for an unknown service, so it is the load probe. Guarding bootout on it keeps
-# the not-loaded path a clean no-op (no bootout error noise). Never let a
-# non-zero status abort the apply.
-if launchctl print "$domain_target" >/dev/null 2>&1; then
-  launchctl bootout "$domain_target" 2>/dev/null || true
-  printf 'retired LaunchAgent %s (booted out of %s)\n' "$label" "$domain_target"
+if uid="$(id -u 2>/dev/null)" && [[ $uid =~ ^[0-9]+$ ]]; then
+  domain_target="gui/$uid/$label"
+  # Probe first: `launchctl print <service>` exits non-zero for an unknown
+  # service, so it is the load probe. A failing probe reads as not-loaded
+  # (it is the only visibility launchd offers here), which keeps the
+  # not-loaded path a clean no-op.
+  if launchctl print "$domain_target" >/dev/null 2>&1; then
+    launchctl bootout "$domain_target" 2>/dev/null || true
+    # Re-probe: only a confirmed absence earns the success message. run_once
+    # will not retry, so a survivor demands the operator's attention NOW,
+    # with the exact command to run.
+    if launchctl print "$domain_target" >/dev/null 2>&1; then
+      printf 'WARNING: LaunchAgent %s is STILL loaded after bootout; this run_once script will not retry.\n' "$label" >&2
+      printf 'Retire it by hand:  launchctl bootout %s\n' "$domain_target" >&2
+    else
+      printf 'retired LaunchAgent %s (booted out of %s)\n' "$label" "$domain_target"
+    fi
+  fi
+else
+  printf 'WARNING: id -u failed; cannot address the gui launchd domain, skipping the unload probe.\n' >&2
+  printf 'If the old agent is still loaded, retire it by hand:  launchctl bootout gui/<your-uid>/%s\n' "$label" >&2
 fi
 
 # Remove a leftover deployed plist if present (the source is already gone).
 if [[ -f $plist ]]; then
-  rm -f "$plist"
-  printf 'removed leftover LaunchAgent plist %s\n' "$plist"
+  if rm -f "$plist" 2>/dev/null; then
+    printf 'removed leftover LaunchAgent plist %s\n' "$plist"
+  else
+    printf 'WARNING: could not remove the leftover plist %s; remove it by hand (this run_once script will not retry).\n' "$plist" >&2
+  fi
 fi
 
 exit 0

--- a/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl
@@ -1,0 +1,35 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+set -euo pipefail
+
+# One-time retirement of the old com.claude.code LaunchAgent — the tmux-coupled
+# claude-restart.sh supervisor that the herdr migration (S4) removed. Deleting
+# the plist SOURCE from the repo does NOT unload an already-running LaunchAgent,
+# so this is the live-side complement: boot the service out of the GUI domain if
+# it is loaded, and delete a leftover deployed plist if one is present. It is a
+# silent no-op once both are already gone (the state on this machine), idempotent
+# on a re-run, and never aborts the apply — a missing service or plist is the
+# expected end state, not an error.
+
+label="com.claude.code"
+plist="$HOME/Library/LaunchAgents/$label.plist"
+domain_target="gui/$(id -u)/$label"
+
+# Unload only when actually loaded: `launchctl print <service>` exits non-zero
+# for an unknown service, so it is the load probe. Guarding bootout on it keeps
+# the not-loaded path a clean no-op (no bootout error noise). Never let a
+# non-zero status abort the apply.
+if launchctl print "$domain_target" >/dev/null 2>&1; then
+  launchctl bootout "$domain_target" 2>/dev/null || true
+  printf 'retired LaunchAgent %s (booted out of %s)\n' "$label" "$domain_target"
+fi
+
+# Remove a leftover deployed plist if present (the source is already gone).
+if [[ -f $plist ]]; then
+  rm -f "$plist"
+  printf 'removed leftover LaunchAgent plist %s\n' "$plist"
+fi
+
+exit 0
+{{ end -}}

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -17,24 +17,41 @@ brew_bin="$brew_prefix/bin/brew"
 "$brew_bin" trust --tap {{ . | quote }} 2>/dev/null || true
 {{ end }}
 # --- live-migration ordering safety (herdr replaces tmux/sesh) ---
-# `brew bundle --cleanup` uninstalls any formula/cask absent from the desired set
-# below — including tmux/sesh once they leave the manifest. Removing the old
-# multiplexer BEFORE herdr is installed and verified would strand a machine with
+# `brew bundle --cleanup` uninstalls any formula/cask absent from the desired
+# set below, including tmux/sesh once they leave the manifest. Removing the old
+# multiplexer BEFORE herdr is installed and healthy would strand a machine with
 # no multiplexer if the herdr install (before_15) or plugin build/verify
 # (after_55/57/58) fails. So withhold the --cleanup that would remove tmux/sesh
-# until herdr is verified — signalled by the stamp run_after_58 writes.
+# until BOTH hold:
+#   1. TRIGGER: the stamp run_after_58 writes is present (its presence is also
+#      interpolated into this rendered body below, so the stamp write re-fires
+#      this run_onchange script on the next apply), and
+#   2. AUTHORITY: a LIVE herdr health check passes in this same apply. The
+#      stamp alone is only proof herdr was healthy at some PAST apply; if herdr
+#      broke since, a stale stamp must not authorize removing the only working
+#      multiplexer.
 #
-# Effect on a not-yet-migrated machine: the first apply installs herdr and builds
-# its plugins and after_58 verifies it; the NEXT apply, seeing the stamp, runs
-# --cleanup and removes tmux/sesh. tmux/sesh are never removed before herdr is
-# proven. bundle_args always carries --file, so it is never an empty array (safe
-# under set -u).
+# Effect on a not-yet-migrated machine: apply N installs herdr, builds its
+# plugins, and after_58 verifies it and writes the stamp, which flips this
+# script's rendered hash; apply N+1 re-runs this script, re-checks herdr LIVE,
+# and runs --cleanup to remove tmux/sesh. tmux/sesh are never removed before
+# herdr is proven healthy in the removing apply itself. bundle_args always
+# carries --file, so it is never an empty array (safe under set -u).
 #
-# ROLLBACK: if herdr never verifies, tmux/sesh stay installed and usable — no
-# teardown happens. To recover a broken cutover, keep using tmux; reinstall with
-# `brew install tmux sesh` if something else removed them, and restore the tmux
-# config from git history. Once herdr is healthy, `chezmoi apply` writes the
-# stamp (via after_58) and the next apply completes the migration.
+# ROLLBACK: if herdr never verifies (or breaks after the stamp was written),
+# tmux/sesh stay installed and usable; no teardown happens. To recover a broken
+# cutover, keep using tmux; reinstall with `brew install tmux sesh` if
+# something else removed them, and restore the tmux config from git history.
+# Once herdr is healthy again, `chezmoi apply` re-writes the stamp (after_58)
+# and the next apply completes the migration.
+#
+# The line below interpolates the stamp's PRESENCE (never its contents; file
+# contents spliced raw into a script are a shell-injection channel) into this
+# rendered body: chezmoi re-runs a run_onchange script only when its rendered
+# content changes, and the stamp file itself is otherwise consulted only at
+# run time, which chezmoi cannot see.
+# herdr-migration-stamp-present: {{ if stat (printf "%s/.cache/herdr-migration/verified" (env "HOME")) }}1{{ else }}0{{ end }}
+{{ includeTemplate "herdr-health-check.sh.tmpl" }}
 herdr_verified_stamp="$HOME/.cache/herdr-migration/verified"
 bundle_args=(--cleanup --file=/dev/stdin)
 multiplexer_present=false
@@ -44,10 +61,16 @@ for multiplexer in tmux sesh; do
     break
   fi
 done
-if [[ $multiplexer_present == true && ! -f $herdr_verified_stamp ]]; then
-  bundle_args=(--file=/dev/stdin)
-  printf 'herdr not yet verified but tmux/sesh still installed: running brew bundle WITHOUT --cleanup so the old multiplexer is not removed before herdr is proven.\n' >&2
-  printf 'The next apply — after run_after_58 verifies herdr and writes %s — runs --cleanup to complete the migration.\n' "$herdr_verified_stamp" >&2
+if [[ $multiplexer_present == true ]]; then
+  if [[ ! -f $herdr_verified_stamp ]]; then
+    bundle_args=(--file=/dev/stdin)
+    printf 'herdr not yet verified but tmux/sesh still installed: running brew bundle WITHOUT --cleanup so the old multiplexer is not removed before herdr is proven.\n' >&2
+    printf 'The next apply, after run_after_58 verifies herdr and writes %s, runs --cleanup to complete the migration.\n' "$herdr_verified_stamp" >&2
+  elif ! herdr_health_reason="$(herdr_health_check)"; then
+    bundle_args=(--file=/dev/stdin)
+    printf 'STALE herdr-verified stamp: %s exists but herdr fails its live health check right now (%s).\n' "$herdr_verified_stamp" "$herdr_health_reason" >&2
+    printf 'Running brew bundle WITHOUT --cleanup so tmux/sesh are not removed while herdr is broken; fix herdr (run_after_58 re-verifies on every apply), then re-apply.\n' >&2
+  fi
 fi
 
 # Use `brew bundle ...` to install all taps, formulae, casks, and macOS App Store apps.

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -19,40 +19,26 @@ brew_bin="$brew_prefix/bin/brew"
 # --- live-migration ordering safety (herdr replaces tmux/sesh) ---
 # `brew bundle --cleanup` uninstalls any formula/cask absent from the desired
 # set below, including tmux/sesh once they leave the manifest. Removing the old
-# multiplexer BEFORE herdr is installed and healthy would strand a machine with
-# no multiplexer if the herdr install (before_15) or plugin build/verify
-# (after_55/57/58) fails. So withhold the --cleanup that would remove tmux/sesh
-# until BOTH hold:
-#   1. TRIGGER: the stamp run_after_58 writes is present (its presence is also
-#      interpolated into this rendered body below, so the stamp write re-fires
-#      this run_onchange script on the next apply), and
-#   2. AUTHORITY: a LIVE herdr health check passes in this same apply. The
-#      stamp alone is only proof herdr was healthy at some PAST apply; if herdr
-#      broke since, a stale stamp must not authorize removing the only working
-#      multiplexer.
+# multiplexer HERE is unsafe: chezmoi runs ALL before_ scripts, THEN updates
+# target files, THEN runs after_ scripts, so a --cleanup in this before_ script
+# would validate and tear down against the PREVIOUS revision's installed herdr,
+# and a broken NEW revision would be discovered only after the fallback was
+# already gone. So this script NEVER removes the legacy multiplexer: while tmux
+# or sesh is installed it withholds --cleanup entirely. run_after_58 owns the
+# teardown (it runs post-target-update): it verifies the just-installed herdr
+# LIVE and, only on success, performs the same cleanup this script withholds.
+# bundle_args always carries --file, so it is never an empty array (safe under
+# set -u).
 #
-# Effect on a not-yet-migrated machine: apply N installs herdr, builds its
-# plugins, and after_58 verifies it and writes the stamp, which flips this
-# script's rendered hash; apply N+1 re-runs this script, re-checks herdr LIVE,
-# and runs --cleanup to remove tmux/sesh. tmux/sesh are never removed before
-# herdr is proven healthy in the removing apply itself. bundle_args always
-# carries --file, so it is never an empty array (safe under set -u).
+# True migration sequence (plugin registration and the session server need a
+# RUNNING herdr server, which ONLY an interactive bashrc starts; a chezmoiscript
+# must never start it): apply once (installs herdr, cleanup deferred here) ->
+# open an interactive terminal so the herdr server starts -> apply again
+# (after_58 verifies herdr and runs the cleanup). On a headless / serverless
+# host the deferral simply persists until an interactive terminal is opened.
 #
-# ROLLBACK: if herdr never verifies (or breaks after the stamp was written),
-# tmux/sesh stay installed and usable; no teardown happens. To recover a broken
-# cutover, keep using tmux; reinstall with `brew install tmux sesh` if
-# something else removed them, and restore the tmux config from git history.
-# Once herdr is healthy again, `chezmoi apply` re-writes the stamp (after_58)
-# and the next apply completes the migration.
-#
-# The line below interpolates the stamp's PRESENCE (never its contents; file
-# contents spliced raw into a script are a shell-injection channel) into this
-# rendered body: chezmoi re-runs a run_onchange script only when its rendered
-# content changes, and the stamp file itself is otherwise consulted only at
-# run time, which chezmoi cannot see.
-# herdr-migration-stamp-present: {{ if stat (printf "%s/.cache/herdr-migration/verified" (env "HOME")) }}1{{ else }}0{{ end }}
-{{ includeTemplate "herdr-health-check.sh.tmpl" }}
-herdr_verified_stamp="$HOME/.cache/herdr-migration/verified"
+# ROLLBACK: while herdr is unverified, tmux/sesh stay installed and usable; no
+# teardown happens. Keep using tmux until after_58 completes the migration.
 bundle_args=(--cleanup --file=/dev/stdin)
 multiplexer_present=false
 for multiplexer in tmux sesh; do
@@ -62,15 +48,9 @@ for multiplexer in tmux sesh; do
   fi
 done
 if [[ $multiplexer_present == true ]]; then
-  if [[ ! -f $herdr_verified_stamp ]]; then
-    bundle_args=(--file=/dev/stdin)
-    printf 'herdr not yet verified but tmux/sesh still installed: running brew bundle WITHOUT --cleanup so the old multiplexer is not removed before herdr is proven.\n' >&2
-    printf 'The next apply, after run_after_58 verifies herdr and writes %s, runs --cleanup to complete the migration.\n' "$herdr_verified_stamp" >&2
-  elif ! herdr_health_reason="$(herdr_health_check)"; then
-    bundle_args=(--file=/dev/stdin)
-    printf 'STALE herdr-verified stamp: %s exists but herdr fails its live health check right now (%s).\n' "$herdr_verified_stamp" "$herdr_health_reason" >&2
-    printf 'Running brew bundle WITHOUT --cleanup so tmux/sesh are not removed while herdr is broken; fix herdr (run_after_58 re-verifies on every apply), then re-apply.\n' >&2
-  fi
+  bundle_args=(--file=/dev/stdin)
+  printf 'Legacy multiplexer (tmux/sesh) still installed: running brew bundle WITHOUT --cleanup so it is not removed before herdr is verified.\n' >&2
+  printf 'run_after_58 owns the teardown and completes the migration once herdr is healthy: open an interactive terminal (bashrc auto-attaches and starts the herdr server), then run chezmoi apply again so after_58 verifies herdr and removes tmux/sesh.\n' >&2
 fi
 
 # Use `brew bundle ...` to install all taps, formulae, casks, and macOS App Store apps.

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -3,16 +3,55 @@
 
 set -euo pipefail
 
+# Resolve the Homebrew prefix once (honoring HOMEBREW_PREFIX, as the autoupdate
+# block below already does) so every brew/uv/volta call goes through one place.
+brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
+brew_bin="$brew_prefix/bin/brew"
+
 # Pre-trust taps that require it. `brew tap` first (no-op if already tapped) so
 # `brew trust` has a target to operate on, then trust. Both idempotent and safe
 # to re-run. Required because `brew bundle` will refuse to install formulae from
 # untrusted taps when HOMEBREW_REQUIRE_TAP_TRUST is set.
 {{ range .packages.macos.homebrew.trusted_taps -}}
-/opt/homebrew/bin/brew tap {{ . | quote }} 2>/dev/null || true
-/opt/homebrew/bin/brew trust --tap {{ . | quote }} 2>/dev/null || true
+"$brew_bin" tap {{ . | quote }} 2>/dev/null || true
+"$brew_bin" trust --tap {{ . | quote }} 2>/dev/null || true
 {{ end }}
+# --- live-migration ordering safety (herdr replaces tmux/sesh) ---
+# `brew bundle --cleanup` uninstalls any formula/cask absent from the desired set
+# below — including tmux/sesh once they leave the manifest. Removing the old
+# multiplexer BEFORE herdr is installed and verified would strand a machine with
+# no multiplexer if the herdr install (before_15) or plugin build/verify
+# (after_55/57/58) fails. So withhold the --cleanup that would remove tmux/sesh
+# until herdr is verified — signalled by the stamp run_after_58 writes.
+#
+# Effect on a not-yet-migrated machine: the first apply installs herdr and builds
+# its plugins and after_58 verifies it; the NEXT apply, seeing the stamp, runs
+# --cleanup and removes tmux/sesh. tmux/sesh are never removed before herdr is
+# proven. bundle_args always carries --file, so it is never an empty array (safe
+# under set -u).
+#
+# ROLLBACK: if herdr never verifies, tmux/sesh stay installed and usable — no
+# teardown happens. To recover a broken cutover, keep using tmux; reinstall with
+# `brew install tmux sesh` if something else removed them, and restore the tmux
+# config from git history. Once herdr is healthy, `chezmoi apply` writes the
+# stamp (via after_58) and the next apply completes the migration.
+herdr_verified_stamp="$HOME/.cache/herdr-migration/verified"
+bundle_args=(--cleanup --file=/dev/stdin)
+multiplexer_present=false
+for multiplexer in tmux sesh; do
+  if "$brew_bin" list "$multiplexer" &>/dev/null; then
+    multiplexer_present=true
+    break
+  fi
+done
+if [[ $multiplexer_present == true && ! -f $herdr_verified_stamp ]]; then
+  bundle_args=(--file=/dev/stdin)
+  printf 'herdr not yet verified but tmux/sesh still installed: running brew bundle WITHOUT --cleanup so the old multiplexer is not removed before herdr is proven.\n' >&2
+  printf 'The next apply — after run_after_58 verifies herdr and writes %s — runs --cleanup to complete the migration.\n' "$herdr_verified_stamp" >&2
+fi
+
 # Use `brew bundle ...` to install all taps, formulae, casks, and macOS App Store apps.
-/opt/homebrew/bin/brew bundle --cleanup --file=/dev/stdin <<EOF
+"$brew_bin" bundle "${bundle_args[@]}" <<EOF
 {{ range .packages.macos.homebrew.taps -}}
 tap {{ . | quote }}
 {{ end -}}
@@ -41,7 +80,7 @@ fi
 
 # Install uv tools (runs after Homebrew so uv is available).
 {{ range .packages.macos.uv -}}
-/opt/homebrew/bin/uv tool install {{ . | quote }}
+"$brew_prefix/bin/uv" tool install {{ . | quote }}
 {{ end -}}
 
 # Install npm global packages (runs after Homebrew so node is available).
@@ -55,8 +94,8 @@ npm install -g {{ . | quote }}
 # shim in ~/.volta/bin/<bin> to Node X so the tool keeps working when Homebrew
 # bumps node majors.
 {{ range .packages.macos.volta -}}
-/opt/homebrew/bin/volta install {{ printf "node@%s" .node | quote }}
-/opt/homebrew/bin/volta run --node {{ .node | quote }} npm install -g {{ .package | quote }}
+"$brew_prefix/bin/volta" install {{ printf "node@%s" .node | quote }}
+"$brew_prefix/bin/volta" run --node {{ .node | quote }} npm install -g {{ .package | quote }}
 {{ end -}}
 
 {{ end -}}

--- a/.chezmoitemplates/herdr-health-check.sh.tmpl
+++ b/.chezmoitemplates/herdr-health-check.sh.tmpl
@@ -1,10 +1,9 @@
 {{- /*
-Shared herdr health check, consumed via includeTemplate by BOTH
-.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl (as the LIVE
-authority that gates `brew bundle --cleanup`, the step that removes the old
-multiplexer) and .chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
-(as the predicate behind the stamp it writes). One definition, two call sites,
-so the gate and the stamp writer cannot drift apart.
+Shared herdr health check, consumed via includeTemplate by
+.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl (which runs the
+full check against the just-installed revision and, on success, performs the
+deferred tmux/sesh cleanup). One definition, one call site today; kept as a
+partial so any future includer inherits the same bounded, fail-closed predicate.
 */ -}}
 # --- shared herdr health check: .chezmoitemplates/herdr-health-check.sh.tmpl ---
 #
@@ -12,34 +11,110 @@ so the gate and the stamp writer cannot drift apart.
 # multiplexer; on failure prints a short reason to stdout and returns 1.
 # It never exits the calling script. Requirements, all mandatory:
 #   1. the herdr binary is present and runnable
-#   2. its config.toml is present AND passes the live reload validation
-#   3. BOTH vendored plugins are registered with the EXACT plugin id, enabled,
+#   2. the session server answers with an array-shaped session list containing
+#      at least one running:true entry and no error envelope (a connectable
+#      socket, checked FIRST so a down server is diagnosed as such and not
+#      misread as an unregistered plugin below)
+#   3. its config.toml is present AND passes the live reload validation
+#   4. BOTH vendored plugins are registered with the EXACT plugin id, enabled,
 #      and warning-free, in an array-shaped plugin list with no error envelope
 #      and no duplicate entries
-#   4. the session server answers with an array-shaped session list containing
-#      at least one running:true entry and no error envelope
 #
-# Exact-id matching alone is NOT enough: herdr keeps disabled plugins
-# registered and lists invalid manifests with warnings, so an id-only check
-# would bless an unusable installation. Only the CLI's real response shape
-# counts (the 0.7.0 plugin list is {"id":...,"result":{"plugins":[...]}});
-# object-shaped or otherwise mixed containers and error envelopes all fail
-# closed as not-healthy.
+# Every herdr call is wrapped in a bounded coreutils timeout: a wedged socket
+# (accepts the connection, never replies) would otherwise hang `plugin list` /
+# `session list` / `server reload-config` forever, and this predicate runs on
+# every apply through its includer, so one wedged server would block all future
+# applies. An expiry counts as unhealthy (fail-closed), never as an abort.
+#
+# What each probe actually proves (no overclaiming): the session-list answer
+# proves only a connectable socket, NOT a functioning server. Real liveness is
+# proven by the bounded timeout (a hung server fails closed) together with
+# `server reload-config`, which forces the running server to re-read and report
+# on config.toml. Exact-id matching alone is likewise NOT enough: herdr keeps
+# disabled plugins registered and lists invalid manifests with warnings, so an
+# id-only check would bless an unusable installation. Only the CLI's real
+# response shape counts (the 0.7.0 plugin list is
+# {"id":...,"result":{"plugins":[...]}}); object-shaped or otherwise mixed
+# containers and error envelopes all fail closed as not-healthy.
 herdr_health_check() {
   local herdr_config="$HOME/.config/herdr/config.toml"
   local -a herdr_required_plugins=(herdr-last-workspace herdr-smart-nav)
   local plugin_id response count session_response running reload_response reload_verdict
+  local herdr_timeout_bin
+  local -a herdr_cli
+
+  # Resolve the coreutils timeout binary once (probe `timeout`, then the
+  # macOS-Homebrew `gtimeout`; coreutils is a declared formula). If neither is
+  # on PATH at run time, fail closed as unhealthy-with-warning rather than risk
+  # an unbounded herdr call that could hang the apply forever.
+  if command -v timeout >/dev/null 2>&1; then
+    herdr_timeout_bin="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    herdr_timeout_bin="gtimeout"
+  else
+    printf 'no coreutils timeout binary (timeout/gtimeout absent); cannot bound herdr calls safely, treating as unhealthy'
+    return 1
+  fi
+  # Every herdr invocation goes through this array so the bound is uniform and
+  # array-safe. 10s is generous for a healthy local socket and short enough
+  # that a wedged one fails fast.
+  herdr_cli=("$herdr_timeout_bin" 10 herdr)
 
   if ! command -v herdr >/dev/null 2>&1; then
     printf 'binary not found'
     return 1
   fi
-  if ! herdr --version >/dev/null 2>&1; then
-    printf 'binary does not run'
+  if ! "${herdr_cli[@]}" --version >/dev/null 2>&1; then
+    printf 'binary does not run (or the call timed out)'
     return 1
   fi
+
+  # Server reachability FIRST: the session server must answer with an
+  # array-shaped session list, no error envelope, and at least one running
+  # session (the strongest non-interactive proof a second session can be
+  # hosted; a full spawn+attach needs a TTY an apply does not have). A down
+  # server is caught here, so the plugin loop below can attribute an empty
+  # plugin list to a genuine non-registration rather than to a down server.
+  # A malformed response maps to -1, which fails the digits-only guard.
+  if ! session_response="$("${herdr_cli[@]}" session list --json 2>/dev/null)"; then
+    printf 'session server unreachable (or the call timed out)'
+    return 1
+  fi
+  running="$(printf '%s' "$session_response" |
+    jq '
+      if (type == "object") and (has("error") | not) and ((.sessions | type) == "array") then
+        [.sessions[] | select((type == "object") and (.running == true))] | length
+      else -1 end' 2>/dev/null || printf 'malformed')"
+  if ! [[ $running =~ ^[0-9]+$ && $running -ge 1 ]]; then
+    printf 'no running session (running count: %s)' "$running"
+    return 1
+  fi
+
   if [[ ! -f $herdr_config ]]; then
     printf 'config.toml missing'
+    return 1
+  fi
+
+  # Config validation: `herdr server reload-config` is the strongest liveness
+  # + config check the 0.7.0 CLI offers (there is no validate-only subcommand;
+  # `herdr config` has only reset-keys). It re-reads config.toml into the
+  # running server and reports status + diagnostics; "applied" with zero
+  # diagnostics is a pass. Side effect note: the reload targets the same file
+  # the server would load anyway, so it is an idempotent sync, not a state
+  # change.
+  if ! reload_response="$("${herdr_cli[@]}" server reload-config 2>/dev/null)"; then
+    printf 'config reload check failed (server did not answer or the call timed out)'
+    return 1
+  fi
+  reload_verdict="$(printf '%s' "$reload_response" |
+    jq -r '
+      if (type == "object") and (has("error") | not)
+        and (.result.status == "applied")
+        and ((.result.diagnostics | type) == "array")
+        and ((.result.diagnostics | length) == 0)
+      then "ok" else "bad" end' 2>/dev/null || printf 'bad')"
+  if [[ $reload_verdict != "ok" ]]; then
+    printf 'config.toml failed live validation (reload-config reported diagnostics or did not apply)'
     return 1
   fi
 
@@ -49,9 +124,11 @@ herdr_health_check() {
   # more than one means duplicate registrations; either fails. A container
   # that is not an array maps to -1 (malformed), and a jq parse failure maps
   # to the literal 'malformed', both of which fail the == "1" comparison.
+  # (A down server was already rejected above, so an empty list here is a
+  # genuine non-registration, not a symptom of an unreachable server.)
   for plugin_id in "${herdr_required_plugins[@]}"; do
-    if ! response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)"; then
-      printf 'plugin query failed for %s' "$plugin_id"
+    if ! response="$("${herdr_cli[@]}" plugin list --plugin "$plugin_id" --json 2>/dev/null)"; then
+      printf 'plugin query failed for %s (or the call timed out)' "$plugin_id"
       return 1
     fi
     if printf '%s' "$response" | jq -e '.error' >/dev/null 2>&1; then
@@ -75,46 +152,5 @@ herdr_health_check() {
     fi
   done
 
-  # The session server must answer with an array-shaped session list, no
-  # error envelope, and at least one running session (the strongest
-  # non-interactive proof a second session can be hosted; a full spawn+attach
-  # needs a TTY an apply does not have). A malformed response maps to -1,
-  # which fails the digits-only guard below.
-  if ! session_response="$(herdr session list --json 2>/dev/null)"; then
-    printf 'session server unreachable'
-    return 1
-  fi
-  running="$(printf '%s' "$session_response" |
-    jq '
-      if (type == "object") and (has("error") | not) and ((.sessions | type) == "array") then
-        [.sessions[] | select((type == "object") and (.running == true))] | length
-      else -1 end' 2>/dev/null || printf 'malformed')"
-  if ! [[ $running =~ ^[0-9]+$ && $running -ge 1 ]]; then
-    printf 'no running session (running count: %s)' "$running"
-    return 1
-  fi
-
-  # Config validation: `herdr server reload-config` is the strongest check the
-  # 0.7.0 CLI offers (there is no validate-only subcommand; `herdr config` has
-  # only reset-keys). It re-reads config.toml into the running server and
-  # reports status + diagnostics; "applied" with zero diagnostics is a pass.
-  # Side effect note: the reload targets the same file the server would load
-  # anyway, so it is an idempotent sync, not a state change. It runs last so
-  # the server is already proven reachable (clearer failure reasons).
-  if ! reload_response="$(herdr server reload-config 2>/dev/null)"; then
-    printf 'config reload check failed (server did not answer)'
-    return 1
-  fi
-  reload_verdict="$(printf '%s' "$reload_response" |
-    jq -r '
-      if (type == "object") and (has("error") | not)
-        and (.result.status == "applied")
-        and ((.result.diagnostics | type) == "array")
-        and ((.result.diagnostics | length) == 0)
-      then "ok" else "bad" end' 2>/dev/null || printf 'bad')"
-  if [[ $reload_verdict != "ok" ]]; then
-    printf 'config.toml failed live validation (reload-config reported diagnostics or did not apply)'
-    return 1
-  fi
   return 0
 }

--- a/.chezmoitemplates/herdr-health-check.sh.tmpl
+++ b/.chezmoitemplates/herdr-health-check.sh.tmpl
@@ -1,0 +1,71 @@
+{{- /*
+Shared herdr health check, consumed via includeTemplate by BOTH
+.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl (as the LIVE
+authority that gates `brew bundle --cleanup`, the step that removes the old
+multiplexer) and .chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+(as the predicate behind the stamp it writes). One definition, two call sites,
+so the gate and the stamp writer cannot drift apart.
+*/ -}}
+# --- shared herdr health check: .chezmoitemplates/herdr-health-check.sh.tmpl ---
+#
+# herdr_health_check: returns 0 iff herdr is currently usable as a
+# multiplexer; on failure prints a short reason to stdout and returns 1.
+# It never exits the calling script and runs no destructive command.
+# Requirements, all mandatory:
+#   1. the herdr binary is present and runnable
+#   2. its config.toml is present
+#   3. BOTH vendored plugins are registered (exact plugin id, via the JSON API)
+#   4. the herdr session server is reachable and reports a running session
+herdr_health_check() {
+  local herdr_config="$HOME/.config/herdr/config.toml"
+  local -a herdr_required_plugins=(herdr-last-workspace herdr-smart-nav)
+  local plugin_id response count session_response running
+
+  if ! command -v herdr >/dev/null 2>&1; then
+    printf 'binary not found'
+    return 1
+  fi
+  if ! herdr --version >/dev/null 2>&1; then
+    printf 'binary does not run'
+    return 1
+  fi
+  if [[ ! -f $herdr_config ]]; then
+    printf 'config.toml missing'
+    return 1
+  fi
+
+  # Both plugins must be registered, matched by EXACT plugin id (never a
+  # substring). An error envelope ({"error":{...}}) is a failed query.
+  for plugin_id in "${herdr_required_plugins[@]}"; do
+    if ! response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)"; then
+      printf 'plugin query failed for %s' "$plugin_id"
+      return 1
+    fi
+    if printf '%s' "$response" | jq -e '.error' >/dev/null 2>&1; then
+      printf 'herdr error envelope querying %s' "$plugin_id"
+      return 1
+    fi
+    count="$(printf '%s' "$response" |
+      jq --arg id "$plugin_id" '[.result.plugins[]? | select(.plugin_id == $id)] | length' 2>/dev/null ||
+      printf '0')"
+    if [[ $count != "1" ]]; then
+      printf 'plugin %s not registered' "$plugin_id"
+      return 1
+    fi
+  done
+
+  # The session server must be reachable and report at least one running
+  # session (the strongest non-interactive proof a second session can be
+  # hosted; a full spawn+attach needs a TTY an apply does not have).
+  if ! session_response="$(herdr session list --json 2>/dev/null)"; then
+    printf 'session server unreachable'
+    return 1
+  fi
+  running="$(printf '%s' "$session_response" |
+    jq '[.sessions[]? | select(.running == true)] | length' 2>/dev/null || printf '0')"
+  if ! [[ $running =~ ^[0-9]+$ && $running -ge 1 ]]; then
+    printf 'no running session'
+    return 1
+  fi
+  return 0
+}

--- a/.chezmoitemplates/herdr-health-check.sh.tmpl
+++ b/.chezmoitemplates/herdr-health-check.sh.tmpl
@@ -10,16 +10,25 @@ so the gate and the stamp writer cannot drift apart.
 #
 # herdr_health_check: returns 0 iff herdr is currently usable as a
 # multiplexer; on failure prints a short reason to stdout and returns 1.
-# It never exits the calling script and runs no destructive command.
-# Requirements, all mandatory:
+# It never exits the calling script. Requirements, all mandatory:
 #   1. the herdr binary is present and runnable
-#   2. its config.toml is present
-#   3. BOTH vendored plugins are registered (exact plugin id, via the JSON API)
-#   4. the herdr session server is reachable and reports a running session
+#   2. its config.toml is present AND passes the live reload validation
+#   3. BOTH vendored plugins are registered with the EXACT plugin id, enabled,
+#      and warning-free, in an array-shaped plugin list with no error envelope
+#      and no duplicate entries
+#   4. the session server answers with an array-shaped session list containing
+#      at least one running:true entry and no error envelope
+#
+# Exact-id matching alone is NOT enough: herdr keeps disabled plugins
+# registered and lists invalid manifests with warnings, so an id-only check
+# would bless an unusable installation. Only the CLI's real response shape
+# counts (the 0.7.0 plugin list is {"id":...,"result":{"plugins":[...]}});
+# object-shaped or otherwise mixed containers and error envelopes all fail
+# closed as not-healthy.
 herdr_health_check() {
   local herdr_config="$HOME/.config/herdr/config.toml"
   local -a herdr_required_plugins=(herdr-last-workspace herdr-smart-nav)
-  local plugin_id response count session_response running
+  local plugin_id response count session_response running reload_response reload_verdict
 
   if ! command -v herdr >/dev/null 2>&1; then
     printf 'binary not found'
@@ -35,7 +44,11 @@ herdr_health_check() {
   fi
 
   # Both plugins must be registered, matched by EXACT plugin id (never a
-  # substring). An error envelope ({"error":{...}}) is a failed query.
+  # substring), enabled, and free of manifest warnings. The count must be
+  # exactly 1: zero means unregistered/disabled/warning-bearing/wrong-id,
+  # more than one means duplicate registrations; either fails. A container
+  # that is not an array maps to -1 (malformed), and a jq parse failure maps
+  # to the literal 'malformed', both of which fail the == "1" comparison.
   for plugin_id in "${herdr_required_plugins[@]}"; do
     if ! response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)"; then
       printf 'plugin query failed for %s' "$plugin_id"
@@ -46,25 +59,61 @@ herdr_health_check() {
       return 1
     fi
     count="$(printf '%s' "$response" |
-      jq --arg id "$plugin_id" '[.result.plugins[]? | select(.plugin_id == $id)] | length' 2>/dev/null ||
-      printf '0')"
+      jq --arg id "$plugin_id" '
+        if (.result.plugins | type) == "array" then
+          [.result.plugins[] | select(
+            (type == "object")
+            and (.plugin_id == $id)
+            and (.enabled == true)
+            and (((.warnings // []) | length) == 0)
+          )] | length
+        else -1 end' 2>/dev/null ||
+      printf 'malformed')"
     if [[ $count != "1" ]]; then
-      printf 'plugin %s not registered' "$plugin_id"
+      printf 'plugin %s not registered+enabled+warning-free exactly once (matches: %s)' "$plugin_id" "$count"
       return 1
     fi
   done
 
-  # The session server must be reachable and report at least one running
-  # session (the strongest non-interactive proof a second session can be
-  # hosted; a full spawn+attach needs a TTY an apply does not have).
+  # The session server must answer with an array-shaped session list, no
+  # error envelope, and at least one running session (the strongest
+  # non-interactive proof a second session can be hosted; a full spawn+attach
+  # needs a TTY an apply does not have). A malformed response maps to -1,
+  # which fails the digits-only guard below.
   if ! session_response="$(herdr session list --json 2>/dev/null)"; then
     printf 'session server unreachable'
     return 1
   fi
   running="$(printf '%s' "$session_response" |
-    jq '[.sessions[]? | select(.running == true)] | length' 2>/dev/null || printf '0')"
+    jq '
+      if (type == "object") and (has("error") | not) and ((.sessions | type) == "array") then
+        [.sessions[] | select((type == "object") and (.running == true))] | length
+      else -1 end' 2>/dev/null || printf 'malformed')"
   if ! [[ $running =~ ^[0-9]+$ && $running -ge 1 ]]; then
-    printf 'no running session'
+    printf 'no running session (running count: %s)' "$running"
+    return 1
+  fi
+
+  # Config validation: `herdr server reload-config` is the strongest check the
+  # 0.7.0 CLI offers (there is no validate-only subcommand; `herdr config` has
+  # only reset-keys). It re-reads config.toml into the running server and
+  # reports status + diagnostics; "applied" with zero diagnostics is a pass.
+  # Side effect note: the reload targets the same file the server would load
+  # anyway, so it is an idempotent sync, not a state change. It runs last so
+  # the server is already proven reachable (clearer failure reasons).
+  if ! reload_response="$(herdr server reload-config 2>/dev/null)"; then
+    printf 'config reload check failed (server did not answer)'
+    return 1
+  fi
+  reload_verdict="$(printf '%s' "$reload_response" |
+    jq -r '
+      if (type == "object") and (has("error") | not)
+        and (.result.status == "applied")
+        and ((.result.diagnostics | type) == "array")
+        and ((.result.diagnostics | length) == 0)
+      then "ok" else "bad" end' 2>/dev/null || printf 'bad')"
+  if [[ $reload_verdict != "ok" ]]; then
+    printf 'config.toml failed live validation (reload-config reported diagnostics or did not apply)'
     return 1
   fi
   return 0

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -2,13 +2,13 @@
 Shared core for the herdr plugin build chezmoiscripts (consumed via
 includeTemplate with (dict "id" "<plugin-id>")). Hashes every plugin build input
 so the calling run_onchange_ script re-runs on change, compiles the binary, and
-registers it with herdr — build and registration are SEPARATE phases, each with
+registers it with herdr; build and registration are SEPARATE phases, each with
 its own failure envelope. Each caller keeps only its plugin-specific pre/postamble.
 */ -}}
 # --- shared plugin build core: .chezmoitemplates/herdr-plugin-build.sh.tmpl ---
 #
 # Plugin source (hashed so this script re-runs on change). EVERY build input is
-# hashed — a change to any one forces a rebuild — so Cargo.toml (the manifest:
+# hashed (a change to any one forces a rebuild), so Cargo.toml (the manifest:
 # deps, edition, package) is hashed alongside Cargo.lock, not omitted:
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/src/main.rs" .id) | sha256sum }}
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/Cargo.lock" .id) | sha256sum }}
@@ -37,7 +37,7 @@ plugin_dir="$HOME/.local/share/herdr/plugins/{{ .id }}"
 plugin_id="{{ .id }}"
 
 # cargo is rustup-managed at the deterministic ~/.cargo/bin/cargo (never a PATH
-# probe — a fresh machine provisions it during THIS apply but ~/.cargo/bin is not
+# probe: a fresh machine provisions it during THIS apply but ~/.cargo/bin is not
 # on the apply shell's PATH yet, and a PATH probe could pick a stray toolchain).
 cargo_bin="$HOME/.cargo/bin/cargo"
 
@@ -76,7 +76,7 @@ plugin_registered() {
 }
 
 # register_plugin: 0 iff the plugin ends up registered (exact id verified).
-# Idempotent — a rebuild re-runs this. `herdr plugin link` talks to the running
+# Idempotent: a rebuild re-runs this. `herdr plugin link` talks to the running
 # herdr server (a headless apply, server down, fails here) and may return a herdr
 # error ENVELOPE with exit 0, so its exit code is NOT trusted: the exact-id
 # re-verify via `plugin list` is the sole source of truth for "registered".
@@ -121,6 +121,12 @@ fi
 # broken source. Leave the trigger retryable via the marker and continue (exit 0
 # via fall-through) so the caller's postamble still runs.
 if register_plugin; then
+  # Clearing the marker changes this script's rendered trigger one more time
+  # (success at marker N leaves a render that differs from the recorded one),
+  # so the NEXT apply runs this script once more; that run is idempotent
+  # (already built, already registered) and re-records the settled render, so
+  # the trigger settles from then on. One extra no-op run is the by-design
+  # cost of the retry mechanism.
   rm -f "$retry_marker"
   printf 'herdr plugin %s built and registered\n' "$plugin_id"
 else

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -1,8 +1,9 @@
 {{- /*
 Shared core for the herdr plugin build chezmoiscripts (consumed via
-includeTemplate with (dict "id" "<plugin-id>")). Hashes the plugin source so
-the calling run_onchange_ script re-runs on change, compiles the binary, and
-links it with herdr. Each caller keeps only its plugin-specific pre/postamble.
+includeTemplate with (dict "id" "<plugin-id>")). Hashes every plugin build input
+so the calling run_onchange_ script re-runs on change, compiles the binary, and
+registers it with herdr — build and registration are SEPARATE phases, each with
+its own failure envelope. Each caller keeps only its plugin-specific pre/postamble.
 */ -}}
 # --- shared plugin build core: .chezmoitemplates/herdr-plugin-build.sh.tmpl ---
 #
@@ -13,46 +14,109 @@ links it with herdr. Each caller keeps only its plugin-specific pre/postamble.
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/Cargo.lock" .id) | sha256sum }}
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/Cargo.toml" .id) | sha256sum }}
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/herdr-plugin.toml" .id) | sha256sum }}
+#
+# Retry state (embedded so a retryable non-success re-fires this run_onchange).
+# A missing toolchain or an unverified registration must NOT consume the trigger:
+# chezmoi records a run_onchange script as done on ANY exit 0, so a bare exit 0
+# on a skipped/failed build makes the next apply believe the work is finished and
+# never retry. Those cases bump the marker below (this partial's run-time half);
+# because the marker's contents are interpolated HERE, bumping it changes this
+# rendered script and chezmoi re-runs it on the next apply. Success clears the
+# marker so the trigger settles. (A hard build failure is different — it exits
+# non-zero, which chezmoi does not record, so it retries on its own.)
+#   retry-attempts: {{ $rm := printf "%s/.cache/herdr-plugin-build/%s.retry" (env "HOME") .id }}{{ if stat $rm }}{{ output "cat" $rm }}{{ else }}0{{ end }}
 
 plugin_dir="$HOME/.local/share/herdr/plugins/{{ .id }}"
 plugin_id="{{ .id }}"
 
-# Resolve cargo at its deterministic rustup location. cargo on this machine is
-# rustup-managed (run_once_before_20 installs rustup into ~/.cargo/bin), so the
-# canonical binary is ALWAYS "$HOME/.cargo/bin/cargo" — use it directly, never a
-# `command -v cargo` PATH probe. A PATH probe would silently pick up a different,
-# unexpected toolchain, and it is wrong for the very case this build must handle:
-# on a fresh machine run_once_before_20 provisions cargo during THIS same apply,
-# but ~/.cargo/bin is not on the apply shell's PATH yet — the absolute path is
-# authoritative precisely because PATH is not. A missing toolchain must NEVER
-# abort the whole apply (this partial is includeTemplate'd into run_onchange
-# chezmoiscripts, so exit 1 here kills the entire apply).
+# cargo is rustup-managed at the deterministic ~/.cargo/bin/cargo (never a PATH
+# probe — a fresh machine provisions it during THIS apply but ~/.cargo/bin is not
+# on the apply shell's PATH yet, and a PATH probe could pick a stray toolchain).
 cargo_bin="$HOME/.cargo/bin/cargo"
+
+# The retry marker path MUST match the template's $rm above ($HOME == homeDir at
+# apply time) so the value the template reads is the value this script writes.
+retry_marker="$HOME/.cache/herdr-plugin-build/${plugin_id}.retry"
+
+# Bump the retry marker: leave the run_onchange trigger un-consumed so the next
+# apply retries. The stored value is a monotonic attempt count, so each retry
+# changes the rendered trigger (a boolean would stop re-firing after one retry).
+bump_retry_marker() {
+  local count=0
+  mkdir -p "$(dirname "$retry_marker")"
+  if [[ -f $retry_marker ]]; then
+    count="$(cat "$retry_marker" 2>/dev/null || printf '0')"
+    [[ $count =~ ^[0-9]+$ ]] || count=0
+  fi
+  printf '%d\n' "$((count + 1))" >"$retry_marker"
+}
+
+# plugin_registered: 0 iff `herdr plugin list` confirms EXACTLY this plugin id is
+# registered. A herdr error envelope ({"error":{...}}) or an empty/absent plugins
+# array is NOT registered. The id is matched exactly (never a substring), so a
+# plugin whose id is a substring of another's cannot false-positive.
+plugin_registered() {
+  local response
+  response="$(herdr plugin list --plugin "$plugin_id" --json 2>/dev/null)" || return 1
+  if printf '%s' "$response" | jq -e '.error' >/dev/null 2>&1; then
+    return 1
+  fi
+  local count
+  count="$(printf '%s' "$response" |
+    jq --arg id "$plugin_id" '[.result.plugins[]? | select(.plugin_id == $id)] | length' 2>/dev/null ||
+    printf '0')"
+  [[ $count == "1" ]]
+}
+
+# register_plugin: 0 iff the plugin ends up registered (exact id verified).
+# Idempotent — a rebuild re-runs this. `herdr plugin link` talks to the running
+# herdr server (a headless apply, server down, fails here) and may return a herdr
+# error ENVELOPE with exit 0, so its exit code is NOT trusted: the exact-id
+# re-verify via `plugin list` is the sole source of truth for "registered".
+register_plugin() {
+  if plugin_registered; then
+    return 0
+  fi
+  local link_output link_error
+  link_output="$(herdr plugin link "$plugin_dir" 2>&1)" || true
+  link_error="$(printf '%s' "$link_output" | jq -e -r '.error.message // empty' 2>/dev/null || true)"
+  if [[ -n $link_error ]]; then
+    printf 'herdr plugin link %s returned an error envelope: %s\n' "$plugin_id" "$link_error" >&2
+  fi
+  plugin_registered
+}
+
+# --- build phase ---
+# A MISSING toolchain is a retryable non-success, not a satisfied trigger: warn
+# loudly, leave the trigger retryable via the marker, and exit 0 so the rest of
+# the apply proceeds (this partial is includeTemplate'd into a run_onchange
+# chezmoiscript, so exit 1 here would abort the whole apply).
 if [[ ! -x $cargo_bin ]]; then
-  # No cargo at the canonical rustup location: skip (exit 0) so the rest of the
-  # apply proceeds. Caveat: exit 0 consumes this run_onchange trigger (chezmoi
-  # records the script hash on any success), so a bare re-apply will NOT rebuild
-  # — after rustup provisions cargo, re-touch the plugin source (or clear
-  # chezmoi's scriptState bucket) to retry.
-  echo "cargo not found at ${cargo_bin}; skipping ${plugin_id} plugin build." >&2
-  echo "rustup (run_once_before_20) did not provision it; install rust, then re-touch the plugin source and re-run chezmoi apply to build it." >&2
+  bump_retry_marker
+  printf 'cargo not found at %s; %s plugin build deferred (trigger left retryable).\n' "$cargo_bin" "$plugin_id" >&2
+  printf 'rustup (run_once_before_20) has not provisioned it yet; the next chezmoi apply retries automatically once cargo exists.\n' >&2
   exit 0
 fi
 
-# Compile the plugin binary. --locked keeps Cargo.lock authoritative so the
-# vendored lockfile does not drift on apply.
-(cd "$plugin_dir" && "$cargo_bin" build --release --locked)
+# Compile. --locked keeps Cargo.lock authoritative so the vendored lockfile does
+# not drift on apply. A real build failure (a compile error in the vendored
+# source) is a genuine defect that must surface, so it fails LOUDLY: exit
+# non-zero aborts the apply (chezmoi does not record it, so it retries once the
+# source is fixed).
+if ! (cd "$plugin_dir" && "$cargo_bin" build --release --locked); then
+  printf 'ERROR: cargo build failed for %s; the vendored plugin source is broken.\n' "$plugin_id" >&2
+  exit 1
+fi
 
-# Link with herdr if not already linked. Linking talks to the running herdr
-# server; if it is not up (e.g. a headless apply), skip with a hint — an
-# interactive session can link later. The link persists once registered.
-# The match is anchored to the plugin's list line ("- <id> ...") because
-# `herdr plugin list` also prints each plugin's local path — an unanchored
-# substring match on the id would false-positive against another plugin's line.
-if herdr plugin list 2>/dev/null | grep -q "^- ${plugin_id} "; then
-  echo "herdr plugin $plugin_id already linked"
-elif herdr plugin link "$plugin_dir" >/dev/null 2>&1; then
-  echo "linked herdr plugin $plugin_id"
+# --- registration phase (its own failure envelope, separate from the build) ---
+# Registration is retryable-quiet, NOT loud: it fails on a headless apply where
+# the herdr server is not up, which is a legitimate "link later" condition, not a
+# broken source. Leave the trigger retryable via the marker and continue (exit 0
+# via fall-through) so the caller's postamble still runs.
+if register_plugin; then
+  rm -f "$retry_marker"
+  printf 'herdr plugin %s built and registered\n' "$plugin_id"
 else
-  echo "could not link $plugin_id (herdr server not running?); link later with: herdr plugin link $plugin_dir" >&2
+  bump_retry_marker
+  printf 'herdr plugin %s built but registration is unverified (herdr server unreachable?); trigger left retryable, the next apply retries.\n' "$plugin_id" >&2
 fi

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -22,9 +22,16 @@ its own failure envelope. Each caller keeps only its plugin-specific pre/postamb
 # never retry. Those cases bump the marker below (this partial's run-time half);
 # because the marker's contents are interpolated HERE, bumping it changes this
 # rendered script and chezmoi re-runs it on the next apply. Success clears the
-# marker so the trigger settles. (A hard build failure is different — it exits
+# marker so the trigger settles. (A hard build failure is different: it exits
 # non-zero, which chezmoi does not record, so it retries on its own.)
-#   retry-attempts: {{ $rm := printf "%s/.cache/herdr-plugin-build/%s.retry" (env "HOME") .id }}{{ if stat $rm }}{{ output "cat" $rm }}{{ else }}0{{ end }}
+#
+# The interpolation is sanitized to the marker's LEADING DIGIT RUN only
+# (regexFind "^[0-9]+"): splicing raw file bytes into a rendered script is a
+# live-shell-injection channel (a marker of '1\nfalse\n' would render `false`
+# as a real command that runs at apply time). A non-numeric or empty marker
+# renders as nothing here (still a safe comment) and is normalized at run
+# time by bump_retry_marker below.
+#   retry-attempts: {{ $rm := printf "%s/.cache/herdr-plugin-build/%s.retry" (env "HOME") .id }}{{ if stat $rm }}{{ (output "cat" $rm) | regexFind "^[0-9]+" }}{{ else }}0{{ end }}
 
 plugin_dir="$HOME/.local/share/herdr/plugins/{{ .id }}"
 plugin_id="{{ .id }}"

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -6,9 +6,12 @@ links it with herdr. Each caller keeps only its plugin-specific pre/postamble.
 */ -}}
 # --- shared plugin build core: .chezmoitemplates/herdr-plugin-build.sh.tmpl ---
 #
-# Plugin source (hashed so this script re-runs on change):
+# Plugin source (hashed so this script re-runs on change). EVERY build input is
+# hashed — a change to any one forces a rebuild — so Cargo.toml (the manifest:
+# deps, edition, package) is hashed alongside Cargo.lock, not omitted:
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/src/main.rs" .id) | sha256sum }}
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/Cargo.lock" .id) | sha256sum }}
+#   {{ include (printf "dot_local/share/herdr/plugins/%s/Cargo.toml" .id) | sha256sum }}
 #   {{ include (printf "dot_local/share/herdr/plugins/%s/herdr-plugin.toml" .id) | sha256sum }}
 
 plugin_dir="$HOME/.local/share/herdr/plugins/{{ .id }}"

--- a/test/claude-code-launchagent-retirement.sh
+++ b/test/claude-code-launchagent-retirement.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-# claude-code-launchagent-retirement.sh — the one-time retirement chezmoiscript
-# must unload the old com.claude.code LaunchAgent and delete a leftover deployed
-# plist, be a silent no-op when both are already gone, be idempotent on a second
-# run, and never abort the apply. Removing the plist SOURCE (done in S4) does NOT
-# unload an already-running LaunchAgent; this is the live-side complement.
+# claude-code-launchagent-retirement.sh: the one-time retirement chezmoiscript
+# (run_once_after_59) must unload the old com.claude.code LaunchAgent and
+# delete a leftover deployed plist, be a silent no-op when both are already
+# gone, be idempotent on a second run, and NEVER abort the apply. Removing the
+# plist SOURCE (done in S4) does NOT unload an already-running LaunchAgent;
+# this is the live-side complement.
+#
+# Honesty contract (run_once never retries, so failures must be loud):
+#   - the retired/success message is printed ONLY when a re-probe confirms the
+#     service is actually gone after bootout
+#   - a bootout that leaves the service loaded prints a LOUD warning naming
+#     the exact manual command to run, and still exits 0
+#   - failing `id`, `launchctl print`, and `rm` paths never abort the apply
+#   - the bootout targets the EXACT domain target gui/<uid>/com.claude.code
+#     (the stub records full argv, so a wrong domain or a similar label fails)
 #
 # It renders the REAL template and runs it against a stub `launchctl` on PATH
-# that models the GUI domain with a state file: `print` reports loaded while the
-# state file exists, `bootout` records its argv and clears the state (so the
-# service is unloaded afterward). No live launchd state is touched.
+# that models the GUI domain with a state file: `print` reports loaded while
+# the state file exists, `bootout` records its argv and clears the state.
+# Failure modes are toggled via env vars. No live launchd state is touched.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -38,18 +48,27 @@ if [[ ! -s $rendered ]]; then
   exit 0
 fi
 
-# Stub launchctl: STATE present => service loaded. `print` exits per load state;
-# `bootout` records argv and clears STATE (service becomes unloaded).
+REAL_UID="$(id -u)"
+TARGET="gui/$REAL_UID/com.claude.code"
+
+# Stub launchctl: records FULL argv for every invocation; STATE file present
+# means the service is loaded. `print` exits per load state (or fails outright
+# under LAUNCHCTL_PRINT_FAIL=1); `bootout` clears STATE on success, or exits
+# 77 leaving STATE intact under LAUNCHCTL_BOOTOUT_FAIL=1.
 make_launchctl_stub() {
   local dir="$1"
   cat >"$dir/launchctl" <<'STUB'
 #!/bin/bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_RECORD"
 case "$1" in
   print)
+    [[ ${LAUNCHCTL_PRINT_FAIL:-0} == 1 ]] && exit 2
     [[ -f $LAUNCHCTL_STATE ]] && exit 0
     exit 113 ;;
   bootout)
-    printf '%s\n' "$*" >>"$LAUNCHCTL_BOOTOUT_RECORD"
+    if [[ ${LAUNCHCTL_BOOTOUT_FAIL:-0} == 1 ]]; then
+      exit 77
+    fi
     rm -f "$LAUNCHCTL_STATE"
     exit 0 ;;
 esac
@@ -58,59 +77,116 @@ STUB
   chmod +x "$dir/launchctl"
 }
 
-# run_case <name> <loaded?> <plist?>
+# run_case <name> <loaded?> <plist?> [failure-mode]
+#   failure-mode: bootout-fails | print-fails | rm-fails | id-fails | none
 run_case() {
-  local name="$1" loaded="$2" plist="$3"
+  local name="$1" loaded="$2" plist="$3" failure="${4:-none}"
   CASE_HOME="$work/$name/home"
   local bin="$work/$name/bin"
   STATE="$work/$name/state"
-  BOOTOUT_RECORD="$work/$name/bootout-argv"
+  RECORD="$work/$name/launchctl-argv"
+  OUT_FILE="$work/$name/stdout"
+  ERR_FILE="$work/$name/stderr"
   PLIST="$CASE_HOME/Library/LaunchAgents/com.claude.code.plist"
   mkdir -p "$bin" "$CASE_HOME/Library/LaunchAgents"
   make_launchctl_stub "$bin"
+  : >"$RECORD"
   [[ $loaded == loaded ]] && : >"$STATE"
   [[ $plist == plist ]] && : >"$PLIST"
+  local bootout_fail=0 print_fail=0
+  case "$failure" in
+    bootout-fails) bootout_fail=1 ;;
+    print-fails) print_fail=1 ;;
+    rm-fails) chmod 555 "$CASE_HOME/Library/LaunchAgents" ;;
+    id-fails)
+      printf '#!/bin/bash\nexit 1\n' >"$bin/id"
+      chmod +x "$bin/id"
+      ;;
+    none) ;;
+    *) fail "unknown failure mode: $failure" ;;
+  esac
   RC=0
   HOME="$CASE_HOME" PATH="$bin:$PATH" \
-    LAUNCHCTL_STATE="$STATE" LAUNCHCTL_BOOTOUT_RECORD="$BOOTOUT_RECORD" \
-    bash "$rendered" >/dev/null 2>&1 || RC=$?
+    LAUNCHCTL_STATE="$STATE" LAUNCHCTL_RECORD="$RECORD" \
+    LAUNCHCTL_BOOTOUT_FAIL="$bootout_fail" LAUNCHCTL_PRINT_FAIL="$print_fail" \
+    bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
+  if [[ $failure == rm-fails ]]; then
+    chmod 755 "$CASE_HOME/Library/LaunchAgents"
+  fi
 }
 
-booted_out() { [[ -s $BOOTOUT_RECORD ]]; }
+bootout_count() { grep -c '^bootout ' "$RECORD" || true; }
 
-# Loaded + plist present: unloaded and plist removed.
+# Loaded + plist present: unloaded (exact target), re-probed, plist removed.
 run_case loaded-plist loaded plist
-[[ $RC -eq 0 ]] || fail "loaded-plist: expected exit 0, got $RC"
-booted_out || fail "loaded-plist: launchctl bootout was not called for a loaded service"
-grep -q 'com.claude.code' "$BOOTOUT_RECORD" || fail "loaded-plist: bootout did not target com.claude.code ($(cat "$BOOTOUT_RECORD"))"
+[[ $RC -eq 0 ]] || fail "loaded-plist: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
+grep -qx "bootout $TARGET" "$RECORD" ||
+  fail "loaded-plist: bootout argv is not exactly 'bootout $TARGET' ($(cat "$RECORD"))"
+grep -qx "print $TARGET" "$RECORD" ||
+  fail "loaded-plist: the load probe argv is not exactly 'print $TARGET' ($(cat "$RECORD"))"
+grep -q 'retired' "$OUT_FILE" ||
+  fail "loaded-plist: no retired message after a confirmed bootout ($(cat "$OUT_FILE"))"
 [[ ! -e $PLIST ]] || fail "loaded-plist: leftover plist was not removed"
 
 # Not loaded + no plist: silent no-op, no bootout.
 run_case clean not-loaded no-plist
 [[ $RC -eq 0 ]] || fail "clean: expected exit 0, got $RC"
-booted_out && fail "clean: bootout called though the service is not loaded"
+[[ "$(bootout_count)" -eq 0 ]] || fail "clean: bootout called though the service is not loaded"
+[[ ! -s $OUT_FILE ]] || fail "clean: expected a silent no-op, got output ($(cat "$OUT_FILE"))"
 
 # Loaded + no plist: unloaded, exit 0.
 run_case loaded-only loaded no-plist
 [[ $RC -eq 0 ]] || fail "loaded-only: expected exit 0, got $RC"
-booted_out || fail "loaded-only: bootout not called for a loaded service"
+[[ "$(bootout_count)" -eq 1 ]] || fail "loaded-only: bootout not called exactly once for a loaded service"
 
 # Not loaded + leftover plist: no bootout, plist still removed.
 run_case plist-only not-loaded plist
 [[ $RC -eq 0 ]] || fail "plist-only: expected exit 0, got $RC"
-booted_out && fail "plist-only: bootout called though the service is not loaded"
+[[ "$(bootout_count)" -eq 0 ]] || fail "plist-only: bootout called though the service is not loaded"
 [[ ! -e $PLIST ]] || fail "plist-only: leftover plist was not removed"
 
-# Idempotence: a loaded service, run twice. The first run boots it out; the
-# second sees it already gone and must NOT bootout again (still exit 0).
+# Bootout FAILS and the service stays loaded: run_once never retries, so the
+# script must NOT claim success; it must print a loud warning naming the exact
+# manual command, and still exit 0 (never abort the apply).
+run_case bootout-fails loaded plist bootout-fails
+[[ $RC -eq 0 ]] || fail "bootout-fails: a failed bootout aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+grep -q 'retired' "$OUT_FILE" &&
+  fail "bootout-fails: retired message printed though the service is STILL loaded ($(cat "$OUT_FILE"))"
+grep -q "launchctl bootout $TARGET" "$ERR_FILE" ||
+  fail "bootout-fails: the warning does not name the exact manual command 'launchctl bootout $TARGET' (stderr: $(cat "$ERR_FILE"))"
+
+# `launchctl print` itself fails: treated as not-loaded (the probe is the only
+# visibility we have), no bootout attempted, exit 0.
+run_case print-fails loaded no-plist print-fails
+[[ $RC -eq 0 ]] || fail "print-fails: a failing probe aborted the apply (rc=$RC)"
+[[ "$(bootout_count)" -eq 0 ]] || fail "print-fails: bootout attempted though the probe never confirmed a loaded service"
+
+# `rm` FAILS (read-only LaunchAgents dir): warn and exit 0, never abort.
+run_case rm-fails not-loaded plist rm-fails
+[[ $RC -eq 0 ]] || fail "rm-fails: a failed plist removal aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ -s $ERR_FILE ]] || fail "rm-fails: no warning printed about the unremovable plist"
+
+# `id -u` FAILS: the launchctl phase is skipped with a warning (no malformed
+# domain target), the plist is still removed, exit 0.
+run_case id-fails loaded plist id-fails
+[[ $RC -eq 0 ]] || fail "id-fails: a failing id aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ "$(bootout_count)" -eq 0 ]] || fail "id-fails: bootout attempted without a valid uid ($(cat "$RECORD"))"
+[[ -s $ERR_FILE ]] || fail "id-fails: no warning printed about the failed uid lookup"
+[[ ! -e $PLIST ]] || fail "id-fails: leftover plist was not removed"
+
+# Idempotence: a loaded service, run twice against the same state. The first
+# run boots it out; the second sees it already gone and must NOT bootout again
+# (still exit 0, still silent).
 run_case idempotent loaded plist
 [[ $RC -eq 0 ]] || fail "idempotent(1): expected exit 0, got $RC"
 RC=0
 HOME="$CASE_HOME" PATH="$work/idempotent/bin:$PATH" \
-  LAUNCHCTL_STATE="$STATE" LAUNCHCTL_BOOTOUT_RECORD="$BOOTOUT_RECORD" \
-  bash "$rendered" >/dev/null 2>&1 || RC=$?
+  LAUNCHCTL_STATE="$STATE" LAUNCHCTL_RECORD="$RECORD" \
+  LAUNCHCTL_BOOTOUT_FAIL=0 LAUNCHCTL_PRINT_FAIL=0 \
+  bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
 [[ $RC -eq 0 ]] || fail "idempotent(2): second run must still exit 0, got $RC"
-[[ $(wc -l <"$BOOTOUT_RECORD") -eq 1 ]] ||
-  fail "idempotent(2): bootout ran again on a second pass ($(cat "$BOOTOUT_RECORD"))"
+[[ "$(bootout_count)" -eq 1 ]] ||
+  fail "idempotent(2): bootout ran again on a second pass ($(cat "$RECORD"))"
+[[ ! -s $OUT_FILE ]] || fail "idempotent(2): second run should be silent ($(cat "$OUT_FILE"))"
 
-printf 'PASS: the retirement script boots out a loaded com.claude.code, removes a leftover plist, no-ops when clean, is idempotent on a second run, and never aborts the apply\n'
+printf 'PASS: the retirement script boots out exactly gui/<uid>/com.claude.code, claims success only after a confirming re-probe, warns loudly (with the manual command) when the service survives, survives id/print/rm failures with exit 0, removes the leftover plist, and is idempotent\n'

--- a/test/claude-code-launchagent-retirement.sh
+++ b/test/claude-code-launchagent-retirement.sh
@@ -52,9 +52,14 @@ REAL_UID="$(id -u)"
 TARGET="gui/$REAL_UID/com.claude.code"
 
 # Stub launchctl: records FULL argv for every invocation; STATE file present
-# means the service is loaded. `print` exits per load state (or fails outright
-# under LAUNCHCTL_PRINT_FAIL=1); `bootout` clears STATE on success, or exits
-# 77 leaving STATE intact under LAUNCHCTL_BOOTOUT_FAIL=1.
+# means the service is loaded. The load probe is TRI-STATE: `print` exits 0
+# (loaded), 113 (the known not-found status on this host, i.e. confirmed
+# absent), or another code (an operational error). By default `print` derives
+# 0/113 from the STATE file; when LAUNCHCTL_PRINT_SEQ_FILE holds a
+# space-separated list of codes, each `print` pops the next one instead (so a
+# specific probe -- first or second -- can be forced to an operational error).
+# `bootout` clears STATE on success, or exits 77 leaving STATE intact under
+# LAUNCHCTL_BOOTOUT_FAIL=1.
 make_launchctl_stub() {
   local dir="$1"
   cat >"$dir/launchctl" <<'STUB'
@@ -62,7 +67,11 @@ make_launchctl_stub() {
 printf '%s\n' "$*" >>"$LAUNCHCTL_RECORD"
 case "$1" in
   print)
-    [[ ${LAUNCHCTL_PRINT_FAIL:-0} == 1 ]] && exit 2
+    if [[ -n ${LAUNCHCTL_PRINT_SEQ_FILE:-} && -s $LAUNCHCTL_PRINT_SEQ_FILE ]]; then
+      read -r code rest <"$LAUNCHCTL_PRINT_SEQ_FILE"
+      printf '%s\n' "$rest" >"$LAUNCHCTL_PRINT_SEQ_FILE"
+      exit "$code"
+    fi
     [[ -f $LAUNCHCTL_STATE ]] && exit 0
     exit 113 ;;
   bootout)
@@ -77,26 +86,33 @@ STUB
   chmod +x "$dir/launchctl"
 }
 
-# run_case <name> <loaded?> <plist?> [failure-mode]
-#   failure-mode: bootout-fails | print-fails | rm-fails | id-fails | none
+# run_case <name> <loaded?> <plist?> [failure-mode] [print-seq]
+#   failure-mode: bootout-fails | rm-fails | id-fails | none
+#   print-seq: optional space-separated `launchctl print` exit codes, one
+#              popped per invocation (overrides the STATE-derived 0/113)
 run_case() {
-  local name="$1" loaded="$2" plist="$3" failure="${4:-none}"
+  local name="$1" loaded="$2" plist="$3" failure="${4:-none}" print_seq="${5:-}"
   CASE_HOME="$work/$name/home"
   local bin="$work/$name/bin"
   STATE="$work/$name/state"
   RECORD="$work/$name/launchctl-argv"
   OUT_FILE="$work/$name/stdout"
   ERR_FILE="$work/$name/stderr"
+  PRINT_SEQ_FILE="$work/$name/print-seq"
   PLIST="$CASE_HOME/Library/LaunchAgents/com.claude.code.plist"
   mkdir -p "$bin" "$CASE_HOME/Library/LaunchAgents"
   make_launchctl_stub "$bin"
   : >"$RECORD"
   [[ $loaded == loaded ]] && : >"$STATE"
   [[ $plist == plist ]] && : >"$PLIST"
-  local bootout_fail=0 print_fail=0
+  local seq_file=""
+  if [[ -n $print_seq ]]; then
+    printf '%s\n' "$print_seq" >"$PRINT_SEQ_FILE"
+    seq_file="$PRINT_SEQ_FILE"
+  fi
+  local bootout_fail=0
   case "$failure" in
     bootout-fails) bootout_fail=1 ;;
-    print-fails) print_fail=1 ;;
     rm-fails) chmod 555 "$CASE_HOME/Library/LaunchAgents" ;;
     id-fails)
       printf '#!/bin/bash\nexit 1\n' >"$bin/id"
@@ -108,7 +124,7 @@ run_case() {
   RC=0
   HOME="$CASE_HOME" PATH="$bin:$PATH" \
     LAUNCHCTL_STATE="$STATE" LAUNCHCTL_RECORD="$RECORD" \
-    LAUNCHCTL_BOOTOUT_FAIL="$bootout_fail" LAUNCHCTL_PRINT_FAIL="$print_fail" \
+    LAUNCHCTL_BOOTOUT_FAIL="$bootout_fail" LAUNCHCTL_PRINT_SEQ_FILE="$seq_file" \
     bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
   if [[ $failure == rm-fails ]]; then
     chmod 755 "$CASE_HOME/Library/LaunchAgents"
@@ -155,11 +171,36 @@ grep -q 'retired' "$OUT_FILE" &&
 grep -q "launchctl bootout $TARGET" "$ERR_FILE" ||
   fail "bootout-fails: the warning does not name the exact manual command 'launchctl bootout $TARGET' (stderr: $(cat "$ERR_FILE"))"
 
-# `launchctl print` itself fails: treated as not-loaded (the probe is the only
-# visibility we have), no bootout attempted, exit 0.
-run_case print-fails loaded no-plist print-fails
-[[ $RC -eq 0 ]] || fail "print-fails: a failing probe aborted the apply (rc=$RC)"
-[[ "$(bootout_count)" -eq 0 ]] || fail "print-fails: bootout attempted though the probe never confirmed a loaded service"
+# TRI-STATE, first probe is an OPERATIONAL ERROR (not 0=loaded, not
+# 113=confirmed-absent): the state is unknown, so the script must NOT bootout
+# and must NOT claim retirement; it warns and exits 0. The argv trace is
+# exactly one `print` (no bootout, no second probe).
+run_case first-probe-error not-loaded no-plist none "2"
+[[ $RC -eq 0 ]] || fail "first-probe-error: an operational probe error aborted the apply (rc=$RC)"
+[[ "$(bootout_count)" -eq 0 ]] ||
+  fail "first-probe-error: bootout attempted though the load state is unknown ($(cat "$RECORD"))"
+grep -q 'retired' "$OUT_FILE" &&
+  fail "first-probe-error: retired message printed though the load state was never determined ($(cat "$OUT_FILE"))"
+[[ -s $ERR_FILE ]] ||
+  fail "first-probe-error: no warning printed about the unexpected probe status"
+[[ "$(printf '%s\n' "$(grep -c '^print ' "$RECORD")")" -eq 1 ]] ||
+  fail "first-probe-error: expected exactly one print probe and no re-probe ($(cat "$RECORD"))"
+
+# TRI-STATE, second probe is an OPERATIONAL ERROR after a bootout: first probe
+# 0 (loaded) -> bootout -> re-probe returns an unexpected status (not
+# 113=confirmed-absent, not 0=still-loaded). Absence is NOT confirmed, so the
+# script must NOT claim retirement; it warns and exits 0. The argv trace is
+# print, bootout, print (in that order).
+run_case second-probe-error loaded no-plist none "0 2"
+[[ $RC -eq 0 ]] || fail "second-probe-error: an operational re-probe error aborted the apply (rc=$RC)"
+[[ "$(bootout_count)" -eq 1 ]] ||
+  fail "second-probe-error: bootout was not attempted exactly once ($(cat "$RECORD"))"
+grep -q 'retired' "$OUT_FILE" &&
+  fail "second-probe-error: retired message printed though the re-probe never confirmed absence ($(cat "$OUT_FILE"))"
+[[ -s $ERR_FILE ]] ||
+  fail "second-probe-error: no warning printed about the unconfirmed unload"
+printf 'print %s\nbootout %s\nprint %s\n' "$TARGET" "$TARGET" "$TARGET" | cmp -s - "$RECORD" ||
+  fail "second-probe-error: argv trace is not exactly print/bootout/print ($(cat "$RECORD"))"
 
 # `rm` FAILS (read-only LaunchAgents dir): warn and exit 0, never abort.
 run_case rm-fails not-loaded plist rm-fails
@@ -182,11 +223,11 @@ run_case idempotent loaded plist
 RC=0
 HOME="$CASE_HOME" PATH="$work/idempotent/bin:$PATH" \
   LAUNCHCTL_STATE="$STATE" LAUNCHCTL_RECORD="$RECORD" \
-  LAUNCHCTL_BOOTOUT_FAIL=0 LAUNCHCTL_PRINT_FAIL=0 \
+  LAUNCHCTL_BOOTOUT_FAIL=0 LAUNCHCTL_PRINT_SEQ_FILE="" \
   bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
 [[ $RC -eq 0 ]] || fail "idempotent(2): second run must still exit 0, got $RC"
 [[ "$(bootout_count)" -eq 1 ]] ||
   fail "idempotent(2): bootout ran again on a second pass ($(cat "$RECORD"))"
 [[ ! -s $OUT_FILE ]] || fail "idempotent(2): second run should be silent ($(cat "$OUT_FILE"))"
 
-printf 'PASS: the retirement script boots out exactly gui/<uid>/com.claude.code, claims success only after a confirming re-probe, warns loudly (with the manual command) when the service survives, survives id/print/rm failures with exit 0, removes the leftover plist, and is idempotent\n'
+printf 'PASS: the retirement script boots out exactly gui/<uid>/com.claude.code, treats the load probe as tri-state (0=loaded, 113=confirmed-absent, else=operational-error), claims retirement ONLY after a re-probe confirms absence (113), warns without any success claim on a still-loaded or operational-error re-probe, warns and makes no change on an operational-error first probe, survives id/rm/bootout failures with exit 0, removes the leftover plist, and is idempotent\n'

--- a/test/claude-code-launchagent-retirement.sh
+++ b/test/claude-code-launchagent-retirement.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# claude-code-launchagent-retirement.sh — the one-time retirement chezmoiscript
+# must unload the old com.claude.code LaunchAgent and delete a leftover deployed
+# plist, be a silent no-op when both are already gone, be idempotent on a second
+# run, and never abort the apply. Removing the plist SOURCE (done in S4) does NOT
+# unload an already-running LaunchAgent; this is the live-side complement.
+#
+# It renders the REAL template and runs it against a stub `launchctl` on PATH
+# that models the GUI domain with a state file: `print` reports loaded while the
+# state file exists, `bootout` records its argv and clears the state (so the
+# service is unloaded afterward). No live launchd state is touched.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not on PATH; cannot render the retirement script\n'
+  exit 0
+fi
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Stub launchctl: STATE present => service loaded. `print` exits per load state;
+# `bootout` records argv and clears STATE (service becomes unloaded).
+make_launchctl_stub() {
+  local dir="$1"
+  cat >"$dir/launchctl" <<'STUB'
+#!/bin/bash
+case "$1" in
+  print)
+    [[ -f $LAUNCHCTL_STATE ]] && exit 0
+    exit 113 ;;
+  bootout)
+    printf '%s\n' "$*" >>"$LAUNCHCTL_BOOTOUT_RECORD"
+    rm -f "$LAUNCHCTL_STATE"
+    exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/launchctl"
+}
+
+# run_case <name> <loaded?> <plist?>
+run_case() {
+  local name="$1" loaded="$2" plist="$3"
+  CASE_HOME="$work/$name/home"
+  local bin="$work/$name/bin"
+  STATE="$work/$name/state"
+  BOOTOUT_RECORD="$work/$name/bootout-argv"
+  PLIST="$CASE_HOME/Library/LaunchAgents/com.claude.code.plist"
+  mkdir -p "$bin" "$CASE_HOME/Library/LaunchAgents"
+  make_launchctl_stub "$bin"
+  [[ $loaded == loaded ]] && : >"$STATE"
+  [[ $plist == plist ]] && : >"$PLIST"
+  RC=0
+  HOME="$CASE_HOME" PATH="$bin:$PATH" \
+    LAUNCHCTL_STATE="$STATE" LAUNCHCTL_BOOTOUT_RECORD="$BOOTOUT_RECORD" \
+    bash "$rendered" >/dev/null 2>&1 || RC=$?
+}
+
+booted_out() { [[ -s $BOOTOUT_RECORD ]]; }
+
+# Loaded + plist present: unloaded and plist removed.
+run_case loaded-plist loaded plist
+[[ $RC -eq 0 ]] || fail "loaded-plist: expected exit 0, got $RC"
+booted_out || fail "loaded-plist: launchctl bootout was not called for a loaded service"
+grep -q 'com.claude.code' "$BOOTOUT_RECORD" || fail "loaded-plist: bootout did not target com.claude.code ($(cat "$BOOTOUT_RECORD"))"
+[[ ! -e $PLIST ]] || fail "loaded-plist: leftover plist was not removed"
+
+# Not loaded + no plist: silent no-op, no bootout.
+run_case clean not-loaded no-plist
+[[ $RC -eq 0 ]] || fail "clean: expected exit 0, got $RC"
+booted_out && fail "clean: bootout called though the service is not loaded"
+
+# Loaded + no plist: unloaded, exit 0.
+run_case loaded-only loaded no-plist
+[[ $RC -eq 0 ]] || fail "loaded-only: expected exit 0, got $RC"
+booted_out || fail "loaded-only: bootout not called for a loaded service"
+
+# Not loaded + leftover plist: no bootout, plist still removed.
+run_case plist-only not-loaded plist
+[[ $RC -eq 0 ]] || fail "plist-only: expected exit 0, got $RC"
+booted_out && fail "plist-only: bootout called though the service is not loaded"
+[[ ! -e $PLIST ]] || fail "plist-only: leftover plist was not removed"
+
+# Idempotence: a loaded service, run twice. The first run boots it out; the
+# second sees it already gone and must NOT bootout again (still exit 0).
+run_case idempotent loaded plist
+[[ $RC -eq 0 ]] || fail "idempotent(1): expected exit 0, got $RC"
+RC=0
+HOME="$CASE_HOME" PATH="$work/idempotent/bin:$PATH" \
+  LAUNCHCTL_STATE="$STATE" LAUNCHCTL_BOOTOUT_RECORD="$BOOTOUT_RECORD" \
+  bash "$rendered" >/dev/null 2>&1 || RC=$?
+[[ $RC -eq 0 ]] || fail "idempotent(2): second run must still exit 0, got $RC"
+[[ $(wc -l <"$BOOTOUT_RECORD") -eq 1 ]] ||
+  fail "idempotent(2): bootout ran again on a second pass ($(cat "$BOOTOUT_RECORD"))"
+
+printf 'PASS: the retirement script boots out a loaded com.claude.code, removes a leftover plist, no-ops when clean, is idempotent on a second run, and never aborts the apply\n'

--- a/test/herdr-build-input-hashing.sh
+++ b/test/herdr-build-input-hashing.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# herdr-build-input-hashing.sh — the rebuild-decision hash (embedded in the
+# rendered run_onchange trigger) must cover EVERY input to the Rust build, so a
+# change to any one forces a rebuild. The build partial
+# (.chezmoitemplates/herdr-plugin-build.sh.tmpl) is includeTemplate'd into both
+# run_onchange_after_55/57 scripts and pins the trigger to the hashes of the
+# plugin source. The four inputs are:
+#
+#   src/main.rs          the plugin source
+#   Cargo.lock           the resolved dependency graph
+#   Cargo.toml           the manifest (deps, edition, package) — a change here
+#                        (e.g. a bumped dependency) MUST force a rebuild
+#   herdr-plugin.toml    the plugin manifest (build/events/actions)
+#
+# This renders each plugin build script with the host chezmoi (same mechanics as
+# the treefmt rendered-template lint: scratch HOME, CI=1) and asserts the render
+# carries the sha256 of ALL FOUR inputs. If any input's hash is absent, changing
+# that input would not change the rendered trigger and chezmoi would not rebuild
+# — the exact defect (Cargo.toml omitted) this test guards against.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# script -> plugin id
+SCRIPTS=(
+  "run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl:herdr-last-workspace"
+  "run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl:herdr-smart-nav"
+)
+
+# The build inputs, relative to a plugin dir. Every one must be hashed.
+INPUTS=(
+  "src/main.rs"
+  "Cargo.lock"
+  "Cargo.toml"
+  "herdr-plugin.toml"
+)
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Host-tool guards: plain test/*.sh scripts run outside the Nix shell.
+for tool in chezmoi shasum; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot render/hash the plugin build inputs\n' "$tool"
+    exit 0
+  fi
+done
+
+# chezmoi's `sha256sum` template function returns the lowercase hex digest, the
+# same value `shasum -a 256` prints in its first field.
+host_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+scratch_home="$(mktemp -d)"
+trap 'rm -rf "$scratch_home"' EXIT
+
+for pair in "${SCRIPTS[@]}"; do
+  script_name="${pair%%:*}"
+  plugin_id="${pair##*:}"
+  script="$REPO_ROOT/.chezmoiscripts/$script_name"
+  plugin_dir="$REPO_ROOT/dot_local/share/herdr/plugins/$plugin_id"
+  [[ -f $script ]] || fail "missing template: $script"
+
+  rendered="$(HOME="$scratch_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$script")" ||
+    fail "chezmoi failed to render $script"
+  [[ -n $rendered ]] || fail "empty render (non-darwin?): $script"
+
+  for input in "${INPUTS[@]}"; do
+    input_path="$plugin_dir/$input"
+    [[ -f $input_path ]] || fail "$plugin_id: missing build input $input"
+    hash="$(host_sha256 "$input_path")"
+    grep -qF "$hash" <<<"$rendered" ||
+      fail "$plugin_id: rendered trigger omits the hash of $input ($hash) — a change to it would not force a rebuild"
+  done
+done
+
+printf 'PASS: both plugin build triggers hash all four build inputs (main.rs, Cargo.lock, Cargo.toml, herdr-plugin.toml)\n'

--- a/test/herdr-build-input-hashing.sh
+++ b/test/herdr-build-input-hashing.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# herdr-build-input-hashing.sh — the rebuild-decision hash (embedded in the
+# herdr-build-input-hashing.sh: the rebuild-decision hash (embedded in the
 # rendered run_onchange trigger) must cover EVERY input to the Rust build, so a
 # change to any one forces a rebuild. The build partial
 # (.chezmoitemplates/herdr-plugin-build.sh.tmpl) is includeTemplate'd into both
@@ -8,15 +8,15 @@
 #
 #   src/main.rs          the plugin source
 #   Cargo.lock           the resolved dependency graph
-#   Cargo.toml           the manifest (deps, edition, package) — a change here
+#   Cargo.toml           the manifest (deps, edition, package); a change here
 #                        (e.g. a bumped dependency) MUST force a rebuild
 #   herdr-plugin.toml    the plugin manifest (build/events/actions)
 #
 # This renders each plugin build script with the host chezmoi (same mechanics as
 # the treefmt rendered-template lint: scratch HOME, CI=1) and asserts the render
 # carries the sha256 of ALL FOUR inputs. If any input's hash is absent, changing
-# that input would not change the rendered trigger and chezmoi would not rebuild
-# — the exact defect (Cargo.toml omitted) this test guards against.
+# that input would not change the rendered trigger and chezmoi would not
+# rebuild: the exact defect (Cargo.toml omitted) this test guards against.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -73,7 +73,7 @@ for pair in "${SCRIPTS[@]}"; do
     [[ -f $input_path ]] || fail "$plugin_id: missing build input $input"
     hash="$(host_sha256 "$input_path")"
     grep -qF "$hash" <<<"$rendered" ||
-      fail "$plugin_id: rendered trigger omits the hash of $input ($hash) — a change to it would not force a rebuild"
+      fail "$plugin_id: rendered trigger omits the hash of $input ($hash); a change to it would not force a rebuild"
   done
 done
 

--- a/test/herdr-build-retry-refire.sh
+++ b/test/herdr-build-retry-refire.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# herdr-build-retry-refire.sh — the retry marker must actually RE-FIRE the
+# run_onchange trigger. chezmoi re-runs a run_onchange script only when its
+# rendered content changes; a retryable non-success (missing cargo, unverified
+# registration) bumps a marker file whose contents the build partial interpolates
+# into the rendered trigger. This test proves that bumping the marker changes the
+# render — so the next apply genuinely re-runs the build — and that a distinct
+# render appears for each successive attempt count (a monotonic counter, not a
+# boolean that would stop re-firing after the first retry), and that clearing the
+# marker returns the render to its settled form.
+#
+# It renders the REAL after_55 template with the host chezmoi against a scratch
+# HOME, planting the marker at the exact path the partial reads
+# ($HOME/.cache/herdr-plugin-build/<id>.retry). Companion to
+# herdr-build-scripts-resilience.sh, which proves the SCRIPT writes the marker;
+# this proves the TEMPLATE reacts to it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl"
+PLUGIN_ID="herdr-last-workspace"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not on PATH; cannot render the plugin build template\n'
+  exit 0
+fi
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+marker="$render_home/.cache/herdr-plugin-build/$PLUGIN_ID.retry"
+mkdir -p "$(dirname "$marker")"
+
+render() {
+  HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT"
+}
+
+# Settled (no marker): the trigger's baseline form.
+rm -f "$marker"
+settled="$(render)" || fail "render failed (no marker)"
+[[ -n $settled ]] || {
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+}
+
+# Attempt 1.
+printf '1\n' >"$marker"
+attempt1="$(render)" || fail "render failed (marker=1)"
+
+# Attempt 2.
+printf '2\n' >"$marker"
+attempt2="$(render)" || fail "render failed (marker=2)"
+
+# Cleared again -> back to settled.
+rm -f "$marker"
+resettled="$(render)" || fail "render failed (marker cleared)"
+
+[[ $settled != "$attempt1" ]] ||
+  fail "bumping the retry marker (0 -> 1) did not change the rendered trigger; chezmoi would not re-run the build"
+[[ $attempt1 != "$attempt2" ]] ||
+  fail "a second retry (1 -> 2) did not change the render; a boolean marker would stall retries after the first"
+[[ $settled == "$resettled" ]] ||
+  fail "clearing the marker did not return the render to its settled form (the trigger would never settle)"
+
+printf 'PASS: the retry marker re-fires the run_onchange trigger — each attempt count renders distinctly and clearing settles it\n'

--- a/test/herdr-build-retry-refire.sh
+++ b/test/herdr-build-retry-refire.sh
@@ -67,4 +67,56 @@ resettled="$(render)" || fail "render failed (marker cleared)"
 [[ $settled == "$resettled" ]] ||
   fail "clearing the marker did not return the render to its settled form (the trigger would never settle)"
 
-printf 'PASS: the retry marker re-fires the run_onchange trigger — each attempt count renders distinctly and clearing settles it\n'
+# --- render-interpolation sanitization (digits only, never raw bytes) -------
+# A hostile multiline marker must not splice raw bytes into the script:
+# '1\nfalse\n' would render a live `false` line that runs at apply time and,
+# under set -e, aborts the whole apply. Only the leading digit run may reach
+# the render: the hostile marker must render byte-identically to a plain '1'.
+printf '1\n' >"$marker"
+plain1="$(render)" || fail "render failed (marker=1, re-render)"
+printf '1\nfalse\n' >"$marker"
+hostile="$(render)" || fail "render failed (hostile multiline marker)"
+[[ $hostile == "$plain1" ]] ||
+  fail "a hostile multiline marker ('1\\nfalse\\n') changed the render beyond the digit run; raw marker bytes are being spliced into the script (live-shell injection at apply time)"
+bash -n <<<"$hostile" || fail "hostile-marker render does not parse"
+
+# An empty marker must render safely (and parse).
+: >"$marker"
+empty_render="$(render)" || fail "render failed (empty marker)"
+bash -n <<<"$empty_render" || fail "empty-marker render does not parse"
+
+# A garbage (non-numeric) marker: no marker bytes reach the render, and it
+# still parses. (The run-time reset of a garbage COUNT is covered in
+# herdr-build-scripts-resilience.sh.)
+printf 'garbage\n' >"$marker"
+garbage_render="$(render)" || fail "render failed (garbage marker)"
+bash -n <<<"$garbage_render" || fail "garbage-marker render does not parse"
+grep -q 'garbage' <<<"$garbage_render" &&
+  fail "garbage marker bytes were spliced into the render"
+
+# --- two consecutive failures progress the marker against the SAME home -----
+# Run the RENDERED script twice with no cargo in the scratch home: each
+# retryable non-success must bump the marker (1 then 2) and each bump must
+# produce a distinct render. This kills both the constant-counter mutant and
+# the delete-the-count-read mutant (either would stall the retry loop after
+# the first failure).
+rm -f "$marker"
+run_rendered() {
+  local script="$render_home/rendered-run.sh"
+  render >"$script" || fail "render failed (for execution)"
+  HOME="$render_home" bash "$script" >/dev/null 2>&1 ||
+    fail "rendered script failed on the missing-cargo path (must exit 0, never abort the apply)"
+}
+run_rendered
+[[ -f $marker ]] || fail "first missing-cargo run did not write the retry marker"
+[[ "$(cat "$marker")" == "1" ]] ||
+  fail "first missing-cargo run wrote marker '$(cat "$marker")', expected 1"
+render_at_1="$(render)" || fail "render failed (marker=1 after run)"
+run_rendered
+[[ "$(cat "$marker")" == "2" ]] ||
+  fail "second missing-cargo run wrote marker '$(cat "$marker")', expected 2 (the counter must be monotonic, not constant)"
+render_at_2="$(render)" || fail "render failed (marker=2 after run)"
+[[ $render_at_1 != "$render_at_2" ]] ||
+  fail "consecutive failures produced identical renders; the second retry would never re-fire"
+
+printf 'PASS: the retry marker re-fires the run_onchange trigger, interpolates digits only (hostile/empty/garbage markers render safely), and consecutive failures against one home progress the marker 1 -> 2 with distinct renders\n'

--- a/test/herdr-build-retry-refire.sh
+++ b/test/herdr-build-retry-refire.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# herdr-build-retry-refire.sh — the retry marker must actually RE-FIRE the
+# herdr-build-retry-refire.sh: the retry marker must actually RE-FIRE the
 # run_onchange trigger. chezmoi re-runs a run_onchange script only when its
 # rendered content changes; a retryable non-success (missing cargo, unverified
 # registration) bumps a marker file whose contents the build partial interpolates
 # into the rendered trigger. This test proves that bumping the marker changes the
-# render — so the next apply genuinely re-runs the build — and that a distinct
+# render (so the next apply genuinely re-runs the build) and that a distinct
 # render appears for each successive attempt count (a monotonic counter, not a
 # boolean that would stop re-firing after the first retry), and that clearing the
 # marker returns the render to its settled form.

--- a/test/herdr-build-scripts-resilience.sh
+++ b/test/herdr-build-scripts-resilience.sh
@@ -1,27 +1,39 @@
 #!/usr/bin/env bash
 # herdr-build-scripts-resilience.sh — the herdr plugin build chezmoiscript
-# (run_onchange_after_55) must survive a fresh/headless machine without aborting
-# the whole `chezmoi apply`. It renders the REAL script with the host chezmoi and
-# runs the rendered body against stub `herdr`/`cargo` on PATH, asserting:
+# (run_onchange_after_55) separates BUILD from REGISTRATION, each with its own
+# failure envelope, and treats a missing toolchain or an unverified registration
+# as a RETRYABLE non-success — NOT a satisfied trigger.
 #
-#   F1  herdr server down (rc=3)      -> script exits 0 (link step tolerates it)
-#   F1  herdr emits error JSON (rc=0) -> script exits 0 (link step tolerates it)
-#   F3  seed shape (built binary)     -> when the build produced a binary, the
-#                                        script runs `<binary> seed` (the MRU seed
-#                                        now lives in the plugin, not in bash — its
-#                                        state-path/idempotence correctness is a
-#                                        Rust cfg(test) concern in src/main.rs);
-#                                        when the build is skipped, seed is not run
-#   F2  cargo only on PATH            -> NOT used: the build resolves cargo at the
-#                                        deterministic ~/.cargo/bin/cargo only, so
-#                                        a PATH-only cargo is ignored (skip+hint)
-#   F2  cargo at ~/.cargo/bin + PATH  -> the absolute ~/.cargo/bin/cargo is the
-#                                        one invoked, never the PATH cargo
-#   F2  cargo absent everywhere       -> script exits 0 with a hint (never aborts)
+# This REVERSES the previous contract (which asserted "cargo absent -> exit 0,
+# never aborts", implying the trigger was consumed/satisfied). chezmoi records a
+# run_onchange script as done on ANY exit 0, so a bare exit 0 on a skipped build
+# would make the next apply believe the work is finished and never retry. The
+# retry state is carried by a marker file the template embeds into the rendered
+# trigger (bumping it re-fires the run_onchange; the re-fire itself is proven in
+# test/herdr-build-input-hashing.sh's sibling render-diff assertions), so the
+# CONTRACT this script checks is expressed as the marker, not the exit code:
 #
-# This exercises the rendered code path itself (not a copy). Stubs shadow the
-# live `herdr`/`cargo` on PATH and stand in for the built plugin binary, so the
-# test never touches the running server or needs a real cargo build.
+#   retryable non-success  -> exit 0, retry marker PRESENT (trigger un-consumed)
+#   full success           -> exit 0, retry marker ABSENT  (trigger settles)
+#   hard build failure     -> exit NON-ZERO (loud; chezmoi does not record it, so
+#                             it retries on its own after the source is fixed)
+#
+# Cases:
+#   R1  missing cargo (absent everywhere) -> retryable: marker present, exit 0,
+#                                            no build, no seed
+#   R1  cargo only on PATH                -> same as missing (only ~/.cargo/bin
+#                                            is authoritative): retryable
+#   R2  build ok + herdr server down      -> registration unverified: retryable
+#                                            (marker present), exit 0
+#   R2  build ok + herdr error envelope   -> registration unverified: retryable
+#   R3  build ok + link registers plugin  -> success: marker ABSENT (cleared even
+#                                            if it pre-existed), exit 0, seed ran
+#   R3  build ok + already registered     -> success, link NOT attempted
+#   R4  cargo build fails (compile error) -> loud: exit NON-ZERO
+#   F2  cargo at ~/.cargo/bin + PATH      -> the absolute cargo is the one used
+#
+# The rendered code path itself is exercised (not a copy). Stubs shadow the live
+# herdr/cargo on PATH and stand in for the built plugin binary.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -73,74 +85,97 @@ path_without_cargo() {
 }
 PATH_NO_CARGO="$(path_without_cargo)"
 
-# Write a stub `herdr` for the given mode into $1.
+# Write a stub `herdr` for the given mode into $1. STATE/$LINK_REC are per-case
+# files the stub uses to model registration across its (stateless) invocations.
+#   registered   -> `plugin list --plugin` reports the plugin from the start
+#   linkok       -> not registered until `plugin link` runs, then reported
+#   down         -> every subcommand fails (server unreachable, exit 3)
+#   errorjson    -> `plugin list`/`plugin link` return a herdr error envelope
 make_herdr_stub() {
-  local dir="$1" mode="$2"
+  local dir="$1" mode="$2" state="$3" link_rec="$4" pid="$5"
   case "$mode" in
-    down) # server unreachable — every subcommand fails
-      cat >"$dir/herdr" <<'STUB'
-#!/bin/bash
-exit 3
-STUB
-      ;;
-    errorjson) # reachable but returns an error envelope with exit 0
-      cat >"$dir/herdr" <<'STUB'
-#!/bin/bash
-if [[ "$1 $2" == "workspace list" ]]; then
-  printf '{"id":"x","error":{"code":-1,"message":"server error"}}\n'
-fi
-exit 0
-STUB
-      ;;
-    happy) # reachable, one focused workspace (id wW)
-      cat >"$dir/herdr" <<'STUB'
-#!/bin/bash
-if [[ "$1 $2" == "workspace list" ]]; then
-  printf '{"result":{"workspaces":[{"focused":true,"workspace_id":"wW","label":"dotfiles"},{"focused":false,"workspace_id":"wY","label":"todoist"}]}}\n'
-fi
-exit 0
-STUB
-      ;;
+    registered) : >"$state" ;; # pre-registered
+    linkok | down | errorjson) rm -f "$state" ;;
     *) fail "unknown herdr stub mode: $mode" ;;
   esac
+  cat >"$dir/herdr" <<STUB
+#!/bin/bash
+mode="$mode"
+state="$state"
+link_rec="$link_rec"
+pid="$pid"
+sub="\$1 \$2"
+if [[ \$mode == down ]]; then
+  exit 3
+fi
+case "\$sub" in
+  "plugin list")
+    if [[ \$mode == errorjson ]]; then
+      printf '{"id":"cli:plugin","error":{"code":-1,"message":"server error"}}\n'
+      exit 0
+    fi
+    if [[ -f \$state ]]; then
+      printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s"}],"type":"plugin_list"}}\n' "\$pid"
+    else
+      printf '{"id":"cli:plugin","result":{"plugins":[],"type":"plugin_list"}}\n'
+    fi
+    exit 0
+    ;;
+  "plugin link")
+    printf '%s\n' "\$*" >>"\$link_rec"
+    if [[ \$mode == errorjson ]]; then
+      printf '{"id":"cli:plugin","error":{"code":-1,"message":"link refused"}}\n'
+      exit 0
+    fi
+    : >"\$state"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
   chmod +x "$dir/herdr"
 }
 
-# Write a stub `cargo` that records its argv into $2, at path $1.
+# Write a stub `cargo` at path $1 recording argv to $2. If $3 == fail, `build`
+# exits non-zero (a real compile failure).
 make_cargo_stub() {
-  local path="$1" record="$2"
+  local path="$1" record="$2" build_mode="${3:-ok}"
   mkdir -p "$(dirname "$path")"
   cat >"$path" <<STUB
 #!/bin/bash
 printf '%s\n' "\$*" >>"$record"
+if [[ "\$1" == build && "$build_mode" == fail ]]; then
+  echo "error: could not compile" >&2
+  exit 101
+fi
 exit 0
 STUB
   chmod +x "$path"
 }
 
-# run_case <name> <herdr-mode> <cargo-mode>
-#   cargo-mode: home     -> cargo only at the absolute ~/.cargo/bin/cargo
-#               pathonly -> cargo only on PATH (must be ignored by the build)
-#               both     -> cargo at BOTH ~/.cargo/bin and on PATH
-#               none     -> no cargo anywhere
-# Populates: RC, ERR (stderr text), CASE_HOME, CARGO_RECORD (absolute-cargo
-# argv), PATH_CARGO_RECORD (PATH-cargo argv), SEED_RECORD (built-binary argv)
+# run_case <name> <herdr-mode> <cargo-mode> [build-mode] [pre-mark]
+#   cargo-mode: home | pathonly | both | none
+#   build-mode: ok | fail   (only meaningful when cargo is present)
+#   pre-mark:   yes -> pre-create the retry marker (to prove success clears it)
+# Populates: RC, ERR, CASE_HOME, CARGO_RECORD, PATH_CARGO_RECORD, SEED_RECORD,
+#            LINK_RECORD, MARKER
 run_case() {
-  local name="$1" herdr_mode="$2" cargo_mode="$3"
+  local name="$1" herdr_mode="$2" cargo_mode="$3" build_mode="${4:-ok}" pre_mark="${5:-no}"
   CASE_HOME="$work/$name/home"
   local bin="$work/$name/bin"
   CARGO_RECORD="$work/$name/cargo-abs-argv"
   PATH_CARGO_RECORD="$work/$name/cargo-path-argv"
   SEED_RECORD="$work/$name/seed-argv"
+  LINK_RECORD="$work/$name/link-argv"
+  MARKER="$CASE_HOME/.cache/herdr-plugin-build/$PLUGIN_ID.retry"
+  local state="$work/$name/herdr-state"
   local plugin_dir="$CASE_HOME/.local/share/herdr/plugins/$PLUGIN_ID"
   mkdir -p "$bin" "$plugin_dir/target/release"
 
-  make_herdr_stub "$bin" "$herdr_mode"
+  make_herdr_stub "$bin" "$herdr_mode" "$state" "$LINK_RECORD" "$PLUGIN_ID"
 
-  # Stand in for the compiled plugin binary the real `cargo build` would emit.
-  # It records its argv so we can assert the script runs it as `<binary> seed`.
-  # (The stub `cargo` never builds anything, so the script would otherwise have
-  # no binary to seed with.)
+  # Stand in for the compiled plugin binary the real `cargo build` would emit;
+  # it records its argv so we can assert the script runs it as `<binary> seed`.
   cat >"$plugin_dir/target/release/last-workspace" <<STUB
 #!/bin/bash
 printf '%s\n' "\$*" >>"$SEED_RECORD"
@@ -148,19 +183,24 @@ exit 0
 STUB
   chmod +x "$plugin_dir/target/release/last-workspace"
 
+  if [[ $pre_mark == yes ]]; then
+    mkdir -p "$(dirname "$MARKER")"
+    printf '2\n' >"$MARKER"
+  fi
+
   local case_path
   case "$cargo_mode" in
     home)
-      make_cargo_stub "$CASE_HOME/.cargo/bin/cargo" "$CARGO_RECORD"
+      make_cargo_stub "$CASE_HOME/.cargo/bin/cargo" "$CARGO_RECORD" "$build_mode"
       case_path="$bin:$PATH_NO_CARGO"
       ;;
     pathonly)
-      make_cargo_stub "$bin/cargo" "$PATH_CARGO_RECORD"
+      make_cargo_stub "$bin/cargo" "$PATH_CARGO_RECORD" "$build_mode"
       case_path="$bin:$PATH_NO_CARGO"
       ;;
     both)
-      make_cargo_stub "$CASE_HOME/.cargo/bin/cargo" "$CARGO_RECORD"
-      make_cargo_stub "$bin/cargo" "$PATH_CARGO_RECORD"
+      make_cargo_stub "$CASE_HOME/.cargo/bin/cargo" "$CARGO_RECORD" "$build_mode"
+      make_cargo_stub "$bin/cargo" "$PATH_CARGO_RECORD" "$build_mode"
       case_path="$bin:$PATH_NO_CARGO"
       ;;
     none)
@@ -176,45 +216,56 @@ STUB
   ERR="$(cat "$errf")"
 }
 
-# --- F1: herdr server down — the link step must not abort the apply --------
-run_case f1-down down home
-[[ $RC -eq 0 ]] || fail "F1 down: expected exit 0, got $RC (stderr: $ERR)"
+marker_present() { [[ -f $MARKER ]]; }
 
-# --- F1: herdr returns an error envelope -----------------------------------
-run_case f1-errorjson errorjson home
-[[ $RC -eq 0 ]] || fail "F1 errorjson: expected exit 0, got $RC (stderr: $ERR)"
+# --- R1: missing cargo (absent everywhere) is a RETRYABLE non-success ---------
+run_case r1-none down none
+[[ $RC -eq 0 ]] || fail "R1 no-cargo: expected exit 0 (must never abort apply), got $RC ($ERR)"
+marker_present || fail "R1 no-cargo: retry marker not written — trigger would be consumed, no retry"
+[[ ! -e $CARGO_RECORD ]] || fail "R1 no-cargo: cargo ran despite being absent"
+[[ ! -e $SEED_RECORD ]] || fail "R1 no-cargo: seed ran despite the build being skipped"
 
-# --- F3: happy path — the script runs the built binary's `seed` subcommand --
-run_case f3-happy happy home
-[[ $RC -eq 0 ]] || fail "F3 happy: expected exit 0, got $RC (stderr: $ERR)"
-[[ -s $SEED_RECORD ]] || fail "F3 happy: the plugin binary was not run to seed the MRU"
-grep -qx 'seed' "$SEED_RECORD" ||
-  fail "F3 happy: binary not invoked as \`<binary> seed\` (recorded: $(cat "$SEED_RECORD"))"
+# --- R1: a PATH-only cargo counts as missing (absolute path authoritative) ----
+run_case r1-pathonly down pathonly
+[[ $RC -eq 0 ]] || fail "R1 pathonly: expected exit 0, got $RC ($ERR)"
+marker_present || fail "R1 pathonly: retry marker not written for a PATH-only (ignored) cargo"
+[[ ! -e $PATH_CARGO_RECORD ]] || fail "R1 pathonly: a PATH cargo was invoked ($(cat "$PATH_CARGO_RECORD"))"
+[[ ! -e $SEED_RECORD ]] || fail "R1 pathonly: seed ran despite the build being skipped"
 
-# --- F2: a PATH-only cargo must NOT be used (deterministic absolute path) ---
-run_case f2-pathonly happy pathonly
-[[ $RC -eq 0 ]] || fail "F2 pathonly: expected exit 0, got $RC (stderr: $ERR)"
-grep -qi 'cargo not found' <<<"$ERR" ||
-  fail "F2 pathonly: a PATH-only cargo must be ignored (skip-with-hint expected) ($ERR)"
-[[ ! -e $PATH_CARGO_RECORD ]] ||
-  fail "F2 pathonly: a PATH cargo was invoked; only ~/.cargo/bin/cargo is authoritative ($(cat "$PATH_CARGO_RECORD"))"
-[[ ! -e $SEED_RECORD ]] ||
-  fail "F2 pathonly: seed ran despite the build being skipped"
+# --- R2: build ok but herdr server down -> registration UNVERIFIED (retryable) -
+run_case r2-down down home
+[[ $RC -eq 0 ]] || fail "R2 down: expected exit 0, got $RC ($ERR)"
+[[ -s $CARGO_RECORD ]] || fail "R2 down: cargo did not build"
+marker_present || fail "R2 down: registration failed but retry marker not written (trigger consumed)"
 
-# --- F2: absolute cargo wins even when a PATH cargo also exists -------------
-run_case f2-both happy both
-[[ $RC -eq 0 ]] || fail "F2 both: expected exit 0, got $RC (stderr: $ERR)"
+# --- R2: build ok but herdr returns an error envelope -> UNVERIFIED (retryable) -
+run_case r2-errorjson errorjson home
+[[ $RC -eq 0 ]] || fail "R2 errorjson: expected exit 0, got $RC ($ERR)"
+marker_present || fail "R2 errorjson: error envelope not treated as retryable non-success"
+
+# --- R3: build ok + link registers the exact plugin -> SUCCESS (marker cleared) -
+run_case r3-linkok linkok home ok yes
+[[ $RC -eq 0 ]] || fail "R3 linkok: expected exit 0, got $RC ($ERR)"
+marker_present && fail "R3 linkok: retry marker still present after a verified registration (not cleared)"
+[[ -s $LINK_RECORD ]] || fail "R3 linkok: plugin was not linked"
+[[ -s $SEED_RECORD ]] || fail "R3 linkok: seed did not run after a successful build"
+
+# --- R3: already registered -> SUCCESS, link NOT attempted (idempotent) --------
+run_case r3-registered registered home
+[[ $RC -eq 0 ]] || fail "R3 registered: expected exit 0, got $RC ($ERR)"
+marker_present && fail "R3 registered: retry marker present despite the plugin already registered"
+[[ ! -e $LINK_RECORD ]] || fail "R3 registered: link attempted for an already-registered plugin ($(cat "$LINK_RECORD"))"
+
+# --- R4: a real cargo build failure fails LOUDLY (exit non-zero) ---------------
+run_case r4-buildfail linkok home fail
+[[ $RC -ne 0 ]] || fail "R4 buildfail: a compile failure must fail loudly (non-zero), got exit 0"
+grep -qi 'build failed' <<<"$ERR" || fail "R4 buildfail: missing a loud build-failure message ($ERR)"
+
+# --- F2: absolute cargo wins even when a PATH cargo also exists ----------------
+run_case f2-both linkok both
+[[ $RC -eq 0 ]] || fail "F2 both: expected exit 0, got $RC ($ERR)"
 [[ -s $CARGO_RECORD ]] || fail "F2 both: ~/.cargo/bin/cargo was not invoked"
 grep -q 'build' "$CARGO_RECORD" || fail "F2 both: absolute cargo not invoked to build ($(cat "$CARGO_RECORD"))"
-[[ ! -e $PATH_CARGO_RECORD ]] ||
-  fail "F2 both: the PATH cargo was invoked instead of the absolute path ($(cat "$PATH_CARGO_RECORD"))"
-[[ -s $SEED_RECORD ]] || fail "F2 both: seed did not run after a successful build"
+[[ ! -e $PATH_CARGO_RECORD ]] || fail "F2 both: the PATH cargo was invoked instead ($(cat "$PATH_CARGO_RECORD"))"
 
-# --- F2: cargo absent everywhere -------------------------------------------
-run_case f2-none down none
-[[ $RC -eq 0 ]] || fail "F2 no-cargo: expected exit 0 (must never abort apply), got $RC (stderr: $ERR)"
-grep -qi 'cargo not found' <<<"$ERR" || fail "F2 no-cargo: missing skip-with-hint message ($ERR)"
-[[ ! -e $CARGO_RECORD ]] || fail "F2 no-cargo: cargo ran despite being absent"
-[[ ! -e $SEED_RECORD ]] || fail "F2 no-cargo: seed ran despite the build being skipped"
-
-printf 'PASS: after_55 tolerates a down/erroring herdr server and a missing cargo toolchain, resolves cargo at the deterministic absolute path, and seeds via the built plugin binary\n'
+printf 'PASS: after_55 separates build from registration, treats missing cargo and unverified registration as retryable (marker present, exit 0), clears the marker on a verified exact-id registration, and fails loudly on a real build error\n'

--- a/test/herdr-build-scripts-resilience.sh
+++ b/test/herdr-build-scripts-resilience.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# herdr-build-scripts-resilience.sh — the herdr plugin build chezmoiscript
+# herdr-build-scripts-resilience.sh: the herdr plugin build chezmoiscript
 # (run_onchange_after_55) separates BUILD from REGISTRATION, each with its own
 # failure envelope, and treats a missing toolchain or an unverified registration
-# as a RETRYABLE non-success — NOT a satisfied trigger.
+# as a RETRYABLE non-success, NOT a satisfied trigger.
 #
 # This REVERSES the previous contract (which asserted "cargo absent -> exit 0,
 # never aborts", implying the trigger was consumed/satisfied). chezmoi records a
@@ -57,7 +57,7 @@ done
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-# Render the darwin-only script once (scratch HOME, CI=1 — same mechanics as the
+# Render the darwin-only script once (scratch HOME, CI=1; same mechanics as the
 # treefmt rendered-template lint). Empty render == non-darwin host: skip.
 rendered="$work/rendered.sh"
 render_home="$(mktemp -d)"
@@ -235,7 +235,7 @@ marker_present() { [[ -f $MARKER ]]; }
 # --- R1: missing cargo (absent everywhere) is a RETRYABLE non-success ---------
 run_case r1-none down none
 [[ $RC -eq 0 ]] || fail "R1 no-cargo: expected exit 0 (must never abort apply), got $RC ($ERR)"
-marker_present || fail "R1 no-cargo: retry marker not written — trigger would be consumed, no retry"
+marker_present || fail "R1 no-cargo: retry marker not written (trigger would be consumed, no retry)"
 [[ ! -e $CARGO_RECORD ]] || fail "R1 no-cargo: cargo ran despite being absent"
 [[ ! -e $SEED_RECORD ]] || fail "R1 no-cargo: seed ran despite the build being skipped"
 

--- a/test/herdr-build-scripts-resilience.sh
+++ b/test/herdr-build-scripts-resilience.sh
@@ -156,7 +156,9 @@ STUB
 # run_case <name> <herdr-mode> <cargo-mode> [build-mode] [pre-mark]
 #   cargo-mode: home | pathonly | both | none
 #   build-mode: ok | fail   (only meaningful when cargo is present)
-#   pre-mark:   yes -> pre-create the retry marker (to prove success clears it)
+#   pre-mark:   yes     -> pre-create the retry marker (proves success clears it)
+#               garbage -> pre-create it with a NON-numeric count (proves the
+#                          run-time normalization resets it before the bump)
 # Populates: RC, ERR, CASE_HOME, CARGO_RECORD, PATH_CARGO_RECORD, SEED_RECORD,
 #            LINK_RECORD, MARKER
 run_case() {
@@ -183,10 +185,22 @@ exit 0
 STUB
   chmod +x "$plugin_dir/target/release/last-workspace"
 
-  if [[ $pre_mark == yes ]]; then
-    mkdir -p "$(dirname "$MARKER")"
-    printf '2\n' >"$MARKER"
-  fi
+  case "$pre_mark" in
+    yes)
+      mkdir -p "$(dirname "$MARKER")"
+      printf '2\n' >"$MARKER"
+      ;;
+    garbage)
+      # 12abc is deliberately arithmetic-hostile: without the run-time
+      # normalization, $((12abc + 1)) is a syntax error that aborts the
+      # rendered script under set -e (a bare identifier like 'garbage' would
+      # evaluate to 0 and mask the missing guard).
+      mkdir -p "$(dirname "$MARKER")"
+      printf '12abc\n' >"$MARKER"
+      ;;
+    no) ;;
+    *) fail "unknown pre-mark mode: $pre_mark" ;;
+  esac
 
   local case_path
   case "$cargo_mode" in
@@ -232,6 +246,15 @@ marker_present || fail "R1 pathonly: retry marker not written for a PATH-only (i
 [[ ! -e $PATH_CARGO_RECORD ]] || fail "R1 pathonly: a PATH cargo was invoked ($(cat "$PATH_CARGO_RECORD"))"
 [[ ! -e $SEED_RECORD ]] || fail "R1 pathonly: seed ran despite the build being skipped"
 
+# --- R1: a GARBAGE marker count is reset at run time (normalization guard) ----
+# The bump normalizes a non-numeric stored count to 0 before incrementing, so
+# a corrupted marker yields a clean count of 1, not a shell arithmetic error.
+run_case r1-garbage-marker down none ok garbage
+[[ $RC -eq 0 ]] || fail "R1 garbage-marker: expected exit 0, got $RC ($ERR)"
+marker_present || fail "R1 garbage-marker: retry marker missing after the bump"
+[[ "$(cat "$MARKER")" == "1" ]] ||
+  fail "R1 garbage-marker: a garbage count was not reset before the bump (got '$(cat "$MARKER")', expected 1)"
+
 # --- R2: build ok but herdr server down -> registration UNVERIFIED (retryable) -
 run_case r2-down down home
 [[ $RC -eq 0 ]] || fail "R2 down: expected exit 0, got $RC ($ERR)"
@@ -266,6 +289,13 @@ run_case f2-both linkok both
 [[ $RC -eq 0 ]] || fail "F2 both: expected exit 0, got $RC ($ERR)"
 [[ -s $CARGO_RECORD ]] || fail "F2 both: ~/.cargo/bin/cargo was not invoked"
 grep -q 'build' "$CARGO_RECORD" || fail "F2 both: absolute cargo not invoked to build ($(cat "$CARGO_RECORD"))"
+# The exact build argv matters: --release places the binary where the seed and
+# the plugin manifest expect it, and --locked keeps the vendored Cargo.lock
+# authoritative so the lockfile cannot drift on apply.
+grep -qw -- '--release' "$CARGO_RECORD" ||
+  fail "F2 both: cargo argv lacks --release ($(cat "$CARGO_RECORD"))"
+grep -qw -- '--locked' "$CARGO_RECORD" ||
+  fail "F2 both: cargo argv lacks --locked ($(cat "$CARGO_RECORD"))"
 [[ ! -e $PATH_CARGO_RECORD ]] || fail "F2 both: the PATH cargo was invoked instead ($(cat "$PATH_CARGO_RECORD"))"
 
 printf 'PASS: after_55 separates build from registration, treats missing cargo and unverified registration as retryable (marker present, exit 0), clears the marker on a verified exact-id registration, and fails loudly on a real build error\n'

--- a/test/herdr-health-check-timeout.sh
+++ b/test/herdr-health-check-timeout.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# herdr-health-check-timeout.sh: a wedged herdr socket (accepts the connection
+# but never replies) would hang `herdr plugin list` / `herdr session list` /
+# `herdr server reload-config` forever. The shared health-check partial
+# (.chezmoitemplates/herdr-health-check.sh.tmpl) runs on every apply through
+# its includers, so one wedged server would block ALL future applies. Every
+# herdr call in the predicate must therefore be bounded by a coreutils timeout;
+# an expiry counts as unhealthy (not-verified), never as a hang.
+#
+# This drives the predicate through BOTH real include sites with a herdr stub
+# that sleeps far past the per-call bound (the "never replies" wedge), each run
+# wrapped in an OUTER watchdog. A run that returns 124 from the watchdog is a
+# hang and fails the test; the fixed predicate returns well within the bound
+# and yields the not-verified outcome (before_10 defers --cleanup; after_58
+# writes no stamp).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BEFORE_10="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+AFTER_58="$REPO_ROOT/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl"
+STAMP_REL=".cache/herdr-migration/verified"
+WATCHDOG_SECONDS=30
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# The outer watchdog needs a coreutils timeout binary too; the whole point is
+# that one exists (coreutils is a declared formula). If neither is present the
+# test cannot assert bounded completion, so skip rather than hang.
+watchdog_bin=""
+if command -v timeout >/dev/null 2>&1; then
+  watchdog_bin="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  watchdog_bin="gtimeout"
+else
+  printf 'SKIP: no coreutils timeout/gtimeout on PATH; cannot run the watchdog\n'
+  exit 0
+fi
+
+for tool in chezmoi jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot render/run the health-check includers\n' "$tool"
+    exit 0
+  fi
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+render_into() {
+  local script="$1" home="$2" out="$3"
+  HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+    <"$script" >"$out" || fail "chezmoi failed to render $script"
+}
+
+# A herdr stub that never replies: every subcommand sleeps far past the bound.
+# --version sleeps too, so the FIRST bounded call already proves the timeout.
+make_sleeping_herdr() {
+  local dir="$1"
+  cat >"$dir/herdr" <<'STUB'
+#!/bin/bash
+sleep 300
+exit 0
+STUB
+  chmod +x "$dir/herdr"
+}
+
+# Stub Homebrew prefix for before_10: brew list reports tmux installed so the
+# script reaches the multiplexer branch; bundle records its argv.
+build_stub_prefix() {
+  local prefix="$1"
+  mkdir -p "$prefix/bin"
+  cat >"$prefix/bin/brew" <<'STUB'
+#!/bin/bash
+case "$1" in
+  list)
+    [[ $2 == tmux ]] && exit 0
+    exit 1 ;;
+  bundle)
+    printf '%s\n' "$*" >>"$BUNDLE_RECORD"
+    cat >/dev/null
+    exit 0 ;;
+esac
+exit 0
+STUB
+  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/uv"
+  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/volta"
+  chmod +x "$prefix/bin/brew" "$prefix/bin/uv" "$prefix/bin/volta"
+}
+
+# --- before_10 include site ------------------------------------------------
+# tmux installed + stamp present drives the current before_10 into its live
+# health check. A wedged herdr must not hang it: it must return within the
+# bound and defer --cleanup (never remove tmux while herdr is unproven).
+b10_home="$work/b10/home"
+b10_prefix="$work/b10/prefix"
+b10_bin="$work/b10/bin"
+b10_bundle="$work/b10/bundle-argv"
+mkdir -p "$b10_home/.config/herdr" "$b10_bin"
+build_stub_prefix "$b10_prefix"
+make_sleeping_herdr "$b10_bin"
+printf '#!/bin/bash\nexit 0\n' >"$b10_bin/npm"
+chmod +x "$b10_bin/npm"
+printf 'x = 1\n' >"$b10_home/.config/herdr/config.toml"
+mkdir -p "$b10_home/$(dirname "$STAMP_REL")"
+: >"$b10_home/$STAMP_REL"
+b10_rendered="$work/b10-rendered.sh"
+render_into "$BEFORE_10" "$b10_home" "$b10_rendered"
+if [[ ! -s $b10_rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+b10_rc=0
+HOME="$b10_home" HOMEBREW_PREFIX="$b10_prefix" PATH="$b10_bin:$PATH" \
+  INSTALLED_PKGS="tmux" BUNDLE_RECORD="$b10_bundle" \
+  "$watchdog_bin" "$WATCHDOG_SECONDS" bash "$b10_rendered" >/dev/null 2>"$work/b10-stderr" || b10_rc=$?
+[[ $b10_rc -ne 124 ]] ||
+  fail "before_10: a wedged herdr socket hung the health check past ${WATCHDOG_SECONDS}s (no bounded timeout on the herdr calls)"
+[[ $b10_rc -eq 0 ]] ||
+  fail "before_10: script errored under a wedged herdr (rc=$b10_rc; stderr: $(cat "$work/b10-stderr"))"
+grep -qw -- '--cleanup' "$b10_bundle" &&
+  fail "before_10: --cleanup passed though the live health check could not prove herdr (wedged socket)"
+
+# --- after_58 include site -------------------------------------------------
+# after_58 runs the health check on every apply. A wedged herdr must not hang
+# it: it must return within the bound and write no stamp.
+a58_home="$work/a58/home"
+a58_bin="$work/a58/bin"
+mkdir -p "$a58_home/.config/herdr" "$a58_bin"
+make_sleeping_herdr "$a58_bin"
+printf 'x = 1\n' >"$a58_home/.config/herdr/config.toml"
+a58_rendered="$work/a58-rendered.sh"
+render_into "$AFTER_58" "$a58_home" "$a58_rendered"
+a58_rc=0
+HOME="$a58_home" PATH="$a58_bin:$PATH" \
+  "$watchdog_bin" "$WATCHDOG_SECONDS" bash "$a58_rendered" >/dev/null 2>"$work/a58-stderr" || a58_rc=$?
+[[ $a58_rc -ne 124 ]] ||
+  fail "after_58: a wedged herdr socket hung the health check past ${WATCHDOG_SECONDS}s (no bounded timeout on the herdr calls)"
+[[ $a58_rc -eq 0 ]] ||
+  fail "after_58: script errored under a wedged herdr (rc=$a58_rc; stderr: $(cat "$work/a58-stderr"))"
+[[ ! -f $a58_home/$STAMP_REL ]] ||
+  fail "after_58: the verified stamp was written though herdr never replied (wedged socket)"
+
+printf 'PASS: every herdr call in the shared predicate is bounded by a coreutils timeout; a wedged (never-replying) herdr yields not-verified within the bound at BOTH include sites (before_10 defers --cleanup, after_58 writes no stamp) instead of hanging the apply\n'

--- a/test/herdr-health-check-timeout.sh
+++ b/test/herdr-health-check-timeout.sh
@@ -2,23 +2,21 @@
 # herdr-health-check-timeout.sh: a wedged herdr socket (accepts the connection
 # but never replies) would hang `herdr plugin list` / `herdr session list` /
 # `herdr server reload-config` forever. The shared health-check partial
-# (.chezmoitemplates/herdr-health-check.sh.tmpl) runs on every apply through
-# its includers, so one wedged server would block ALL future applies. Every
-# herdr call in the predicate must therefore be bounded by a coreutils timeout;
-# an expiry counts as unhealthy (not-verified), never as a hang.
+# (.chezmoitemplates/herdr-health-check.sh.tmpl) runs on every apply through its
+# includer (run_after_58), so one wedged server would block ALL future applies.
+# Every herdr call in the predicate must therefore be bounded by a coreutils
+# timeout; an expiry counts as unhealthy (not-verified), never as a hang.
 #
-# This drives the predicate through BOTH real include sites with a herdr stub
-# that sleeps far past the per-call bound (the "never replies" wedge), each run
-# wrapped in an OUTER watchdog. A run that returns 124 from the watchdog is a
-# hang and fails the test; the fixed predicate returns well within the bound
-# and yields the not-verified outcome (before_10 defers --cleanup; after_58
-# writes no stamp).
+# This drives the predicate through its real include site (after_58) with a
+# herdr stub that sleeps far past the per-call bound (the "never replies" wedge)
+# and a legacy multiplexer installed so the health check is actually reached,
+# the whole run wrapped in an OUTER watchdog. A run that returns 124 from the
+# watchdog is a hang and fails the test; the fixed predicate returns well within
+# the bound and yields the not-verified outcome (no cleanup is performed).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BEFORE_10="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
 AFTER_58="$REPO_ROOT/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl"
-STAMP_REL=".cache/herdr-migration/verified"
 WATCHDOG_SECONDS=30
 
 fail() {
@@ -41,19 +39,13 @@ fi
 
 for tool in chezmoi jq; do
   if ! command -v "$tool" >/dev/null 2>&1; then
-    printf 'SKIP: %s not on PATH; cannot render/run the health-check includers\n' "$tool"
+    printf 'SKIP: %s not on PATH; cannot render/run the health-check includer\n' "$tool"
     exit 0
   fi
 done
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-
-render_into() {
-  local script="$1" home="$2" out="$3"
-  HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
-    <"$script" >"$out" || fail "chezmoi failed to render $script"
-}
 
 # A herdr stub that never replies: every subcommand sleeps far past the bound.
 # --version sleeps too, so the FIRST bounded call already proves the timeout.
@@ -67,12 +59,11 @@ STUB
   chmod +x "$dir/herdr"
 }
 
-# Stub Homebrew prefix for before_10: brew list reports tmux installed so the
-# script reaches the multiplexer branch; bundle records its argv.
-build_stub_prefix() {
-  local prefix="$1"
-  mkdir -p "$prefix/bin"
-  cat >"$prefix/bin/brew" <<'STUB'
+# Stub brew so after_58 sees tmux installed (reaching the health check) and can
+# record any bundle cleanup argv. A wedged herdr must never let cleanup run.
+make_brew_stub() {
+  local dir="$1"
+  cat >"$dir/brew" <<'STUB'
 #!/bin/bash
 case "$1" in
   list)
@@ -85,62 +76,37 @@ case "$1" in
 esac
 exit 0
 STUB
-  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/uv"
-  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/volta"
-  chmod +x "$prefix/bin/brew" "$prefix/bin/uv" "$prefix/bin/volta"
+  chmod +x "$dir/brew"
 }
 
-# --- before_10 include site ------------------------------------------------
-# tmux installed + stamp present drives the current before_10 into its live
-# health check. A wedged herdr must not hang it: it must return within the
-# bound and defer --cleanup (never remove tmux while herdr is unproven).
-b10_home="$work/b10/home"
-b10_prefix="$work/b10/prefix"
-b10_bin="$work/b10/bin"
-b10_bundle="$work/b10/bundle-argv"
-mkdir -p "$b10_home/.config/herdr" "$b10_bin"
-build_stub_prefix "$b10_prefix"
-make_sleeping_herdr "$b10_bin"
-printf '#!/bin/bash\nexit 0\n' >"$b10_bin/npm"
-chmod +x "$b10_bin/npm"
-printf 'x = 1\n' >"$b10_home/.config/herdr/config.toml"
-mkdir -p "$b10_home/$(dirname "$STAMP_REL")"
-: >"$b10_home/$STAMP_REL"
-b10_rendered="$work/b10-rendered.sh"
-render_into "$BEFORE_10" "$b10_home" "$b10_rendered"
-if [[ ! -s $b10_rendered ]]; then
+# after_58 runs the health check on every apply once a legacy multiplexer is
+# installed. A wedged herdr must not hang it: it must return within the bound
+# and perform no cleanup.
+a58_home="$work/a58/home"
+a58_prefix="$work/a58/prefix"
+a58_bin="$work/a58/bin"
+a58_bundle="$work/a58/bundle-argv"
+mkdir -p "$a58_home/.config/herdr" "$a58_prefix/bin" "$a58_bin"
+make_sleeping_herdr "$a58_bin"
+make_brew_stub "$a58_prefix/bin"
+printf 'x = 1\n' >"$a58_home/.config/herdr/config.toml"
+a58_rendered="$work/a58-rendered.sh"
+HOME="$a58_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$AFTER_58" >"$a58_rendered" || fail "chezmoi failed to render $AFTER_58"
+if [[ ! -s $a58_rendered ]]; then
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi
-b10_rc=0
-HOME="$b10_home" HOMEBREW_PREFIX="$b10_prefix" PATH="$b10_bin:$PATH" \
-  INSTALLED_PKGS="tmux" BUNDLE_RECORD="$b10_bundle" \
-  "$watchdog_bin" "$WATCHDOG_SECONDS" bash "$b10_rendered" >/dev/null 2>"$work/b10-stderr" || b10_rc=$?
-[[ $b10_rc -ne 124 ]] ||
-  fail "before_10: a wedged herdr socket hung the health check past ${WATCHDOG_SECONDS}s (no bounded timeout on the herdr calls)"
-[[ $b10_rc -eq 0 ]] ||
-  fail "before_10: script errored under a wedged herdr (rc=$b10_rc; stderr: $(cat "$work/b10-stderr"))"
-grep -qw -- '--cleanup' "$b10_bundle" &&
-  fail "before_10: --cleanup passed though the live health check could not prove herdr (wedged socket)"
-
-# --- after_58 include site -------------------------------------------------
-# after_58 runs the health check on every apply. A wedged herdr must not hang
-# it: it must return within the bound and write no stamp.
-a58_home="$work/a58/home"
-a58_bin="$work/a58/bin"
-mkdir -p "$a58_home/.config/herdr" "$a58_bin"
-make_sleeping_herdr "$a58_bin"
-printf 'x = 1\n' >"$a58_home/.config/herdr/config.toml"
-a58_rendered="$work/a58-rendered.sh"
-render_into "$AFTER_58" "$a58_home" "$a58_rendered"
 a58_rc=0
-HOME="$a58_home" PATH="$a58_bin:$PATH" \
+HOME="$a58_home" HOMEBREW_PREFIX="$a58_prefix" PATH="$a58_bin:$PATH" \
+  INSTALLED_PKGS="tmux" BUNDLE_RECORD="$a58_bundle" \
   "$watchdog_bin" "$WATCHDOG_SECONDS" bash "$a58_rendered" >/dev/null 2>"$work/a58-stderr" || a58_rc=$?
 [[ $a58_rc -ne 124 ]] ||
   fail "after_58: a wedged herdr socket hung the health check past ${WATCHDOG_SECONDS}s (no bounded timeout on the herdr calls)"
 [[ $a58_rc -eq 0 ]] ||
   fail "after_58: script errored under a wedged herdr (rc=$a58_rc; stderr: $(cat "$work/a58-stderr"))"
-[[ ! -f $a58_home/$STAMP_REL ]] ||
-  fail "after_58: the verified stamp was written though herdr never replied (wedged socket)"
+if [[ -f $a58_bundle ]] && grep -q 'cleanup' "$a58_bundle"; then
+  fail "after_58: brew bundle cleanup ran though herdr never replied (wedged socket)"
+fi
 
-printf 'PASS: every herdr call in the shared predicate is bounded by a coreutils timeout; a wedged (never-replying) herdr yields not-verified within the bound at BOTH include sites (before_10 defers --cleanup, after_58 writes no stamp) instead of hanging the apply\n'
+printf 'PASS: every herdr call in the shared predicate is bounded by a coreutils timeout; a wedged (never-replying) herdr yields not-verified within the bound at the after_58 include site (no cleanup performed) instead of hanging the apply\n'

--- a/test/herdr-migration-ordering.sh
+++ b/test/herdr-migration-ordering.sh
@@ -88,7 +88,8 @@ case "$1" in
   tap | trust | autoupdate) exit 0 ;;
   list)
     pkg="$2"
-    for installed in $INSTALLED_PKGS; do
+    read -ra installed_packages <<<"$INSTALLED_PKGS"
+    for installed in "${installed_packages[@]}"; do
       [[ $pkg == "$installed" ]] && exit 0
     done
     exit 1 ;;

--- a/test/herdr-migration-ordering.sh
+++ b/test/herdr-migration-ordering.sh
@@ -1,34 +1,29 @@
 #!/usr/bin/env bash
-# herdr-migration-ordering.sh: run_onchange_before_10-system-packages must NOT
-# let `brew bundle --cleanup` remove the old multiplexer (tmux/sesh) before
-# herdr is installed AND currently healthy. `--cleanup` uninstalls anything
-# installed but absent from the desired set, so once tmux/sesh leave the
-# manifest a bare --cleanup on a not-yet-migrated machine would strip the only
-# multiplexer the moment before herdr's install/verify; if that fails, the
-# machine is stranded.
+# herdr-migration-ordering.sh: run_onchange_before_10-system-packages must NEVER
+# remove the old multiplexer (tmux/sesh) itself. `brew bundle --cleanup`
+# uninstalls anything installed but absent from the desired set, so once
+# tmux/sesh leave the manifest a --cleanup here would strip the only multiplexer.
+# Chezmoi runs ALL before_ scripts, THEN updates target files, THEN runs after_
+# scripts, so a --cleanup in this before_ script would validate/tear down against
+# the PREVIOUS revision and a broken new revision would only surface after the
+# fallback was gone. The teardown therefore lives in run_after_58
+# (post-target-update); before_10's only job is to WITHHOLD --cleanup while a
+# legacy multiplexer is installed.
 #
-# The invariant has two halves:
-#
-#   1. TRIGGER: the stamp run_after_58 writes must be part of before_10's
-#      RENDERED body (a presence boolean), because chezmoi re-runs a
-#      run_onchange script only when its rendered content changes. Without
-#      this, the stamp write at apply N would not re-fire before_10 at apply
-#      N+1 and the teardown would wait for an unrelated package-data edit.
-#   2. AUTHORITY: cleanup passes only when the stamp is present AND a LIVE
-#      herdr health check succeeds in the same apply. A stale stamp (written
-#      while healthy, herdr broken since) must NOT authorize the teardown.
-#
-# Short-circuit: when neither tmux nor sesh is installed (already migrated),
-# cleanup always proceeds and the health check is skipped entirely.
+# Invariant: while tmux OR sesh is installed, before_10 runs `brew bundle`
+# WITHOUT --cleanup and prints a deferral note that names the interactive
+# activation step (open a terminal so the herdr server starts, then re-apply so
+# after_58 verifies and cleans). When neither is installed (already migrated),
+# --cleanup proceeds normally. before_10 makes NO herdr contact and consults no
+# stamp -- all migration verification moved to after_58.
 #
 # This renders the REAL before_10 and runs it with a stub Homebrew prefix
-# (brew/uv/volta), a stub npm, and a stub herdr on PATH; nothing real is
-# installed. The exact `brew bundle` argv and the stderr warnings are captured.
+# (brew/uv/volta) and a stub npm on PATH; nothing real is installed. The exact
+# `brew bundle` argv and the stderr warnings are captured.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
-STAMP_REL=".cache/herdr-migration/verified"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -46,35 +41,15 @@ done
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-render_into() {
-  local home="$1" out="$2"
-  HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
-    <"$SCRIPT" >"$out" || fail "chezmoi failed to render $SCRIPT (HOME=$home)"
-}
-
-# --- render-level trigger oracle (stamp presence must change the render) -----
-# chezmoi re-runs a run_onchange script only when its rendered content changes,
-# so the stamp's PRESENCE must be interpolated into the body. Render once with
-# the stamp absent and once with it present: the two bodies must differ. This
-# is the exact regression oracle for "the stamp write re-fires before_10".
-no_stamp_home="$work/render-no-stamp"
-stamp_home="$work/render-stamp"
-mkdir -p "$no_stamp_home" "$stamp_home/$(dirname "$STAMP_REL")"
-: >"$stamp_home/$STAMP_REL"
-render_into "$no_stamp_home" "$work/render-no-stamp.sh"
-render_into "$stamp_home" "$work/render-stamp.sh"
-if [[ ! -s $work/render-no-stamp.sh ]]; then
+rendered="$work/rendered.sh"
+render_home="$work/render-home"
+mkdir -p "$render_home"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+if [[ ! -s $rendered ]]; then
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi
-if cmp -s "$work/render-no-stamp.sh" "$work/render-stamp.sh"; then
-  fail "rendered before_10 is identical with and without the stamp; the stamp write would never re-fire the run_onchange trigger (cleanup would wait for an unrelated package-data edit)"
-fi
-
-# The runtime cases below all execute the no-stamp render; the stamp check and
-# the health check both happen at RUN time, so one rendered body exercises
-# every case.
-rendered="$work/render-no-stamp.sh"
 
 # Stub Homebrew prefix: brew (tap/trust/list/bundle/autoupdate), uv, volta.
 # brew `list <pkg>` reports "installed" only for names in $INSTALLED_PKGS;
@@ -105,59 +80,18 @@ STUB
   chmod +x "$prefix/bin/brew" "$prefix/bin/uv" "$prefix/bin/volta"
 }
 
-# Stub herdr, two modes:
-#   healthy -> version ok, both plugins registered+enabled+warning-free,
-#              session running, config reload applied with no diagnostics
-#   broken  -> every invocation fails (the binary does not run)
-make_herdr_stub() {
-  local dir="$1" mode="$2"
-  cat >"$dir/herdr" <<STUB
-#!/bin/bash
-mode="$mode"
-if [[ \$mode == broken ]]; then
-  exit 1
-fi
-if [[ \$1 == --version ]]; then
-  echo "herdr 0.7.0-test"
-  exit 0
-fi
-sub="\$1 \$2"
-case "\$sub" in
-  "plugin list")
-    # args: plugin list --plugin <id> --json
-    id="\$4"
-    printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true}],"type":"plugin_list"}}\n' "\$id"
-    exit 0 ;;
-  "session list")
-    printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'
-    exit 0 ;;
-  "server reload-config")
-    printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}\n'
-    exit 0 ;;
-esac
-exit 0
-STUB
-  chmod +x "$dir/herdr"
-}
-
-# run_case <name> <installed-pkgs> <stamp?> <herdr-mode>
+# run_case <name> <installed-pkgs>
 run_case() {
-  local name="$1" installed="$2" stamp="$3" herdr_mode="$4"
+  local name="$1" installed="$2"
   local case_home="$work/$name/home"
   local prefix="$work/$name/prefix"
   local path_bin="$work/$name/path-bin"
   BUNDLE_RECORD="$work/$name/bundle-argv"
   ERR_FILE="$work/$name/stderr"
-  mkdir -p "$case_home/.config/herdr" "$path_bin"
+  mkdir -p "$case_home" "$path_bin"
   build_stub_prefix "$prefix"
-  make_herdr_stub "$path_bin" "$herdr_mode"
   printf '#!/bin/bash\nexit 0\n' >"$path_bin/npm"
   chmod +x "$path_bin/npm"
-  printf 'x = 1\n' >"$case_home/.config/herdr/config.toml"
-  if [[ $stamp == stamp ]]; then
-    mkdir -p "$case_home/$(dirname "$STAMP_REL")"
-    : >"$case_home/$STAMP_REL"
-  fi
   RC=0
   HOME="$case_home" HOMEBREW_PREFIX="$prefix" \
     PATH="$path_bin:$PATH" INSTALLED_PKGS="$installed" BUNDLE_RECORD="$BUNDLE_RECORD" \
@@ -166,40 +100,29 @@ run_case() {
 
 cleanup_used() { grep -qw -- '--cleanup' "$BUNDLE_RECORD"; }
 
-# tmux still installed, no stamp -> defer cleanup, and SAY so (the deferral
-# warning is part of the contract: silently withholding --cleanup would leave
-# the operator with no clue why tmux/sesh survive).
-run_case tmux-no-stamp "tmux" no-stamp healthy
-[[ $RC -eq 0 ]] || fail "tmux-no-stamp: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-[[ -s $BUNDLE_RECORD ]] || fail "tmux-no-stamp: brew bundle was never invoked"
-cleanup_used && fail "tmux-no-stamp: --cleanup passed though tmux is installed and herdr is unverified (would strand the machine)"
+# tmux still installed -> defer cleanup, and SAY so, naming the interactive
+# activation step (the deferral note is part of the contract: silently
+# withholding --cleanup would leave the operator with no clue why tmux/sesh
+# survive or how to finish the migration).
+run_case tmux-present "tmux"
+[[ $RC -eq 0 ]] || fail "tmux-present: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ -s $BUNDLE_RECORD ]] || fail "tmux-present: brew bundle was never invoked"
+cleanup_used && fail "tmux-present: --cleanup passed though tmux is installed (before_10 must never tear down the multiplexer)"
 grep -q 'WITHOUT --cleanup' "$ERR_FILE" ||
-  fail "tmux-no-stamp: the deferral warning was not printed (stderr: $(cat "$ERR_FILE"))"
+  fail "tmux-present: the deferral note was not printed (stderr: $(cat "$ERR_FILE"))"
+grep -qi 'interactive terminal' "$ERR_FILE" ||
+  fail "tmux-present: the deferral note does not name the interactive activation step (stderr: $(cat "$ERR_FILE"))"
+grep -q 'after_58' "$ERR_FILE" ||
+  fail "tmux-present: the deferral note does not point at after_58 as the teardown owner (stderr: $(cat "$ERR_FILE"))"
 
-# sesh still installed, no stamp -> defer cleanup.
-run_case sesh-no-stamp "sesh" no-stamp healthy
-cleanup_used && fail "sesh-no-stamp: --cleanup passed though sesh is installed and herdr is unverified"
+# sesh still installed -> defer cleanup too.
+run_case sesh-present "sesh"
+[[ $RC -eq 0 ]] || fail "sesh-present: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+cleanup_used && fail "sesh-present: --cleanup passed though sesh is installed"
 
-# tmux installed, stamp present, herdr LIVE-healthy -> cleanup proceeds.
-run_case tmux-stamp-healthy "tmux" stamp healthy
-[[ $RC -eq 0 ]] || fail "tmux-stamp-healthy: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-cleanup_used || fail "tmux-stamp-healthy: --cleanup not passed though the stamp is present and herdr is live-healthy (migration would never complete)"
+# Neither installed (already migrated) -> --cleanup proceeds normally.
+run_case none "wget"
+[[ $RC -eq 0 ]] || fail "none: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+cleanup_used || fail "none: --cleanup withheld though no multiplexer is installed (migrated machines must still get cleanup)"
 
-# tmux installed, stamp present, herdr NOW BROKEN -> the stale stamp must NOT
-# authorize the teardown: the live health check is the cleanup authority.
-run_case tmux-stamp-stale "tmux" stamp broken
-[[ $RC -eq 0 ]] || fail "tmux-stamp-stale: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-cleanup_used && fail "tmux-stamp-stale: --cleanup passed on a STALE stamp though herdr is currently broken (would remove the only working multiplexer)"
-grep -qi 'stale' "$ERR_FILE" ||
-  fail "tmux-stamp-stale: no stale-stamp warning printed (stderr: $(cat "$ERR_FILE"))"
-
-# No multiplexer installed -> cleanup proceeds regardless of stamp or herdr
-# health (nothing to strand; the machine is already migrated). herdr broken in
-# both cases proves the gate and the health check are skipped entirely.
-run_case none-no-stamp "" no-stamp broken
-cleanup_used || fail "none-no-stamp: --cleanup withheld though no multiplexer is installed (nothing to strand)"
-
-run_case none-stamp "" stamp broken
-cleanup_used || fail "none-stamp: --cleanup withheld though no multiplexer is installed"
-
-printf 'PASS: before_10 renders the stamp presence into its trigger, defers cleanup while tmux/sesh is installed unless the stamp is present AND herdr passes a live health check, warns on deferral and on a stale stamp, and skips the gate when no multiplexer remains\n'
+printf 'PASS: before_10 withholds --cleanup while tmux/sesh is installed (deferral note names the interactive activation step and after_58 as the teardown owner), makes no herdr contact, and lets --cleanup proceed once no multiplexer remains\n'

--- a/test/herdr-migration-ordering.sh
+++ b/test/herdr-migration-ordering.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# herdr-migration-ordering.sh — run_onchange_before_10-system-packages must NOT
+# let `brew bundle --cleanup` remove the old multiplexer (tmux/sesh) before herdr
+# is installed AND verified. `--cleanup` uninstalls anything installed but absent
+# from the desired set, so once tmux/sesh leave the manifest a bare --cleanup on
+# a not-yet-migrated machine would strip the only multiplexer the moment before
+# herdr's install/verify — if that fails, the machine is stranded.
+#
+# The invariant: pass --cleanup UNLESS (tmux or sesh is still installed AND the
+# herdr-verified stamp is absent). The stamp is written by run_after_58 (proven
+# in herdr-migration-verify.sh). This renders the REAL before_10 and runs it with
+# a stub Homebrew prefix (brew/uv/volta) and a stub npm on PATH — nothing real is
+# installed — capturing the exact `brew bundle` argv.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+fi
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Stub Homebrew prefix: brew (tap/trust/list/bundle/autoupdate), uv, volta. brew
+# `list <pkg>` reports "installed" only for names in $INSTALLED_PKGS; `bundle`
+# records its argv and swallows the Brewfile on stdin.
+build_stub_prefix() {
+  local prefix="$1"
+  mkdir -p "$prefix/bin"
+  cat >"$prefix/bin/brew" <<'STUB'
+#!/bin/bash
+case "$1" in
+  tap | trust | autoupdate) exit 0 ;;
+  list)
+    pkg="$2"
+    for installed in $INSTALLED_PKGS; do
+      [[ $pkg == "$installed" ]] && exit 0
+    done
+    exit 1 ;;
+  bundle)
+    printf '%s\n' "$*" >>"$BUNDLE_RECORD"
+    cat >/dev/null
+    exit 0 ;;
+esac
+exit 0
+STUB
+  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/uv"
+  printf '#!/bin/bash\nexit 0\n' >"$prefix/bin/volta"
+  chmod +x "$prefix/bin/brew" "$prefix/bin/uv" "$prefix/bin/volta"
+}
+
+# run_case <name> <installed-pkgs> <stamp?>
+run_case() {
+  local name="$1" installed="$2" stamp="$3"
+  local case_home="$work/$name/home"
+  local prefix="$work/$name/prefix"
+  local path_bin="$work/$name/path-bin"
+  BUNDLE_RECORD="$work/$name/bundle-argv"
+  mkdir -p "$case_home" "$path_bin"
+  build_stub_prefix "$prefix"
+  printf '#!/bin/bash\nexit 0\n' >"$path_bin/npm"
+  chmod +x "$path_bin/npm"
+  if [[ $stamp == stamp ]]; then
+    mkdir -p "$case_home/.cache/herdr-migration"
+    : >"$case_home/.cache/herdr-migration/verified"
+  fi
+  RC=0
+  HOME="$case_home" HOMEBREW_PREFIX="$prefix" \
+    PATH="$path_bin:$PATH" INSTALLED_PKGS="$installed" BUNDLE_RECORD="$BUNDLE_RECORD" \
+    bash "$rendered" >/dev/null 2>&1 || RC=$?
+}
+
+cleanup_used() { grep -qw -- '--cleanup' "$BUNDLE_RECORD"; }
+
+# tmux still installed, herdr NOT verified -> defer cleanup (no --cleanup).
+run_case tmux-no-stamp "tmux" no-stamp
+[[ $RC -eq 0 ]] || fail "tmux-no-stamp: script errored (rc=$RC)"
+[[ -s $BUNDLE_RECORD ]] || fail "tmux-no-stamp: brew bundle was never invoked"
+cleanup_used && fail "tmux-no-stamp: --cleanup passed though tmux is installed and herdr is unverified (would strand the machine)"
+
+# sesh still installed, herdr NOT verified -> defer cleanup.
+run_case sesh-no-stamp "sesh" no-stamp
+cleanup_used && fail "sesh-no-stamp: --cleanup passed though sesh is installed and herdr is unverified"
+
+# tmux installed, herdr verified (stamp) -> cleanup proceeds.
+run_case tmux-stamp "tmux" stamp
+cleanup_used || fail "tmux-stamp: --cleanup not passed though herdr is verified (migration would never complete)"
+
+# No multiplexer installed -> cleanup proceeds regardless of stamp.
+run_case none-no-stamp "" no-stamp
+cleanup_used || fail "none-no-stamp: --cleanup withheld though no multiplexer is installed (nothing to strand)"
+
+run_case none-stamp "" stamp
+cleanup_used || fail "none-stamp: --cleanup withheld though no multiplexer is installed"
+
+printf 'PASS: before_10 defers brew bundle --cleanup while tmux/sesh is installed and herdr is unverified, and passes it once herdr is verified or no multiplexer is present\n'

--- a/test/herdr-migration-ordering.sh
+++ b/test/herdr-migration-ordering.sh
@@ -1,48 +1,84 @@
 #!/usr/bin/env bash
-# herdr-migration-ordering.sh — run_onchange_before_10-system-packages must NOT
-# let `brew bundle --cleanup` remove the old multiplexer (tmux/sesh) before herdr
-# is installed AND verified. `--cleanup` uninstalls anything installed but absent
-# from the desired set, so once tmux/sesh leave the manifest a bare --cleanup on
-# a not-yet-migrated machine would strip the only multiplexer the moment before
-# herdr's install/verify — if that fails, the machine is stranded.
+# herdr-migration-ordering.sh: run_onchange_before_10-system-packages must NOT
+# let `brew bundle --cleanup` remove the old multiplexer (tmux/sesh) before
+# herdr is installed AND currently healthy. `--cleanup` uninstalls anything
+# installed but absent from the desired set, so once tmux/sesh leave the
+# manifest a bare --cleanup on a not-yet-migrated machine would strip the only
+# multiplexer the moment before herdr's install/verify; if that fails, the
+# machine is stranded.
 #
-# The invariant: pass --cleanup UNLESS (tmux or sesh is still installed AND the
-# herdr-verified stamp is absent). The stamp is written by run_after_58 (proven
-# in herdr-migration-verify.sh). This renders the REAL before_10 and runs it with
-# a stub Homebrew prefix (brew/uv/volta) and a stub npm on PATH — nothing real is
-# installed — capturing the exact `brew bundle` argv.
+# The invariant has two halves:
+#
+#   1. TRIGGER: the stamp run_after_58 writes must be part of before_10's
+#      RENDERED body (a presence boolean), because chezmoi re-runs a
+#      run_onchange script only when its rendered content changes. Without
+#      this, the stamp write at apply N would not re-fire before_10 at apply
+#      N+1 and the teardown would wait for an unrelated package-data edit.
+#   2. AUTHORITY: cleanup passes only when the stamp is present AND a LIVE
+#      herdr health check succeeds in the same apply. A stale stamp (written
+#      while healthy, herdr broken since) must NOT authorize the teardown.
+#
+# Short-circuit: when neither tmux nor sesh is installed (already migrated),
+# cleanup always proceeds and the health check is skipped entirely.
+#
+# This renders the REAL before_10 and runs it with a stub Homebrew prefix
+# (brew/uv/volta), a stub npm, and a stub herdr on PATH; nothing real is
+# installed. The exact `brew bundle` argv and the stderr warnings are captured.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+STAMP_REL=".cache/herdr-migration/verified"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
 
-if ! command -v chezmoi >/dev/null 2>&1; then
-  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
-  exit 0
-fi
+for tool in chezmoi jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot render/run before_10\n' "$tool"
+    exit 0
+  fi
+done
 [[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-rendered="$work/rendered.sh"
-render_home="$(mktemp -d)"
-HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
-  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
-rm -rf "$render_home"
-if [[ ! -s $rendered ]]; then
+render_into() {
+  local home="$1" out="$2"
+  HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+    <"$SCRIPT" >"$out" || fail "chezmoi failed to render $SCRIPT (HOME=$home)"
+}
+
+# --- render-level trigger oracle (stamp presence must change the render) -----
+# chezmoi re-runs a run_onchange script only when its rendered content changes,
+# so the stamp's PRESENCE must be interpolated into the body. Render once with
+# the stamp absent and once with it present: the two bodies must differ. This
+# is the exact regression oracle for "the stamp write re-fires before_10".
+no_stamp_home="$work/render-no-stamp"
+stamp_home="$work/render-stamp"
+mkdir -p "$no_stamp_home" "$stamp_home/$(dirname "$STAMP_REL")"
+: >"$stamp_home/$STAMP_REL"
+render_into "$no_stamp_home" "$work/render-no-stamp.sh"
+render_into "$stamp_home" "$work/render-stamp.sh"
+if [[ ! -s $work/render-no-stamp.sh ]]; then
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi
+if cmp -s "$work/render-no-stamp.sh" "$work/render-stamp.sh"; then
+  fail "rendered before_10 is identical with and without the stamp; the stamp write would never re-fire the run_onchange trigger (cleanup would wait for an unrelated package-data edit)"
+fi
 
-# Stub Homebrew prefix: brew (tap/trust/list/bundle/autoupdate), uv, volta. brew
-# `list <pkg>` reports "installed" only for names in $INSTALLED_PKGS; `bundle`
-# records its argv and swallows the Brewfile on stdin.
+# The runtime cases below all execute the no-stamp render; the stamp check and
+# the health check both happen at RUN time, so one rendered body exercises
+# every case.
+rendered="$work/render-no-stamp.sh"
+
+# Stub Homebrew prefix: brew (tap/trust/list/bundle/autoupdate), uv, volta.
+# brew `list <pkg>` reports "installed" only for names in $INSTALLED_PKGS;
+# `bundle` records its argv and swallows the Brewfile on stdin.
 build_stub_prefix() {
   local prefix="$1"
   mkdir -p "$prefix/bin"
@@ -68,48 +104,101 @@ STUB
   chmod +x "$prefix/bin/brew" "$prefix/bin/uv" "$prefix/bin/volta"
 }
 
-# run_case <name> <installed-pkgs> <stamp?>
+# Stub herdr, two modes:
+#   healthy -> version ok, both plugins registered+enabled+warning-free,
+#              session running, config reload applied with no diagnostics
+#   broken  -> every invocation fails (the binary does not run)
+make_herdr_stub() {
+  local dir="$1" mode="$2"
+  cat >"$dir/herdr" <<STUB
+#!/bin/bash
+mode="$mode"
+if [[ \$mode == broken ]]; then
+  exit 1
+fi
+if [[ \$1 == --version ]]; then
+  echo "herdr 0.7.0-test"
+  exit 0
+fi
+sub="\$1 \$2"
+case "\$sub" in
+  "plugin list")
+    # args: plugin list --plugin <id> --json
+    id="\$4"
+    printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true}],"type":"plugin_list"}}\n' "\$id"
+    exit 0 ;;
+  "session list")
+    printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'
+    exit 0 ;;
+  "server reload-config")
+    printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}\n'
+    exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/herdr"
+}
+
+# run_case <name> <installed-pkgs> <stamp?> <herdr-mode>
 run_case() {
-  local name="$1" installed="$2" stamp="$3"
+  local name="$1" installed="$2" stamp="$3" herdr_mode="$4"
   local case_home="$work/$name/home"
   local prefix="$work/$name/prefix"
   local path_bin="$work/$name/path-bin"
   BUNDLE_RECORD="$work/$name/bundle-argv"
-  mkdir -p "$case_home" "$path_bin"
+  ERR_FILE="$work/$name/stderr"
+  mkdir -p "$case_home/.config/herdr" "$path_bin"
   build_stub_prefix "$prefix"
+  make_herdr_stub "$path_bin" "$herdr_mode"
   printf '#!/bin/bash\nexit 0\n' >"$path_bin/npm"
   chmod +x "$path_bin/npm"
+  printf 'x = 1\n' >"$case_home/.config/herdr/config.toml"
   if [[ $stamp == stamp ]]; then
-    mkdir -p "$case_home/.cache/herdr-migration"
-    : >"$case_home/.cache/herdr-migration/verified"
+    mkdir -p "$case_home/$(dirname "$STAMP_REL")"
+    : >"$case_home/$STAMP_REL"
   fi
   RC=0
   HOME="$case_home" HOMEBREW_PREFIX="$prefix" \
     PATH="$path_bin:$PATH" INSTALLED_PKGS="$installed" BUNDLE_RECORD="$BUNDLE_RECORD" \
-    bash "$rendered" >/dev/null 2>&1 || RC=$?
+    bash "$rendered" >/dev/null 2>"$ERR_FILE" || RC=$?
 }
 
 cleanup_used() { grep -qw -- '--cleanup' "$BUNDLE_RECORD"; }
 
-# tmux still installed, herdr NOT verified -> defer cleanup (no --cleanup).
-run_case tmux-no-stamp "tmux" no-stamp
-[[ $RC -eq 0 ]] || fail "tmux-no-stamp: script errored (rc=$RC)"
+# tmux still installed, no stamp -> defer cleanup, and SAY so (the deferral
+# warning is part of the contract: silently withholding --cleanup would leave
+# the operator with no clue why tmux/sesh survive).
+run_case tmux-no-stamp "tmux" no-stamp healthy
+[[ $RC -eq 0 ]] || fail "tmux-no-stamp: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
 [[ -s $BUNDLE_RECORD ]] || fail "tmux-no-stamp: brew bundle was never invoked"
 cleanup_used && fail "tmux-no-stamp: --cleanup passed though tmux is installed and herdr is unverified (would strand the machine)"
+grep -q 'WITHOUT --cleanup' "$ERR_FILE" ||
+  fail "tmux-no-stamp: the deferral warning was not printed (stderr: $(cat "$ERR_FILE"))"
 
-# sesh still installed, herdr NOT verified -> defer cleanup.
-run_case sesh-no-stamp "sesh" no-stamp
+# sesh still installed, no stamp -> defer cleanup.
+run_case sesh-no-stamp "sesh" no-stamp healthy
 cleanup_used && fail "sesh-no-stamp: --cleanup passed though sesh is installed and herdr is unverified"
 
-# tmux installed, herdr verified (stamp) -> cleanup proceeds.
-run_case tmux-stamp "tmux" stamp
-cleanup_used || fail "tmux-stamp: --cleanup not passed though herdr is verified (migration would never complete)"
+# tmux installed, stamp present, herdr LIVE-healthy -> cleanup proceeds.
+run_case tmux-stamp-healthy "tmux" stamp healthy
+[[ $RC -eq 0 ]] || fail "tmux-stamp-healthy: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+cleanup_used || fail "tmux-stamp-healthy: --cleanup not passed though the stamp is present and herdr is live-healthy (migration would never complete)"
 
-# No multiplexer installed -> cleanup proceeds regardless of stamp.
-run_case none-no-stamp "" no-stamp
+# tmux installed, stamp present, herdr NOW BROKEN -> the stale stamp must NOT
+# authorize the teardown: the live health check is the cleanup authority.
+run_case tmux-stamp-stale "tmux" stamp broken
+[[ $RC -eq 0 ]] || fail "tmux-stamp-stale: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+cleanup_used && fail "tmux-stamp-stale: --cleanup passed on a STALE stamp though herdr is currently broken (would remove the only working multiplexer)"
+grep -qi 'stale' "$ERR_FILE" ||
+  fail "tmux-stamp-stale: no stale-stamp warning printed (stderr: $(cat "$ERR_FILE"))"
+
+# No multiplexer installed -> cleanup proceeds regardless of stamp or herdr
+# health (nothing to strand; the machine is already migrated). herdr broken in
+# both cases proves the gate and the health check are skipped entirely.
+run_case none-no-stamp "" no-stamp broken
 cleanup_used || fail "none-no-stamp: --cleanup withheld though no multiplexer is installed (nothing to strand)"
 
-run_case none-stamp "" stamp
+run_case none-stamp "" stamp broken
 cleanup_used || fail "none-stamp: --cleanup withheld though no multiplexer is installed"
 
-printf 'PASS: before_10 defers brew bundle --cleanup while tmux/sesh is installed and herdr is unverified, and passes it once herdr is verified or no multiplexer is present\n'
+printf 'PASS: before_10 renders the stamp presence into its trigger, defers cleanup while tmux/sesh is installed unless the stamp is present AND herdr passes a live health check, warns on deferral and on a stale stamp, and skips the gate when no multiplexer remains\n'

--- a/test/herdr-migration-verify.sh
+++ b/test/herdr-migration-verify.sh
@@ -69,6 +69,9 @@ fi
 #   session-down     -> `session list` fails (server unreachable)
 #   session-stopped  -> session list answers but no entry is running:true
 #   config-invalid   -> reload-config reports diagnostics (config rejected)
+#   config-rejected-empty-diag -> reload-config reports status "rejected" with
+#                       an EMPTY diagnostics array (decouples the status check
+#                       from the diagnostics check; see the mutation case below)
 make_herdr_stub() {
   local dir="$1" mode="$2"
   cat >"$dir/herdr" <<STUB
@@ -124,6 +127,10 @@ case "\$sub" in
   "server reload-config")
     if [[ \$mode == config-invalid ]]; then
       printf '{"id":"cli:server:reload-config","result":{"diagnostics":["unknown key: keybindingz"],"status":"rejected","type":"config_reload"}}\n'
+      exit 0
+    fi
+    if [[ \$mode == config-rejected-empty-diag ]]; then
+      printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"rejected","type":"config_reload"}}\n'
       exit 0
     fi
     printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}\n'
@@ -227,6 +234,17 @@ done
 run_case reject-no-config healthy "tmux" no-config
 [[ $RC -eq 0 ]] || fail "reject-no-config: expected exit 0, got $RC"
 cleanup_ran && fail "reject-no-config: brew bundle cleanup ran though config.toml is absent"
+
+# Reload reports status "rejected" but with an EMPTY diagnostics array. The
+# config-invalid stub above couples a non-applied status with NON-empty
+# diagnostics, so the diagnostics-length check alone would still reject it and
+# a deleted `.result.status == "applied"` mutant would survive. This case
+# decouples the two: with the status check deleted, empty diagnostics would
+# read as a pass and cleanup would run against a REJECTED config. The predicate
+# must still reject it (no cleanup), which kills that mutant.
+run_case reject-rejected-empty-diag config-rejected-empty-diag "tmux" config
+[[ $RC -eq 0 ]] || fail "reject-rejected-empty-diag: expected exit 0, got $RC"
+cleanup_ran && fail "reject-rejected-empty-diag: brew bundle cleanup ran though reload-config reported status 'rejected' (only the empty diagnostics happened to match; the status check must still reject it)"
 
 # --- never-abort: cleanup itself fails ---------------------------------------
 # herdr verified but `brew bundle cleanup` exits non-zero: warn and exit 0, do

--- a/test/herdr-migration-verify.sh
+++ b/test/herdr-migration-verify.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
-# herdr-migration-verify.sh — run_after_58-herdr-migration-verify writes the
+# herdr-migration-verify.sh: run_after_58-herdr-migration-verify writes the
 # herdr-verified stamp ONLY when herdr is fully proven as a multiplexer, and
-# removes it otherwise. The stamp is the signal run_onchange_before_10 consults
-# before it lets `brew bundle --cleanup` remove the old multiplexer (tmux/sesh):
-# no stamp, no teardown. Verification requires ALL of:
+# removes it otherwise. The stamp is the TRIGGER signal run_onchange_before_10
+# consults (and re-checks live) before it lets `brew bundle --cleanup` remove
+# the old multiplexer (tmux/sesh): no stamp, no teardown. The shared predicate
+# (.chezmoitemplates/herdr-health-check.sh.tmpl) requires ALL of:
 #
 #   1. the herdr binary is present and runnable
-#   2. its config.toml is present
-#   3. BOTH vendored plugins are registered (exact plugin id)
-#   4. the herdr session server is reachable and reports a running session
-#      (the strongest non-interactive proof a second session can be hosted — a
-#      full spawn+attach needs a TTY the apply does not have)
+#   2. its config.toml is present AND passes the live reload validation
+#      (`herdr server reload-config` reports status "applied" with an empty
+#      diagnostics array; herdr 0.7.0 offers no validate-only subcommand)
+#   3. BOTH vendored plugins are registered with the EXACT plugin id, enabled,
+#      and warning-free, in an array-shaped plugin list with no error envelope
+#      and no duplicate entries
+#   4. the session server answers with an array-shaped session list containing
+#      at least one running:true entry and no error envelope
 #
-# The script never aborts the apply (exit 0 always) and is idempotent. It is
-# exercised by rendering the REAL template and running it against stub herdr on
-# PATH with a scratch HOME.
+# Exact-id-only matching is NOT enough: a probe with an invalid config, a
+# disabled warning-bearing plugin, and one running session used to earn the
+# stamp (herdr keeps disabled plugins registered and lists invalid manifests
+# with warnings), so the predicate must reject those unusable installations.
+#
+# The script never aborts the apply (exit 0 always, even when filesystem
+# operations on the stamp fail) and is idempotent. It is exercised by
+# rendering the REAL template and running it against a stub herdr on PATH
+# with a scratch HOME.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -47,40 +57,78 @@ if [[ ! -s $rendered ]]; then
   exit 0
 fi
 
-# Stub herdr. Modes flip one health signal each to prove the stamp needs ALL of
-# them. `plugins` lists which plugin ids `plugin list --plugin` reports.
-#   healthy       -> version ok, both plugins, session running
-#   plugin-missing-> only herdr-last-workspace reports (smart-nav absent)
-#   session-down  -> `session list` fails (server unreachable)
-#   binary-broken -> `herdr --version` fails
+# Stub herdr. Modes flip one health signal each to prove the stamp needs ALL
+# of them; the healthy shape mirrors the live 0.7.0 CLI (enabled:true, no
+# warnings key, id envelope on plugin/reload responses).
+#   healthy          -> version ok, both plugins enabled+warning-free,
+#                       session running, config reload applied cleanly
+#   binary-broken    -> every invocation fails (`herdr --version` included)
+#   plugin-missing   -> smart-nav absent from its plugin list
+#   plugin-disabled  -> smart-nav registered but enabled:false
+#   plugin-warning   -> smart-nav enabled but carrying a manifest warning
+#   plugin-wrong-id  -> the list returns a DIFFERENT plugin_id than requested
+#   plugin-duplicate -> two entries for the same plugin id
+#   plugin-mixed     -> .result.plugins is an object, not an array
+#   session-down     -> `session list` fails (server unreachable)
+#   session-stopped  -> session list answers but no entry is running:true
+#   config-invalid   -> reload-config reports diagnostics (config rejected)
 make_herdr_stub() {
   local dir="$1" mode="$2"
   cat >"$dir/herdr" <<STUB
 #!/bin/bash
 mode="$mode"
+if [[ \$mode == binary-broken ]]; then
+  exit 1
+fi
+if [[ \$1 == --version ]]; then
+  echo "herdr 0.7.0-test"
+  exit 0
+fi
 sub="\$1 \$2"
 case "\$sub" in
-  "--version ")
-    [[ \$mode == binary-broken ]] && exit 1
-    echo "herdr 0.7.0-preview.test"
-    exit 0 ;;
-esac
-if [[ \$1 == --version ]]; then
-  [[ \$mode == binary-broken ]] && exit 1
-  echo "herdr 0.7.0-preview.test"; exit 0
-fi
-case "\$sub" in
-  "session list")
-    [[ \$mode == session-down ]] && exit 3
-    printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'
-    exit 0 ;;
   "plugin list")
     # args: plugin list --plugin <id> --json
     id="\$4"
-    if [[ \$mode == plugin-missing && \$id == herdr-smart-nav ]]; then
-      printf '{"result":{"plugins":[],"type":"plugin_list"}}\n'; exit 0
+    if [[ \$id == herdr-smart-nav ]]; then
+      case "\$mode" in
+        plugin-missing)
+          printf '{"id":"cli:plugin","result":{"plugins":[],"type":"plugin_list"}}\n'
+          exit 0 ;;
+        plugin-disabled)
+          printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":false}],"type":"plugin_list"}}\n' "\$id"
+          exit 0 ;;
+        plugin-warning)
+          printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true,"warnings":["invalid manifest field: events"]}],"type":"plugin_list"}}\n' "\$id"
+          exit 0 ;;
+        plugin-wrong-id)
+          printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"herdr-imposter","enabled":true}],"type":"plugin_list"}}\n'
+          exit 0 ;;
+        plugin-duplicate)
+          printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true},{"plugin_id":"%s","enabled":true}],"type":"plugin_list"}}\n' "\$id" "\$id"
+          exit 0 ;;
+        plugin-mixed)
+          printf '{"id":"cli:plugin","result":{"plugins":{"plugin_id":"%s","enabled":true},"type":"plugin_list"}}\n' "\$id"
+          exit 0 ;;
+      esac
     fi
-    printf '{"result":{"plugins":[{"plugin_id":"%s"}],"type":"plugin_list"}}\n' "\$id"
+    printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true}],"type":"plugin_list"}}\n' "\$id"
+    exit 0 ;;
+  "session list")
+    if [[ \$mode == session-down ]]; then
+      exit 3
+    fi
+    if [[ \$mode == session-stopped ]]; then
+      printf '{"sessions":[{"default":true,"name":"default","running":false}]}\n'
+      exit 0
+    fi
+    printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'
+    exit 0 ;;
+  "server reload-config")
+    if [[ \$mode == config-invalid ]]; then
+      printf '{"id":"cli:server:reload-config","result":{"diagnostics":["unknown key: keybindingz"],"status":"rejected","type":"config_reload"}}\n'
+      exit 0
+    fi
+    printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}\n'
     exit 0 ;;
 esac
 exit 0
@@ -88,12 +136,16 @@ STUB
   chmod +x "$dir/herdr"
 }
 
-# run_case <name> <mode> <config?> <pre-stamp?>
+# run_case <name> <mode> <config?> <pre-stamp?> [fs-sabotage]
+#   fs-sabotage: dir-at-stamp     -> a DIRECTORY occupies the stamp path
+#                unwritable-cache -> ~/.cache is read-only and the stamp
+#                                    subdir does not exist (mkdir -p fails)
 run_case() {
-  local name="$1" mode="$2" config="$3" pre_stamp="$4"
+  local name="$1" mode="$2" config="$3" pre_stamp="$4" sabotage="${5:-none}"
   CASE_HOME="$work/$name/home"
   local bin="$work/$name/bin"
   STAMP="$CASE_HOME/$STAMP_REL"
+  ERR_FILE="$work/$name/stderr"
   mkdir -p "$bin" "$CASE_HOME/.config/herdr"
   make_herdr_stub "$bin" "$mode"
   [[ $config == config ]] && printf 'x = 1\n' >"$CASE_HOME/.config/herdr/config.toml"
@@ -101,15 +153,30 @@ run_case() {
     mkdir -p "$(dirname "$STAMP")"
     : >"$STAMP"
   fi
+  case "$sabotage" in
+    dir-at-stamp)
+      mkdir -p "$STAMP"
+      ;;
+    unwritable-cache)
+      mkdir -p "$CASE_HOME/.cache"
+      chmod 555 "$CASE_HOME/.cache"
+      ;;
+    none) ;;
+    *) fail "unknown sabotage mode: $sabotage" ;;
+  esac
   RC=0
-  HOME="$CASE_HOME" PATH="$bin:$PATH" bash "$rendered" >/dev/null 2>&1 || RC=$?
+  HOME="$CASE_HOME" PATH="$bin:$PATH" bash "$rendered" >/dev/null 2>"$ERR_FILE" || RC=$?
+  # Re-open a sabotaged read-only dir so the EXIT-trap cleanup can remove it.
+  if [[ $sabotage == unwritable-cache ]]; then
+    chmod 755 "$CASE_HOME/.cache"
+  fi
 }
 
 stamp_present() { [[ -f $STAMP ]]; }
 
 # Healthy: stamp written, exit 0.
 run_case healthy healthy config no-stamp
-[[ $RC -eq 0 ]] || fail "healthy: expected exit 0, got $RC"
+[[ $RC -eq 0 ]] || fail "healthy: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
 stamp_present || fail "healthy: verified stamp was not written despite herdr fully healthy"
 
 # Idempotent: a second run on a healthy host keeps the stamp, still exit 0.
@@ -117,24 +184,81 @@ run_case healthy-again healthy config pre-stamp
 [[ $RC -eq 0 ]] || fail "healthy-again: expected exit 0, got $RC"
 stamp_present || fail "healthy-again: stamp removed on a healthy second run (not idempotent)"
 
-# One plugin missing: NOT verified — stamp absent, and a stale stamp is removed.
+# One plugin missing: NOT verified; a stale stamp is removed.
 run_case plugin-missing plugin-missing config pre-stamp
 [[ $RC -eq 0 ]] || fail "plugin-missing: expected exit 0, got $RC"
 stamp_present && fail "plugin-missing: stamp present though a plugin is not registered"
+
+# Plugin registered but DISABLED: an unusable installation must not stamp.
+run_case plugin-disabled plugin-disabled config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-disabled: expected exit 0, got $RC"
+stamp_present && fail "plugin-disabled: stamp present though a required plugin is disabled"
+
+# Plugin enabled but carrying a manifest WARNING: not proven usable.
+run_case plugin-warning plugin-warning config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-warning: expected exit 0, got $RC"
+stamp_present && fail "plugin-warning: stamp present though a required plugin carries warnings"
+
+# The list answers with a DIFFERENT plugin id: exact-id equality must reject
+# it (kills any relaxation of the id match to a substring or any-entry check).
+run_case plugin-wrong-id plugin-wrong-id config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-wrong-id: expected exit 0, got $RC"
+stamp_present && fail "plugin-wrong-id: stamp present though the list returned a different plugin id"
+
+# Duplicate entries for one id: exactly-one is the contract.
+run_case plugin-duplicate plugin-duplicate config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-duplicate: expected exit 0, got $RC"
+stamp_present && fail "plugin-duplicate: stamp present though the plugin list carries duplicate entries"
+
+# Object-shaped (mixed) plugins container: only the CLI's real array shape
+# counts; anything else is malformed and must not verify.
+run_case plugin-mixed plugin-mixed config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-mixed: expected exit 0, got $RC"
+stamp_present && fail "plugin-mixed: stamp present though the plugins container is not an array"
 
 # Session server down: NOT verified.
 run_case session-down session-down config pre-stamp
 [[ $RC -eq 0 ]] || fail "session-down: expected exit 0, got $RC"
 stamp_present && fail "session-down: stamp present though the session server is unreachable"
 
+# Session list answers but nothing is running: NOT verified.
+run_case session-stopped session-stopped config pre-stamp
+[[ $RC -eq 0 ]] || fail "session-stopped: expected exit 0, got $RC"
+stamp_present && fail "session-stopped: stamp present though no session is running"
+
 # Config missing: NOT verified.
 run_case no-config healthy no-config pre-stamp
 [[ $RC -eq 0 ]] || fail "no-config: expected exit 0, got $RC"
 stamp_present && fail "no-config: stamp present though config.toml is absent"
+
+# Config present but REJECTED by the live reload validation: NOT verified.
+run_case config-invalid config-invalid config pre-stamp
+[[ $RC -eq 0 ]] || fail "config-invalid: expected exit 0, got $RC"
+stamp_present && fail "config-invalid: stamp present though herdr rejected the config with diagnostics"
 
 # Binary broken: NOT verified.
 run_case binary-broken binary-broken config pre-stamp
 [[ $RC -eq 0 ]] || fail "binary-broken: expected exit 0, got $RC"
 stamp_present && fail "binary-broken: stamp present though the herdr binary does not run"
 
-printf 'PASS: run_after_58 writes the herdr-verified stamp only when binary, config, both plugins, and the session server all check out, removes it otherwise, and never aborts the apply\n'
+# --- never-abort guarantees (the apply must survive filesystem sabotage) ----
+
+# A DIRECTORY occupies the stamp path, herdr healthy: the truncate fails; the
+# script must warn and exit 0, not abort the apply.
+run_case dir-at-stamp-healthy healthy config no-stamp dir-at-stamp
+[[ $RC -eq 0 ]] || fail "dir-at-stamp-healthy: a directory at the stamp path aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ -s $ERR_FILE ]] || fail "dir-at-stamp-healthy: no warning printed about the unwritable stamp"
+
+# A DIRECTORY occupies the stamp path, herdr broken: the rm fails; the script
+# must warn and exit 0.
+run_case dir-at-stamp-broken binary-broken config no-stamp dir-at-stamp
+[[ $RC -eq 0 ]] || fail "dir-at-stamp-broken: a directory at the stamp path aborted the apply on the not-verified path (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ -s $ERR_FILE ]] || fail "dir-at-stamp-broken: no warning printed about the unremovable stamp path"
+
+# ~/.cache is read-only and the stamp subdir is missing, herdr healthy: the
+# mkdir fails; the script must warn and exit 0.
+run_case unwritable-cache healthy config no-stamp unwritable-cache
+[[ $RC -eq 0 ]] || fail "unwritable-cache: an unwritable cache dir aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+[[ -s $ERR_FILE ]] || fail "unwritable-cache: no warning printed about the unwritable cache dir"
+
+printf 'PASS: run_after_58 stamps only a fully healthy herdr (binary, validated config, both plugins enabled+warning-free by exact id in an array-shaped list, running session), rejects disabled/warning/wrong-id/duplicate/mixed/stopped/invalid-config states, and never aborts the apply even under filesystem sabotage\n'

--- a/test/herdr-migration-verify.sh
+++ b/test/herdr-migration-verify.sh
@@ -1,35 +1,31 @@
 #!/usr/bin/env bash
-# herdr-migration-verify.sh: run_after_58-herdr-migration-verify writes the
-# herdr-verified stamp ONLY when herdr is fully proven as a multiplexer, and
-# removes it otherwise. The stamp is the TRIGGER signal run_onchange_before_10
-# consults (and re-checks live) before it lets `brew bundle --cleanup` remove
-# the old multiplexer (tmux/sesh): no stamp, no teardown. The shared predicate
-# (.chezmoitemplates/herdr-health-check.sh.tmpl) requires ALL of:
+# herdr-migration-verify.sh: run_after_58-herdr-migration-verify runs
+# post-target-update and owns the deferred tmux/sesh teardown that before_10
+# withholds. Its state machine:
 #
-#   1. the herdr binary is present and runnable
-#   2. its config.toml is present AND passes the live reload validation
-#      (`herdr server reload-config` reports status "applied" with an empty
-#      diagnostics array; herdr 0.7.0 offers no validate-only subcommand)
-#   3. BOTH vendored plugins are registered with the EXACT plugin id, enabled,
-#      and warning-free, in an array-shaped plugin list with no error envelope
-#      and no duplicate entries
-#   4. the session server answers with an array-shaped session list containing
-#      at least one running:true entry and no error envelope
+#   1. SHORT-CIRCUIT: if neither tmux nor sesh is installed there is nothing to
+#      migrate. Make NO herdr contact at all (this also removes the routine
+#      reload-config side effect on already-migrated machines) and exit 0.
+#   2. Otherwise run the shared health check
+#      (.chezmoitemplates/herdr-health-check.sh.tmpl) against the CURRENT
+#      (just-installed) herdr. It requires ALL of: the binary runs; the session
+#      server answers with a running session; config.toml passes the live
+#      reload validation; both vendored plugins are registered by EXACT id,
+#      enabled, and warning-free in an array-shaped list.
+#   3. On full verification, perform the deferred cleanup itself: regenerate the
+#      Brewfile from the same package data before_10 uses and run
+#      `brew bundle cleanup --force` with it (the removal before_10 withheld).
+#   4. On ANY verification failure, warn loudly (naming the interactive
+#      activation step) and exit 0; the migration retries naturally next apply.
 #
-# Exact-id-only matching is NOT enough: a probe with an invalid config, a
-# disabled warning-bearing plugin, and one running session used to earn the
-# stamp (herdr keeps disabled plugins registered and lists invalid manifests
-# with warnings), so the predicate must reject those unusable installations.
-#
-# The script never aborts the apply (exit 0 always, even when filesystem
-# operations on the stamp fail) and is idempotent. It is exercised by
-# rendering the REAL template and running it against a stub herdr on PATH
-# with a scratch HOME.
+# The script never aborts the apply (exit 0 always, even when the cleanup
+# fails) and holds no stamp -- it re-derives everything from live state each
+# apply. It is exercised by rendering the REAL template and running it against a
+# stub herdr and a stub brew on PATH with a scratch HOME.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl"
-STAMP_REL=".cache/herdr-migration/verified"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -57,9 +53,10 @@ if [[ ! -s $rendered ]]; then
   exit 0
 fi
 
-# Stub herdr. Modes flip one health signal each to prove the stamp needs ALL
-# of them; the healthy shape mirrors the live 0.7.0 CLI (enabled:true, no
-# warnings key, id envelope on plugin/reload responses).
+# Stub herdr. Modes flip one health signal each to prove cleanup needs ALL of
+# them; the healthy shape mirrors the live 0.7.0 CLI (enabled:true, no warnings
+# key, id envelope on plugin/reload responses). Every invocation appends its
+# argv to $HERDR_RECORD so a test can prove herdr was (or was not) contacted.
 #   healthy          -> version ok, both plugins enabled+warning-free,
 #                       session running, config reload applied cleanly
 #   binary-broken    -> every invocation fails (`herdr --version` included)
@@ -76,6 +73,7 @@ make_herdr_stub() {
   local dir="$1" mode="$2"
   cat >"$dir/herdr" <<STUB
 #!/bin/bash
+printf '%s\n' "\$*" >>"\$HERDR_RECORD"
 mode="$mode"
 if [[ \$mode == binary-broken ]]; then
   exit 1
@@ -136,129 +134,106 @@ STUB
   chmod +x "$dir/herdr"
 }
 
-# run_case <name> <mode> <config?> <pre-stamp?> [fs-sabotage]
-#   fs-sabotage: dir-at-stamp     -> a DIRECTORY occupies the stamp path
-#                unwritable-cache -> ~/.cache is read-only and the stamp
-#                                    subdir does not exist (mkdir -p fails)
-run_case() {
-  local name="$1" mode="$2" config="$3" pre_stamp="$4" sabotage="${5:-none}"
-  CASE_HOME="$work/$name/home"
-  local bin="$work/$name/bin"
-  STAMP="$CASE_HOME/$STAMP_REL"
-  ERR_FILE="$work/$name/stderr"
-  mkdir -p "$bin" "$CASE_HOME/.config/herdr"
-  make_herdr_stub "$bin" "$mode"
-  [[ $config == config ]] && printf 'x = 1\n' >"$CASE_HOME/.config/herdr/config.toml"
-  if [[ $pre_stamp == pre-stamp ]]; then
-    mkdir -p "$(dirname "$STAMP")"
-    : >"$STAMP"
-  fi
-  case "$sabotage" in
-    dir-at-stamp)
-      mkdir -p "$STAMP"
-      ;;
-    unwritable-cache)
-      mkdir -p "$CASE_HOME/.cache"
-      chmod 555 "$CASE_HOME/.cache"
-      ;;
-    none) ;;
-    *) fail "unknown sabotage mode: $sabotage" ;;
-  esac
-  RC=0
-  HOME="$CASE_HOME" PATH="$bin:$PATH" bash "$rendered" >/dev/null 2>"$ERR_FILE" || RC=$?
-  # Re-open a sabotaged read-only dir so the EXIT-trap cleanup can remove it.
-  if [[ $sabotage == unwritable-cache ]]; then
-    chmod 755 "$CASE_HOME/.cache"
-  fi
+# Stub brew: `list <pkg>` reports installed only for names in $INSTALLED_PKGS;
+# `bundle` records its full argv and exits per $BREW_BUNDLE_RC (so a cleanup
+# failure can be simulated). after_58 passes the Brewfile via --file, not stdin,
+# so the stub must NOT read stdin (doing so would block on an unclosed fd).
+make_brew_stub() {
+  local dir="$1"
+  cat >"$dir/brew" <<'STUB'
+#!/bin/bash
+case "$1" in
+  list)
+    pkg="$2"
+    read -ra installed_packages <<<"$INSTALLED_PKGS"
+    for installed in "${installed_packages[@]}"; do
+      [[ $pkg == "$installed" ]] && exit 0
+    done
+    exit 1 ;;
+  bundle)
+    printf '%s\n' "$*" >>"$BUNDLE_RECORD"
+    exit "${BREW_BUNDLE_RC:-0}" ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/brew"
 }
 
-stamp_present() { [[ -f $STAMP ]]; }
+# run_case <name> <herdr-mode> <installed-pkgs> <config?> [brew-bundle-rc]
+run_case() {
+  local name="$1" mode="$2" installed="$3" config="$4" bundle_rc="${5:-0}"
+  CASE_HOME="$work/$name/home"
+  local prefix="$work/$name/prefix"
+  local path_bin="$work/$name/path-bin"
+  HERDR_RECORD="$work/$name/herdr-argv"
+  BUNDLE_RECORD="$work/$name/bundle-argv"
+  ERR_FILE="$work/$name/stderr"
+  OUT_FILE="$work/$name/stdout"
+  mkdir -p "$prefix/bin" "$path_bin" "$CASE_HOME/.config/herdr"
+  make_brew_stub "$prefix/bin"
+  make_herdr_stub "$path_bin" "$mode"
+  : >"$HERDR_RECORD"
+  [[ $config == config ]] && printf 'x = 1\n' >"$CASE_HOME/.config/herdr/config.toml"
+  RC=0
+  HOME="$CASE_HOME" HOMEBREW_PREFIX="$prefix" PATH="$path_bin:$PATH" \
+    INSTALLED_PKGS="$installed" HERDR_RECORD="$HERDR_RECORD" \
+    BUNDLE_RECORD="$BUNDLE_RECORD" BREW_BUNDLE_RC="$bundle_rc" \
+    bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
+}
 
-# Healthy: stamp written, exit 0.
-run_case healthy healthy config no-stamp
-[[ $RC -eq 0 ]] || fail "healthy: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
-stamp_present || fail "healthy: verified stamp was not written despite herdr fully healthy"
+cleanup_ran() { [[ -f $BUNDLE_RECORD ]] && grep -q 'bundle cleanup --force' "$BUNDLE_RECORD"; }
+herdr_contacted() { [[ -s $HERDR_RECORD ]]; }
 
-# Idempotent: a second run on a healthy host keeps the stamp, still exit 0.
-run_case healthy-again healthy config pre-stamp
-[[ $RC -eq 0 ]] || fail "healthy-again: expected exit 0, got $RC"
-stamp_present || fail "healthy-again: stamp removed on a healthy second run (not idempotent)"
+# --- short-circuit: fresh/already-migrated machine, no multiplexer -----------
+# No tmux/sesh installed: NO herdr contact, no cleanup, exit 0. herdr is broken
+# to prove it is never invoked (the short-circuit precedes any health check).
+run_case fresh-no-op binary-broken "wget" config
+[[ $RC -eq 0 ]] || fail "fresh-no-op: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
+herdr_contacted && fail "fresh-no-op: herdr was contacted though no multiplexer is installed (short-circuit skipped)"
+cleanup_ran && fail "fresh-no-op: brew bundle cleanup ran though nothing needs migrating"
 
-# One plugin missing: NOT verified; a stale stamp is removed.
-run_case plugin-missing plugin-missing config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-missing: expected exit 0, got $RC"
-stamp_present && fail "plugin-missing: stamp present though a plugin is not registered"
+# --- migration host, happy path ----------------------------------------------
+# tmux installed + herdr fully healthy: verify, then run brew bundle cleanup
+# --force to remove tmux/sesh. The success message is printed.
+run_case migrate-happy healthy "tmux" config
+[[ $RC -eq 0 ]] || fail "migrate-happy: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
+herdr_contacted || fail "migrate-happy: herdr was never contacted though tmux is installed"
+cleanup_ran || fail "migrate-happy: brew bundle cleanup --force did not run though herdr is verified (migration would never complete)"
+grep -q 'migration complete' "$OUT_FILE" ||
+  fail "migrate-happy: no migration-complete message after a verified cleanup ($(cat "$OUT_FILE"))"
 
-# Plugin registered but DISABLED: an unusable installation must not stamp.
-run_case plugin-disabled plugin-disabled config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-disabled: expected exit 0, got $RC"
-stamp_present && fail "plugin-disabled: stamp present though a required plugin is disabled"
+# --- serverless host: defers forever without ever cleaning -------------------
+# tmux installed, herdr present but its session server is down (no interactive
+# terminal ever started it): NOT verified, no cleanup, and the warning must name
+# the interactive activation step. Exit 0 (retries next apply).
+run_case serverless session-down "tmux" config
+[[ $RC -eq 0 ]] || fail "serverless: expected exit 0, got $RC"
+herdr_contacted || fail "serverless: herdr was never contacted though tmux is installed"
+cleanup_ran && fail "serverless: brew bundle cleanup ran though the herdr server is down (would remove the only multiplexer)"
+grep -qi 'interactive terminal' "$ERR_FILE" ||
+  fail "serverless: the deferral warning does not name the interactive activation step ($(cat "$ERR_FILE"))"
 
-# Plugin enabled but carrying a manifest WARNING: not proven usable.
-run_case plugin-warning plugin-warning config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-warning: expected exit 0, got $RC"
-stamp_present && fail "plugin-warning: stamp present though a required plugin carries warnings"
+# --- predicate rejection cases: multiplexer present, but herdr unhealthy ------
+# Each unhealthy mode must block the cleanup. Cleanup running under any of these
+# would remove the only working multiplexer against an unusable herdr.
+for mode in binary-broken plugin-missing plugin-disabled plugin-warning \
+  plugin-wrong-id plugin-duplicate plugin-mixed session-stopped config-invalid; do
+  run_case "reject-$mode" "$mode" "tmux" config
+  [[ $RC -eq 0 ]] || fail "reject-$mode: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
+  cleanup_ran && fail "reject-$mode: brew bundle cleanup ran though herdr is unhealthy ($mode)"
+done
 
-# The list answers with a DIFFERENT plugin id: exact-id equality must reject
-# it (kills any relaxation of the id match to a substring or any-entry check).
-run_case plugin-wrong-id plugin-wrong-id config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-wrong-id: expected exit 0, got $RC"
-stamp_present && fail "plugin-wrong-id: stamp present though the list returned a different plugin id"
+# config.toml absent, herdr otherwise healthy: NOT verified, no cleanup.
+run_case reject-no-config healthy "tmux" no-config
+[[ $RC -eq 0 ]] || fail "reject-no-config: expected exit 0, got $RC"
+cleanup_ran && fail "reject-no-config: brew bundle cleanup ran though config.toml is absent"
 
-# Duplicate entries for one id: exactly-one is the contract.
-run_case plugin-duplicate plugin-duplicate config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-duplicate: expected exit 0, got $RC"
-stamp_present && fail "plugin-duplicate: stamp present though the plugin list carries duplicate entries"
+# --- never-abort: cleanup itself fails ---------------------------------------
+# herdr verified but `brew bundle cleanup` exits non-zero: warn and exit 0, do
+# NOT abort the apply. tmux/sesh may remain; the next apply retries.
+run_case cleanup-fails healthy "tmux" config 5
+[[ $RC -eq 0 ]] || fail "cleanup-fails: a failing brew bundle cleanup aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
+cleanup_ran || fail "cleanup-fails: brew bundle cleanup was expected to be attempted"
+[[ -s $ERR_FILE ]] || fail "cleanup-fails: no warning printed about the failed cleanup"
 
-# Object-shaped (mixed) plugins container: only the CLI's real array shape
-# counts; anything else is malformed and must not verify.
-run_case plugin-mixed plugin-mixed config pre-stamp
-[[ $RC -eq 0 ]] || fail "plugin-mixed: expected exit 0, got $RC"
-stamp_present && fail "plugin-mixed: stamp present though the plugins container is not an array"
-
-# Session server down: NOT verified.
-run_case session-down session-down config pre-stamp
-[[ $RC -eq 0 ]] || fail "session-down: expected exit 0, got $RC"
-stamp_present && fail "session-down: stamp present though the session server is unreachable"
-
-# Session list answers but nothing is running: NOT verified.
-run_case session-stopped session-stopped config pre-stamp
-[[ $RC -eq 0 ]] || fail "session-stopped: expected exit 0, got $RC"
-stamp_present && fail "session-stopped: stamp present though no session is running"
-
-# Config missing: NOT verified.
-run_case no-config healthy no-config pre-stamp
-[[ $RC -eq 0 ]] || fail "no-config: expected exit 0, got $RC"
-stamp_present && fail "no-config: stamp present though config.toml is absent"
-
-# Config present but REJECTED by the live reload validation: NOT verified.
-run_case config-invalid config-invalid config pre-stamp
-[[ $RC -eq 0 ]] || fail "config-invalid: expected exit 0, got $RC"
-stamp_present && fail "config-invalid: stamp present though herdr rejected the config with diagnostics"
-
-# Binary broken: NOT verified.
-run_case binary-broken binary-broken config pre-stamp
-[[ $RC -eq 0 ]] || fail "binary-broken: expected exit 0, got $RC"
-stamp_present && fail "binary-broken: stamp present though the herdr binary does not run"
-
-# --- never-abort guarantees (the apply must survive filesystem sabotage) ----
-
-# A DIRECTORY occupies the stamp path, herdr healthy: the truncate fails; the
-# script must warn and exit 0, not abort the apply.
-run_case dir-at-stamp-healthy healthy config no-stamp dir-at-stamp
-[[ $RC -eq 0 ]] || fail "dir-at-stamp-healthy: a directory at the stamp path aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-[[ -s $ERR_FILE ]] || fail "dir-at-stamp-healthy: no warning printed about the unwritable stamp"
-
-# A DIRECTORY occupies the stamp path, herdr broken: the rm fails; the script
-# must warn and exit 0.
-run_case dir-at-stamp-broken binary-broken config no-stamp dir-at-stamp
-[[ $RC -eq 0 ]] || fail "dir-at-stamp-broken: a directory at the stamp path aborted the apply on the not-verified path (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-[[ -s $ERR_FILE ]] || fail "dir-at-stamp-broken: no warning printed about the unremovable stamp path"
-
-# ~/.cache is read-only and the stamp subdir is missing, herdr healthy: the
-# mkdir fails; the script must warn and exit 0.
-run_case unwritable-cache healthy config no-stamp unwritable-cache
-[[ $RC -eq 0 ]] || fail "unwritable-cache: an unwritable cache dir aborted the apply (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-[[ -s $ERR_FILE ]] || fail "unwritable-cache: no warning printed about the unwritable cache dir"
-
-printf 'PASS: run_after_58 stamps only a fully healthy herdr (binary, validated config, both plugins enabled+warning-free by exact id in an array-shaped list, running session), rejects disabled/warning/wrong-id/duplicate/mixed/stopped/invalid-config states, and never aborts the apply even under filesystem sabotage\n'
+printf 'PASS: after_58 short-circuits with no herdr contact when no multiplexer is installed, verifies the current herdr (binary, running session, validated config, both plugins enabled+warning-free by exact id) before running brew bundle cleanup --force, defers with an activation-step warning on any unhealthy state or a serverless host, and never aborts the apply even when the cleanup fails\n'

--- a/test/herdr-migration-verify.sh
+++ b/test/herdr-migration-verify.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# herdr-migration-verify.sh — run_after_58-herdr-migration-verify writes the
+# herdr-verified stamp ONLY when herdr is fully proven as a multiplexer, and
+# removes it otherwise. The stamp is the signal run_onchange_before_10 consults
+# before it lets `brew bundle --cleanup` remove the old multiplexer (tmux/sesh):
+# no stamp, no teardown. Verification requires ALL of:
+#
+#   1. the herdr binary is present and runnable
+#   2. its config.toml is present
+#   3. BOTH vendored plugins are registered (exact plugin id)
+#   4. the herdr session server is reachable and reports a running session
+#      (the strongest non-interactive proof a second session can be hosted — a
+#      full spawn+attach needs a TTY the apply does not have)
+#
+# The script never aborts the apply (exit 0 always) and is idempotent. It is
+# exercised by rendering the REAL template and running it against stub herdr on
+# PATH with a scratch HOME.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl"
+STAMP_REL=".cache/herdr-migration/verified"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot render/run the verify script\n' "$tool"
+    exit 0
+  fi
+done
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Stub herdr. Modes flip one health signal each to prove the stamp needs ALL of
+# them. `plugins` lists which plugin ids `plugin list --plugin` reports.
+#   healthy       -> version ok, both plugins, session running
+#   plugin-missing-> only herdr-last-workspace reports (smart-nav absent)
+#   session-down  -> `session list` fails (server unreachable)
+#   binary-broken -> `herdr --version` fails
+make_herdr_stub() {
+  local dir="$1" mode="$2"
+  cat >"$dir/herdr" <<STUB
+#!/bin/bash
+mode="$mode"
+sub="\$1 \$2"
+case "\$sub" in
+  "--version ")
+    [[ \$mode == binary-broken ]] && exit 1
+    echo "herdr 0.7.0-preview.test"
+    exit 0 ;;
+esac
+if [[ \$1 == --version ]]; then
+  [[ \$mode == binary-broken ]] && exit 1
+  echo "herdr 0.7.0-preview.test"; exit 0
+fi
+case "\$sub" in
+  "session list")
+    [[ \$mode == session-down ]] && exit 3
+    printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'
+    exit 0 ;;
+  "plugin list")
+    # args: plugin list --plugin <id> --json
+    id="\$4"
+    if [[ \$mode == plugin-missing && \$id == herdr-smart-nav ]]; then
+      printf '{"result":{"plugins":[],"type":"plugin_list"}}\n'; exit 0
+    fi
+    printf '{"result":{"plugins":[{"plugin_id":"%s"}],"type":"plugin_list"}}\n' "\$id"
+    exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/herdr"
+}
+
+# run_case <name> <mode> <config?> <pre-stamp?>
+run_case() {
+  local name="$1" mode="$2" config="$3" pre_stamp="$4"
+  CASE_HOME="$work/$name/home"
+  local bin="$work/$name/bin"
+  STAMP="$CASE_HOME/$STAMP_REL"
+  mkdir -p "$bin" "$CASE_HOME/.config/herdr"
+  make_herdr_stub "$bin" "$mode"
+  [[ $config == config ]] && printf 'x = 1\n' >"$CASE_HOME/.config/herdr/config.toml"
+  if [[ $pre_stamp == pre-stamp ]]; then
+    mkdir -p "$(dirname "$STAMP")"
+    : >"$STAMP"
+  fi
+  RC=0
+  HOME="$CASE_HOME" PATH="$bin:$PATH" bash "$rendered" >/dev/null 2>&1 || RC=$?
+}
+
+stamp_present() { [[ -f $STAMP ]]; }
+
+# Healthy: stamp written, exit 0.
+run_case healthy healthy config no-stamp
+[[ $RC -eq 0 ]] || fail "healthy: expected exit 0, got $RC"
+stamp_present || fail "healthy: verified stamp was not written despite herdr fully healthy"
+
+# Idempotent: a second run on a healthy host keeps the stamp, still exit 0.
+run_case healthy-again healthy config pre-stamp
+[[ $RC -eq 0 ]] || fail "healthy-again: expected exit 0, got $RC"
+stamp_present || fail "healthy-again: stamp removed on a healthy second run (not idempotent)"
+
+# One plugin missing: NOT verified — stamp absent, and a stale stamp is removed.
+run_case plugin-missing plugin-missing config pre-stamp
+[[ $RC -eq 0 ]] || fail "plugin-missing: expected exit 0, got $RC"
+stamp_present && fail "plugin-missing: stamp present though a plugin is not registered"
+
+# Session server down: NOT verified.
+run_case session-down session-down config pre-stamp
+[[ $RC -eq 0 ]] || fail "session-down: expected exit 0, got $RC"
+stamp_present && fail "session-down: stamp present though the session server is unreachable"
+
+# Config missing: NOT verified.
+run_case no-config healthy no-config pre-stamp
+[[ $RC -eq 0 ]] || fail "no-config: expected exit 0, got $RC"
+stamp_present && fail "no-config: stamp present though config.toml is absent"
+
+# Binary broken: NOT verified.
+run_case binary-broken binary-broken config pre-stamp
+[[ $RC -eq 0 ]] || fail "binary-broken: expected exit 0, got $RC"
+stamp_present && fail "binary-broken: stamp present though the herdr binary does not run"
+
+printf 'PASS: run_after_58 writes the herdr-verified stamp only when binary, config, both plugins, and the session server all check out, removes it otherwise, and never aborts the apply\n'

--- a/test/herdr-plugin-build-template.sh
+++ b/test/herdr-plugin-build-template.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# herdr-plugin-build-template.sh — the two herdr plugin build chezmoiscripts
+# herdr-plugin-build-template.sh: the two herdr plugin build chezmoiscripts
 # (run_onchange_after_55/57) must share the .chezmoitemplates partial and verify
 # registration with an EXACT plugin-id match.
 #
 # Why exact: registration is confirmed by querying the plugin by id over the
-# JSON API — `herdr plugin list --plugin <id> --json` — and asserting the result
+# JSON API (`herdr plugin list --plugin <id> --json`) and asserting the result
 # contains an entry whose plugin_id EQUALS the id (jq `select(.plugin_id == $id)`,
 # equality, not a substring). A substring/any-plugin check (e.g. a bare
 # `grep -q "$plugin_id"` against the human list, where every id also appears

--- a/test/herdr-plugin-build-template.sh
+++ b/test/herdr-plugin-build-template.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 # herdr-plugin-build-template.sh — the two herdr plugin build chezmoiscripts
-# (run_onchange_after_55/57) must share the .chezmoitemplates partial and link
-# with an ANCHORED plugin-list match.
+# (run_onchange_after_55/57) must share the .chezmoitemplates partial and verify
+# registration with an EXACT plugin-id match.
 #
-# Why anchored: `herdr plugin list` prints one line per plugin shaped like
-#   - <plugin-id> (<Name>) enabled [local:<path>]
-# An unanchored `grep -q "$plugin_id"` is a substring match — a plugin id that
-# is a substring of another id, or of any plugin's local PATH (every id appears
-# inside its own path suffix and could appear inside another's), false-positives
-# and silently skips linking. Pinning the id to its list line ("- <id> ") makes
-# the check exact.
+# Why exact: registration is confirmed by querying the plugin by id over the
+# JSON API — `herdr plugin list --plugin <id> --json` — and asserting the result
+# contains an entry whose plugin_id EQUALS the id (jq `select(.plugin_id == $id)`,
+# equality, not a substring). A substring/any-plugin check (e.g. a bare
+# `grep -q "$plugin_id"` against the human list, where every id also appears
+# inside its own local path) would false-positive against another plugin's line
+# and silently skip linking. Equality on the parsed id cannot.
 #
 # Renders both templates with the host chezmoi (same mechanics as the
 # rendered-template lint in treefmt.nix: scratch HOME, CI=1) and asserts:
-#   1. each render carries the anchored grep: grep -q "^- ${plugin_id} "
-#   2. each render carries the shared-partial marker (both scripts consume
+#   1. each render queries the exact plugin id: herdr plugin list --plugin "$plugin_id" --json
+#   2. each render matches the id by equality: jq select(.plugin_id == $id)
+#   3. each render carries the shared-partial marker (both scripts consume
 #      .chezmoitemplates/herdr-plugin-build.sh.tmpl)
-#   3. each render still parses standalone (bash -n)
+#   4. each render still parses standalone (bash -n)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -27,7 +28,9 @@ SCRIPTS=(
 )
 
 # shellcheck disable=SC2016  # the non-expanding ${plugin_id} literal is the point
-ANCHORED_GREP='grep -q "^- ${plugin_id} "'
+EXACT_QUERY='herdr plugin list --plugin "$plugin_id" --json'
+# shellcheck disable=SC2016  # the literal jq program is the point
+EXACT_MATCH='select(.plugin_id == $id)'
 PARTIAL_MARKER='.chezmoitemplates/herdr-plugin-build.sh.tmpl'
 
 fail() {
@@ -53,16 +56,20 @@ for script in "${SCRIPTS[@]}"; do
     fail "chezmoi failed to render $script"
   [[ -n $rendered ]] || fail "empty render (non-darwin?): $script"
 
-  # 1) anchored plugin-list match
-  grep -qF "$ANCHORED_GREP" <<<"$rendered" ||
-    fail "$(basename "$script"): plugin-link check is not the anchored match ($ANCHORED_GREP)"
+  # 1) exact plugin-id query over the JSON API
+  grep -qF "$EXACT_QUERY" <<<"$rendered" ||
+    fail "$(basename "$script"): registration does not query the exact plugin id ($EXACT_QUERY)"
 
-  # 2) shared partial marker
+  # 2) equality match on the parsed id (never a substring)
+  grep -qF "$EXACT_MATCH" <<<"$rendered" ||
+    fail "$(basename "$script"): registration does not match the id by equality ($EXACT_MATCH)"
+
+  # 3) shared partial marker
   grep -qF "$PARTIAL_MARKER" <<<"$rendered" ||
     fail "$(basename "$script"): render does not carry the shared partial marker ($PARTIAL_MARKER)"
 
-  # 3) render is standalone-valid bash
+  # 4) render is standalone-valid bash
   bash -n <<<"$rendered" || fail "$(basename "$script"): rendered script does not parse"
 done
 
-printf 'PASS: both plugin build scripts share the partial and use the anchored plugin-list match\n'
+printf 'PASS: both plugin build scripts share the partial and verify registration by exact plugin id\n'


### PR DESCRIPTION
## Context

This dotfiles repository is being modernized: `main` is rebuilt slice by slice while the live
machine keeps applying from the `integration/modernization` branch until a final cutover. The
terminal multiplexer moved from tmux to herdr earlier in the project, and a 2026-07-10 external
audit flagged the migration machinery as fragile: a fresh machine could lose its only
multiplexer before its replacement provably worked.

This PR is the Wave-3b hardening of that machinery.

## Summary

- The brew bundle cleanup that removes tmux and sesh now runs only after the freshly applied
  herdr installation passes a live health check, in the post-apply verification script, never
  before it.
- Every herdr CLI call in the health check is wrapped in a 10 second timeout, so a frozen herdr
  server can no longer hang a `chezmoi apply`.
- The plugin build partial treats missing cargo and failed plugin registration as retryable
  states via a sanitized counter marker that re-fires the next apply, instead of silently
  consuming the one-shot trigger; real build failures stay loud.
- A one-time script retires the obsolete `com.claude.code` LaunchAgent with a tri-state probe
  that claims success only after the label is confirmed absent.
- Key files:
  - `.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl` (cleanup deferral)
  - `.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl` (verification, then cleanup)
  - `.chezmoitemplates/herdr-health-check.sh.tmpl` (shared health predicate)
  - `.chezmoitemplates/herdr-plugin-build.sh.tmpl` (retry marker)
  - `.chezmoiscripts/run_once_after_59-retire-claude-code-launchagent.sh.tmpl` (retirement)
  - eight `test/herdr-*` and `test/claude-code-*` test files

## What changed

The ordering fix is the heart of the PR. Chezmoi runs `before_` scripts, then updates target
files, then runs `after_` scripts, so any health check inside the package script could only ever
validate the previous revision. The package script now simply withholds `--cleanup` while tmux
or sesh is installed, and the post-apply verification script owns the rest: it short-circuits on
machines with nothing to migrate, otherwise health-checks the just-applied herdr (binary,
config reload accepted, both plugins registered and enabled and warning-free, session server
answering, all bounded by timeouts) and only then performs the deferred cleanup itself. A
machine mid-migration therefore keeps its old multiplexer until the new one demonstrably works
in the revision that was just written to disk.

The health predicate rejects the states that previously slipped through: disabled plugins,
warning-bearing entries, object-shaped or error envelopes, invalid configs, and a server that is
down or frozen. The retry marker in the plugin build partial is interpolated into the rendered
script as digits only, at render time and at run time, so a corrupted marker file can neither
execute as shell nor wedge an apply. The retirement script distinguishes loaded, confirmed
absent, and operational error, and never converts a probe failure into a success claim.

On a genuinely migrating host the true sequence is documented where it happens: apply once
(cleanup deferred), open an interactive terminal so the herdr server starts, apply again
(verification passes and cleanup runs).

## How it was reviewed

Two independent reviewers went over the branch twice each: a fresh-context Claude reviewer and
an OpenAI Codex review (gpt-5.6-sol, ultra reasoning effort). Round 1 found the trigger and
stale-stamp ordering flaws, the weak verification predicate, a raw-bytes marker interpolation
that a multiline file could turn into apply-time shell, and swallowed retirement failures.
Round 2 proved the frozen-server hang with a never-replying socket, spotted that the cleanup
still validated the previous revision, and showed probe errors masquerading as confirmed
absence. Each round ended in one fix wave; the final fixes were verified directly by the
conductor: full test suite green, every touched template rendered and shellchecked, and the
message-only history rewrite proven content-identical by tree hash.

## Effect of merging

`main` gains the hardened migration machinery. Nothing changes on any live machine: the primary
machine applies from the integration branch until the D1 cutover, and it is already migrated,
so the gate short-circuits there without contacting herdr. Three early commit messages were
reworded to satisfy the repository's no-em-dash rule via a message-only rebase; the content
tree hash before and after is identical.
