### PR TITLE
Programmatic rendered-template lint coverage and doc corrections (Wave 3c)

### DIFF
--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -27,7 +27,7 @@
 macos:
   system_setup:
     - description: "Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
-      command: "$HOME/.local/bin/install-nix-repair-hook.sh"
+      command: '"$HOME/.local/bin/install-nix-repair-hook.sh"'
       sudo: true
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net

--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-firewall-gatekeeper-monitor-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-firewall-gatekeeper-monitor-launchagent.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if eq .chezmoi.os "darwin" }}
+{{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # run_onchange_after_60-load-osquery-firewall-gatekeeper-monitor-launchagent.sh
 # plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist.tmpl" | sha256sum }}

--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-results-alerter-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-results-alerter-launchagent.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if eq .chezmoi.os "darwin" }}
+{{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # run_onchange_after_60-load-osquery-results-alerter-launchagent.sh
 # plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-results-alerter.plist.tmpl" | sha256sum }}

--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-uptime-watchdog-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-uptime-watchdog-launchagent.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if eq .chezmoi.os "darwin" }}
+{{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # run_onchange_after_60-load-osquery-uptime-watchdog-launchagent.sh
 # plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist.tmpl" | sha256sum }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,19 +257,20 @@ Shell templates contain Go template syntax that shellcheck can't parse directly,
 `shellcheck-rendered-template` formatter in `treefmt.nix` renders first
 (`CI=1 chezmoi execute-template --no-tty <file`) and shellchecks the result. Its include list is
 discovered programmatically at Nix eval time, not hand-picked: every `.chezmoiscripts/*.sh.tmpl` plus
-every shell `dot_*.tmpl` (first line a shell shebang or `# shellcheck shell=` directive, or a Go-template
-directive whose first non-directive line is such a shebang), minus any template that (or whose
-`includeTemplate` partial) invokes `keepassxc` through a `{{ ... }}` directive, since those need an
-interactive KeePassXC unlock. One includeTemplate fragment
-(`.chezmoitemplates/herdr-plugin-build.sh.tmpl`) is excluded with a documented reason because it only
-renders through its includers. After a successful render, a blank (empty or whitespace-only) result is
-skipped rather than shellchecked, so an OS-gated template on the other OS (which renders to nothing) does
-not fail SC2148; a render failure stays fatal. `test/rendered-template-coverage.sh` enforces this
-universe: it re-reads the formatter's actual include list via `nix eval` and fails when discovery drops a
-template, with a fixture layer under `test/fixtures/render-coverage` guarding the classifier against
-blind spots. The `CI=1` env var is defensive (vestigial from an earlier bashrc CI-vs-interactive branch).
-A sibling formatter, `osquery-config-render`, renders the JSON-bodied `.chezmoitemplates/osquery/*.conf`
-templates via `includeTemplate` and validates the result with jq.
+every shell `dot_*.tmpl` at the repo root (first line a shell shebang or `# shellcheck shell=` directive,
+or a Go-template directive whose first non-directive line is such a shebang), minus any template that (or
+whose `includeTemplate` partial) invokes `keepassxc` through a `{{ ... }}` directive, since those need an
+interactive KeePassXC unlock. Two includeTemplate fragments
+(`.chezmoitemplates/herdr-plugin-build.sh.tmpl` and `.chezmoitemplates/herdr-health-check.sh.tmpl`) are
+excluded with documented reasons because they only render through their includers. After a successful
+render, a blank (empty or whitespace-only) result is skipped rather than shellchecked, so an OS-gated
+template on the other OS (which renders to nothing) does not fail SC2148; a render failure stays fatal.
+`test/rendered-template-coverage.sh` enforces this universe: it re-reads the formatter's actual include
+list via `nix eval` and fails when discovery drops a template, with a fixture layer under
+`test/fixtures/render-coverage` guarding the classifier against blind spots. The `CI=1` env var is
+defensive (vestigial from an earlier bashrc CI-vs-interactive branch). A sibling formatter,
+`osquery-config-render`, renders the JSON-bodied `.chezmoitemplates/osquery/*.conf` templates via
+`includeTemplate` and validates the result with jq.
 
 ### OS Targeting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ See https://www.chezmoi.io/user-guide/manage-different-types-of-file/ for the `m
 
 ### Git Hooks
 
-All three hooks live in the **user-wide** hooks dir — `core.hooksPath = ~/.config/git/hooks` (set in
+All three hooks live in the **user-wide** hooks dir (`core.hooksPath = ~/.config/git/hooks`, set in
 `dot_gitconfig.tmpl`), so they apply to every repo:
 
 - **`prepare-commit-msg` — user-wide AI commit messages.** Prepopulates a Conventional Commits message
@@ -253,15 +253,23 @@ Templates conditionally branch on `.chezmoi.os` and, where they pull secrets, ca
 
 ### Template Shellcheck Workaround
 
-Shell templates contain Go template syntax that shellcheck can't parse directly. The
-`shellcheck-rendered-template` formatter in `treefmt.nix` renders first:
-`CI=1 chezmoi execute-template --no-tty <file | shellcheck -`. Six templates are rendered —
-`dot_bashrc.tmpl`, the osquery setup script, the three herdr install/build chezmoiscripts, and the
-tailscaled status reminder; none calls `keepassxc`, so the `CI=1` env var is defensive (vestigial from an
-earlier version where bashrc had a CI-vs-interactive branch). Other templates with CI branches (e.g.
-`identity.yml.tmpl`) are not shell-linted. A sibling formatter, `osquery-config-render`, renders the
-JSON-bodied `.chezmoitemplates/osquery/*.conf` templates via `includeTemplate` and validates the result
-with jq.
+Shell templates contain Go template syntax that shellcheck can't parse directly, so the
+`shellcheck-rendered-template` formatter in `treefmt.nix` renders first
+(`CI=1 chezmoi execute-template --no-tty <file`) and shellchecks the result. Its include list is
+discovered programmatically at Nix eval time, not hand-picked: every `.chezmoiscripts/*.sh.tmpl` plus
+every shell `dot_*.tmpl` (first line a shell shebang or `# shellcheck shell=` directive, or a Go-template
+directive whose first non-directive line is such a shebang), minus any template that (or whose
+`includeTemplate` partial) invokes `keepassxc` through a `{{ ... }}` directive, since those need an
+interactive KeePassXC unlock. One includeTemplate fragment
+(`.chezmoitemplates/herdr-plugin-build.sh.tmpl`) is excluded with a documented reason because it only
+renders through its includers. After a successful render, a blank (empty or whitespace-only) result is
+skipped rather than shellchecked, so an OS-gated template on the other OS (which renders to nothing) does
+not fail SC2148; a render failure stays fatal. `test/rendered-template-coverage.sh` enforces this
+universe: it re-reads the formatter's actual include list via `nix eval` and fails when discovery drops a
+template, with a fixture layer under `test/fixtures/render-coverage` guarding the classifier against
+blind spots. The `CI=1` env var is defensive (vestigial from an earlier bashrc CI-vs-interactive branch).
+A sibling formatter, `osquery-config-render`, renders the JSON-bodied `.chezmoitemplates/osquery/*.conf`
+templates via `includeTemplate` and validates the result with jq.
 
 ### OS Targeting
 
@@ -284,7 +292,8 @@ bats, chezmoi, and zizmor.
 GitHub Actions (`.github/workflows/lint.yml`) runs on `macos-latest` on pushes to main and PRs, with
 workflow-level `permissions: contents: read`, `persist-credentials: false` on checkout, and actions
 SHA-pinned to full commit SHAs (`.github/dependabot.yml` keeps the pins fresh weekly; its PRs auto-merge
-once the lint check passes, via `.github/workflows/dependabot-automerge.yml`). Steps:
+once the lint check passes, via `.github/workflows/dependabot-automerge.yml`; `lint` is a required status
+check on `main` under branch protection, so the auto-merge cannot land until it is green). Steps:
 `nix flake check --all-systems` (the treefmt drift gate), `just test`, and
 `zizmor --offline .github/workflows` — the latter two inside the flake's `run` shell.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ See https://www.chezmoi.io/user-guide/manage-different-types-of-file/ for the `m
 
 ### Git Hooks
 
-Both hooks live in the **user-wide** hooks dir — `core.hooksPath = ~/.config/git/hooks` (set in
+All three hooks live in the **user-wide** hooks dir — `core.hooksPath = ~/.config/git/hooks` (set in
 `dot_gitconfig.tmpl`), so they apply to every repo:
 
 - **`prepare-commit-msg` — user-wide AI commit messages.** Prepopulates a Conventional Commits message
@@ -283,8 +283,9 @@ bats, chezmoi, and zizmor.
 
 GitHub Actions (`.github/workflows/lint.yml`) runs on `macos-latest` on pushes to main and PRs, with
 workflow-level `permissions: contents: read`, `persist-credentials: false` on checkout, and actions
-SHA-pinned to full commit SHAs (`.github/dependabot.yml` keeps the pins fresh weekly; no auto-merge).
-Steps: `nix flake check --all-systems` (the treefmt drift gate), `just test`, and
+SHA-pinned to full commit SHAs (`.github/dependabot.yml` keeps the pins fresh weekly; its PRs auto-merge
+once the lint check passes, via `.github/workflows/dependabot-automerge.yml`). Steps:
+`nix flake check --all-systems` (the treefmt drift gate), `just test`, and
 `zizmor --offline .github/workflows` — the latter two inside the flake's `run` shell.
 
 ### Agent Skills (cross-harness store)

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -17,6 +17,8 @@
   **less-common / not-widely-known** acronym is avoided altogether — spell it out every time, never
   introduce the short form (e.g. write "file integrity monitoring", never "FIM").
 - Use the `humanizer` skill on prose longer than a paragraph.
+- **No em-dashes, ever**: not in prose, PR descriptions, commits, docs, or replies. Use commas, periods,
+  or parentheses.
 
 ## Verification and sources of truth
 
@@ -75,7 +77,24 @@ Require per-invocation confirmation. Blanket "yes" doesn't carry over.
 Claude Code" footer.** Commits look as if the user authored them directly.
 
 Use the `conventional-commits` skill. A global `prepare-commit-msg` hook at `~/.config/git/hooks/`
-prepopulates messages via Claude haiku; `SKIP_AI_COMMIT=1` bypasses.
+prepopulates messages via Claude sonnet; `SKIP_AI_COMMIT=1` bypasses.
+
+## Pull request descriptions
+
+Run every PR description through the `humanizer` skill before posting. Structure, in order:
+
+1. `## Context`: orient someone with zero session context (what the project/branch is, why this PR
+   exists). Two short paragraphs max. Define shorthand at first use; no unexplained project jargon.
+1. `## Summary`: a bullet list, 3-5 bullets, each SHORT and SELF-CONTAINED (an itemized change list:
+   deleting any bullet must not strip context another bullet needs; no "all 44" referring back, no "the
+   original" pointing elsewhere). Reference key files by path; use a labeled sub-list when there are
+   several.
+1. Detail sections: `## What changed`, `## How it was reviewed` (when review shaped the result),
+   `## Effect of merging` (what merging does and does not do, e.g. live-machine impact).
+
+Rules: never speak about the audience in third person ("a reader will find..."); imperative directions
+are fine ("see the coverage matrix"). Never imply a referenced document contains content it doesn't. Keep
+the body current: when review rounds change the facts, update the description.
 
 ## Task tracking
 

--- a/scripts/lib-shellcheck-rendered-template.sh
+++ b/scripts/lib-shellcheck-rendered-template.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=bash
+# Per-file body of the treefmt `shellcheck-rendered-template` formatter, factored
+# out so test/rendered-template-shellcheck-wrapper.sh can drive it with a stubbed
+# chezmoi and shellcheck. treefmt.nix sources this verbatim (builtins.readFile)
+# into the formatter's writeShellApplication text; chezmoi and shellcheck come
+# from the derivation's runtimeInputs there and from PATH stubs in the test.
+#
+# Skip semantic: after a SUCCESSFUL render, a blank (empty or whitespace-only)
+# result means an OS-gated template on the other OS has nothing to lint, so the
+# lint step is skipped (an empty body would fail SC2148). A render FAILURE stays
+# fatal.
+#
+# Usage: render_and_shellcheck_one <file>  -> 0 on ok/skip, non-zero on failure.
+render_and_shellcheck_one() {
+  local file="$1"
+  local rendered
+  if ! rendered="$(CI=1 chezmoi --source "$PWD" execute-template --no-tty <"$file")"; then
+    printf 'shellcheck-rendered-template: chezmoi render failed: %s\n' "$file" >&2
+    return 1
+  fi
+  if [[ -z ${rendered//[[:space:]]/} ]]; then
+    return 0
+  fi
+  if ! printf '%s\n' "$rendered" | shellcheck -; then
+    printf 'shellcheck-rendered-template: rendered template failed shellcheck: %s\n' "$file" >&2
+    return 1
+  fi
+  return 0
+}

--- a/scripts/render-coverage-classifier.nix
+++ b/scripts/render-coverage-classifier.nix
@@ -1,0 +1,132 @@
+# Pure (builtins-only) classifier for the rendered-template coverage discovery.
+#
+# This is the SINGLE source of truth for "which shell templates can render
+# headless and are therefore safe to hand to the shellcheck-rendered-template
+# formatter". treefmt.nix imports it to build that formatter's include list, and
+# test/rendered-template-coverage.sh drives the SAME functions through `nix eval`
+# against the fixture matrix (beside a bash mirror), asserting agreement case by
+# case. Before this file existed the Nix predicates were unexported let-bindings,
+# so weakening one left every fixture green; now a weakened predicate here fails
+# the fixture matrix directly.
+#
+# No `lib`, no `pkgs`: everything is `builtins`, so the test can import it with a
+# bare `nix eval --impure` and no flake machinery. Every helper is textually
+# mirrored by a bash function in the test; keep the two in lockstep.
+rec {
+  # File split into lines (drop the capture sublists builtins.split emits).
+  fileLines = path: builtins.filter builtins.isString (builtins.split "\n" (builtins.readFile path));
+
+  # A line invokes keepassxc when the identifier keepassxc/keepassxcAttribute
+  # appears ANYWHERE inside a Go-template action `{{ ... }}`, not only as the
+  # first token: `{{ $e := keepassxc "x" }}` counts. A Go-template COMMENT
+  # (`{{/* ... */}}`, in any trim form) does not, and a bare shell `#` comment
+  # that merely mentions keepassxc does not (it carries no `{{`). Actions in this
+  # repo are single-line, so the scan is per line.
+  lineCallsKeepassxc =
+    line:
+    builtins.match ".*[{][{][^}]*keepassxc.*" line != null
+    && builtins.match "[[:space:]]*[{][{]-?[[:space:]]*/[*].*" line == null;
+
+  directCallsKeepassxc = path: builtins.any lineCallsKeepassxc (fileLines path);
+
+  # Parse a single line for an includeTemplate directive `{{ includeTemplate <arg> ... }}`.
+  # Returns null (no directive), { name = "<literal>"; } for a double-quoted or
+  # backtick raw-string name, or { dynamic = true; } when the name argument is
+  # not a static string literal (a $var, (expr), or .field) and so cannot be
+  # resolved at eval time. Anchored on `{{` so prose mentioning includeTemplate
+  # inside a comment body (which carries no `{{` on that line) is not a directive.
+  parseIncludeLine =
+    line:
+    let
+      m = builtins.match ".*[{][{]-?[[:space:]]*includeTemplate[[:space:]]+(.*)" line;
+    in
+    if m == null then
+      null
+    else
+      let
+        rest = builtins.head m;
+        dq = builtins.match "\"([^\"]*)\".*" rest;
+        bt = builtins.match "`([^`]*)`.*" rest;
+      in
+      if dq != null then
+        { name = builtins.head dq; }
+      else if bt != null then
+        { name = builtins.head bt; }
+      else
+        { dynamic = true; };
+
+  # All includeTemplate directives in a file: { dynamic = bool; names = [str]; }.
+  includeDirectives =
+    path:
+    let
+      hits = builtins.filter (x: x != null) (map parseIncludeLine (fileLines path));
+    in
+    {
+      dynamic = builtins.any (h: h ? dynamic) hits;
+      names = map (h: h.name) (builtins.filter (h: h ? name) hits);
+    };
+
+  # A template cannot render headless (is UNSAFE) when it, or any partial it
+  # includeTemplates (transitively, literal names resolved against includeBase),
+  # calls keepassxc, OR when any includeTemplate name cannot be resolved
+  # statically (conservative rejection). Cycle-protected: a partial already on
+  # the current include chain contributes no new unsafety, so a cyclic pair
+  # terminates. A literal include whose partial is absent under includeBase is
+  # skipped (it would fail at real render time, a separate concern).
+  rendersUnsafe =
+    includeBase: path:
+    let
+      go =
+        visited: p:
+        if builtins.elem p visited then
+          false
+        else if directCallsKeepassxc p then
+          true
+        else
+          let
+            incs = includeDirectives p;
+          in
+          if incs.dynamic then
+            true
+          else
+            builtins.any (
+              name:
+              let
+                partial = includeBase + "/${name}";
+              in
+              builtins.pathExists partial && go (visited ++ [ p ]) partial
+            ) incs.names;
+    in
+    go [ ] path;
+
+  # A template is a shell template when its first line is a shell shebang (or a
+  # `# shellcheck shell=` directive), OR its first line is a Go-template
+  # directive and its first non-directive line is such a shebang (the
+  # osquery-loader shape).
+  isShellShebangLine =
+    line: builtins.match "#!.*sh.*" line != null || builtins.match "# shellcheck shell=.*" line != null;
+  isGoDirectiveLine = line: builtins.match "[[:space:]]*[{][{].*" line != null;
+  isShellTemplate =
+    path:
+    let
+      ls = fileLines path;
+      first = if ls == [ ] then "" else builtins.head ls;
+      nonDirective = builtins.filter (l: !(isGoDirectiveLine l)) ls;
+      firstNonDirective = if nonDirective == [ ] then "" else builtins.head nonDirective;
+    in
+    isShellShebangLine first || (isGoDirectiveLine first && isShellShebangLine firstNonDirective);
+
+  isShTmpl = path: builtins.match ".*\\.sh\\.tmpl" (builtins.baseNameOf path) != null;
+
+  # The coverage verdict for a template: "covered" when it is a shell template
+  # (a *.sh.tmpl, or shell-classified by shape) that can render headless;
+  # "excluded" otherwise. Mirrors the bash fixture oracle in the test.
+  classify =
+    includeBase: path:
+    if rendersUnsafe includeBase path then
+      "excluded"
+    else if isShTmpl path || isShellTemplate path then
+      "covered"
+    else
+      "excluded";
+}

--- a/test/fixtures/render-coverage/assignment_keepassxc.sh.tmpl
+++ b/test/fixtures/render-coverage/assignment_keepassxc.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture (item 2a): keepassxc invoked in assignment form, so it is NOT the first
+# token after {{. The action-scoped detector must still mark it unsafe
+# (verdict: excluded); a first-token-only matcher would miss it.
+set -euo pipefail
+{{ $entry := keepassxc "Fixture :: Example" }}
+echo "{{ $entry.Password }}"

--- a/test/fixtures/render-coverage/chain_middle.tmpl
+++ b/test/fixtures/render-coverage/chain_middle.tmpl
@@ -1,0 +1,3 @@
+{{/* Fixture middle link (item 2c): safe itself, but pulls in the secret partial,
+so a one-level traversal would stop here and miss the keepassxc call below. */ -}}
+{{ includeTemplate "partial_secret.tmpl" . }}

--- a/test/fixtures/render-coverage/chain_root.sh.tmpl
+++ b/test/fixtures/render-coverage/chain_root.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture (item 2c): root -> middle -> secret. The transitive traversal must
+# recurse two levels to reach keepassxc (verdict: excluded); a one-level check
+# would classify this covered.
+set -euo pipefail
+{{ includeTemplate "chain_middle.tmpl" . }}
+echo "done"

--- a/test/fixtures/render-coverage/covered_comment.sh.tmpl
+++ b/test/fixtures/render-coverage/covered_comment.sh.tmpl
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Fixture: a shell template that mentions keepassxc ONLY in a comment. A naive
-# substring matcher would wrongly exclude it; the template-call detector must
-# leave it covered because there is no {{ ... keepassxc ... }} directive.
+# Fixture: a shell template that names keepassxc ONLY in shell comments, never in
+# a Go-template action. A naive substring matcher would wrongly exclude it; the
+# action-scoped detector must leave it covered because no Go-template action here
+# invokes keepassxc.
 # This script does not call keepassxc; the secret is fetched elsewhere.
 set -euo pipefail
 echo "no secret here"

--- a/test/fixtures/render-coverage/covered_comment.sh.tmpl
+++ b/test/fixtures/render-coverage/covered_comment.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture: a shell template that mentions keepassxc ONLY in a comment. A naive
+# substring matcher would wrongly exclude it; the template-call detector must
+# leave it covered because there is no {{ ... keepassxc ... }} directive.
+# This script does not call keepassxc; the secret is fetched elsewhere.
+set -euo pipefail
+echo "no secret here"

--- a/test/fixtures/render-coverage/cyclic_a.sh.tmpl
+++ b/test/fixtures/render-coverage/cyclic_a.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture (item 2, cycle): A includes B, B includes A. The transitive traversal
+# must terminate (cycle protection) and, since no link calls keepassxc, classify
+# it covered without hanging.
+set -euo pipefail
+{{ includeTemplate "cyclic_b.tmpl" . }}
+echo "done"

--- a/test/fixtures/render-coverage/cyclic_b.tmpl
+++ b/test/fixtures/render-coverage/cyclic_b.tmpl
@@ -1,0 +1,3 @@
+{{/* Fixture cycle partner B: includes A back, forming a cycle. No keepassxc, so
+the cycle-protected traversal must terminate and report safe. */ -}}
+{{ includeTemplate "cyclic_a.sh.tmpl" . }}

--- a/test/fixtures/render-coverage/dot_conditional.tmpl
+++ b/test/fixtures/render-coverage/dot_conditional.tmpl
@@ -1,0 +1,8 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# Fixture: a dot_*.tmpl whose first line is a Go conditional and whose first
+# non-directive line is a shell shebang (the osquery-loader shape). The
+# classifier must still recognize it as a shell template (verdict: covered).
+set -euo pipefail
+echo "darwin only"
+{{- end }}

--- a/test/fixtures/render-coverage/dynamic_include.sh.tmpl
+++ b/test/fixtures/render-coverage/dynamic_include.sh.tmpl
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Fixture (item 2, dynamic): the include name is a variable, unresolvable at eval
+# time. Conservative rejection marks it unsafe (verdict: excluded) even though it
+# is a shell template, because we cannot know what it pulls in.
+set -euo pipefail
+{{ $name := "partial_secret.tmpl" }}
+{{ includeTemplate $name . }}
+echo "done"

--- a/test/fixtures/render-coverage/excluded_include.sh.tmpl
+++ b/test/fixtures/render-coverage/excluded_include.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture: a shell template that calls no secret itself but pulls in a partial
+# via includeTemplate whose body calls keepassxc. The transitive check (one
+# level) must mark it unsafe (verdict: excluded).
+set -euo pipefail
+{{ includeTemplate "partial_secret.tmpl" . }}
+echo "done"

--- a/test/fixtures/render-coverage/excluded_keepassxc.sh.tmpl
+++ b/test/fixtures/render-coverage/excluded_keepassxc.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fixture: a shell template that invokes keepassxc through a Go-template
+# directive (the paren-grouped form used across this repo). The detector must
+# mark it unsafe (verdict: excluded) because it cannot render headless.
+set -euo pipefail
+token={{ (keepassxc "Fixture :: Example").Password | quote }}
+echo "$token"

--- a/test/fixtures/render-coverage/executable_hook.tmpl
+++ b/test/fixtures/render-coverage/executable_hook.tmpl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Fixture: extensionless executable_*.tmpl whose first line is a shell shebang.
+# The classifier must recognize it as a shell template (verdict: covered).
+set -euo pipefail
+echo "hook ran"

--- a/test/fixtures/render-coverage/partial_secret.tmpl
+++ b/test/fixtures/render-coverage/partial_secret.tmpl
@@ -1,0 +1,3 @@
+{{/* Fixture partial included by excluded_include.sh.tmpl. Its keepassxc call is
+what makes the includer transitively unsafe. */ -}}
+password={{ keepassxcAttribute "Fixture :: Example" "password" }}

--- a/test/fixtures/render-coverage/plain_non_shell.tmpl
+++ b/test/fixtures/render-coverage/plain_non_shell.tmpl
@@ -1,0 +1,4 @@
+[section]
+# Fixture: a non-shell template (no shebang, no Go-directive-then-shebang). The
+# classifier must exclude it from the shell universe (verdict: excluded).
+key = {{ .chezmoi.hostname }}

--- a/test/fixtures/render-coverage/raw_string_include.sh.tmpl
+++ b/test/fixtures/render-coverage/raw_string_include.sh.tmpl
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Fixture (item 2b): the includeTemplate name is a backtick raw-string literal,
+# not a double-quoted one. The parser must read it and follow the include to the
+# secret partial (verdict: excluded); a double-quote-only parser would miss the
+# include and wrongly classify this covered.
+set -euo pipefail
+{{ includeTemplate `partial_secret.tmpl` . }}
+echo "done"

--- a/test/rendered-template-coverage.sh
+++ b/test/rendered-template-coverage.sh
@@ -16,9 +16,11 @@
 # It reads the formatter's ACTUAL include list straight from treefmt.nix via
 # `nix eval` (with a stub `pkgs`), so it tracks the programmatic discovery
 # exactly: red against the old 6-template hand-list, green once discovery covers
-# them all. A fixture layer (test/fixtures/render-coverage) drives the SAME
-# classifier against synthetic templates so shared discovery/test blind spots
-# stay visible.
+# them all. A fixture layer (test/fixtures/render-coverage) drives the classifier
+# against synthetic templates BOTH ways — the bash mirror in this file and the
+# production Nix predicates in scripts/render-coverage-classifier.nix (via
+# `nix eval`) — so weakening either side fails a fixture instead of passing
+# silently.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1 && pwd)"
@@ -33,32 +35,70 @@ fail() {
 
 # ---- classifier (shared by the universe enumeration and the fixture oracle) --
 
-# A template invokes keepassxc only through a Go-template directive: a line
-# containing `{{` followed (after optional trim markers, whitespace, pipes, or
-# grouping parens) by `keepassxc`/`keepassxcAttribute`. A bare comment that
-# merely mentions keepassxc does NOT count, so it stays covered. Mirrors the
-# `directCallsKeepassxc` predicate in treefmt.nix.
+# A line invokes keepassxc when keepassxc/keepassxcAttribute appears ANYWHERE
+# inside a Go-template action `{{ ... }}` (not only as the first token, so
+# `{{ $e := keepassxc "x" }}` counts), and the line is not a Go-template comment
+# (`{{/* ... */}}`, in any trim form). A bare shell `#` comment that merely names
+# keepassxc carries no `{{` and does not count, so it stays covered. Mirrors
+# `lineCallsKeepassxc` in scripts/render-coverage-classifier.nix.
 line_calls_keepassxc() { # <file>
-  grep -Eq '[{][{][-(|[:space:]]*keepassxc' "$1"
+  local hits
+  hits="$(grep -E '[{][{][^}]*keepassxc' "$1" 2>/dev/null |
+    grep -vE '^[[:space:]]*[{][{]-?[[:space:]]*/[*]' || true)"
+  [[ -n $hits ]]
 }
 
-# includeTemplate "<literal>" partial names a template references (literal
-# strings in this repo). Mirrors `includeTemplateNames` in treefmt.nix.
-include_template_names() { # <file>
-  grep -Eo 'includeTemplate[[:space:]]+"[^"]+"' "$1" | sed -E 's/.*"([^"]+)"/\1/'
+# Parse includeTemplate directives, one emitted line per directive:
+#   L<TAB><name>  a double-quoted OR backtick raw-string literal partial name
+#   D             a name that is not a static string literal (a $var, (expr), or
+#                 .field) and so cannot be resolved statically
+# Anchored on `{{` so prose mentioning includeTemplate inside a comment body
+# (which carries no `{{` on that line) is not treated as a directive. Mirrors
+# `parseIncludeLine`/`includeDirectives` in the classifier.
+include_directives() { # <file>
+  local inc_re='[{][{]-?[[:space:]]*includeTemplate[[:space:]]+(.*)'
+  # SC2016: the backtick in bt_re is a literal ERE atom (backtick raw-string
+  # delimiter), deliberately not command substitution.
+  # shellcheck disable=SC2016
+  local dq_re='^"([^"]*)"' bt_re='^`([^`]*)`'
+  local line rest
+  while IFS= read -r line; do
+    [[ $line =~ $inc_re ]] || continue
+    rest="${BASH_REMATCH[1]}"
+    if [[ $rest =~ $dq_re ]]; then
+      printf 'L\t%s\n' "${BASH_REMATCH[1]}"
+    elif [[ $rest =~ $bt_re ]]; then
+      printf 'L\t%s\n' "${BASH_REMATCH[1]}"
+    else
+      printf 'D\n'
+    fi
+  done <"$1"
 }
 
-# A template is unsafe if it, OR any `.chezmoitemplates/` partial it includes
-# (one level; base overridable for the fixture oracle), calls keepassxc.
-calls_keepassxc() { # <file> [include_base]
-  local file="$1" base="${2:-.chezmoitemplates}" name partial
+# A template cannot render headless (is UNSAFE) when it, or any partial it
+# includeTemplates transitively (literal names resolved against <base>), calls
+# keepassxc, OR when any include name is dynamic (unresolvable). Cycle-protected
+# via a visited set so a cyclic include pair terminates. Mirrors `rendersUnsafe`
+# in scripts/render-coverage-classifier.nix.
+renders_unsafe() { # <file> [include_base]
+  local -A _visited=()
+  _renders_unsafe "$1" "${2:-.chezmoitemplates}"
+}
+_renders_unsafe() { # <file> <base>  (shares _visited with renders_unsafe)
+  local file="$1" base="$2" line kind name partial
+  [[ -n ${_visited["$file"]:-} ]] && return 1
+  _visited["$file"]=1
   line_calls_keepassxc "$file" && return 0
-  while IFS= read -r -u3 name; do
-    [[ -n $name ]] || continue
+  while IFS= read -r -u3 line; do
+    kind="${line%%$'\t'*}"
+    if [[ $kind == D ]]; then
+      return 0
+    fi
+    name="${line#*$'\t'}"
     partial="$base/$name"
     [[ -f $partial ]] || continue
-    line_calls_keepassxc "$partial" && return 0
-  done 3< <(include_template_names "$file")
+    _renders_unsafe "$partial" "$base" && return 0
+  done 3< <(include_directives "$file")
   return 1
 }
 
@@ -113,7 +153,7 @@ consider() { # add a candidate template to the universe once, dropping keepassxc
   [[ -n ${seen["$path"]:-} ]] && return 0
   seen["$path"]=1
   [[ -f $path ]] || return 0
-  if calls_keepassxc "$path"; then
+  if renders_unsafe "$path"; then
     return 0
   fi
   safe+=("$path")
@@ -205,12 +245,15 @@ for path in "${!EXCLUDED[@]}"; do
   fi
 done
 
-# 4. Fixture oracle: run the SAME classifier against synthetic templates so the
-# vacuous discovery clauses (shell classification, keepassxc filter, transitive
-# include) keep a permanent oracle. verdict = covered when the classifier would
-# admit the template to the safe universe, excluded otherwise.
+# 4. Fixture oracle: the SAME classifier runs THREE ways per fixture and all
+# three must agree — the expected verdict, the bash mirror above, and the
+# PRODUCTION Nix classifier (scripts/render-coverage-classifier.nix) evaluated
+# via `nix eval`. Driving the real Nix predicates here (not just the bash mirror)
+# is what makes weakening EITHER side fail the matrix instead of passing
+# silently. verdict = covered when a shell template can render headless, excluded
+# otherwise.
 fixture_verdict() { # <file> <include_base>
-  if calls_keepassxc "$1" "$2"; then
+  if renders_unsafe "$1" "$2"; then
     printf 'excluded'
     return
   fi
@@ -221,6 +264,13 @@ fixture_verdict() { # <file> <include_base>
   printf 'excluded'
 }
 
+# The production Nix classifier's verdict for a fixture, read straight from
+# scripts/render-coverage-classifier.nix so a weakened Nix predicate fails here.
+nix_classify() { # <fixture_file>
+  nix eval --impure --raw --expr \
+    "(import ./scripts/render-coverage-classifier.nix).classify (./${FIXTURE_DIR}) (./$1)"
+}
+
 declare -A FIXTURE_EXPECT=(
   ["executable_hook.tmpl"]=covered
   ["dot_conditional.tmpl"]=covered
@@ -228,16 +278,25 @@ declare -A FIXTURE_EXPECT=(
   ["excluded_keepassxc.sh.tmpl"]=excluded
   ["excluded_include.sh.tmpl"]=excluded
   ["plain_non_shell.tmpl"]=excluded
+  ["assignment_keepassxc.sh.tmpl"]=excluded
+  ["raw_string_include.sh.tmpl"]=excluded
+  ["chain_root.sh.tmpl"]=excluded
+  ["dynamic_include.sh.tmpl"]=excluded
+  ["cyclic_a.sh.tmpl"]=covered
 )
 
 for name in "${!FIXTURE_EXPECT[@]}"; do
   file="$FIXTURE_DIR/$name"
   [[ -f $file ]] || fail "missing fixture: $file"
-  got="$(fixture_verdict "$file" "$FIXTURE_DIR")"
   want="${FIXTURE_EXPECT[$name]}"
-  [[ $got == "$want" ]] ||
-    fail "fixture $name classified '$got', expected '$want' (classifier regressed)"
+  got_bash="$(fixture_verdict "$file" "$FIXTURE_DIR")"
+  [[ $got_bash == "$want" ]] ||
+    fail "fixture $name: bash mirror classified '$got_bash', expected '$want' (bash classifier regressed)"
+  got_nix="$(nix_classify "$file")" ||
+    fail "fixture $name: nix eval of the classifier failed"
+  [[ $got_nix == "$want" ]] ||
+    fail "fixture $name: Nix classifier classified '$got_nix', expected '$want' (Nix classifier regressed)"
 done
 
-printf 'rendered-template-coverage: OK (%d safely renderable, %d covered, %d excluded-with-reason, %d fixtures)\n' \
+printf 'rendered-template-coverage: OK (%d safely renderable, %d covered, %d excluded-with-reason, %d fixtures bash+nix)\n' \
   "${#safe[@]}" "${#covered[@]}" "${#EXCLUDED[@]}" "${#FIXTURE_EXPECT[@]}"

--- a/test/rendered-template-coverage.sh
+++ b/test/rendered-template-coverage.sh
@@ -92,6 +92,7 @@ is_shell_template() { # <file>
 # list cannot rot.
 declare -A EXCLUDED=(
   [".chezmoitemplates/herdr-plugin-build.sh.tmpl"]='includeTemplate fragment: needs a (dict "id" ...) arg, so it never renders standalone; exercised through its includers run_onchange_after_55/57, which ARE covered'
+  [".chezmoitemplates/herdr-health-check.sh.tmpl"]='includeTemplate fragment: defines a shell function with no standalone shebang entry point, so it never renders on its own; exercised through its covered includer run_after_58-herdr-migration-verify'
 )
 
 # Host-tool guards: plain test/*.sh scripts run with host tools.

--- a/test/rendered-template-coverage.sh
+++ b/test/rendered-template-coverage.sh
@@ -17,9 +17,9 @@
 # `nix eval` (with a stub `pkgs`), so it tracks the programmatic discovery
 # exactly: red against the old 6-template hand-list, green once discovery covers
 # them all. A fixture layer (test/fixtures/render-coverage) drives the classifier
-# against synthetic templates BOTH ways — the bash mirror in this file and the
+# against synthetic templates BOTH ways: the bash mirror in this file and the
 # production Nix predicates in scripts/render-coverage-classifier.nix (via
-# `nix eval`) — so weakening either side fails a fixture instead of passing
+# `nix eval`), so weakening either side fails a fixture instead of passing
 # silently.
 set -euo pipefail
 
@@ -246,7 +246,7 @@ for path in "${!EXCLUDED[@]}"; do
 done
 
 # 4. Fixture oracle: the SAME classifier runs THREE ways per fixture and all
-# three must agree — the expected verdict, the bash mirror above, and the
+# three must agree: the expected verdict, the bash mirror above, and the
 # PRODUCTION Nix classifier (scripts/render-coverage-classifier.nix) evaluated
 # via `nix eval`. Driving the real Nix predicates here (not just the bash mirror)
 # is what makes weakening EITHER side fail the matrix instead of passing

--- a/test/rendered-template-coverage.sh
+++ b/test/rendered-template-coverage.sh
@@ -1,30 +1,92 @@
 #!/usr/bin/env bash
-# rendered-template-coverage.sh — the treefmt `shellcheck-rendered-template`
-# formatter must render+shellcheck EVERY safely renderable shell template, not a
-# hand-picked subset. The 2026-07-10 audit found the old hand-list covered 6 of
-# ~20 shell templates, hiding four render failures.
+# rendered-template-coverage.sh. The treefmt rendered-template lint formatter
+# must render and lint EVERY safely renderable shell template, not a hand-picked
+# subset. The 2026-07-10 audit found the old hand-list covered 6 of ~20 shell
+# templates, hiding four render failures.
 #
 # "Safely renderable" = every `*.sh.tmpl` plus the shell `dot_*.tmpl` (first line
-# a shell shebang or a `# shellcheck shell=` directive), MINUS any template that
-# calls `keepassxc` (those need an interactive KeePassXC unlock and cannot render
-# in the headless Nix check sandbox).
+# a shell shebang or a `# shellcheck shell=` directive, OR a Go-template
+# directive whose first non-directive line is such a shebang), MINUS any
+# template that itself, or a `.chezmoitemplates/` partial it includes, invokes
+# keepassxc through a Go-template directive (those need an interactive KeePassXC
+# unlock and cannot render in the headless Nix check sandbox).
 #
-# This test builds that universe independently and fails when a member is neither
-# covered by the formatter nor listed in EXCLUDED below with a reason. It reads
-# the formatter's ACTUAL include list straight from treefmt.nix via `nix eval`
-# (with a stub `pkgs`), so it tracks the programmatic discovery exactly: red
-# against the old 6-template hand-list, green once discovery covers them all.
+# This test builds that universe independently and fails when a member is
+# neither covered by the formatter nor listed in EXCLUDED below with a reason.
+# It reads the formatter's ACTUAL include list straight from treefmt.nix via
+# `nix eval` (with a stub `pkgs`), so it tracks the programmatic discovery
+# exactly: red against the old 6-template hand-list, green once discovery covers
+# them all. A fixture layer (test/fixtures/render-coverage) drives the SAME
+# classifier against synthetic templates so shared discovery/test blind spots
+# stay visible.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$REPO_ROOT"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+FIXTURE_DIR="test/fixtures/render-coverage"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
 
-# Shell *.sh.tmpl templates that are deliberately NOT standalone-covered. Key =
+# ---- classifier (shared by the universe enumeration and the fixture oracle) --
+
+# A template invokes keepassxc only through a Go-template directive: a line
+# containing `{{` followed (after optional trim markers, whitespace, pipes, or
+# grouping parens) by `keepassxc`/`keepassxcAttribute`. A bare comment that
+# merely mentions keepassxc does NOT count, so it stays covered. Mirrors the
+# `directCallsKeepassxc` predicate in treefmt.nix.
+line_calls_keepassxc() { # <file>
+  grep -Eq '[{][{][-(|[:space:]]*keepassxc' "$1"
+}
+
+# includeTemplate "<literal>" partial names a template references (literal
+# strings in this repo). Mirrors `includeTemplateNames` in treefmt.nix.
+include_template_names() { # <file>
+  grep -Eo 'includeTemplate[[:space:]]+"[^"]+"' "$1" | sed -E 's/.*"([^"]+)"/\1/'
+}
+
+# A template is unsafe if it, OR any `.chezmoitemplates/` partial it includes
+# (one level; base overridable for the fixture oracle), calls keepassxc.
+calls_keepassxc() { # <file> [include_base]
+  local file="$1" base="${2:-.chezmoitemplates}" name partial
+  line_calls_keepassxc "$file" && return 0
+  while IFS= read -r -u3 name; do
+    [[ -n $name ]] || continue
+    partial="$base/$name"
+    [[ -f $partial ]] || continue
+    line_calls_keepassxc "$partial" && return 0
+  done 3< <(include_template_names "$file")
+  return 1
+}
+
+is_shell_shebang_line() { # <line>
+  [[ $1 == '#!'*sh* || $1 == '# shellcheck shell='* ]]
+}
+is_go_directive_line() { # <line>
+  [[ $1 =~ ^[[:space:]]*\{\{ ]]
+}
+
+# A template is a shell template when its first line is a shell shebang, OR its
+# first line is a Go-template directive and its first NON-directive line is a
+# shell shebang (the osquery-loader shape). Mirrors `isShellTemplate` in
+# treefmt.nix.
+is_shell_template() { # <file>
+  local file="$1" first firstnon
+  first="$(head -n 1 "$file")"
+  is_shell_shebang_line "$first" && return 0
+  if is_go_directive_line "$first"; then
+    firstnon="$(grep -vE '^[[:space:]]*\{\{' "$file" | head -n 1)"
+    is_shell_shebang_line "$firstnon" && return 0
+  fi
+  return 1
+}
+
+# ---- excluded set -----------------------------------------------------------
+
+# Shell templates that are deliberately NOT standalone-covered. Key =
 # repo-relative path; value = the reason. Each is re-validated below (must be a
 # real, non-keepassxc shell template that the formatter does NOT cover) so this
 # list cannot rot.
@@ -50,28 +112,46 @@ consider() { # add a candidate template to the universe once, dropping keepassxc
   [[ -n ${seen["$path"]:-} ]] && return 0
   seen["$path"]=1
   [[ -f $path ]] || return 0
-  if grep -q 'keepassxc' "$path"; then
+  if calls_keepassxc "$path"; then
     return 0
   fi
   safe+=("$path")
   safe_set["$path"]=1
 }
 
-# Every tracked *.sh.tmpl anywhere in the tree.
+# Every tracked *.sh.tmpl anywhere in the tree (fixtures excluded).
 while IFS= read -r path; do
+  [[ $path == "$FIXTURE_DIR"/* ]] && continue
   consider "$path"
 done < <(git ls-files '*.sh.tmpl' | sort)
 
-# Shell dot_*.tmpl (by basename), first line a shebang or a shellcheck directive.
+# Shell dot_*.tmpl (by basename), classified as a shell template (fixtures excluded).
 while IFS= read -r path; do
+  [[ $path == "$FIXTURE_DIR"/* ]] && continue
+  [[ -f $path ]] || continue
   [[ $(basename "$path") == dot_*.tmpl ]] || continue
-  first="$(head -n 1 "$path")"
-  if [[ $first == '#!'*sh* || $first == '# shellcheck shell='* ]]; then
-    consider "$path"
-  fi
+  is_shell_template "$path" && consider "$path"
 done < <(git ls-files '*.tmpl' | sort)
 
-[[ ${#safe[@]} -gt 0 ]] || fail "found no safely renderable shell templates — universe enumeration is broken"
+[[ ${#safe[@]} -gt 0 ]] || fail "found no safely renderable shell templates (universe enumeration is broken)"
+
+# The discovery does NOT scan extensionless executable_*.tmpl shell templates
+# (none are tracked today). Assert that stays true, so the arrival of one forces
+# a decision (add the shape to treefmt discovery + this universe, or keep it
+# out) instead of silently escaping coverage. Fixtures are exempt.
+declare -a stray_exec=()
+while IFS= read -r path; do
+  [[ $path == "$FIXTURE_DIR"/* ]] && continue
+  [[ -f $path ]] || continue
+  [[ $(basename "$path") == executable_*.tmpl ]] || continue
+  [[ $(basename "$path") == *.sh.tmpl ]] && continue
+  is_shell_template "$path" && stray_exec+=("$path")
+done < <(git ls-files '*.tmpl' | sort)
+if [[ ${#stray_exec[@]} -gt 0 ]]; then
+  printf 'FAIL: extensionless executable_*.tmpl shell template(s) exist, but discovery does not scan that shape:\n' >&2
+  printf '  - %s\n' "${stray_exec[@]}" >&2
+  fail "decide: add executable_*.tmpl to treefmt discovery AND this universe, or keep them out of the shell set"
+fi
 
 # ---- covered set: the formatter's ACTUAL includes, read from treefmt.nix -----
 covered_raw="$(
@@ -104,22 +184,59 @@ if [[ ${#missing[@]} -gt 0 ]]; then
   fail "extend the treefmt discovery to cover them, or add each to EXCLUDED with a documented reason"
 fi
 
-# 2. No covered entry is a phantom or an unsafe (keepassxc/non-shell) template.
+# 2. No covered entry is a phantom, an untracked file, or an unsafe template.
 for path in "${!covered[@]}"; do
   [[ -f $path ]] || fail "treefmt covers a non-existent file: $path"
-  [[ -n ${safe_set["$path"]:-} ]] ||
-    fail "treefmt covers '$path', which is not in the safely renderable universe (keepassxc caller, or not a shell template)"
+  [[ -n ${safe_set["$path"]:-} ]] && continue
+  if ! git ls-files --error-unmatch "$path" >/dev/null 2>&1; then
+    fail "treefmt covers '$path', but it is an untracked template; git add it (the universe is built from git ls-files)"
+  fi
+  fail "treefmt covers '$path', which is not in the safely renderable universe (keepassxc caller, or not a shell template)"
 done
 
 # 3. Every EXCLUDED entry is real, safe, and genuinely uncovered (no stale rows).
 for path in "${!EXCLUDED[@]}"; do
   [[ -f $path ]] || fail "EXCLUDED lists a non-existent file: $path"
   [[ -n ${safe_set["$path"]:-} ]] ||
-    fail "EXCLUDED entry '$path' is not a safely renderable shell template — drop it"
+    fail "EXCLUDED entry '$path' is not a safely renderable shell template; drop it"
   if [[ -n ${covered["$path"]:-} ]]; then
-    fail "EXCLUDED entry '$path' is also covered by treefmt — remove it from EXCLUDED"
+    fail "EXCLUDED entry '$path' is also covered by treefmt; remove it from EXCLUDED"
   fi
 done
 
-printf 'rendered-template-coverage: OK (%d safely renderable, %d covered, %d excluded-with-reason)\n' \
-  "${#safe[@]}" "${#covered[@]}" "${#EXCLUDED[@]}"
+# 4. Fixture oracle: run the SAME classifier against synthetic templates so the
+# vacuous discovery clauses (shell classification, keepassxc filter, transitive
+# include) keep a permanent oracle. verdict = covered when the classifier would
+# admit the template to the safe universe, excluded otherwise.
+fixture_verdict() { # <file> <include_base>
+  if calls_keepassxc "$1" "$2"; then
+    printf 'excluded'
+    return
+  fi
+  if [[ $1 == *.sh.tmpl ]] || is_shell_template "$1"; then
+    printf 'covered'
+    return
+  fi
+  printf 'excluded'
+}
+
+declare -A FIXTURE_EXPECT=(
+  ["executable_hook.tmpl"]=covered
+  ["dot_conditional.tmpl"]=covered
+  ["covered_comment.sh.tmpl"]=covered
+  ["excluded_keepassxc.sh.tmpl"]=excluded
+  ["excluded_include.sh.tmpl"]=excluded
+  ["plain_non_shell.tmpl"]=excluded
+)
+
+for name in "${!FIXTURE_EXPECT[@]}"; do
+  file="$FIXTURE_DIR/$name"
+  [[ -f $file ]] || fail "missing fixture: $file"
+  got="$(fixture_verdict "$file" "$FIXTURE_DIR")"
+  want="${FIXTURE_EXPECT[$name]}"
+  [[ $got == "$want" ]] ||
+    fail "fixture $name classified '$got', expected '$want' (classifier regressed)"
+done
+
+printf 'rendered-template-coverage: OK (%d safely renderable, %d covered, %d excluded-with-reason, %d fixtures)\n' \
+  "${#safe[@]}" "${#covered[@]}" "${#EXCLUDED[@]}" "${#FIXTURE_EXPECT[@]}"

--- a/test/rendered-template-coverage.sh
+++ b/test/rendered-template-coverage.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# rendered-template-coverage.sh — the treefmt `shellcheck-rendered-template`
+# formatter must render+shellcheck EVERY safely renderable shell template, not a
+# hand-picked subset. The 2026-07-10 audit found the old hand-list covered 6 of
+# ~20 shell templates, hiding four render failures.
+#
+# "Safely renderable" = every `*.sh.tmpl` plus the shell `dot_*.tmpl` (first line
+# a shell shebang or a `# shellcheck shell=` directive), MINUS any template that
+# calls `keepassxc` (those need an interactive KeePassXC unlock and cannot render
+# in the headless Nix check sandbox).
+#
+# This test builds that universe independently and fails when a member is neither
+# covered by the formatter nor listed in EXCLUDED below with a reason. It reads
+# the formatter's ACTUAL include list straight from treefmt.nix via `nix eval`
+# (with a stub `pkgs`), so it tracks the programmatic discovery exactly: red
+# against the old 6-template hand-list, green once discovery covers them all.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Shell *.sh.tmpl templates that are deliberately NOT standalone-covered. Key =
+# repo-relative path; value = the reason. Each is re-validated below (must be a
+# real, non-keepassxc shell template that the formatter does NOT cover) so this
+# list cannot rot.
+declare -A EXCLUDED=(
+  [".chezmoitemplates/herdr-plugin-build.sh.tmpl"]='includeTemplate fragment: needs a (dict "id" ...) arg, so it never renders standalone; exercised through its includers run_onchange_after_55/57, which ARE covered'
+)
+
+# Host-tool guards: plain test/*.sh scripts run with host tools.
+for tool in nix git; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot check rendered-template coverage\n' "$tool"
+    exit 0
+  fi
+done
+
+# ---- universe: every safely renderable shell template -----------------------
+declare -A seen=()
+declare -a safe=()
+declare -A safe_set=()
+
+consider() { # add a candidate template to the universe once, dropping keepassxc callers
+  local path="$1"
+  [[ -n ${seen["$path"]:-} ]] && return 0
+  seen["$path"]=1
+  [[ -f $path ]] || return 0
+  if grep -q 'keepassxc' "$path"; then
+    return 0
+  fi
+  safe+=("$path")
+  safe_set["$path"]=1
+}
+
+# Every tracked *.sh.tmpl anywhere in the tree.
+while IFS= read -r path; do
+  consider "$path"
+done < <(git ls-files '*.sh.tmpl' | sort)
+
+# Shell dot_*.tmpl (by basename), first line a shebang or a shellcheck directive.
+while IFS= read -r path; do
+  [[ $(basename "$path") == dot_*.tmpl ]] || continue
+  first="$(head -n 1 "$path")"
+  if [[ $first == '#!'*sh* || $first == '# shellcheck shell='* ]]; then
+    consider "$path"
+  fi
+done < <(git ls-files '*.tmpl' | sort)
+
+[[ ${#safe[@]} -gt 0 ]] || fail "found no safely renderable shell templates — universe enumeration is broken"
+
+# ---- covered set: the formatter's ACTUAL includes, read from treefmt.nix -----
+covered_raw="$(
+  nix eval --impure --raw --expr \
+    'builtins.concatStringsSep "\n" ((import ./treefmt.nix { pkgs = {}; }).settings.formatter.shellcheck-rendered-template.includes)'
+)" || fail "nix eval of treefmt.nix shellcheck-rendered-template.includes failed"
+
+declare -A covered=()
+if [[ -n $covered_raw ]]; then
+  while IFS= read -r path; do
+    covered["$path"]=1
+  done <<<"$covered_raw"
+fi
+
+[[ ${#covered[@]} -gt 0 ]] || fail "treefmt.nix declares no rendered-template includes at all"
+
+# ---- assertions -------------------------------------------------------------
+
+# 1. Every safely renderable template is covered OR excluded-with-reason.
+declare -a missing=()
+for path in "${safe[@]}"; do
+  [[ -n ${covered["$path"]:-} ]] && continue
+  [[ -n ${EXCLUDED["$path"]:-} ]] && continue
+  missing+=("$path")
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  printf 'FAIL: %d shell template(s) neither covered by treefmt shellcheck-rendered-template nor EXCLUDED:\n' \
+    "${#missing[@]}" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  fail "extend the treefmt discovery to cover them, or add each to EXCLUDED with a documented reason"
+fi
+
+# 2. No covered entry is a phantom or an unsafe (keepassxc/non-shell) template.
+for path in "${!covered[@]}"; do
+  [[ -f $path ]] || fail "treefmt covers a non-existent file: $path"
+  [[ -n ${safe_set["$path"]:-} ]] ||
+    fail "treefmt covers '$path', which is not in the safely renderable universe (keepassxc caller, or not a shell template)"
+done
+
+# 3. Every EXCLUDED entry is real, safe, and genuinely uncovered (no stale rows).
+for path in "${!EXCLUDED[@]}"; do
+  [[ -f $path ]] || fail "EXCLUDED lists a non-existent file: $path"
+  [[ -n ${safe_set["$path"]:-} ]] ||
+    fail "EXCLUDED entry '$path' is not a safely renderable shell template — drop it"
+  if [[ -n ${covered["$path"]:-} ]]; then
+    fail "EXCLUDED entry '$path' is also covered by treefmt — remove it from EXCLUDED"
+  fi
+done
+
+printf 'rendered-template-coverage: OK (%d safely renderable, %d covered, %d excluded-with-reason)\n' \
+  "${#safe[@]}" "${#covered[@]}" "${#EXCLUDED[@]}"

--- a/test/rendered-template-shellcheck-wrapper.sh
+++ b/test/rendered-template-shellcheck-wrapper.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# rendered-template-shellcheck-wrapper.sh drives the per-file body of the treefmt
+# rendered-template lint formatter (factored into
+# scripts/lib-shellcheck-rendered-template.sh) with a stubbed chezmoi and lint
+# tool, proving the blank-render skip semantic:
+#   (a) a template that renders whitespace-only -> skip, exit 0, shellcheck NOT run
+#   (b) a template that renders a real script    -> shellcheck runs, exit follows it
+#   (c) a chezmoi render failure                 -> fatal (non-zero), no skip
+#   (d) a rendered script that fails shellcheck   -> fatal (non-zero)
+set -euo pipefail
+
+REPO_ROOT="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+  pwd
+)"
+LIB="$REPO_ROOT/scripts/lib-shellcheck-rendered-template.sh"
+
+[[ -f $LIB ]] || {
+  printf 'FAIL: missing %s\n' "$LIB" >&2
+  exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---- stub chezmoi + shellcheck on PATH ------------------------------------
+STUBS="$WORK/bin"
+mkdir -p "$STUBS"
+
+# chezmoi stub: pass the template body through as the "render" (so the fixture
+# file's own content is what shellcheck sees), unless STUB_CHEZMOI_FAIL is set.
+cat >"$STUBS/chezmoi" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n ${STUB_CHEZMOI_FAIL:-} ]]; then
+  echo "stub chezmoi: render failure" >&2
+  exit 1
+fi
+cat
+EOF
+
+# lint-tool stub: record that it ran, drain stdin, exit per STUB_SHELLCHECK_EXIT.
+cat >"$STUBS/shellcheck" <<'EOF'
+#!/usr/bin/env bash
+: >"$SHELLCHECK_MARKER"
+cat >/dev/null
+exit "${STUB_SHELLCHECK_EXIT:-0}"
+EOF
+
+chmod +x "$STUBS/chezmoi" "$STUBS/shellcheck"
+PATH="$STUBS:$PATH"
+export PATH
+
+SHELLCHECK_MARKER="$WORK/shellcheck-ran"
+export SHELLCHECK_MARKER
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+fails=0
+check() { # <name> <expected-rc> <expected-marker: yes|no|any>
+  local name="$1" want_rc="$2" want_marker="$3" got_rc=0
+  rm -f "$SHELLCHECK_MARKER"
+  if render_and_shellcheck_one "$TEMPLATE"; then got_rc=0; else got_rc=$?; fi
+  if [[ $want_rc == zero && $got_rc -ne 0 ]]; then
+    printf 'FAIL: %s: expected exit 0, got %d\n' "$name" "$got_rc" >&2
+    fails=1
+  fi
+  if [[ $want_rc == nonzero && $got_rc -eq 0 ]]; then
+    printf 'FAIL: %s: expected non-zero exit, got 0\n' "$name" >&2
+    fails=1
+  fi
+  if [[ $want_marker == yes && ! -e $SHELLCHECK_MARKER ]]; then
+    printf 'FAIL: %s: expected shellcheck to run, it did not\n' "$name" >&2
+    fails=1
+  fi
+  if [[ $want_marker == no && -e $SHELLCHECK_MARKER ]]; then
+    printf 'FAIL: %s: expected shellcheck NOT to run, it did\n' "$name" >&2
+    fails=1
+  fi
+}
+
+# (a) whitespace-only render -> skip, exit 0, shellcheck not run.
+TEMPLATE="$WORK/blank.tmpl"
+printf '   \n\t\n' >"$TEMPLATE"
+check "blank render skips" zero no
+
+# (b) real script render -> shellcheck runs, exit 0.
+TEMPLATE="$WORK/real.tmpl"
+printf '#!/bin/bash\necho hi\n' >"$TEMPLATE"
+check "real render runs shellcheck" zero yes
+
+# (c) chezmoi render failure -> fatal.
+TEMPLATE="$WORK/real.tmpl"
+export STUB_CHEZMOI_FAIL=1
+check "render failure is fatal" nonzero any
+unset STUB_CHEZMOI_FAIL
+
+# (d) rendered script fails shellcheck -> fatal.
+TEMPLATE="$WORK/real.tmpl"
+export STUB_SHELLCHECK_EXIT=1
+check "shellcheck failure is fatal" nonzero yes
+unset STUB_SHELLCHECK_EXIT
+
+if [[ $fails -ne 0 ]]; then
+  printf 'rendered-template-shellcheck-wrapper: FAILURES above\n' >&2
+  exit 1
+fi
+printf 'rendered-template-shellcheck-wrapper: OK\n'

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -99,6 +99,50 @@ let
       exit "$status"
     '';
   };
+
+  # Programmatic discovery of the safely renderable shell templates handed to the
+  # shellcheck-rendered-template formatter below. The 2026-07-10 audit found the
+  # old hand-list covered 6 of ~20 shell templates, hiding four render failures.
+  # The set is every `.chezmoiscripts/*.sh.tmpl` plus the shell `dot_*.tmpl` at
+  # the repo root, MINUS any template that calls `keepassxc` (those need an
+  # interactive KeePassXC unlock and cannot render in the headless check sandbox).
+  # Computed from the tree at eval time with `builtins` ONLY (no `lib`), so
+  # test/rendered-template-coverage.sh can re-read this exact list through
+  # `nix eval` with a stub `pkgs`.
+  callsKeepassxc = path: builtins.length (builtins.split "keepassxc" (builtins.readFile path)) > 1;
+
+  chezmoiscriptShellTemplates =
+    let
+      dir = ./.chezmoiscripts;
+      entries = builtins.readDir dir;
+      names = builtins.filter (
+        name:
+        entries.${name} == "regular"
+        && builtins.match ".*\\.sh\\.tmpl" name != null
+        && !(callsKeepassxc (dir + "/${name}"))
+      ) (builtins.attrNames entries);
+    in
+    map (name: ".chezmoiscripts/${name}") names;
+
+  rootShellDotTemplates =
+    let
+      dir = ./.;
+      entries = builtins.readDir dir;
+      firstLine = path: builtins.head (builtins.split "\n" (builtins.readFile path));
+      isShellFirstLine =
+        line: builtins.match "#!.*sh.*" line != null || builtins.match "# shellcheck shell=.*" line != null;
+    in
+    builtins.filter (
+      name:
+      entries.${name} == "regular"
+      && builtins.match "dot_.*\\.tmpl" name != null
+      && isShellFirstLine (firstLine (dir + "/${name}"))
+      && !(callsKeepassxc (dir + "/${name}"))
+    ) (builtins.attrNames entries);
+
+  renderedShellTemplates = builtins.sort (a: b: a < b) (
+    chezmoiscriptShellTemplates ++ rootShellDotTemplates
+  );
 in
 {
   projectRootFile = "flake.nix";
@@ -215,21 +259,13 @@ in
   };
 
   # Chezmoi-specific checks ported from lint.sh (see the let-bindings above).
-  # NOTE: run_onchange_after_41-macos-system-setup.sh.tmpl is deliberately
-  # excluded: its pre-existing nix-repair record renders an unquoted
-  # `sudo $HOME/...` that fails rendered shellcheck (SC2086), so including it
-  # today breaks the gate. Inclusion is owned by the render-coverage
-  # stabilization PR (2026-07-10 audit).
+  # `includes` is discovered programmatically (renderedShellTemplates, above):
+  # every safely renderable shell template, not a hand-picked subset.
+  # test/rendered-template-coverage.sh guards that the discovery never silently
+  # drops a template.
   settings.formatter.shellcheck-rendered-template = {
     command = shellcheckRenderedTemplate;
-    includes = [
-      "dot_bashrc.tmpl"
-      ".chezmoiscripts/run_onchange_before_15-install-herdr.sh.tmpl"
-      ".chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl"
-      ".chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl"
-      ".chezmoiscripts/run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl"
-      ".chezmoiscripts/run_onchange_after_66-tailscaled-status.sh.tmpl"
-    ];
+    includes = renderedShellTemplates;
   };
   settings.formatter.osquery-config-render = {
     command = osqueryConfigRender;

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -49,7 +49,10 @@ let
   # parse directly: render first, then shellcheck the result. CI=1 keeps the
   # templates on their non-interactive branch; --source "$PWD" so
   # includeTemplate resolves against this checkout's .chezmoitemplates
-  # (treefmt runs formatters from the tree root).
+  # (treefmt runs formatters from the tree root). The per-file body lives in
+  # scripts/lib-shellcheck-rendered-template.sh (sourced verbatim below) so
+  # test/rendered-template-shellcheck-wrapper.sh can drive its blank-render skip
+  # semantic with a stubbed chezmoi and shellcheck.
   shellcheckRenderedTemplate = pkgs.writeShellApplication {
     name = "shellcheck-rendered-template";
     runtimeInputs = [
@@ -60,12 +63,10 @@ let
       # chezmoi needs a writable HOME; the Nix check sandbox has none.
       HOME="$(mktemp -d)"
       export HOME
+      ${builtins.readFile ./scripts/lib-shellcheck-rendered-template.sh}
       status=0
       for file do
-        CI=1 chezmoi --source "$PWD" execute-template --no-tty <"$file" | shellcheck - || {
-          echo "shellcheck-rendered-template: rendered template failed shellcheck: $file" >&2
-          status=1
-        }
+        render_and_shellcheck_one "$file" || status=1
       done
       exit "$status"
     '';
@@ -104,12 +105,62 @@ let
   # shellcheck-rendered-template formatter below. The 2026-07-10 audit found the
   # old hand-list covered 6 of ~20 shell templates, hiding four render failures.
   # The set is every `.chezmoiscripts/*.sh.tmpl` plus the shell `dot_*.tmpl` at
-  # the repo root, MINUS any template that calls `keepassxc` (those need an
-  # interactive KeePassXC unlock and cannot render in the headless check sandbox).
-  # Computed from the tree at eval time with `builtins` ONLY (no `lib`), so
-  # test/rendered-template-coverage.sh can re-read this exact list through
-  # `nix eval` with a stub `pkgs`.
-  callsKeepassxc = path: builtins.length (builtins.split "keepassxc" (builtins.readFile path)) > 1;
+  # the repo root, MINUS any template that (or whose included partials) invokes
+  # keepassxc (those need an interactive KeePassXC unlock and cannot render in
+  # the headless check sandbox). Computed from the tree at eval time with
+  # `builtins` ONLY (no `lib`), so test/rendered-template-coverage.sh can re-read
+  # this exact list through `nix eval` with a stub `pkgs`. The classifier is kept
+  # textually close to that test's bash classifier; a fixture layer under
+  # test/fixtures/render-coverage guards both against shared blind spots.
+  fileLines = path: builtins.filter builtins.isString (builtins.split "\n" (builtins.readFile path));
+
+  # A template invokes keepassxc only through a Go-template directive: a line
+  # containing `{{` followed (after optional trim markers, whitespace, pipes, or
+  # grouping parens) by keepassxc/keepassxcAttribute. A bare comment that merely
+  # mentions keepassxc does NOT count, so it stays covered.
+  directCallsKeepassxc =
+    path:
+    builtins.any (line: builtins.match ".*[{][{][-(|[:space:]]*keepassxc.*" line != null) (
+      fileLines path
+    );
+
+  # includeTemplate "<literal>" partial names a template references.
+  includeTemplateNames =
+    path:
+    map (m: builtins.head m) (
+      builtins.filter builtins.isList (
+        builtins.split "includeTemplate[[:space:]]+\"([^\"]+)\"" (builtins.readFile path)
+      )
+    );
+
+  # Unsafe if the template OR any .chezmoitemplates/ partial it includes (one
+  # level; partial names are literal) calls keepassxc.
+  callsKeepassxc =
+    path:
+    directCallsKeepassxc path
+    || builtins.any (
+      name:
+      let
+        partial = ./.chezmoitemplates + "/${name}";
+      in
+      builtins.pathExists partial && directCallsKeepassxc partial
+    ) (includeTemplateNames path);
+
+  # A template is a shell template when its first line is a shell shebang, OR its
+  # first line is a Go-template directive and its first non-directive line is a
+  # shell shebang (the osquery-loader shape).
+  isShellShebangLine =
+    line: builtins.match "#!.*sh.*" line != null || builtins.match "# shellcheck shell=.*" line != null;
+  isGoDirectiveLine = line: builtins.match "[[:space:]]*[{][{].*" line != null;
+  isShellTemplate =
+    path:
+    let
+      ls = fileLines path;
+      first = if ls == [ ] then "" else builtins.head ls;
+      nonDirective = builtins.filter (l: !(isGoDirectiveLine l)) ls;
+      firstNonDirective = if nonDirective == [ ] then "" else builtins.head nonDirective;
+    in
+    isShellShebangLine first || (isGoDirectiveLine first && isShellShebangLine firstNonDirective);
 
   chezmoiscriptShellTemplates =
     let
@@ -128,15 +179,12 @@ let
     let
       dir = ./.;
       entries = builtins.readDir dir;
-      firstLine = path: builtins.head (builtins.split "\n" (builtins.readFile path));
-      isShellFirstLine =
-        line: builtins.match "#!.*sh.*" line != null || builtins.match "# shellcheck shell=.*" line != null;
     in
     builtins.filter (
       name:
       entries.${name} == "regular"
       && builtins.match "dot_.*\\.tmpl" name != null
-      && isShellFirstLine (firstLine (dir + "/${name}"))
+      && isShellTemplate (dir + "/${name}")
       && !(callsKeepassxc (dir + "/${name}"))
     ) (builtins.attrNames entries);
 

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -105,62 +105,16 @@ let
   # shellcheck-rendered-template formatter below. The 2026-07-10 audit found the
   # old hand-list covered 6 of ~20 shell templates, hiding four render failures.
   # The set is every `.chezmoiscripts/*.sh.tmpl` plus the shell `dot_*.tmpl` at
-  # the repo root, MINUS any template that (or whose included partials) invokes
-  # keepassxc (those need an interactive KeePassXC unlock and cannot render in
-  # the headless check sandbox). Computed from the tree at eval time with
-  # `builtins` ONLY (no `lib`), so test/rendered-template-coverage.sh can re-read
-  # this exact list through `nix eval` with a stub `pkgs`. The classifier is kept
-  # textually close to that test's bash classifier; a fixture layer under
-  # test/fixtures/render-coverage guards both against shared blind spots.
-  fileLines = path: builtins.filter builtins.isString (builtins.split "\n" (builtins.readFile path));
-
-  # A template invokes keepassxc only through a Go-template directive: a line
-  # containing `{{` followed (after optional trim markers, whitespace, pipes, or
-  # grouping parens) by keepassxc/keepassxcAttribute. A bare comment that merely
-  # mentions keepassxc does NOT count, so it stays covered.
-  directCallsKeepassxc =
-    path:
-    builtins.any (line: builtins.match ".*[{][{][-(|[:space:]]*keepassxc.*" line != null) (
-      fileLines path
-    );
-
-  # includeTemplate "<literal>" partial names a template references.
-  includeTemplateNames =
-    path:
-    map (m: builtins.head m) (
-      builtins.filter builtins.isList (
-        builtins.split "includeTemplate[[:space:]]+\"([^\"]+)\"" (builtins.readFile path)
-      )
-    );
-
-  # Unsafe if the template OR any .chezmoitemplates/ partial it includes (one
-  # level; partial names are literal) calls keepassxc.
-  callsKeepassxc =
-    path:
-    directCallsKeepassxc path
-    || builtins.any (
-      name:
-      let
-        partial = ./.chezmoitemplates + "/${name}";
-      in
-      builtins.pathExists partial && directCallsKeepassxc partial
-    ) (includeTemplateNames path);
-
-  # A template is a shell template when its first line is a shell shebang, OR its
-  # first line is a Go-template directive and its first non-directive line is a
-  # shell shebang (the osquery-loader shape).
-  isShellShebangLine =
-    line: builtins.match "#!.*sh.*" line != null || builtins.match "# shellcheck shell=.*" line != null;
-  isGoDirectiveLine = line: builtins.match "[[:space:]]*[{][{].*" line != null;
-  isShellTemplate =
-    path:
-    let
-      ls = fileLines path;
-      first = if ls == [ ] then "" else builtins.head ls;
-      nonDirective = builtins.filter (l: !(isGoDirectiveLine l)) ls;
-      firstNonDirective = if nonDirective == [ ] then "" else builtins.head nonDirective;
-    in
-    isShellShebangLine first || (isGoDirectiveLine first && isShellShebangLine firstNonDirective);
+  # the repo root, MINUS any template that cannot render headless: one that (or
+  # whose included partials, transitively) invokes keepassxc, or that has an
+  # includeTemplate name which cannot be resolved statically. Both predicates
+  # come from the importable, builtins-only classifier in
+  # scripts/render-coverage-classifier.nix. That SAME file is what
+  # test/rendered-template-coverage.sh drives through a fixture matrix via
+  # `nix eval`, so weakening a predicate there fails the fixtures rather than
+  # silently passing while this list stays unchanged.
+  classifier = import ./scripts/render-coverage-classifier.nix;
+  includeBase = ./.chezmoitemplates;
 
   chezmoiscriptShellTemplates =
     let
@@ -170,7 +124,7 @@ let
         name:
         entries.${name} == "regular"
         && builtins.match ".*\\.sh\\.tmpl" name != null
-        && !(callsKeepassxc (dir + "/${name}"))
+        && !(classifier.rendersUnsafe includeBase (dir + "/${name}"))
       ) (builtins.attrNames entries);
     in
     map (name: ".chezmoiscripts/${name}") names;
@@ -184,8 +138,8 @@ let
       name:
       entries.${name} == "regular"
       && builtins.match "dot_.*\\.tmpl" name != null
-      && isShellTemplate (dir + "/${name}")
-      && !(callsKeepassxc (dir + "/${name}"))
+      && classifier.isShellTemplate (dir + "/${name}")
+      && !(classifier.rendersUnsafe includeBase (dir + "/${name}"))
     ) (builtins.attrNames entries);
 
   renderedShellTemplates = builtins.sort (a: b: a < b) (


### PR DESCRIPTION
## Context

This dotfiles repository is being modernized: `main` is rebuilt slice by slice while the live
machine keeps applying from the `integration/modernization` branch until a final cutover. A
2026-07-10 external audit found that the treefmt lint gate rendered and shellchecked only 6
hand-listed chezmoi shell templates while about 20 existed, hiding four real render failures,
and that several active doc claims had gone stale.

This PR is the Wave-3c fix for both: rendered-template coverage becomes programmatic and
self-enforcing, and the stale claims are corrected.

## Summary

- Lint now discovers and shellchecks every renderable template (6 to 24), not a hand-list.
- Fixed the four render failures the old hand-list hid.
- Blank OS-gated renders are skipped, so they no longer fail on the other platform.
- New coverage test fails whenever a template is neither covered nor excluded-with-reason.
- One classifier, shared by discovery and the test, with 11 fixtures guarding it.
- Corrected stale hook, Dependabot, and commit-model claims in the CLAUDE docs.
- Key files: `treefmt.nix`, `scripts/render-coverage-classifier.nix`, `test/rendered-template-coverage.sh`, `CLAUDE.md`


## What changed

- Discovery classifies a template as safely renderable when it is a `.sh.tmpl` chezmoiscript or
  a repo-root shell `dot_*.tmpl`, minus anything that reaches a `keepassxc` call (those need an
  interactive unlock and cannot render in the headless Nix sandbox).
- The keepassxc detection matches the call anywhere inside a template action, assignments
  included, not just as the first token.
- `includeTemplate` names are parsed in both double-quoted and raw-string form, include chains
  are followed recursively with cycle protection, and a dynamically-named include is treated as
  unsafe.
- The classifier predicates live once, in `scripts/render-coverage-classifier.nix`, and the
  coverage test drives the same fixture set through them via `nix eval` beside a bash mirror,
  so weakening either side turns a fixture red instead of passing silently.
- A template that should not be standalone-rendered gets an entry in the test's EXCLUDED set
  with a written reason, which the test re-validates so the list cannot rot.
- The coverage test proved itself during this PR: when the branch was updated over the merged
  herdr work, it immediately flagged the new health-check partial as neither covered nor
  excluded; that partial is now excluded with its reason.

## How it was reviewed

Two independent reviewers went over the branch twice each: a fresh-context Claude reviewer and
an OpenAI Codex review (gpt-5.6-sol, ultra reasoning effort). Round 1 found the Linux blank-
render failure and the shared classifier blind spots. Round 2 proved the fixtures never touched
the production Nix predicates and demonstrated three concrete classifier bypasses against the
installed chezmoi. The final fixes made the Nix classifier directly testable and closed each
bypass with a red-first fixture. The conductor then verified the result: coverage test and
wrapper test green, the treefmt check derivation builds, and zero em-dashes in added lines
outside the sanctioned parity block.

## Effect of merging

`main`'s lint gate goes from 6 to 24 rendered-and-shellchecked templates, with drift structurally
impossible to reintroduce silently: a new renderable template must either be covered by
discovery or carry a written exclusion reason, enforced by the test suite on every commit and in
CI. Nothing changes on any live machine; the primary machine applies from the integration branch
until the D1 cutover.
