### PR TITLE
Harden the weekly skills updater against live-session swaps and unsafe deletes (Wave 3a)

### DIFF
--- a/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
@@ -31,11 +31,14 @@
 # the render. A multiline marker would otherwise become live shell executed at
 # apply time. The marker is interpolated DIGITS-ONLY via regexFind "^[0-9]+" (so
 # a hostile marker contributes at most leading digits, and even that lands inside
-# a comment line), and the run-time bump clamps the counter to digits too.
+# a comment line), and the run-time bump clamps the counter to digits AND forces
+# base-10 too. The marker is read through a shell guard (cat ... 2>/dev/null ||
+# true) so an UNREADABLE (mode-000) or absent marker yields the safe zero path
+# instead of aborting the whole render on a cat error.
 #
 # lock hash:     {{ include "dot_agents/custom-skill-lock.json" | sha256sum }}
 # updater hash:  {{ include "dot_local/bin/executable_update-skills.sh" | sha256sum }}
-# pending retry: {{ if stat (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending") }}{{ (output "cat" (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending")) | regexFind "^[0-9]+" }}{{ end }}
+# pending retry: {{ if stat (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending") }}{{ (output "sh" "-c" (printf "cat %s 2>/dev/null || true" (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending" | squote))) | regexFind "^[0-9]+" }}{{ end }}
 set -euo pipefail
 
 UPDATER="$HOME/.local/bin/update-skills.sh"
@@ -57,12 +60,14 @@ if "$UPDATER" --install-only; then
 else
   # Failure: bump a monotonic retry counter (never exit non-zero, which would
   # abort the whole apply). The changed digits re-fire run_onchange next apply.
-  # Clamp to digits at run time as defence in depth beside the render-time
-  # regexFind sanitizer.
+  # Defence in depth beside the render-time regexFind sanitizer: take only the
+  # first line (a multiline marker is inert), bound to a few digits, and force
+  # base-10 so a leading-zero marker like 08 is never read as invalid octal.
   mkdir -p "$MARKER_DIR"
   count="$(cat "$MARKER" 2>/dev/null || echo 0)"
-  [[ $count =~ ^[0-9]+$ ]] || count=0
-  count=$((count + 1))
+  count="${count%%$'\n'*}"
+  [[ $count =~ ^[0-9]{1,6}$ ]] || count=0
+  count=$((10#$count + 1))
   printf '%s\n' "$count" >"$MARKER"
   printf 'update-skills first-install pass failed (attempt %s); it will retry on the next apply\n' "$count" >&2
   if [[ -x $RELAY ]]; then

--- a/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
@@ -3,31 +3,70 @@
 #
 # Fresh-machine bootstrap: install any ABSENT roster skill at apply time so a new
 # machine reproduces the full store immediately, instead of waiting for the
-# weekly Monday LaunchAgent (com.webdavis.update-skills — RunAtLoad=false, so its
+# weekly Monday LaunchAgent (com.webdavis.update-skills, RunAtLoad=false, so its
 # first chance is Monday at the earliest). Audit Fix 2 (PR #36).
 #
 # run_onchange re-fires whenever the lock OR the updater source changes (the two
 # hashes below), so adding/removing a skill or changing the installer re-syncs
 # the store on the next apply. On an already-provisioned machine the install pass
-# finds nothing absent and returns quickly — idempotent.
+# finds nothing absent and returns quickly (idempotent).
 #
 # --install-only runs ONLY the npx + clawhub install passes for ABSENT skills,
 # plus the symlink-fan-out convergence, the Codex overlay re-assert, and the
 # superpowers routing re-assert. It skips the weekly npx/clawhub UPDATE passes,
-# the hermes registry-update phase, and the fork drift-check — and, crucially, it
-# never SWAPS a skill folder (it only adds absent ones), so it is safe to run
-# unattended at apply time even while an agent session is live: the updater's
-# idle-gate exempts --install-only for exactly this reason.
+# the hermes registry-update phase, and the fork drift-check, and it never SWAPS
+# a skill folder (it only adds absent ones), so it is safe to run unattended at
+# apply time even while an agent session is live.
 #
-# lock hash:    {{ include "dot_agents/custom-skill-lock.json" | sha256sum }}
-# updater hash: {{ include "dot_local/bin/executable_update-skills.sh" | sha256sum }}
+# RETRY WITHOUT ABORTING THE APPLY. A chezmoiscript that exits non-zero aborts
+# the whole `chezmoi apply`, so a failed first install must NOT exit non-zero.
+# Instead, on failure we bump a monotonic counter in the pending-marker file;
+# its digits are interpolated into the "pending retry" line below, so this
+# rendered script's content changes and run_onchange re-fires on the next apply
+# until a run succeeds and removes the marker. Removing the marker flips the hash
+# one final time, so exactly one more settle apply re-fires (idempotent, no-op);
+# that is expected.
+#
+# SECURITY (parallel-branch review lesson): NEVER splice raw marker bytes into
+# the render. A multiline marker would otherwise become live shell executed at
+# apply time. The marker is interpolated DIGITS-ONLY via regexFind "^[0-9]+" (so
+# a hostile marker contributes at most leading digits, and even that lands inside
+# a comment line), and the run-time bump clamps the counter to digits too.
+#
+# lock hash:     {{ include "dot_agents/custom-skill-lock.json" | sha256sum }}
+# updater hash:  {{ include "dot_local/bin/executable_update-skills.sh" | sha256sum }}
+# pending retry: {{ if stat (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending") }}{{ (output "cat" (joinPath .chezmoi.homeDir ".local/state/skills/first-install-pending")) | regexFind "^[0-9]+" }}{{ end }}
 set -euo pipefail
 
 UPDATER="$HOME/.local/bin/update-skills.sh"
+MARKER_DIR="$HOME/.local/state/skills"
+MARKER="$MARKER_DIR/first-install-pending"
+RELAY="$HOME/.local/bin/relay.sh"
 
 # Soft-gate on the deployed updater existing: a half-provisioned machine (updater
 # not yet applied) skips silently, exactly like the other loader chezmoiscripts.
-if [[ -x $UPDATER ]]; then
-  "$UPDATER" --install-only ||
-    printf 'update-skills first-install pass reported an issue (continuing)\n' >&2
+if [[ ! -x $UPDATER ]]; then
+  exit 0
+fi
+
+if "$UPDATER" --install-only; then
+  # Success: clear any pending marker so future applies stop re-firing on it.
+  # This removal flips the rendered hash once more, so exactly one further settle
+  # apply re-fires run_onchange (idempotent, nothing absent to install).
+  rm -f "$MARKER"
+else
+  # Failure: bump a monotonic retry counter (never exit non-zero, which would
+  # abort the whole apply). The changed digits re-fire run_onchange next apply.
+  # Clamp to digits at run time as defence in depth beside the render-time
+  # regexFind sanitizer.
+  mkdir -p "$MARKER_DIR"
+  count="$(cat "$MARKER" 2>/dev/null || echo 0)"
+  [[ $count =~ ^[0-9]+$ ]] || count=0
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$MARKER"
+  printf 'update-skills first-install pass failed (attempt %s); it will retry on the next apply\n' "$count" >&2
+  if [[ -x $RELAY ]]; then
+    "$RELAY" --agent update-skills --state first-install-failed --project skills \
+      --detail "first-install --install-only failed on this machine (attempt $count); it re-fires on the next apply" || true
+  fi
 fi

--- a/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl
@@ -1,0 +1,33 @@
+#!/bin/bash
+# run_onchange_after_64-update-skills-first-install.sh
+#
+# Fresh-machine bootstrap: install any ABSENT roster skill at apply time so a new
+# machine reproduces the full store immediately, instead of waiting for the
+# weekly Monday LaunchAgent (com.webdavis.update-skills — RunAtLoad=false, so its
+# first chance is Monday at the earliest). Audit Fix 2 (PR #36).
+#
+# run_onchange re-fires whenever the lock OR the updater source changes (the two
+# hashes below), so adding/removing a skill or changing the installer re-syncs
+# the store on the next apply. On an already-provisioned machine the install pass
+# finds nothing absent and returns quickly — idempotent.
+#
+# --install-only runs ONLY the npx + clawhub install passes for ABSENT skills,
+# plus the symlink-fan-out convergence, the Codex overlay re-assert, and the
+# superpowers routing re-assert. It skips the weekly npx/clawhub UPDATE passes,
+# the hermes registry-update phase, and the fork drift-check — and, crucially, it
+# never SWAPS a skill folder (it only adds absent ones), so it is safe to run
+# unattended at apply time even while an agent session is live: the updater's
+# idle-gate exempts --install-only for exactly this reason.
+#
+# lock hash:    {{ include "dot_agents/custom-skill-lock.json" | sha256sum }}
+# updater hash: {{ include "dot_local/bin/executable_update-skills.sh" | sha256sum }}
+set -euo pipefail
+
+UPDATER="$HOME/.local/bin/update-skills.sh"
+
+# Soft-gate on the deployed updater existing: a half-provisioned machine (updater
+# not yet applied) skips silently, exactly like the other loader chezmoiscripts.
+if [[ -x $UPDATER ]]; then
+  "$UPDATER" --install-only ||
+    printf 'update-skills first-install pass reported an issue (continuing)\n' >&2
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,32 +313,33 @@ the per-harness declarations, or the settings modify-template's `skillOverrides`
 
 - **npx-tracked** (the `npxTracked` table, 23 skills): the store copy is installed and refreshed by the
   official npx `skills` CLI from an official GitHub upstream, latest from `main` (no pin).
-  `~/.local/bin/update-skills.sh` installs any absent one with
-  `npx skills add <repo> --skill <name> --agent claude-code --agent codex -g -y` — the multi-agent form
-  lands the real dir in the store and plants the relative `~/.claude/skills` symlink (no `~/.codex` dir;
-  Codex reads the store natively) — and the weekly `npx skills update -g` pass refreshes them all. These
-  skills are NOT vendored in chezmoi. Includes the 13 curated HeyGen HyperFrames skills (router
-  `hyperframes`; domains `hyperframes-core/-animation/-keyframes/-creative`, `media-use`,
-  `hyperframes-cli`, `hyperframes-registry`; workflows `general-video`, `website-to-video`,
-  `faceless-explainer`, `embedded-captions`, `motion-graphics` — `figma`, `music-to-video`, and four
-  others deliberately excluded). Also includes `home-assistant-best-practices` (the official
-  `homeassistant-ai/skills` repo's one skill): Home Assistant config/YAML AUTHORING guidance, not runtime
-  control — it complements the clawhub-tracked `home-assistant` runtime skill everywhere, and it is the
-  one Home Assistant skill that DOES fan out to hermes (default profile), as authoring guidance atop
-  Bob's native Home Assistant runtime tools.
+  `~/.local/bin/update-skills.sh` installs and refreshes them via an explicit
+  `npx skills add <repo> --skill <name> --agent claude-code --agent codex -g -y` per repo group, run
+  against the weekly candidate generation (never the bulk `npx skills update`, whose lock-walk logs some
+  failures at exit 0; the explicit add also reconciles lock-absent roster skills). No `~/.codex` dir;
+  Codex reads the store natively. These skills are NOT vendored in chezmoi. Includes the 13 curated
+  HeyGen HyperFrames skills (router `hyperframes`; domains
+  `hyperframes-core/-animation/-keyframes/-creative`, `media-use`, `hyperframes-cli`,
+  `hyperframes-registry`; workflows `general-video`, `website-to-video`, `faceless-explainer`,
+  `embedded-captions`, `motion-graphics`; `figma`, `music-to-video`, and four others deliberately
+  excluded). Also includes `home-assistant-best-practices` (the official `homeassistant-ai/skills` repo's
+  one skill): Home Assistant config/YAML AUTHORING guidance, not runtime control; it complements the
+  clawhub-tracked `home-assistant` runtime skill everywhere, and it is the one Home Assistant skill that
+  DOES fan out to hermes (default profile), as authoring guidance atop Bob's native Home Assistant
+  runtime tools.
 - **ClawHub-tracked** (the `clawhubTracked` table, 3 skills: `home-assistant`, `sql-toolkit`,
   `summarize-pro`): the store copy is installed and refreshed by the `clawhub` CLI from ClawHub — the npx
   lane cannot source ClawHub (`npx skills add` is GitHub-only), so ClawHub-only skills get their own
   auto-update lane instead of staying vendored. Each entry records the owner-qualified slug and registry.
   `update-skills.sh` installs an absent one in a throwaway `--workdir` and moves the CLI's nested
-  `@owner/<name>` output flat into the store as `<store>/<name>` (v0.23.1 always nests; the skill's
-  `.clawhub/origin.json` travels along and pins the owner); the weekly pass then refreshes each in place
-  with `clawhub --workdir ~/.agents --dir skills update <name>` — bare store names resolve through
-  `origin.json` even when several ClawHub users publish the name. Two mechanical realities (verified
-  live): Finder `.DS_Store` litter breaks the CLI's fingerprint match, so it is scrubbed pre-update, and
-  the repo-asserted Codex overlay makes the CLI refuse with "local changes" — the pass sets exactly that
-  file aside (byte-equal check) and retries once, and any OTHER local change is a loud relayed WARN.
-  Automation never passes `--force`, and never `--force-install` (ClawHub's scan bypass).
+  `@owner/<name>` output flat into the candidate store (v0.23.1 always nests; the skill's
+  `.clawhub/origin.json` travels along and pins the owner); the weekly lane then refreshes each in place
+  with `clawhub --workdir <candidate>/.agents --dir skills update <name>` (bare store names resolve
+  through `origin.json` even when several ClawHub users publish the name). Two mechanical realities
+  (verified live): Finder `.DS_Store` litter breaks the CLI's fingerprint match, so it is scrubbed
+  pre-update, and the repo-asserted Codex overlay makes the CLI refuse with "local changes"; the pass
+  sets exactly that file aside (byte-equal check) and retries once, and any OTHER local change is a loud
+  relayed WARN. Automation never passes `--force`, and never `--force-install` (ClawHub's scan bypass).
 - **Vendored** (committed under `dot_agents/skills/`, refreshed only by `chezmoi apply`): the `forks`
   table records each one's upstream for weekly drift-watch. `moshi` and `herdr` are deliberate content
   forks (`fork: true`); `elevenlabs` is vendored because npx cannot install it full-tree (its `SKILL.md`
@@ -422,13 +423,33 @@ documented in the lock's `forks` notes. The weekly run drift-checks the `forks` 
 changed, alerts in the run log (`~/.local/log/skills/`) and via `relay.sh` when that exists — after the
 hand comparison, bump that fork's `lastComparedTreeHash` to the new upstream hash.
 
-`update-skills.sh` runs weekly via the `com.webdavis.update-skills` LaunchAgent (Monday 04:00,
-`RunAtLoad=false`, logs to `~/.local/log/skills/`); it refuses to swap skills while an agent harness is
-running (`UPDATE_SKILLS_FORCE=1` bypasses, used by tests) — the same gate covers the hermes
-registry-update phase, which runs after the store refresh (hermes skill updates are unattended-safe: no
-GUI restarts, no gateway restart; sessions pick up content at next start, and a deferred run just means
-the updates land next week). The script installs only what the lock declares, so the registered-skill
-count cannot grow from a run.
+**Generation-exchange updates:** every npx- and clawhub-tracked skill lives inside ONE live generation
+directory, `~/.agents/.skills-current` (real dirs under `skills/`, the npx CLI lock, and
+`generation.json` as the ready marker); the store names `~/.agents/skills/<name>` are stable symlinks
+into it and `~/.agents/.skill-lock.json` is a symlink to its lock, so sibling references like
+`../hyperframes-core` stay coherent within one generation. The weekly run builds a candidate generation
+as a fake HOME under `~/.agents/.skills-generations/<id>/home`, runs the package-CLI lanes against it
+under `env -i` (HOME/XDG/TMPDIR/npm cache pinned inside), validates the whole candidate, and publishes
+with one atomic exchange (`gmv --exchange --no-copy -T`); a lane or validation failure discards the whole
+candidate and the live generation is untouched. The honest guarantee: any path resolution during or after
+the exchange yields a complete tree from exactly one generation; a session that cached a resolved path
+keeps a complete previous generation for at least a week (one is retained), then gets a clean ENOENT,
+never partial content. Out-of-band writers (the HyperFrames workflows self-update via
+`npx hyperframes skills update`, upstream-controlled, no supported disable) bypass this exactly as they
+always did; the weekly recovery pass detects a store real dir where a link is expected and re-absorbs
+that content into the next candidate. The weekly success stamp is the ISO week PLUS the roster-lock and
+updater hashes, so a roster or updater change after a Monday success un-stamps the week and a later slot
+rebuilds; per-skill failure streaks escalate the alert wording at 2 consecutive failed weeks. Accepted
+narrowing: the explicit add targets `--agent claude-code --agent codex` only, so out-of-roster agent
+copies (devin, goose) are no longer refreshed by these runs.
+
+`update-skills.sh` runs weekly via the `com.webdavis.update-skills` LaunchAgent (24 hourly Monday retry
+slots, 00:00-23:00, `RunAtLoad=false`, logs to `~/.local/log/skills/`); a slot defers while a harness
+shows recent activity and the last slot alerts loudly (`UPDATE_SKILLS_FORCE=1` bypasses, used by tests);
+the same gate covers the hermes registry-update phase, which runs after the store refresh (hermes skill
+updates are unattended-safe: no GUI restarts, no gateway restart; sessions pick up content at next start,
+and a deferred run just means the updates land on a later slot). The script installs only what the lock
+declares, so the registered-skill count cannot grow from a run.
 
 **Adding a skill:** if it has an official full-tree GitHub upstream, add an `npxTracked` entry
 (`{"repo": "owner/repo"}`); if it is ClawHub-published, add a `clawhubTracked` entry

--- a/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
@@ -8,6 +8,9 @@
   <array>
     <string>/opt/homebrew/bin/bash</string>
     <string>{{ .chezmoi.homeDir }}/.local/bin/update-skills.sh</string>
+    <!-- Marks this as a scheduled (not manual) run: only a scheduled run with no
+         later slot remaining this week claims retry-budget exhaustion. -->
+    <string>--scheduled</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>

--- a/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
@@ -21,7 +21,7 @@
   <!-- Four Monday retry slots (04:00/08:00/12:00/16:00). A slot that finds an
        interactive harness session defers and leaves no weekly success stamp, so
        the next slot retries; once a slot succeeds, the rest no-op on the stamp.
-       The 16:00 slot is the LAST — a deferral there alerts loudly. Keep the last
+       The 16:00 slot is the LAST (a deferral there alerts loudly). Keep the last
        hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR in update-skills.sh. -->
   <key>StartCalendarInterval</key>
   <array>

--- a/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
@@ -18,15 +18,46 @@
   </dict>
   <key>RunAtLoad</key>
   <false/>
+  <!-- Four Monday retry slots (04:00/08:00/12:00/16:00). A slot that finds an
+       interactive harness session defers and leaves no weekly success stamp, so
+       the next slot retries; once a slot succeeds, the rest no-op on the stamp.
+       The 16:00 slot is the LAST — a deferral there alerts loudly. Keep the last
+       hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR in update-skills.sh. -->
   <key>StartCalendarInterval</key>
-  <dict>
-    <key>Weekday</key>
-    <integer>1</integer>
-    <key>Hour</key>
-    <integer>4</integer>
-    <key>Minute</key>
-    <integer>0</integer>
-  </dict>
+  <array>
+    <dict>
+      <key>Weekday</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>4</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Weekday</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>8</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Weekday</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>12</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <dict>
+      <key>Weekday</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>16</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+  </array>
   <key>StandardOutPath</key>
   <string>{{ .chezmoi.homeDir }}/.local/log/skills/update-skills.log</string>
   <key>StandardErrorPath</key>

--- a/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
@@ -21,45 +21,24 @@
   </dict>
   <key>RunAtLoad</key>
   <false/>
-  <!-- Four Monday retry slots (04:00/08:00/12:00/16:00). A slot that finds an
-       interactive harness session defers and leaves no weekly success stamp, so
-       the next slot retries; once a slot succeeds, the rest no-op on the stamp.
-       The 16:00 slot is the LAST (a deferral there alerts loudly). Keep the last
-       hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR in update-skills.sh. -->
+  <!-- 24 hourly Monday retry slots (00:00..23:00), generated programmatically.
+       A slot that finds a harness with recent activity defers and leaves no
+       weekly success stamp, so the next slot retries; once a slot succeeds, the
+       rest no-op on the stamp. The 23:00 slot is the LAST (a deferral there
+       alerts loudly). Keep the last hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR
+       in update-skills.sh. -->
   <key>StartCalendarInterval</key>
   <array>
+{{- range $hour := until 24 }}
     <dict>
       <key>Weekday</key>
       <integer>1</integer>
       <key>Hour</key>
-      <integer>4</integer>
+      <integer>{{ $hour }}</integer>
       <key>Minute</key>
       <integer>0</integer>
     </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>1</integer>
-      <key>Hour</key>
-      <integer>8</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>1</integer>
-      <key>Hour</key>
-      <integer>12</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>1</integer>
-      <key>Hour</key>
-      <integer>16</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
+{{- end }}
   </array>
   <key>StandardOutPath</key>
   <string>{{ .chezmoi.homeDir }}/.local/log/skills/update-skills.log</string>

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -68,11 +68,16 @@
 #                       clawhub updates, the hermes registry-update phase, and
 #                       the fork drift-check)
 #   --check-forks-only  run only the fork/vendored upstream drift-check
-# Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate. The idle-gate is the check
-#      below that makes this script refuse to swap skill folders while an agent
-#      harness (claude, codex, or hermes) is running, so a skill is never yanked
-#      out from under a live session. FORCE=1 accepts that risk for test runs
-#      and deliberate manual runs.
+# Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
+#      The idle-gate makes this script refuse to swap skill folders while an
+#      INTERACTIVE harness session (claude/codex/hermes) is running, so a skill is
+#      never yanked out from under a live session — persistent background daemons
+#      (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do NOT
+#      defer it (see __update_skills_harness_active). The weekly run is scheduled
+#      across four Monday slots; a per-week success stamp
+#      (~/.local/state/update-skills/last-success) makes the extra slots no-ops
+#      after one succeeds, and the last slot alerts if it still cannot run. FORCE=1
+#      accepts the swap risk for test runs and deliberate manual runs.
 set -euo pipefail
 
 # This script clones and inspects git repos in temp dirs (fork drift-check). If
@@ -88,6 +93,13 @@ CLAUDE="$HOME/.claude/skills"
 HERMES="$HOME/.hermes/skills"            # the default profile (Bob)
 HERMES_PROFILES="$HOME/.hermes/profiles" # specialist profiles: <name>/skills
 LOCKDIR="$AGENTS/.update-skills.lock.d"
+STATE_DIR="$HOME/.local/state/update-skills"
+SUCCESS_STAMP="$STATE_DIR/last-success" # ISO year-week (%G-%V) of the last fully successful weekly run
+# The plist fires four Monday retry slots — 04:00/08:00/12:00/16:00 (see
+# Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl). This is the hour
+# of the LAST slot: a deferral here means the weekly retry budget is exhausted,
+# so the run alerts LOUDLY instead of failing silent. Keep in sync with the plist.
+readonly UPDATE_SKILLS_LAST_SLOT_HOUR="16"
 # The Codex on-demand policy overlay this script asserts into store skill dirs
 # (see assert_codex_overlays) — also what the clawhub update pass recognizes as
 # its OWN file when the CLI refuses over it (see update_clawhub_tracked).
@@ -119,6 +131,58 @@ for arg in "$@"; do
 done
 
 log() { printf '[update-skills] %s\n' "$*"; }
+
+# idle-gate discriminator: is an INTERACTIVE agent-harness session using the
+# store right now? Returns 0 (defer — never swap a skill out from under a live
+# session) for an interactive Claude Code / Codex / hermes session, 1 (proceed)
+# when only persistent background daemons are up.
+#
+# The old gate was `pgrep -x claude || -x codex || -x hermes`, which deferred on
+# ANY match, INCLUDING persistent daemons — so the weekly run could defer forever
+# (the audit logged two such deferrals). We instead read full argv (ps -xo args=)
+# and key on the EXECUTABLE (argv[0] basename), excluding the daemon shapes.
+#
+# Ground truth (dresden, read-only ps, 2026-07-10):
+#   DAEMONS (proceed) — none is an interactive session:
+#     python -m hermes_cli.main gateway run --replace   (hermes gateway: argv[0]
+#         is `python`, so it is ignored outright — and note `pgrep -x hermes`
+#         never even matched it, comm=python; the OLD gate's real defer-forever
+#         driver on THIS machine was long-lived `claude --remote-control` bridges)
+#     .../claude --bg-spare | daemon run | --bg-pty-host   (Claude bg helpers)
+#     codex app-server [--analytics-default-enabled]       (Codex app server)
+#   INTERACTIVE (defer):
+#     /opt/homebrew/bin/claude [--remote-control|resume|-p ...]  (a Claude TUI)
+#     codex [resume <id>]                                        (a Codex CLI session)
+#     .../hermes -c <prompt> | hermes -p <profile>               (an interactive hermes run)
+#
+# Keying on argv[0]'s basename means prompt text or paths that merely CONTAIN
+# "codex"/"claude" (a `node .../codex-companion.mjs` helper, a bash -c carrying a
+# prompt about codex) never false-positive — argv[0] there is `node`/`bash`.
+__update_skills_is_interactive_harness() {
+  local args="$1" cmd base
+  cmd="${args%% *}" # argv[0] (the executable)
+  base="${cmd##*/}" # its basename
+  case "$base" in
+    claude | codex | hermes) ;; # a candidate harness binary
+    *) return 1 ;;              # anything else (python gateway, node, bash, GUI helpers) is not
+  esac
+  # Exclude the daemon shapes by the rest of argv.
+  case "$args" in
+    *hermes_cli.main*gateway* | *'hermes gateway'*) return 1 ;; # hermes gateway
+    *'claude --bg-'* | *'claude daemon run'*) return 1 ;;       # Claude bg spare/daemon/pty-host
+    *'codex app-server'*) return 1 ;;                           # Codex app server
+  esac
+  return 0
+}
+
+__update_skills_harness_active() {
+  local args
+  while IFS= read -r args; do
+    [[ -n $args ]] || continue
+    __update_skills_is_interactive_harness "$args" && return 0
+  done < <(ps -xo args= 2>/dev/null)
+  return 1
+}
 
 ensure_symlink() {
   local skill="$1"
@@ -347,9 +411,34 @@ if ! mkdir "$LOCKDIR" 2>/dev/null; then
 fi
 trap 'rm -rf "$LOCKDIR"' EXIT
 
-# idle-gate: defer while a harness is actively using skills (belt-and-suspenders on npx's own swap)
-if [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && { pgrep -x claude >/dev/null 2>&1 || pgrep -x codex >/dev/null 2>&1 || pgrep -x hermes >/dev/null 2>&1; }; then
-  log "a harness (claude/codex/hermes) is running; deferring this run"
+# weekly success stamp: the four Monday plist slots share one ISO week; once a
+# slot completes a full run this week, the remaining slots are no-ops. A deferral
+# writes no stamp, so the next slot retries. FORCE and dry-run bypass; the
+# install-only / check-forks-only partial runs never consult or write it.
+if [[ -z $INSTALL_ONLY ]] && [[ -z $CHECK_FORKS_ONLY ]] && [[ $DRYRUN != "--dry-run" ]] &&
+  [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] &&
+  [[ -f $SUCCESS_STAMP && "$(cat "$SUCCESS_STAMP" 2>/dev/null)" == "$(date +%G-%V)" ]]; then
+  log "weekly skills update already succeeded this week ($(cat "$SUCCESS_STAMP")); nothing to do"
+  exit 0
+fi
+
+# idle-gate: defer while an INTERACTIVE harness session is using the store, so a
+# skill is never swapped out from under a live session. Persistent background
+# daemons (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do
+# NOT count — blocking on them is what deferred the weekly run forever (see
+# __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests, manual
+# runs). On the LAST Monday slot the retry budget is spent, so a deferral there
+# alerts LOUDLY rather than failing silent.
+if [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
+  log "an interactive harness session (claude/codex/hermes) is using the store; deferring this run"
+  if [[ "$(date +%H)" == "$UPDATE_SKILLS_LAST_SLOT_HOUR" ]]; then
+    log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred — the weekly skills update did not run this week"
+    if command -v alerter >/dev/null 2>&1; then
+      alerter --timeout 30 --title "update-skills" \
+        --message "Weekly skills update deferred every Monday slot — an agent session was always active. Run it by hand when idle (~/.local/bin/update-skills.sh)." \
+        --sound default >/dev/null 2>&1 || true
+    fi
+  fi
   exit 0
 fi
 
@@ -624,5 +713,12 @@ update_hermes_registry_skills
 # 6) watch the vendored/fork upstreams (alert-only; see the function above)
 log "fork drift-check"
 check_fork_drift
+
+# record this week's success so the remaining Monday slots no-op — the run used
+# to defer forever with no stamp and no bounded retry budget (audit Fix 1)
+if [[ $DRYRUN != "--dry-run" ]]; then
+  mkdir -p "$STATE_DIR"
+  date +%G-%V >"$SUCCESS_STAMP"
+fi
 
 log "done${DRYRUN:+ (dry-run)}"

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -74,11 +74,15 @@
 #                       scheduled run with no later slot remaining this week
 #                       claims retry-budget exhaustion (a manual run never does)
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
-#      The idle-gate (fail-closed) makes this script refuse to swap skill folders
-#      while ANY agent-harness process (claude/codex/hermes) is running, session
-#      OR daemon, so a skill is never yanked out from under a live session (argv
-#      shape cannot prove idleness here; see __update_skills_harness_active). The
-#      weekly run is scheduled across four Monday slots; a per-week success stamp
+#      The idle-gate (activity-based, fail-closed) makes this script refuse to
+#      swap skill folders only while a harness (claude/codex/hermes) shows RECENT
+#      activity — the newest mtime among its per-turn activity files is within
+#      IDLE_THRESHOLD (default 15 min). It runs UNATTENDED: an always-up bridge no
+#      longer defers the weekly run forever; a machine quiet for the window
+#      proceeds (see __update_skills_should_defer). Override the window with
+#      UPDATE_SKILLS_IDLE_THRESHOLD (seconds) and each harness's probe dir with
+#      UPDATE_SKILLS_{CLAUDE,CODEX,HERMES}_ACTIVITY_DIR (tests do). The weekly run
+#      is scheduled across four Monday slots; a per-week success stamp
 #      (~/.local/state/update-skills/last-success) makes the extra slots no-ops
 #      after one succeeds, and the last scheduled slot alerts if it still cannot
 #      run. FORCE=1 accepts the swap risk for test runs and deliberate manual runs.
@@ -100,6 +104,19 @@ LOCKDIR="$AGENTS/.update-skills.lock.d"
 STATE_DIR="$HOME/.local/state/update-skills"
 SUCCESS_STAMP="$STATE_DIR/last-success"               # ISO year-week (%G-%V) of the last fully successful weekly run
 SCHEDULED_WEEK_STAMP="$STATE_DIR/last-scheduled-week" # ISO week of the last SCHEDULED attempt (item 6)
+# Activity-based idle gate (Wave 3a fix3). The gate judges recent harness
+# ACTIVITY, not mere process existence, so the weekly run is UNATTENDED (on the
+# daily driver a `claude --remote-control` bridge is always up; deferring on its
+# existence alone would defer forever). The window and each harness's probe dir
+# are env-overridable (defaults below); tests point the dirs at a tmp HOME and
+# shrink the window. IDLE_THRESHOLD is in SECONDS (default 15 minutes). The probe
+# dirs are the empirically verified per-turn activity locations on this machine
+# (see __update_skills_activity_state).
+IDLE_THRESHOLD_SECONDS="${UPDATE_SKILLS_IDLE_THRESHOLD:-900}"
+[[ $IDLE_THRESHOLD_SECONDS =~ ^[0-9]+$ ]] || IDLE_THRESHOLD_SECONDS=900
+CLAUDE_ACTIVITY_DIR="${UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR:-$HOME/.claude/projects}"
+CODEX_ACTIVITY_DIR="${UPDATE_SKILLS_CODEX_ACTIVITY_DIR:-$HOME/.codex/sessions}"
+HERMES_ACTIVITY_DIR="${UPDATE_SKILLS_HERMES_ACTIVITY_DIR:-$HOME/.hermes/logs}"
 # The plist fires four Monday retry slots (04:00/08:00/12:00/16:00; see
 # Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl). This is the hour
 # of the LAST slot: a scheduled deferral at/after it, or a coalesced catch-up on
@@ -205,15 +222,29 @@ __update_skills_alert() {
   fi
 }
 
-# idle-gate discriminator (Wave 3a item 1, fail-closed). Argv SHAPE cannot prove
-# idleness on this machine: every interactive Claude launch carries
-# --remote-control (the bridge is on by default), and Codex `app-server` and the
-# Hermes gateway both host live agent turns in-process. So the old daemon-shape
-# allowlist (which declared those "daemon-shaped" argv idle and swapped skills
-# under them) is DELETED. The gate is now simply: if ANY process whose EFFECTIVE
-# program resolves to exactly claude, codex, or hermes exists, DEFER. This trades
-# occasional deferral for never-swap-under-a-live-session, which the design
-# explicitly tolerates (a deferred run just lands the updates next week).
+# idle-gate discriminator (Wave 3a fix3, fail-closed). The gate judges recent
+# harness ACTIVITY, not mere process existence. Rationale: argv SHAPE cannot
+# prove idleness on this machine (every interactive Claude launch carries
+# --remote-control, the bridge is on by default; Codex `app-server` and the
+# Hermes gateway both host live turns in-process), so we cannot tell a live
+# session from an idle bridge by its argv. Deferring on process existence alone
+# (the round-2 gate) meant the always-up bridge deferred the weekly run FOREVER
+# and forced a manual run. So the gate now: (1) if NO process resolves to a
+# harness, PROCEED (fast path, evidence never probed); (2) if a harness process
+# exists, probe every harness PRESENT on the machine for recent file activity and
+# DEFER only while at least one is fresh (within IDLE_THRESHOLD); (3) fail closed
+# — an unreadable process table or a probe error counts as ACTIVE. This is the
+# UNATTENDED norm: the weekly run proceeds whenever the machine has been quiet for
+# IDLE_THRESHOLD, even with a bridge up.
+#
+# PR-facing tradeoff: the gate reads mtimes, not a lock the harnesses hold, so
+# there is a narrow race — a session that starts writing in the millisecond after
+# the probe scans could have a skill folder swapped mid-turn. The window is tiny
+# and the blast radius is one weekly run; the design accepts it as the unattended
+# tradeoff. FOLLOW-UP (a task exists): the durable fix is a versioned skills store
+# with an atomic symlink flip (a running session keeps its resolved inode; new
+# sessions pick up the flipped version), after which this activity gate becomes
+# belt-and-suspenders rather than the sole guard.
 #
 # __update_skills_effective_program resolves one `ps -xo args=` line to its
 # harness name (or empty). It is interpreter-aware (item 2): when the program is
@@ -301,19 +332,101 @@ __update_skills_is_interactive_harness() {
   esac
 }
 
+# Enumerate the process table for agent-harness processes. Returns:
+#   0 = at least one agent-harness process (claude/codex/hermes) is running
+#   1 = ps read cleanly and NO harness process exists (the fast-path signal)
+#   2 = ps could not be read (or yielded nothing — it must at minimum list this
+#       very process): FAIL CLOSED, the caller must defer.
 __update_skills_harness_active() {
   local ps_output args
-  # Fail CLOSED: if ps errors, or yields nothing (it must at minimum list this
-  # very process), treat the world as busy and defer rather than risk swapping
-  # skills under an unreadable process table.
   if ! ps_output="$(ps -xo args= 2>/dev/null)" || [[ -z $ps_output ]]; then
-    return 0
+    return 2
   fi
   while IFS= read -r args; do
     [[ -n $args ]] || continue
     __update_skills_is_interactive_harness "$args" && return 0
   done <<<"$ps_output"
   return 1
+}
+
+# Recent-activity probe for one harness's activity dir, against a cutoff SENTINEL
+# file whose mtime is (now - IDLE_THRESHOLD). Returns:
+#   0 = ACTIVE  — a file newer than the sentinel exists, OR the probe errored
+#                 (unreadable dir / scan failure): fail closed and treat as active
+#   1 = STALE   — the dir is present and readable but its newest file is older
+#                 than the window
+#   2 = ABSENT  — the dir does not exist: this harness is not installed, so it
+#                 contributes NO evidence and must not block
+#
+# The sentinel + POSIX `-newer` is deliberate: macOS's BSD `/usr/bin/find` does
+# NOT parse `-newermt "@<epoch>"` (verified: "Can't parse date/time: @…"), so a
+# sentinel whose mtime is the cutoff is the portable primitive. `-print -quit`
+# bails on the first newer file (cheap: a full idle scan of ~3.2k Claude
+# transcripts is ~25 ms; only a fully idle machine scans them all). find exits
+# non-zero on a scan error (e.g. an unreadable subtree), which we treat as ACTIVE.
+#
+# Empirically verified per-turn activity sources on this machine (2026-07-11):
+#   Claude Code: ~/.claude/projects/**/<session>.jsonl — the transcript is
+#     appended per turn; the FILE mtime is the signal (directory mtimes do NOT
+#     propagate on append: verified live, newest file mtime == wall clock during
+#     an active turn while the enclosing dir mtime lagged ~45s).
+#   Codex: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl — the per-turn rollout
+#     transcript (verified: mtimes advance per turn, stale while idle).
+#   Hermes: ~/.hermes/logs/agent.log (and siblings) — the gateway's per-run/turn
+#     log (verified: agent.log mtime advances while the gateway serves a turn).
+__update_skills_activity_state() {
+  local dir="$1" sentinel="$2" newer
+  [[ -d $dir ]] || return 2            # not installed → no evidence
+  [[ -r $dir && -x $dir ]] || return 0 # present but unreadable → fail closed
+  if ! newer="$(find "$dir" -type f -newer "$sentinel" -print -quit 2>/dev/null)"; then
+    return 0 # scan error → fail closed → ACTIVE
+  fi
+  [[ -n $newer ]] && return 0 # a file newer than the cutoff → ACTIVE
+  return 1                    # every file older than the window → STALE
+}
+
+# Build a temp sentinel file whose mtime is (now - IDLE_THRESHOLD). Prints its
+# path on success (rc 0); rc 1 if it could not be built (the caller fails closed).
+__update_skills_make_cutoff_sentinel() {
+  local cutoff sentinel stamp
+  cutoff=$(($(date +%s) - IDLE_THRESHOLD_SECONDS))
+  sentinel="$(mktemp)" || return 1
+  # date -r <epoch> is BSD (this is a macOS LaunchAgent script); the test's date
+  # stub execs the real date for -r, so this is exercised faithfully.
+  stamp="$(date -r "$cutoff" +%Y%m%d%H%M.%S 2>/dev/null)" || {
+    rm -f "$sentinel"
+    return 1
+  }
+  if ! touch -t "$stamp" "$sentinel" 2>/dev/null; then
+    rm -f "$sentinel"
+    return 1
+  fi
+  printf '%s' "$sentinel"
+}
+
+# The full gate decision: return 0 to DEFER, 1 to PROCEED. See the discriminator
+# comment above for the three-step rationale.
+__update_skills_should_defer() {
+  __update_skills_harness_active
+  case $? in
+    1) return 1 ;; # no harness process → PROCEED (fast path; probes untouched)
+    2) return 0 ;; # ps unreadable → fail closed → DEFER
+  esac
+  # A harness process exists: judge idleness by ACTIVITY across every PRESENT
+  # harness. DEFER as soon as one shows recent activity (or errors); PROCEED only
+  # when every present harness is stale (and absent ones contribute nothing).
+  local sentinel dir state defer=1
+  sentinel="$(__update_skills_make_cutoff_sentinel)" || return 0 # no sentinel → fail closed
+  for dir in "$CLAUDE_ACTIVITY_DIR" "$CODEX_ACTIVITY_DIR" "$HERMES_ACTIVITY_DIR"; do
+    __update_skills_activity_state "$dir" "$sentinel"
+    state=$?
+    if [[ $state -eq 0 ]]; then # ACTIVE → DEFER (finish the loop, then clean up)
+      defer=0
+      break
+    fi
+  done
+  rm -f "$sentinel"
+  return $((defer == 0 ? 0 : 1))
 }
 
 # updater-owned link = a SYMLINK whose literal target is EXACTLY this user's
@@ -888,22 +1001,22 @@ if [[ -z $INSTALL_ONLY ]] && [[ -z $CHECK_FORKS_ONLY ]] && [[ $DRYRUN != "--dry-
   exit 0
 fi
 
-# idle-gate (fail-closed): defer while ANY agent-harness process (claude/codex/
-# hermes) is running, so a skill is never swapped out from under a live session.
-# Argv shape cannot distinguish a live session from a background daemon here, so
-# the gate errs toward deferral (a deferred run just lands the updates next week;
-# see __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests,
-# manual runs). --install-only is EXEMPT: it only ADDS absent skills (never swaps
-# a folder), so it is safe under a live session, this is what lets the fresh-
-# machine bootstrap run --install-only unattended at apply time. On the last
-# SCHEDULED slot the retry budget is spent, so a deferral there alerts LOUDLY
-# rather than failing silent.
+# idle-gate (activity-based, fail-closed): defer only while a harness shows
+# RECENT activity (within IDLE_THRESHOLD), so the weekly run is UNATTENDED — an
+# always-up bridge no longer defers it forever. A machine quiet for the window
+# proceeds and swaps skills; a live turn defers to next slot. FAIL CLOSED: an
+# unreadable process table or a probe error counts as active. UPDATE_SKILLS_FORCE=1
+# bypasses everything (tests, manual runs). --install-only is EXEMPT: it only ADDS
+# absent skills (never swaps a folder), so it is safe under a live session, this
+# is what lets the fresh-machine bootstrap run --install-only unattended at apply
+# time. On the last SCHEDULED slot the retry budget is spent, so a deferral there
+# alerts LOUDLY rather than failing silent. See __update_skills_should_defer.
 __update_skills_note_scheduled_attempt
-if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
-  log "a live harness session (claude/codex/hermes) is using the store, or the process table could not be read (fail-closed); deferring this run"
+if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_should_defer; then
+  log "a harness showed recent activity (within IDLE_THRESHOLD), or the process table could not be read (fail-closed); deferring this run"
   if __update_skills_scheduled_budget_exhausted; then
     log "EXHAUSTED: the last scheduled retry slot for this week still deferred; the weekly skills update did not run this week"
-    __update_skills_alert "Weekly skills update deferred on every scheduled slot (an agent session was always active). Run it by hand when idle (~/.local/bin/update-skills.sh)."
+    __update_skills_alert "Weekly skills update deferred on every scheduled slot (the machine had agent activity at all four Monday slots). Run it by hand when idle (~/.local/bin/update-skills.sh)."
   fi
   exit 0
 fi

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -485,6 +485,30 @@ __update_skills_hermes_profile_universe() {
     done
   fi
 }
+# Reject a managed hermes dir reached THROUGH a directory symlink (item 8). A
+# profiles/<name> or <name>/skills symlink pointing outside ~/.hermes would let
+# convergence create or REMOVE links in that foreign target, decided from the
+# literal relative link text. We take the ruling's reject-symlink branch: when
+# the profile dir OR its skills child is a symlink, we never converge through it
+# (so the managed dir is always a real path under ~/.hermes and every removal
+# stays within this user's tree). Returns 0 = safe to converge, 1 = skip.
+__update_skills_hermes_dir_safe() {
+  local profile="$1" link_dir="$2" profile_dir
+  if [[ $profile == "default" ]]; then
+    profile_dir="$HOME/.hermes"
+  else
+    profile_dir="$HERMES_PROFILES/$profile"
+  fi
+  if [[ -L $profile_dir ]]; then
+    log "converge: WARN hermes profile dir $profile_dir is a symlink; skipping (never converge through a directory symlink)"
+    return 1
+  fi
+  if [[ -L $link_dir ]]; then
+    log "converge: WARN hermes skills dir $link_dir is a symlink; skipping (never converge through a directory symlink)"
+    return 1
+  fi
+  return 0
+}
 converge_hermes_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   local profile link_dir prefix skill
@@ -502,6 +526,7 @@ converge_hermes_skills() {
       link_dir="$HERMES_PROFILES/$profile/skills"
       prefix="../../../../.agents/skills"
     fi
+    __update_skills_hermes_dir_safe "$profile" "$link_dir" || continue
     desired=()
     while IFS= read -r skill; do
       [[ -n $skill ]] || continue

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -82,7 +82,7 @@
 #      proceeds (see __update_skills_should_defer). Override the window with
 #      UPDATE_SKILLS_IDLE_THRESHOLD (seconds) and each harness's probe dir with
 #      UPDATE_SKILLS_{CLAUDE,CODEX,HERMES}_ACTIVITY_DIR (tests do). The weekly run
-#      is scheduled across four Monday slots; a per-week success stamp
+#      is scheduled across 24 hourly Monday slots; a per-week success stamp
 #      (~/.local/state/update-skills/last-success) makes the extra slots no-ops
 #      after one succeeds, and the last scheduled slot alerts if it still cannot
 #      run. FORCE=1 accepts the swap risk for test runs and deliberate manual runs.
@@ -145,12 +145,12 @@ IDLE_THRESHOLD_SECONDS="${UPDATE_SKILLS_IDLE_THRESHOLD:-900}"
 CLAUDE_ACTIVITY_DIR="${UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR:-$HOME/.claude/projects}"
 CODEX_ACTIVITY_DIR="${UPDATE_SKILLS_CODEX_ACTIVITY_DIR:-$HOME/.codex/sessions}"
 HERMES_ACTIVITY_DIR="${UPDATE_SKILLS_HERMES_ACTIVITY_DIR:-$HOME/.hermes/logs}"
-# The plist fires four Monday retry slots (04:00/08:00/12:00/16:00; see
+# The plist fires 24 hourly Monday retry slots (00:00..23:00; see
 # Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl). This is the hour
 # of the LAST slot: a scheduled deferral at/after it, or a coalesced catch-up on
 # a later weekday, means the weekly retry budget is exhausted, so the run alerts
 # LOUDLY instead of failing silent. Keep in sync with the plist.
-readonly UPDATE_SKILLS_LAST_SLOT_HOUR="16"
+readonly UPDATE_SKILLS_LAST_SLOT_HOUR="23"
 # The Codex on-demand policy overlay this script asserts into store skill dirs
 # (see assert_codex_overlays) — also what the clawhub update pass recognizes as
 # its OWN file when the CLI refuses over it (see update_clawhub_tracked).
@@ -201,10 +201,10 @@ record_required_failure() {
 }
 
 # True when no further SCHEDULED slot remains this ISO week to retry a failed or
-# deferred run. The plist fires four Monday slots (04/08/12/16); launchd may
+# deferred run. The plist fires 24 hourly Monday slots (00..23); launchd may
 # COALESCE a missed slot and deliver it on a later day (a catch-up), which is
 # also the week's last scheduled chance. So a later slot remains ONLY when today
-# is Monday BEFORE the last slot hour; Monday at/after 16:00, or any later
+# is Monday BEFORE the last slot hour; Monday at/after 23:00, or any later
 # weekday (a coalesced catch-up), means the scheduled budget for this week is
 # spent. date +%u is 1 for Monday; base-10 forces the hour compare so 08 is not
 # read as invalid octal.
@@ -273,6 +273,15 @@ __gen_hash_file() {
 # built). A change in either must invalidate the weekly stamp and force a rebuild.
 __gen_custom_lock_hash() { __gen_hash_file "$CUSTOM_SKILL_LOCK"; }
 __gen_updater_hash() { __gen_hash_file "${BASH_SOURCE[0]}"; }
+
+# The weekly success stamp value: the ISO year-week PLUS the custom-lock hash and
+# the updater hash. A roster change (custom-lock) or an updater change after a
+# Monday success no longer matches the stamp, so the week UN-STAMPS and a later
+# slot rebuilds. The stamp thus means "this EXACT desired state already succeeded
+# this week", not merely "some run succeeded this week" (brief: stamp inputs).
+__update_skills_stamp_value() {
+  printf '%s %s %s' "$(date +%G-%V)" "$(__gen_custom_lock_hash)" "$(__gen_updater_hash)"
+}
 
 # A sortable, collision-resistant generation id: epoch seconds + pid + random.
 # Sortable-by-time is what lets prune keep the newest previous and delete older.
@@ -1718,14 +1727,17 @@ else
   trap '__update_skills_release_lock' EXIT
 fi
 
-# weekly success stamp: the four Monday plist slots share one ISO week; once a
-# slot completes a full run this week, the remaining slots are no-ops. A deferral
-# writes no stamp, so the next slot retries. FORCE and dry-run bypass; the
-# install-only / check-forks-only partial runs never consult or write it.
+# weekly success stamp: the 24 Monday plist slots share one stamp; once a slot
+# completes a full run for the CURRENT desired state this week, the remaining
+# slots are no-ops. The stamp is the ISO week PLUS the custom-lock and updater
+# hashes, so a roster or updater change after a Monday success un-stamps the week
+# and the next slot rebuilds. A deferral writes no stamp, so the next slot
+# retries. FORCE and dry-run bypass; install-only / check-forks-only never
+# consult or write it.
 if [[ -z $INSTALL_ONLY ]] && [[ -z $CHECK_FORKS_ONLY ]] && [[ $DRYRUN != "--dry-run" ]] &&
   [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] &&
-  [[ -f $SUCCESS_STAMP && "$(cat "$SUCCESS_STAMP" 2>/dev/null)" == "$(date +%G-%V)" ]]; then
-  log "weekly skills update already succeeded this week ($(cat "$SUCCESS_STAMP")); nothing to do"
+  [[ -f $SUCCESS_STAMP && "$(cat "$SUCCESS_STAMP" 2>/dev/null)" == "$(__update_skills_stamp_value)" ]]; then
+  log "weekly skills update already succeeded this week for the current roster; nothing to do"
   exit 0
 fi
 
@@ -1744,7 +1756,7 @@ if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN
   log "a harness showed recent activity (within IDLE_THRESHOLD), or the process table could not be read (fail-closed); deferring this run"
   if __update_skills_scheduled_budget_exhausted; then
     log "EXHAUSTED: the last scheduled retry slot for this week still deferred; the weekly skills update did not run this week"
-    __update_skills_alert "Weekly skills update deferred on every scheduled slot (the machine had agent activity at all four Monday slots). Run it by hand when idle (~/.local/bin/update-skills.sh)."
+    __update_skills_alert "Weekly skills update deferred on every scheduled slot (the machine had agent activity at every Monday slot). Run it by hand when idle (~/.local/bin/update-skills.sh)."
   fi
   exit 0
 fi
@@ -2055,19 +2067,20 @@ log "fork drift-check"
 check_fork_drift
 
 # Record this week's success ONLY when zero required phases failed. The stamp is
-# an ISO year-week key (date +%G-%V): %G is the ISO week-numbering YEAR and %V is
-# the ISO week (01-53), so the four Monday slots share one key and a slot no-ops
-# once one has fully succeeded this week. %G (not %Y) is what keeps a year-
-# boundary week correct: the days of ISO week 01 that fall in late December carry
-# the NEXT year's %G, and the late-December days of week 52/53 carry the current
-# %G, so the key never collides or splits across the boundary (52/53/01 verified).
-# When a required phase failed we WITHHOLD the stamp, so a later scheduled slot
-# retries; and for a scheduled run with no slot remaining this week we alert (the
-# retry budget is spent). A dry run records nothing.
+# the ISO year-week key (date +%G-%V) PLUS the custom-lock and updater hashes
+# (see __update_skills_stamp_value). %G (not %Y) keeps a year-boundary week
+# correct: the days of ISO week 01 that fall in late December carry the NEXT
+# year's %G, and the late-December days of week 52/53 carry the current %G, so the
+# key never collides or splits across the boundary (52/53/01 verified). The two
+# hashes make the stamp mean "this exact desired state succeeded this week", so a
+# roster or updater change after a Monday success un-stamps the week and the next
+# slot rebuilds. When a required phase failed we WITHHOLD the stamp, so a later
+# scheduled slot retries; and for a scheduled run with no slot remaining this
+# week we alert (the retry budget is spent). A dry run records nothing.
 if [[ $DRYRUN != "--dry-run" ]]; then
   if [[ $REQUIRED_FAILURES -eq 0 ]]; then
     mkdir -p "$STATE_DIR"
-    date +%G-%V >"$SUCCESS_STAMP"
+    __update_skills_stamp_value >"$SUCCESS_STAMP"
   else
     log "WITHHOLDING the weekly success stamp: $REQUIRED_FAILURES required-phase failure(s) this run; a later scheduled slot will retry"
     if __update_skills_scheduled_budget_exhausted; then

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -284,20 +284,28 @@ __update_skills_harness_active() {
   return 1
 }
 
-# updater-owned link = a SYMLINK whose literal target points under
-# ~/.agents/skills. The literal readlink target is matched (not a resolved path),
-# so this holds for a DANGLING link too — its string still points into the store.
-# ONLY such links are ever replaced or removed by convergence; real dirs
-# (hub-owned registry dirs, hermes's catalog) and non-store symlinks are never
-# touched, and neither is any name in a profile the lock does not map.
+# updater-owned link = a SYMLINK whose literal target is EXACTLY this user's
+# store followed by a single skill basename: either the absolute "$STORE/<name>"
+# or the exact relative prefix the fan-out plants for the calling dir
+# ("$expected_prefix/<name>"). The literal readlink target is matched (not a
+# resolved path), so this still holds for a DANGLING link. Matching the exact
+# prefix (not a loose ".agents/skills/" substring) is the fix for the audit's
+# false positives: a foreign link like /tmp/x/.agents/skills/y or
+# /Users/other/.agents/skills/y is NOT owned and must survive. <name> is a
+# single path segment, so a target reaching deeper (".../skills/a/b") is not
+# owned either. ONLY owned links are ever replaced or removed by convergence.
+#   __update_skills_is_owned_link <path> <expected_prefix>
 __update_skills_is_owned_link() {
-  local path="$1" target
+  local path="$1" expected_prefix="$2" target name
   [[ -L $path ]] || return 1
   target="$(readlink "$path" 2>/dev/null || true)"
   case "$target" in
-    *.agents/skills/*) return 0 ;;
+    "$STORE"/*) name="${target#"$STORE"/}" ;;
+    "$expected_prefix"/*) name="${target#"$expected_prefix"/}" ;;
+    *) return 1 ;;
   esac
-  return 1
+  # a single valid skill basename: no slash, no leading dot, allowed chars only
+  [[ $name == "${name%%/*}" && $name =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
 }
 
 # Converge one managed dir to a desired {name -> "$prefix/$name"} set:
@@ -337,7 +345,7 @@ converge_dir() {
       if [[ -L $path ]]; then
         current="$(readlink "$path" 2>/dev/null || true)"
         [[ $current == "$target" ]] && continue # already correct
-        if __update_skills_is_owned_link "$path"; then
+        if __update_skills_is_owned_link "$path" "$prefix"; then
           if [[ -n $additive ]]; then
             log "converge: WARN $path points to $current, not $target; --install-only is additive and leaves it (a full run repairs)"
           elif [[ -n $dry ]]; then
@@ -379,7 +387,7 @@ converge_dir() {
       done
     fi
     [[ -n $is_desired ]] && continue
-    if __update_skills_is_owned_link "$path"; then
+    if __update_skills_is_owned_link "$path" "$prefix"; then
       old_target="$(readlink "$path" 2>/dev/null || true)"
       if [[ -n $dry ]]; then
         log "converge: would remove stale $path (currently $old_target)"
@@ -417,8 +425,12 @@ converge_claude_skills() {
 # deliberate "not available in hermes from the store" state, not an error.
 # Collision-named skills (humanizer, hyperframes) never fan out: hermes's catalog
 # wins those names (operator ruling), so a stale store link at such a name IS
-# removed by convergence, but creating one never happens. Only the profiles the
-# lock names are walked — a profile the lock does not map is never touched.
+# removed by convergence, but creating one never happens. The walk universe is
+# every profile the lock maps PLUS every profile with an EXISTING hermes skills
+# dir on disk, so a profile whose last mapped skill was de-mapped is still walked
+# and its stale updater-owned links get reaped (they would otherwise linger
+# forever). Only owned links are ever removed, so a foreign file in the same dir
+# survives.
 HERMES_COLLISION_NAMES=(humanizer hyperframes)
 is_hermes_collision_name() {
   local collision_entry
@@ -427,14 +439,29 @@ is_hermes_collision_name() {
   done
   return 1
 }
+# The profile walk universe: names the lock maps, plus "default" and every
+# specialist whose skills dir already exists on disk.
+__update_skills_hermes_profile_universe() {
+  jq -r '.hermesProfiles // {} | [.[][]?] | unique | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null
+  [[ -d $HERMES ]] && printf 'default\n'
+  local profile_skills_dir profile_name
+  if [[ -d $HERMES_PROFILES ]]; then
+    for profile_skills_dir in "$HERMES_PROFILES"/*/skills; do
+      [[ -d $profile_skills_dir ]] || continue
+      profile_name="${profile_skills_dir%/skills}"
+      printf '%s\n' "${profile_name##*/}"
+    done
+  fi
+}
 converge_hermes_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   local profile link_dir prefix skill
   local -a profiles=() desired=()
+  # No early return: an empty universe simply walks nothing. A de-mapped profile
+  # is reached via its on-disk dir even though the lock no longer names it.
   while IFS= read -r profile; do
     [[ -n $profile ]] && profiles+=("$profile")
-  done < <(jq -r '.hermesProfiles // {} | [.[][]?] | unique | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-  [[ ${#profiles[@]} -gt 0 ]] || return 0
+  done < <(__update_skills_hermes_profile_universe | sort -u)
   for profile in "${profiles[@]}"; do
     if [[ $profile == "default" ]]; then
       link_dir="$HERMES"

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -520,9 +520,12 @@ fi
 # daemons (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do
 # NOT count — blocking on them is what deferred the weekly run forever (see
 # __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests, manual
-# runs). On the LAST Monday slot the retry budget is spent, so a deferral there
-# alerts LOUDLY rather than failing silent.
-if [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
+# runs). --install-only is EXEMPT: it only ADDS absent skills (never swaps a
+# folder), so it is safe under a live session — this is what lets the fresh-
+# machine bootstrap run --install-only unattended at apply time. On the LAST
+# Monday slot the retry budget is spent, so a deferral there alerts LOUDLY rather
+# than failing silent.
+if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
   log "an interactive harness session (claude/codex/hermes) is using the store; deferring this run"
   if [[ "$(date +%H)" == "$UPDATE_SKILLS_LAST_SLOT_HOUR" ]]; then
     log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred — the weekly skills update did not run this week"

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -96,7 +96,11 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 AGENTS="$HOME/.agents"
 STORE="$AGENTS/skills"
-CUSTOM_SKILL_LOCK="$AGENTS/custom-skill-lock.json" # the skills this repo wants, deployed by chezmoi (ours)
+# The roster (desired state) this repo wants, deployed by chezmoi. Normally
+# ~/.agents/custom-skill-lock.json; the --build-lanes sub-invocation (run inside
+# a candidate fake HOME) is handed the REAL lock path via UPDATE_SKILLS_LOCK_PATH
+# so it reads the desired roster while writing only into the candidate.
+CUSTOM_SKILL_LOCK="${UPDATE_SKILLS_LOCK_PATH:-$AGENTS/custom-skill-lock.json}"
 CLAUDE="$HOME/.claude/skills"
 HERMES="$HOME/.hermes/skills"            # the default profile (Bob)
 HERMES_PROFILES="$HOME/.hermes/profiles" # specialist profiles: <name>/skills
@@ -125,6 +129,9 @@ SKILL_LOCK_LINK="$AGENTS/.skill-lock.json"
 GENERATION_META_NAME="generation.json"
 # GNU coreutils mv (has --exchange; BSD /bin/mv does not). Tests can override.
 GMV="${UPDATE_SKILLS_GMV:-gmv}"
+# This script's own path, for the env -i re-invocation that runs the build lanes
+# inside a candidate fake HOME (see __gen_run_lanes / --build-lanes).
+UPDATE_SKILLS_SELF="${BASH_SOURCE[0]}"
 # Activity-based idle gate (Wave 3a fix3). The gate judges recent harness
 # ACTIVITY, not mere process existence, so the weekly run is UNATTENDED (on the
 # daily driver a `claude --remote-control` bridge is always up; deferring on its
@@ -163,12 +170,14 @@ DRYRUN=""
 INSTALL_ONLY=""
 CHECK_FORKS_ONLY=""
 SCHEDULED=""
+BUILD_LANES="" # internal: run the generation build lanes inside a candidate HOME
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRYRUN="--dry-run" ;;
     --install-only) INSTALL_ONLY=1 ;;
     --check-forks-only) CHECK_FORKS_ONLY=1 ;;
     --scheduled) SCHEDULED=1 ;;
+    --build-lanes) BUILD_LANES=1 ;;
     *)
       printf 'update-skills: unknown argument: %s\n' "$arg" >&2
       exit 2
@@ -356,6 +365,19 @@ __gen_plant_store_link() {
   fi
   [[ -e $link ]] && return 1 # a real dir/file we do not own; caller decides
   ln -s "$want" "$link"
+}
+
+# Post-publish reconciliation for a re-absorbed competing-writer name: the store
+# still holds the redundant real dir (its content was cloned into the now-live
+# generation), so garbage-destroy it and plant the stable store symlink. The
+# content is preserved in the generation, so this is non-destructive.
+__gen_absorb_store_link() {
+  local name="$1"
+  local link="$STORE/$name"
+  if [[ -d $link && ! -L $link ]]; then
+    __gen_garbage_destroy "$link"
+  fi
+  __gen_plant_store_link "$name"
 }
 
 # Plant (or repair) the ~/.agents/.skill-lock.json symlink into the live
@@ -637,6 +659,278 @@ __gen_migrate() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# CANDIDATE BUILD + LANES + VALIDATION (brief steps 2-4).
+# ---------------------------------------------------------------------------
+# Outputs of __gen_build_candidate, consumed by the run orchestration and tests.
+GEN_CANDIDATE_HOME=""
+GEN_CANDIDATE_AGENTS=""
+
+# Build the candidate generation at .skills-generations/<id>/home/.agents: a fake
+# HOME whose .agents/skills starts as cp -c clones of the CURRENT generation,
+# absorbing any competing-writer real-dir drift recorded in GEN_REABSORB (its
+# content wins over the current generation's copy), with the current .skill-lock.json
+# seeded. Sets GEN_CANDIDATE_HOME / GEN_CANDIDATE_AGENTS. Returns 1 on any error.
+#   __gen_build_candidate <id>
+__gen_build_candidate() {
+  local id="$1"
+  local home="$GENERATIONS/$id/home"
+  local agents="$home/.agents"
+  __gen_garbage_destroy "$GENERATIONS/$id"
+  mkdir -p "$agents/skills" || return 1
+  # Clone the current generation's skills (real dirs) into the candidate.
+  if [[ -d "$SKILLS_CURRENT/skills" ]]; then
+    local skill_path name
+    for skill_path in "$SKILLS_CURRENT/skills"/*; do
+      [[ -d $skill_path ]] || continue
+      name="${skill_path##*/}"
+      cp -c -R "$skill_path" "$agents/skills/$name" 2>/dev/null ||
+        cp -R "$skill_path" "$agents/skills/$name" || return 1
+    done
+  fi
+  # Absorb competing-writer drift: a store real-dir's content overrides the clone.
+  local reabsorb
+  for reabsorb in "${GEN_REABSORB[@]:-}"; do
+    [[ -n $reabsorb ]] || continue
+    [[ -d "$STORE/$reabsorb" && ! -L "$STORE/$reabsorb" ]] || continue
+    __gen_garbage_destroy "$agents/skills/$reabsorb"
+    cp -c -R "$STORE/$reabsorb" "$agents/skills/$reabsorb" 2>/dev/null ||
+      cp -R "$STORE/$reabsorb" "$agents/skills/$reabsorb" || return 1
+  done
+  # Seed the npx lock from the current generation (or an empty object).
+  if [[ -f "$SKILLS_CURRENT/.skill-lock.json" ]]; then
+    cp -c "$SKILLS_CURRENT/.skill-lock.json" "$agents/.skill-lock.json" 2>/dev/null ||
+      cp "$SKILLS_CURRENT/.skill-lock.json" "$agents/.skill-lock.json" || return 1
+  else
+    printf '{}\n' >"$agents/.skill-lock.json" || return 1
+  fi
+  GEN_CANDIDATE_HOME="$home"
+  GEN_CANDIDATE_AGENTS="$agents"
+  log "candidate generation $id built at $GEN_CANDIDATE_AGENTS (home $GEN_CANDIDATE_HOME)"
+  return 0
+}
+
+# npx lane (brief step 3): explicit `skills add <repo> --skill <name> ...` per
+# npxTracked entry, GROUPED by repo (NOT a bulk `update`, whose lock-walk logs
+# some failures at exit 0). Operating on $STORE, which in --build-lanes mode is
+# the candidate's store (HOME points there). This reconciles lock-absent roster
+# skills too, since `add` installs-or-refreshes every entry. Each failure is a
+# required failure (the whole candidate is discarded on any).
+__gen_lane_npx() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  local -a repos=()
+  local repo
+  while IFS= read -r repo; do
+    [[ -n $repo ]] && repos+=("$repo")
+  done < <(jq -r '.npxTracked // {} | [.[].repo] | unique | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  local -a skill_args
+  local name
+  for repo in "${repos[@]:-}"; do
+    [[ -n $repo ]] || continue
+    skill_args=()
+    while IFS= read -r name; do
+      [[ -n $name ]] && skill_args+=(--skill "$name")
+    done < <(jq -r --arg r "$repo" '.npxTracked // {} | to_entries[]
+      | select(.value.repo == $r) | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+    [[ ${#skill_args[@]} -gt 0 ]] || continue
+    if npx --yes skills@latest add "$repo" "${skill_args[@]}" \
+      --agent claude-code --agent codex -g -y 2>&1 | tr -d '\r' | tail -3; then
+      log "npx add: $repo (${#skill_args[@]} skill arg tokens)"
+    else
+      log "npx add failed: $repo (continuing; candidate will be discarded)"
+      record_required_failure "npx add $repo failed"
+    fi
+  done
+}
+
+# clawhub lane against the candidate store: install any absent clawhub-tracked
+# skill (throwaway --workdir, flatten the nested @owner/<name>), then refresh
+# every present one in place. Telemetry off, never --force. A separate scratch
+# workdir keeps the store lock free of @owner phantom keys.
+__gen_lane_clawhub() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
+  if ! command -v clawhub >/dev/null 2>&1; then
+    log "clawhub not on PATH but clawhubTracked is non-empty; candidate cannot be completed"
+    record_required_failure "clawhub missing with a non-empty clawhubTracked table (build lane)"
+    return 0
+  fi
+  local skill slug registry tmp_workdir installed_dir overlay_file update_output
+  local -a clawhub_cmd
+  while IFS=$'\t' read -r -u3 skill slug registry; do
+    if [[ ! -e "$STORE/$skill" ]]; then
+      [[ -n $slug ]] || continue
+      tmp_workdir="$(mktemp -d)"
+      clawhub_cmd=(clawhub --no-input --workdir "$tmp_workdir" --dir skills)
+      [[ -n $registry ]] && clawhub_cmd+=(--registry "$registry")
+      if "${clawhub_cmd[@]}" install "$slug" 2>&1 | tail -2; then
+        installed_dir="$tmp_workdir/skills/$slug"
+        [[ -d $installed_dir ]] || installed_dir="$tmp_workdir/skills/$skill"
+        if [[ -d $installed_dir ]]; then
+          mv "$installed_dir" "$STORE/$skill"
+          log "clawhub install: $skill from $slug"
+        else
+          record_required_failure "clawhub install $skill produced no store dir"
+        fi
+      else
+        record_required_failure "clawhub install $skill failed"
+      fi
+      rm -rf "$tmp_workdir"
+      continue
+    fi
+    # present: refresh in place (bare name resolves via origin.json)
+    [[ -d "$STORE/$skill" && ! -L "$STORE/$skill" ]] || continue
+    rm -f "$STORE/$skill/.DS_Store"
+    if ! update_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)"; then
+      record_required_failure "clawhub update $skill failed"
+      printf '%s\n' "$update_output"
+      continue
+    fi
+    if printf '%s\n' "$update_output" | grep -q 'local changes'; then
+      overlay_file="$STORE/$skill/agents/openai.yaml"
+      if [[ -f $overlay_file && "$(<"$overlay_file")" == "$CODEX_POLICY" ]]; then
+        rm "$overlay_file"
+        rmdir "$STORE/$skill/agents" 2>/dev/null || true
+        if update_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)" &&
+          ! printf '%s\n' "$update_output" | grep -q 'local changes'; then
+          continue
+        fi
+        mkdir -p "$STORE/$skill/agents"
+        printf '%s\n' "$CODEX_POLICY" >"$overlay_file"
+      fi
+      record_required_failure "clawhub update $skill refused over local changes"
+    fi
+  done 3< <(jq -r '.clawhubTracked // {} | to_entries[]
+    | [.key, (.value.slug // ""), (.value.registry // "")] | @tsv' \
+    "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+}
+
+# Codex overlays against the candidate store: every on-demand skill carries
+# agents/openai.yaml with allow_implicit_invocation disabled (append when the
+# upstream ships its own openai.yaml, never overwrite). Idempotent.
+__gen_assert_overlays() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  local skill overlay_file
+  while IFS= read -r skill; do
+    [[ -d "$STORE/$skill" && ! -L "$STORE/$skill" ]] || continue
+    overlay_file="$STORE/$skill/agents/openai.yaml"
+    if [[ -f $overlay_file ]] && grep -q 'allow_implicit_invocation: false' "$overlay_file"; then
+      continue
+    fi
+    mkdir -p "$STORE/$skill/agents" || {
+      record_required_failure "candidate overlay dir for $skill could not be created"
+      continue
+    }
+    if [[ -f $overlay_file ]]; then
+      printf '\n%s\n' "$CODEX_POLICY" >>"$overlay_file" ||
+        record_required_failure "candidate overlay append for $skill failed"
+    else
+      printf '%s\n' "$CODEX_POLICY" >"$overlay_file" ||
+        record_required_failure "candidate overlay write for $skill failed"
+    fi
+  done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+}
+
+# --build-lanes body: runs INSIDE the candidate fake HOME (env -i, HOME set by
+# __gen_run_lanes). $STORE etc. resolve to the candidate. Runs the three build
+# lanes, writes generation.json LAST as the ready marker, and exits non-zero on
+# any required failure so the parent discards the whole candidate.
+__gen_do_build_lanes() {
+  local id="${UPDATE_SKILLS_GEN_ID:-$(__gen_new_id)}"
+  mkdir -p "$STORE"
+  log "build lane: npx"
+  __gen_lane_npx
+  log "build lane: clawhub"
+  __gen_lane_clawhub
+  log "build lane: codex overlays"
+  __gen_assert_overlays
+  # The ready marker goes at .agents/generation.json (one level above skills/).
+  __gen_write_meta "$AGENTS" "$id"
+  [[ $REQUIRED_FAILURES -eq 0 ]]
+}
+
+# Parent side: run the build lanes against a candidate home under env -i, with
+# HOME, every XDG_* dir, TMPDIR, and the npm cache/config pinned INSIDE the
+# candidate, so a lane can only write into the candidate (isolation). PATH is
+# passed through so npx/clawhub/jq/gmv resolve (and tests can prepend stubs).
+#   __gen_run_lanes <candidate-home> <id>
+# Returns the re-invocation's exit status (non-zero = discard the candidate).
+__gen_run_lanes() {
+  local home="$1" id="$2"
+  mkdir -p "$home/.cache" "$home/.config" "$home/.local/share" "$home/.local/state" "$home/.tmp" "$home/.npm"
+  env -i \
+    PATH="$PATH" \
+    HOME="$home" \
+    XDG_CACHE_HOME="$home/.cache" \
+    XDG_CONFIG_HOME="$home/.config" \
+    XDG_DATA_HOME="$home/.local/share" \
+    XDG_STATE_HOME="$home/.local/state" \
+    TMPDIR="$home/.tmp" \
+    npm_config_cache="$home/.npm" \
+    UPDATE_SKILLS_GMV="$GMV" \
+    UPDATE_SKILLS_GEN_ID="$id" \
+    UPDATE_SKILLS_LOCK_PATH="$CUSTOM_SKILL_LOCK" \
+    UPDATE_SKILLS_BUILD_LANES=1 \
+    bash "$UPDATE_SKILLS_SELF" --build-lanes
+}
+
+# Validate a fully-built candidate generation (brief step 4): every roster
+# tracked skill present with a SKILL.md, on-demand overlays in place, expected
+# origin metadata (clawhub skills carry .clawhub/origin.json), the npx lock is
+# valid JSON, and the ready marker is present. Returns 0 valid, 1 invalid (the
+# caller garbage-renames the candidate and records a required failure — never a
+# partial promotion).
+#   __gen_validate_candidate <candidate-agents-dir>
+__gen_validate_candidate() {
+  local agents="$1"
+  local skills="$agents/skills"
+  [[ -d $skills ]] || {
+    log "validate: candidate has no skills dir"
+    return 1
+  }
+  __gen_is_complete "$agents" || {
+    log "validate: candidate has no ready marker"
+    return 1
+  }
+  # npx lock must be valid JSON.
+  jq -e . "$agents/.skill-lock.json" >/dev/null 2>&1 || {
+    log "validate: candidate .skill-lock.json is not valid JSON"
+    return 1
+  }
+  local name
+  # every npx- and clawhub-tracked roster skill present with a SKILL.md
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    [[ -d "$skills/$name" ]] || {
+      log "validate: tracked skill $name is missing from the candidate"
+      return 1
+    }
+    [[ -f "$skills/$name/SKILL.md" ]] || {
+      log "validate: tracked skill $name has no SKILL.md"
+      return 1
+    }
+  done < <(__gen_tracked_names)
+  # clawhub-tracked skills carry origin metadata
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    [[ -f "$skills/$name/.clawhub/origin.json" ]] || {
+      log "validate: clawhub skill $name is missing .clawhub/origin.json"
+      return 1
+    }
+  done < <(jq -r '.clawhubTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  # on-demand skills present in the candidate carry the Codex overlay (a vendored
+  # on-demand skill lives outside the generation, so it is absent here and skipped)
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    [[ -d "$skills/$name" ]] || continue
+    grep -q 'allow_implicit_invocation: false' "$skills/$name/agents/openai.yaml" 2>/dev/null || {
+      log "validate: on-demand skill $name is missing its Codex overlay"
+      return 1
+    }
+  done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  return 0
+}
+
 # Lib-only sourcing gate: a test that sets UPDATE_SKILLS_LIB_ONLY=1 and sources
 # this script gets the config + machinery functions above WITHOUT running the
 # main flow (the lanes, idle gate, and publish orchestration below never fire).
@@ -645,6 +939,15 @@ __gen_migrate() {
 if [[ ${UPDATE_SKILLS_LIB_ONLY:-} == 1 ]]; then
   # shellcheck disable=SC2317 # exit is reached when executed (return fails outside a sourced file)
   return 0 2>/dev/null || exit 0
+fi
+
+# --build-lanes: this process IS the env -i sub-invocation running inside a
+# candidate fake HOME (see __gen_run_lanes). Run only the generation build lanes
+# against the candidate store and exit; the parent handles recovery, validation,
+# publish, fan-out, and the idle gate. No lock, no stamp, no idle gate here.
+if [[ -n $BUILD_LANES ]]; then
+  __gen_do_build_lanes
+  exit $?
 fi
 
 # idle-gate discriminator (Wave 3a fix3, fail-closed). The gate judges recent

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -104,6 +104,27 @@ LOCKDIR="$AGENTS/.update-skills.lock.d"
 STATE_DIR="$HOME/.local/state/update-skills"
 SUCCESS_STAMP="$STATE_DIR/last-success"               # ISO year-week (%G-%V) of the last fully successful weekly run
 SCHEDULED_WEEK_STAMP="$STATE_DIR/last-scheduled-week" # ISO week of the last SCHEDULED attempt (item 6)
+
+# Generation-exchange store model (Wave 3a fix4). The LIVE generation is a REAL
+# directory .skills-current holding skills/<name> real dirs, the npx CLI lock
+# .skill-lock.json, and generation.json (the READY marker, written last: id +
+# createdAt + custom-lock hash + updater hash). The store ~/.agents/skills/<name>
+# are stable literal symlinks into ../.skills-current/skills/<name>, and
+# ~/.agents/.skill-lock.json is a symlink into .skills-current/.skill-lock.json.
+# Both keep resolving across a publish because .skills-current is a stable PATH
+# whose CONTENTS are swapped by ONE renameat2 RENAME_EXCHANGE
+# (gmv --exchange --no-copy -T), so any lookup during or after the swap yields a
+# complete tree from exactly one generation. Candidate generations are built as a
+# fake HOME under .skills-generations/<id>/home, on the SAME device as
+# .skills-current so the same-filesystem exchange works. Exactly one previous
+# generation is retained (a session that cached a resolved path keeps a complete
+# tree for at least a week); older ones are garbage-renamed then deleted.
+SKILLS_CURRENT="$AGENTS/.skills-current"
+GENERATIONS="$AGENTS/.skills-generations"
+SKILL_LOCK_LINK="$AGENTS/.skill-lock.json"
+GENERATION_META_NAME="generation.json"
+# GNU coreutils mv (has --exchange; BSD /bin/mv does not). Tests can override.
+GMV="${UPDATE_SKILLS_GMV:-gmv}"
 # Activity-based idle gate (Wave 3a fix3). The gate judges recent harness
 # ACTIVITY, not mere process existence, so the weekly run is UNATTENDED (on the
 # daily driver a `claude --remote-control` bridge is always up; deferring on its
@@ -221,6 +242,410 @@ __update_skills_alert() {
     "$relay_script" --agent update-skills --state exhausted --project skills --detail "$detail" || true
   fi
 }
+
+# ============================================================================
+# Generation-exchange machinery (Wave 3a fix4). See the SKILLS_CURRENT config
+# block above for the store model. These functions are dormant unless the main
+# flow calls them; they are unit-tested in isolation via UPDATE_SKILLS_LIB_ONLY.
+# ============================================================================
+
+# sha256 of a file (or the empty-input hash when absent), first field only.
+__gen_hash_file() {
+  local path="$1"
+  [[ -f $path ]] || {
+    printf '%s' "-"
+    return 0
+  }
+  shasum -a 256 "$path" 2>/dev/null | awk '{print $1}'
+}
+
+# The two hashes that define "the desired state" for a generation: the roster
+# lock (what skills the repo wants + how) and this updater script (how they are
+# built). A change in either must invalidate the weekly stamp and force a rebuild.
+__gen_custom_lock_hash() { __gen_hash_file "$CUSTOM_SKILL_LOCK"; }
+__gen_updater_hash() { __gen_hash_file "${BASH_SOURCE[0]}"; }
+
+# A sortable, collision-resistant generation id: epoch seconds + pid + random.
+# Sortable-by-time is what lets prune keep the newest previous and delete older.
+__gen_new_id() { printf '%s-%s-%s' "$(date +%s)" "$$" "${RANDOM}${RANDOM}"; }
+
+# Two paths are on the same filesystem (required for renameat2 RENAME_EXCHANGE).
+__gen_same_device() {
+  local a b
+  a="$(stat -f %d "$1" 2>/dev/null)" || return 1
+  b="$(stat -f %d "$2" 2>/dev/null)" || return 1
+  [[ -n $a && $a == "$b" ]]
+}
+
+# Write generation.json LAST, as the ready marker. Its presence + matching
+# hashes is what recovery uses to tell a complete candidate from a leftover.
+#   __gen_write_meta <generation-dir> <id>
+__gen_write_meta() {
+  local dir="$1" id="$2" meta="$1/$GENERATION_META_NAME"
+  jq -n \
+    --arg id "$id" \
+    --arg createdAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg customLockHash "$(__gen_custom_lock_hash)" \
+    --arg updaterHash "$(__gen_updater_hash)" \
+    '{id: $id, createdAt: $createdAt, customLockHash: $customLockHash, updaterHash: $updaterHash}' \
+    >"$meta"
+}
+
+# Read one field from a generation.json (empty when absent/unreadable).
+#   __gen_meta_field <generation-dir> <field>
+__gen_meta_field() {
+  local meta="$1/$GENERATION_META_NAME"
+  [[ -f $meta ]] || return 0
+  jq -r --arg f "$2" '.[$f] // ""' "$meta" 2>/dev/null || true
+}
+
+# A generation dir is COMPLETE iff it has skills/, the npx lock, and a
+# generation.json carrying a non-empty id (the ready marker was fully written).
+__gen_is_complete() {
+  local dir="$1"
+  [[ -d "$dir/skills" ]] || return 1
+  [[ -f "$dir/.skill-lock.json" ]] || return 1
+  [[ -n "$(__gen_meta_field "$dir" id)" ]]
+}
+
+# A complete generation MATCHES the current desired state iff its recorded
+# hashes equal the live lock+updater hashes.
+__gen_meta_matches_desired() {
+  local dir="$1"
+  [[ "$(__gen_meta_field "$dir" customLockHash)" == "$(__gen_custom_lock_hash)" ]] || return 1
+  [[ "$(__gen_meta_field "$dir" updaterHash)" == "$(__gen_updater_hash)" ]]
+}
+
+# Destroy a path the crash-safe way: rename it to a clearly-garbage sibling name
+# FIRST (atomic), then rm -rf. A crash between the two leaves a *.garbage.*
+# name that recovery/prune resumes deleting; nothing a live link resolves into
+# ever carries a garbage name, so a half-deleted tree is never mistaken for live.
+__gen_garbage_destroy() {
+  local path="$1" garbage
+  [[ -e $path || -L $path ]] || return 0
+  garbage="${path%/}.garbage.$$.${RANDOM}"
+  if mv "$path" "$garbage" 2>/dev/null; then
+    rm -rf "$garbage" 2>/dev/null || true
+  else
+    rm -rf "$path" 2>/dev/null || true
+  fi
+}
+
+# Resume any interrupted deletion: sweep *.garbage.* leftovers under a parent.
+__gen_sweep_garbage() {
+  local parent="$1" entry
+  [[ -d $parent ]] || return 0
+  for entry in "$parent"/*.garbage.*; do
+    [[ -e $entry || -L $entry ]] || continue
+    rm -rf "$entry" 2>/dev/null || true
+  done
+}
+
+# Plant (or repair) the stable store link for one skill: ~/.agents/skills/<name>
+# -> ../.skills-current/skills/<name>. Idempotent; only ever writes an
+# updater-owned link, never clobbers a real dir it does not own.
+__gen_plant_store_link() {
+  local name="$1"
+  local link="$STORE/$name"
+  local want="../.skills-current/skills/$name"
+  mkdir -p "$STORE"
+  if [[ -L $link ]]; then
+    [[ "$(readlink "$link" 2>/dev/null || true)" == "$want" ]] && return 0
+    ln -sfn "$want" "$link"
+    return 0
+  fi
+  [[ -e $link ]] && return 1 # a real dir/file we do not own; caller decides
+  ln -s "$want" "$link"
+}
+
+# Plant (or repair) the ~/.agents/.skill-lock.json symlink into the live
+# generation's lock. Idempotent.
+__gen_plant_lock_link() {
+  local want=".skills-current/.skill-lock.json"
+  if [[ -L $SKILL_LOCK_LINK ]]; then
+    [[ "$(readlink "$SKILL_LOCK_LINK" 2>/dev/null || true)" == "$want" ]] && return 0
+  fi
+  ln -sfn "$want" "$SKILL_LOCK_LINK"
+}
+
+# PUBLISH: swap a fully-built candidate generation dir into place as the new
+# .skills-current with ONE atomic exchange, then retain the displaced previous
+# generation and prune older ones.
+#   __gen_publish <candidate-generation-dir>
+# Preconditions (all checked): candidate and .skills-current are both real dirs
+# on the same device, and the candidate is complete (ready marker present). On
+# success .skills-current holds the new generation and the previous generation
+# is retained under .skills-generations/<old-id>. Returns 0 on publish, 1 on any
+# precondition failure (caller records a required failure; live state untouched).
+__gen_publish() {
+  local candidate="$1" old_id
+  [[ -d $candidate && ! -L $candidate ]] || {
+    log "publish: candidate $candidate is not a real directory"
+    return 1
+  }
+  [[ -d $SKILLS_CURRENT && ! -L $SKILLS_CURRENT ]] || {
+    log "publish: $SKILLS_CURRENT is not a real directory"
+    return 1
+  }
+  __gen_is_complete "$candidate" || {
+    log "publish: candidate $candidate is not complete (no ready marker)"
+    return 1
+  }
+  __gen_same_device "$candidate" "$SKILLS_CURRENT" || {
+    log "publish: candidate and .skills-current are on different devices; exchange impossible"
+    return 1
+  }
+  old_id="$(__gen_meta_field "$SKILLS_CURRENT" id)"
+  [[ -n $old_id ]] || old_id="pre-$(__gen_new_id)" # a first-migrated current may predate meta
+  # THE atomic publish: renameat2 RENAME_EXCHANGE. After it, .skills-current is
+  # the new generation and $candidate holds the complete PREVIOUS generation.
+  if ! "$GMV" --exchange --no-copy -T "$candidate" "$SKILLS_CURRENT" 2>/dev/null; then
+    log "publish: gmv --exchange failed; live generation untouched"
+    return 1
+  fi
+  mkdir -p "$GENERATIONS"
+  # Retain the displaced previous generation under its id (garbage-destroy any
+  # name collision first so the rename lands cleanly).
+  local retained="$GENERATIONS/$old_id"
+  __gen_garbage_destroy "$retained"
+  mv "$candidate" "$retained" 2>/dev/null || __gen_garbage_destroy "$candidate"
+  __gen_prune_generations "$old_id"
+  return 0
+}
+
+# Keep EXACTLY the one just-retained previous generation; garbage-destroy every
+# other generation dir. Never touch a staging/home dir that may still be in use
+# by the caller (those live under .skills-generations/<id>/home during a build;
+# a retained generation is a bare <id> dir). The just-retained id is preserved.
+#   __gen_prune_generations <keep-id>
+__gen_prune_generations() {
+  local keep_id="$1" entry name
+  [[ -d $GENERATIONS ]] || return 0
+  __gen_sweep_garbage "$GENERATIONS"
+  for entry in "$GENERATIONS"/*; do
+    [[ -d $entry ]] || continue
+    name="${entry##*/}"
+    [[ $name == "$keep_id" ]] && continue
+    # A retained previous generation is a bare <id> dir with a generation.json;
+    # a build workspace is <id>/home/... . Only prune retained generations here.
+    [[ -f "$entry/$GENERATION_META_NAME" ]] || continue
+    __gen_garbage_destroy "$entry"
+  done
+}
+
+# The generation-owned skills: exactly the npx- and clawhub-tracked roster
+# names. These live inside .skills-current/skills/ and their store entries are
+# symlinks; vendored and app-owned skills stay real in the store, outside the
+# generation.
+__gen_tracked_names() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  jq -r '((.npxTracked // {}) + (.clawhubTracked // {})) | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null
+}
+
+# True when a store entry is the correct migrated symlink for a tracked skill.
+__gen_store_link_correct() {
+  local name="$1"
+  local link="$STORE/$name"
+  [[ -L $link ]] || return 1
+  [[ "$(readlink "$link" 2>/dev/null || true)" == "../.skills-current/skills/$name" ]]
+}
+
+# ---------------------------------------------------------------------------
+# RECOVERY state table (brief step 1). Runs before the idle gate and stamp
+# logic. Self-heals what it can and records two things the main flow acts on:
+#   GEN_REABSORB[]      — tracked names whose store entry is a REAL DIR where a
+#                         link is expected (a competing writer, e.g. the
+#                         HyperFrames self-updater, or an interrupted migration):
+#                         re-absorb that content into this run's candidate.
+#   GEN_REUSE_CANDIDATE — a complete, unpublished candidate whose generation.json
+#                         matches the current desired state: the main flow may
+#                         publish it instead of rebuilding.
+# The self-healed cases: incomplete staging leftovers are garbage-destroyed;
+# published-generation link drift (stale .skill-lock.json link or store links)
+# is repaired; partial-prune garbage is swept; retained generations beyond the
+# newest one are pruned.
+# ---------------------------------------------------------------------------
+GEN_REABSORB=()
+GEN_REUSE_CANDIDATE=""
+__gen_recover() {
+  GEN_REABSORB=()
+  GEN_REUSE_CANDIDATE=""
+  __gen_sweep_garbage "$GENERATIONS"
+  __gen_sweep_garbage "$STORE"
+  local entry id newest_retained="" newest_epoch=-1 epoch cand_agents
+  if [[ -d $GENERATIONS ]]; then
+    for entry in "$GENERATIONS"/*; do
+      [[ -d $entry ]] || continue
+      id="${entry##*/}"
+      case "$id" in *.garbage.*) continue ;; esac
+      # A build workspace: .skills-generations/<id>/home/.agents .
+      if [[ -d "$entry/home" ]]; then
+        cand_agents="$entry/home/.agents"
+        if __gen_is_complete "$cand_agents" && __gen_meta_matches_desired "$cand_agents"; then
+          # A complete candidate matching desired state: reusable (keep the
+          # newest such by createdAt is overkill — one is enough to publish).
+          [[ -z $GEN_REUSE_CANDIDATE ]] && GEN_REUSE_CANDIDATE="$cand_agents"
+          continue
+        fi
+        log "recovery: deleting incomplete or stale staging $entry"
+        __gen_garbage_destroy "$entry"
+        continue
+      fi
+      # A retained previous generation: bare <id> dir with a generation.json.
+      if [[ -f "$entry/$GENERATION_META_NAME" ]] && __gen_is_complete "$entry"; then
+        epoch="${id%%-*}"
+        [[ $epoch =~ ^[0-9]+$ ]] || epoch=0
+        if [[ $epoch -gt $newest_epoch ]]; then
+          [[ -n $newest_retained ]] && __gen_garbage_destroy "$newest_retained"
+          newest_retained="$entry"
+          newest_epoch=$epoch
+        else
+          __gen_garbage_destroy "$entry"
+        fi
+        continue
+      fi
+      # Anything else in the generations dir is leftover garbage.
+      log "recovery: deleting leftover $entry"
+      __gen_garbage_destroy "$entry"
+    done
+  fi
+  # A published live generation: repair its stable links, and detect any tracked
+  # store entry that is a REAL DIR (competing writer) to re-absorb this run.
+  if __gen_is_complete "$SKILLS_CURRENT"; then
+    __gen_plant_lock_link || log "recovery: could not repair the .skill-lock.json link"
+    local name link
+    while IFS= read -r name; do
+      [[ -n $name ]] || continue
+      link="$STORE/$name"
+      if [[ -d $link && ! -L $link ]]; then
+        log "recovery: store/$name is a real dir where a link is expected (competing writer); recording for re-absorption"
+        GEN_REABSORB+=("$name")
+      elif [[ ! -e $link && ! -L $link ]]; then
+        # a tracked skill present in the generation but missing its store link
+        if [[ -d "$SKILLS_CURRENT/skills/$name" ]]; then __gen_plant_store_link "$name" || true; fi
+      elif [[ -L $link ]] && ! __gen_store_link_correct "$name"; then
+        __gen_plant_store_link "$name" || true
+      fi
+    done < <(__gen_tracked_names)
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# MIGRATION (brief "Migration"): first run on a machine with the old flat store
+# (~/.agents/skills/<name> real dirs, ~/.agents/.skill-lock.json a real file).
+# Build .skills-current from the existing tracked real dirs (clone), then per
+# tracked store entry atomically EXCHANGE the real dir with a prebuilt hidden
+# symlink so the store name never dangles and a crash leaves either
+# complete-legacy or complete-migrated per entry. Idempotent: an entry already
+# pointing at the generation is skipped. The .skill-lock.json symlink is planted
+# the same exchange way. Vendored and app-owned store entries are left untouched
+# (outside the generation). Returns 0 when migration ran or was already done.
+# ---------------------------------------------------------------------------
+__gen_migration_needed() {
+  # Needed when no live generation exists yet but a flat store does.
+  __gen_is_complete "$SKILLS_CURRENT" && return 1
+  [[ -d $STORE ]]
+}
+__gen_migrate() {
+  [[ -d $STORE ]] || return 0
+  local id name src link_stub
+  id="$(__gen_new_id)"
+  # 1) Build .skills-current as a real dir from the existing tracked real dirs.
+  if ! __gen_is_complete "$SKILLS_CURRENT"; then
+    local staging="$GENERATIONS/migrate-$id"
+    __gen_garbage_destroy "$staging"
+    mkdir -p "$staging/skills"
+    while IFS= read -r name; do
+      [[ -n $name ]] || continue
+      src="$STORE/$name"
+      # Only clone a real dir; a symlink here is already migrated/app-owned.
+      [[ -d $src && ! -L $src ]] || continue
+      cp -c -R "$src" "$staging/skills/$name" 2>/dev/null || cp -R "$src" "$staging/skills/$name"
+    done < <(__gen_tracked_names)
+    # Seed the npx lock from the flat one (or an empty object).
+    if [[ -f $SKILL_LOCK_LINK && ! -L $SKILL_LOCK_LINK ]]; then
+      cp -c "$SKILL_LOCK_LINK" "$staging/.skill-lock.json" 2>/dev/null || cp "$SKILL_LOCK_LINK" "$staging/.skill-lock.json"
+    else
+      printf '{}\n' >"$staging/.skill-lock.json"
+    fi
+    __gen_write_meta "$staging" "$id"
+    __gen_is_complete "$staging" || {
+      log "migration: built staging is not complete; aborting (flat store untouched)"
+      __gen_garbage_destroy "$staging"
+      return 1
+    }
+    # Promote staging to the live .skills-current. On a fresh machine .skills-current
+    # is absent, so a plain rename publishes it atomically.
+    if [[ ! -e $SKILLS_CURRENT ]]; then
+      mkdir -p "$GENERATIONS"
+      mv "$staging" "$SKILLS_CURRENT" || {
+        log "migration: could not promote staging to .skills-current"
+        __gen_garbage_destroy "$staging"
+        return 1
+      }
+    else
+      # .skills-current exists but is incomplete: exchange it in, garbage the old.
+      if __gen_same_device "$staging" "$SKILLS_CURRENT" &&
+        "$GMV" --exchange --no-copy -T "$staging" "$SKILLS_CURRENT" 2>/dev/null; then
+        __gen_garbage_destroy "$staging"
+      else
+        __gen_garbage_destroy "$staging"
+        log "migration: could not exchange staging into an incomplete .skills-current"
+        return 1
+      fi
+    fi
+  fi
+  # 2) Per tracked entry, atomically swap the flat real dir for a store symlink.
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    __gen_store_link_correct "$name" && continue # idempotent: already migrated
+    [[ -d "$SKILLS_CURRENT/skills/$name" ]] || continue
+    link="$STORE/$name"
+    if [[ -d $link && ! -L $link ]]; then
+      # legacy real dir: exchange it with a prebuilt hidden symlink
+      link_stub="$STORE/.$name.migrating.$$"
+      __gen_garbage_destroy "$link_stub"
+      ln -s "../.skills-current/skills/$name" "$link_stub"
+      if __gen_same_device "$link_stub" "$link" &&
+        "$GMV" --exchange --no-copy -T "$link_stub" "$link" 2>/dev/null; then
+        __gen_garbage_destroy "$link_stub" # now holds the displaced real dir (garbage)
+        log "migration: store/$name -> generation link (legacy dir absorbed)"
+      else
+        __gen_garbage_destroy "$link_stub"
+        log "migration: could not exchange store/$name; leaving the legacy dir"
+        record_required_failure "migration exchange for $name failed"
+      fi
+    elif [[ ! -e $link && ! -L $link ]]; then
+      __gen_plant_store_link "$name" || true # absent: just plant the link
+    fi
+  done < <(__gen_tracked_names)
+  # 3) Plant the .skill-lock.json symlink the same exchange way.
+  if [[ -f $SKILL_LOCK_LINK && ! -L $SKILL_LOCK_LINK ]]; then
+    link_stub="$AGENTS/.skill-lock.json.migrating.$$"
+    __gen_garbage_destroy "$link_stub"
+    ln -s ".skills-current/.skill-lock.json" "$link_stub"
+    if __gen_same_device "$link_stub" "$SKILL_LOCK_LINK" &&
+      "$GMV" --exchange --no-copy -T "$link_stub" "$SKILL_LOCK_LINK" 2>/dev/null; then
+      __gen_garbage_destroy "$link_stub"
+    else
+      __gen_garbage_destroy "$link_stub"
+      __gen_plant_lock_link || true
+    fi
+  else
+    __gen_plant_lock_link || true
+  fi
+  return 0
+}
+
+# Lib-only sourcing gate: a test that sets UPDATE_SKILLS_LIB_ONLY=1 and sources
+# this script gets the config + machinery functions above WITHOUT running the
+# main flow (the lanes, idle gate, and publish orchestration below never fire).
+# `return` only works in a sourced file; when the script is executed normally
+# the variable is unset, so this is a no-op.
+if [[ ${UPDATE_SKILLS_LIB_ONLY:-} == 1 ]]; then
+  # shellcheck disable=SC2317 # exit is reached when executed (return fails outside a sourced file)
+  return 0 2>/dev/null || exit 0
+fi
 
 # idle-gate discriminator (Wave 3a fix3, fail-closed). The gate judges recent
 # harness ACTIVITY, not mere process existence. Rationale: argv SHAPE cannot

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -70,6 +70,9 @@
 #                       weekly npx and clawhub updates, the hermes registry-update
 #                       phase, and the fork drift-check)
 #   --check-forks-only  run only the fork/vendored upstream drift-check
+#   --scheduled         mark this as a LaunchAgent (scheduled) run; only a
+#                       scheduled run with no later slot remaining this week
+#                       claims retry-budget exhaustion (a manual run never does)
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
 #      The idle-gate (fail-closed) makes this script refuse to swap skill folders
 #      while ANY agent-harness process (claude/codex/hermes) is running, session
@@ -95,11 +98,13 @@ HERMES="$HOME/.hermes/skills"            # the default profile (Bob)
 HERMES_PROFILES="$HOME/.hermes/profiles" # specialist profiles: <name>/skills
 LOCKDIR="$AGENTS/.update-skills.lock.d"
 STATE_DIR="$HOME/.local/state/update-skills"
-SUCCESS_STAMP="$STATE_DIR/last-success" # ISO year-week (%G-%V) of the last fully successful weekly run
+SUCCESS_STAMP="$STATE_DIR/last-success"               # ISO year-week (%G-%V) of the last fully successful weekly run
+SCHEDULED_WEEK_STAMP="$STATE_DIR/last-scheduled-week" # ISO week of the last SCHEDULED attempt (item 6)
 # The plist fires four Monday retry slots (04:00/08:00/12:00/16:00; see
 # Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl). This is the hour
-# of the LAST slot: a deferral here means the weekly retry budget is exhausted,
-# so the run alerts LOUDLY instead of failing silent. Keep in sync with the plist.
+# of the LAST slot: a scheduled deferral at/after it, or a coalesced catch-up on
+# a later weekday, means the weekly retry budget is exhausted, so the run alerts
+# LOUDLY instead of failing silent. Keep in sync with the plist.
 readonly UPDATE_SKILLS_LAST_SLOT_HOUR="16"
 # The Codex on-demand policy overlay this script asserts into store skill dirs
 # (see assert_codex_overlays) — also what the clawhub update pass recognizes as
@@ -119,11 +124,13 @@ readonly CODEX_POLICY=$'policy:\n  allow_implicit_invocation: false'
 DRYRUN=""
 INSTALL_ONLY=""
 CHECK_FORKS_ONLY=""
+SCHEDULED=""
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRYRUN="--dry-run" ;;
     --install-only) INSTALL_ONLY=1 ;;
     --check-forks-only) CHECK_FORKS_ONLY=1 ;;
+    --scheduled) SCHEDULED=1 ;;
     *)
       printf 'update-skills: unknown argument: %s\n' "$arg" >&2
       exit 2
@@ -139,25 +146,50 @@ log() { printf '[update-skills] %s\n' "$*"; }
 # WITHIN a run, but every failure is RECORDED here. ADVISORY phases (fork
 # drift-watch, the cua-driver pack refresh) only inform and are never recorded.
 # The weekly success stamp is written ONLY when zero required failures occurred,
-# so a transient failure leaves the stamp absent and a later Monday slot retries.
+# so a transient failure leaves the stamp absent and a later scheduled slot retries.
 REQUIRED_FAILURES=0
 record_required_failure() {
   REQUIRED_FAILURES=$((REQUIRED_FAILURES + 1))
   log "REQUIRED-FAILURE: $*"
 }
 
-# True when now is Monday at or after the last retry slot hour, i.e. no further
-# scheduled slot remains this week to retry a failed or deferred run. date +%u
-# is 1 for Monday; the hour is stripped of a leading zero so 08 is not read as
-# an invalid octal in the arithmetic compare.
-__update_skills_is_last_monday_slot() {
+# True when no further SCHEDULED slot remains this ISO week to retry a failed or
+# deferred run. The plist fires four Monday slots (04/08/12/16); launchd may
+# COALESCE a missed slot and deliver it on a later day (a catch-up), which is
+# also the week's last scheduled chance. So a later slot remains ONLY when today
+# is Monday BEFORE the last slot hour; Monday at/after 16:00, or any later
+# weekday (a coalesced catch-up), means the scheduled budget for this week is
+# spent. date +%u is 1 for Monday; base-10 forces the hour compare so 08 is not
+# read as invalid octal.
+__update_skills_no_scheduled_slot_remains() {
   local dow hour
   dow="$(date +%u)"
   hour="$(date +%H)"
   hour="${hour#0}"
-  [[ $dow == "1" ]] || return 1
   [[ -n $hour ]] || hour=0
-  [[ $hour -ge $UPDATE_SKILLS_LAST_SLOT_HOUR ]]
+  [[ $dow =~ ^[0-9]+$ ]] || return 0
+  [[ $hour =~ ^[0-9]+$ ]] || hour=0
+  if [[ $dow == "1" && $((10#$hour)) -lt $((10#$UPDATE_SKILLS_LAST_SLOT_HOUR)) ]]; then
+    return 1 # Monday, before the last slot: a later scheduled slot remains
+  fi
+  return 0 # no later scheduled slot this week
+}
+
+# Exhaustion is claimed ONLY for a SCHEDULED run (the LaunchAgent passes
+# --scheduled) with no later slot remaining this week. A manual run warns loudly
+# elsewhere but never claims scheduled-budget exhaustion.
+__update_skills_scheduled_budget_exhausted() {
+  [[ -n $SCHEDULED ]] || return 1
+  __update_skills_no_scheduled_slot_remains
+}
+
+# Record the ISO week of this scheduled attempt so a coalesced catch-up on a
+# later day is recognized as this week's scheduled cycle (item 6). Best-effort.
+__update_skills_note_scheduled_attempt() {
+  [[ -n $SCHEDULED ]] || return 0
+  [[ $DRYRUN == "--dry-run" ]] && return 0
+  mkdir -p "$STATE_DIR" 2>/dev/null || return 0
+  date +%G-%V >"$SCHEDULED_WEEK_STAMP" 2>/dev/null || true
 }
 
 # Loud alert on both channels the brief names: a local alerter notification and
@@ -841,11 +873,12 @@ fi
 # machine bootstrap run --install-only unattended at apply time. On the last
 # SCHEDULED slot the retry budget is spent, so a deferral there alerts LOUDLY
 # rather than failing silent.
+__update_skills_note_scheduled_attempt
 if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
   log "a live harness session (claude/codex/hermes) is using the store, or the process table could not be read (fail-closed); deferring this run"
-  if __update_skills_is_last_monday_slot; then
-    log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred; the weekly skills update did not run this week"
-    __update_skills_alert "Weekly skills update deferred on every Monday slot (an agent session was always active). Run it by hand when idle (~/.local/bin/update-skills.sh)."
+  if __update_skills_scheduled_budget_exhausted; then
+    log "EXHAUSTED: the last scheduled retry slot for this week still deferred; the weekly skills update did not run this week"
+    __update_skills_alert "Weekly skills update deferred on every scheduled slot (an agent session was always active). Run it by hand when idle (~/.local/bin/update-skills.sh)."
   fi
   exit 0
 fi
@@ -1162,18 +1195,18 @@ check_fork_drift
 # boundary week correct: the days of ISO week 01 that fall in late December carry
 # the NEXT year's %G, and the late-December days of week 52/53 carry the current
 # %G, so the key never collides or splits across the boundary (52/53/01 verified).
-# When a required phase failed we WITHHOLD the stamp, so a later Monday slot
-# retries; and if no slot remains this Monday we alert (the retry budget is
-# spent). A dry run records nothing.
+# When a required phase failed we WITHHOLD the stamp, so a later scheduled slot
+# retries; and for a scheduled run with no slot remaining this week we alert (the
+# retry budget is spent). A dry run records nothing.
 if [[ $DRYRUN != "--dry-run" ]]; then
   if [[ $REQUIRED_FAILURES -eq 0 ]]; then
     mkdir -p "$STATE_DIR"
     date +%G-%V >"$SUCCESS_STAMP"
   else
-    log "WITHHOLDING the weekly success stamp: $REQUIRED_FAILURES required-phase failure(s) this run; a later Monday slot will retry"
-    if __update_skills_is_last_monday_slot; then
-      log "EXHAUSTED: required-phase failures on the last Monday slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00); the weekly skills update did not fully succeed this week"
-      __update_skills_alert "Weekly skills update finished with $REQUIRED_FAILURES required-phase failure(s) and no Monday slot remains. Check ~/.local/log/skills/."
+    log "WITHHOLDING the weekly success stamp: $REQUIRED_FAILURES required-phase failure(s) this run; a later scheduled slot will retry"
+    if __update_skills_scheduled_budget_exhausted; then
+      log "EXHAUSTED: required-phase failures on the last scheduled slot for this week; the weekly skills update did not fully succeed this week"
+      __update_skills_alert "Weekly skills update finished with $REQUIRED_FAILURES required-phase failure(s) and no scheduled slot remains this week. Check ~/.local/log/skills/."
     fi
   fi
 fi

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -73,7 +73,7 @@
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
 #      The idle-gate makes this script refuse to swap skill folders while an
 #      INTERACTIVE harness session (claude/codex/hermes) is running, so a skill is
-#      never yanked out from under a live session — persistent background daemons
+#      never yanked out from under a live session. Persistent background daemons
 #      (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do NOT
 #      defer it (see __update_skills_harness_active). The weekly run is scheduled
 #      across four Monday slots; a per-week success stamp
@@ -97,7 +97,7 @@ HERMES_PROFILES="$HOME/.hermes/profiles" # specialist profiles: <name>/skills
 LOCKDIR="$AGENTS/.update-skills.lock.d"
 STATE_DIR="$HOME/.local/state/update-skills"
 SUCCESS_STAMP="$STATE_DIR/last-success" # ISO year-week (%G-%V) of the last fully successful weekly run
-# The plist fires four Monday retry slots — 04:00/08:00/12:00/16:00 (see
+# The plist fires four Monday retry slots (04:00/08:00/12:00/16:00; see
 # Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl). This is the hour
 # of the LAST slot: a deferral here means the weekly retry budget is exhausted,
 # so the run alerts LOUDLY instead of failing silent. Keep in sync with the plist.
@@ -401,7 +401,7 @@ converge_dir() {
 }
 
 # Claude fan-out: every store skill (the full roster) gets a ~/.claude/skills
-# link. Claude is not profile-scoped — tiering there is the settings
+# link. Claude is not profile-scoped, tiering there is the settings
 # modify-template's job, not the fan-out's.
 converge_claude_skills() {
   local -a desired=()
@@ -421,7 +421,7 @@ converge_claude_skills() {
 # Hermes fan-out is profile-driven by the lock's hermesProfiles map. "default" is
 # ~/.hermes/skills (Bob), any other name is ~/.hermes/profiles/<name>/skills
 # (created here when absent, so a mapping can land before its profile exists on
-# this machine). A [] mapping — or a missing table — gets no hermes link: the
+# this machine). A [] mapping (or a missing table) gets no hermes link: the
 # deliberate "not available in hermes from the store" state, not an error.
 # Collision-named skills (humanizer, hyperframes) never fan out: hermes's catalog
 # wins those names (operator ruling), so a stale store link at such a name IS
@@ -738,10 +738,10 @@ fi
 # idle-gate: defer while an INTERACTIVE harness session is using the store, so a
 # skill is never swapped out from under a live session. Persistent background
 # daemons (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do
-# NOT count — blocking on them is what deferred the weekly run forever (see
+# NOT count, blocking on them is what deferred the weekly run forever (see
 # __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests, manual
 # runs). --install-only is EXEMPT: it only ADDS absent skills (never swaps a
-# folder), so it is safe under a live session — this is what lets the fresh-
+# folder), so it is safe under a live session, this is what lets the fresh-
 # machine bootstrap run --install-only unattended at apply time. On the LAST
 # Monday slot the retry budget is spent, so a deferral there alerts LOUDLY rather
 # than failing silent.
@@ -1020,7 +1020,7 @@ update_clawhub_tracked
 refresh_app_owned_cua_pack
 
 # 2) CONVERGE the fan-out: every store skill is symlinked into Claude, and into
-#    exactly the hermes profile skills dirs its hermesProfiles mapping names —
+#    exactly the hermes profile skills dirs its hermesProfiles mapping names,
 #    creating missing links, repairing wrong/dangling targets, and removing
 #    updater-owned links that drifted out of the desired set
 converge_claude_skills

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -132,55 +132,113 @@ done
 
 log() { printf '[update-skills] %s\n' "$*"; }
 
-# idle-gate discriminator: is an INTERACTIVE agent-harness session using the
-# store right now? Returns 0 (defer — never swap a skill out from under a live
-# session) for an interactive Claude Code / Codex / hermes session, 1 (proceed)
-# when only persistent background daemons are up.
+# idle-gate discriminator: is a LIVE interactive agent-harness session using the
+# store right now? Returns 0 (defer, never swap a skill out from under a live
+# session) for a live Claude Code / Codex / hermes session, 1 (proceed) when
+# only persistent background daemons are up.
 #
-# The old gate was `pgrep -x claude || -x codex || -x hermes`, which deferred on
-# ANY match, INCLUDING persistent daemons — so the weekly run could defer forever
-# (the audit logged two such deferrals). We instead read full argv (ps -xo args=)
-# and key on the EXECUTABLE (argv[0] basename), excluding the daemon shapes.
+# The old gate keyed on argv[0]'s basename and substring-matched daemon phrases
+# against the whole flattened argv. Two proven holes: (a) a hermes session execs
+# a python console script, so argv[0] is `python` and the session was never seen
+# as an agent at all (the gate swapped skills under a live hermes session); (b)
+# prompt free text containing a daemon phrase (a `claude -p "restart the hermes
+# gateway"` one-shot) was substring-matched as a daemon, so a live session was
+# read as a daemon and proceeded. The rewrite keys on the argv EFFECTIVE program
+# and on the single flags-position token, never on free text.
+#
+# Algorithm (Wave 3a conductor ruling), applied to one `ps -xo args=` line:
+#   1. Tokenize argv and find the EFFECTIVE program. When token0's basename is a
+#      python interpreter (python, python3, python3.12, ...): a hermes session
+#      is `python /path/bin/hermes ...` (token1 is the console-script path) and
+#      the gateway is `python -m hermes_cli.main ...` (token1 is -m). So:
+#        - token1 == "-m": effective program = the module's leading identifier
+#          (hermes_cli.main -> hermes), flags-position token = token3;
+#        - otherwise:      effective program = basename(token1), flags-position
+#          token = token2.
+#      For a non-python token0: effective program = basename(token0),
+#      flags-position token = token1.
+#   2. AGENT process iff the effective program is EXACTLY claude, codex, or
+#      hermes; anything else (node, bash, a plain python tool) proceeds.
+#   3. DAEMON iff the flags-position token EXACTLY matches that harness's daemon
+#      shape (never a substring, never free text):
+#        hermes -> gateway
+#        claude -> --remote-control | --bg-spare | --bg-pty-host | daemon
+#        codex  -> app-server
+#      A daemon proceeds; every other agent process is a live session -> defer.
 #
 # Ground truth (dresden, read-only ps, 2026-07-10):
-#   DAEMONS (proceed) — none is an interactive session:
-#     python -m hermes_cli.main gateway run --replace   (hermes gateway: argv[0]
-#         is `python`, so it is ignored outright — and note `pgrep -x hermes`
-#         never even matched it, comm=python; the OLD gate's real defer-forever
-#         driver on THIS machine was long-lived `claude --remote-control` bridges)
+#   DAEMONS (proceed):
+#     python -m hermes_cli.main gateway run --replace      (hermes gateway)
+#     /opt/homebrew/bin/claude --remote-control            (Remote Control bridge)
 #     .../claude --bg-spare | daemon run | --bg-pty-host   (Claude bg helpers)
 #     codex app-server [--analytics-default-enabled]       (Codex app server)
-#   INTERACTIVE (defer):
-#     /opt/homebrew/bin/claude [--remote-control|resume|-p ...]  (a Claude TUI)
-#     codex [resume <id>]                                        (a Codex CLI session)
-#     .../hermes -c <prompt> | hermes -p <profile>               (an interactive hermes run)
+#   LIVE SESSIONS (defer):
+#     .../python .../bin/hermes -c <prompt>                (hermes console session)
+#     /opt/homebrew/bin/claude -p <prompt> | resume        (a Claude one-shot/TUI)
+#     codex [resume <id>]                                  (a Codex CLI session)
 #
-# Keying on argv[0]'s basename means prompt text or paths that merely CONTAIN
-# "codex"/"claude" (a `node .../codex-companion.mjs` helper, a bash -c carrying a
-# prompt about codex) never false-positive — argv[0] there is `node`/`bash`.
+# A Remote Control bridge is a daemon by SHAPE (flags-position --remote-control);
+# a session that bridge spawns is a SEPARATE claude process WITHOUT that
+# positional flag, so it defers normally.
 __update_skills_is_interactive_harness() {
-  local args="$1" cmd base
-  cmd="${args%% *}" # argv[0] (the executable)
-  base="${cmd##*/}" # its basename
-  case "$base" in
-    claude | codex | hermes) ;; # a candidate harness binary
-    *) return 1 ;;              # anything else (python gateway, node, bash, GUI helpers) is not
+  local args="$1"
+  local -a tokens
+  read -ra tokens <<<"$args"
+  [[ ${#tokens[@]} -gt 0 ]] || return 1
+  local base0 effective first_arg module
+  base0="${tokens[0]##*/}"
+  case "$base0" in
+    python | python[0-9]*)
+      if [[ ${tokens[1]:-} == "-m" ]]; then
+        module="${tokens[2]:-}"
+        module="${module%%.*}"    # hermes_cli.main -> hermes_cli
+        effective="${module%%_*}" # hermes_cli -> hermes
+        first_arg="${tokens[3]:-}"
+      else
+        effective="${tokens[1]:-}"
+        effective="${effective##*/}" # basename of the script path
+        first_arg="${tokens[2]:-}"
+      fi
+      ;;
+    *)
+      effective="$base0"
+      first_arg="${tokens[1]:-}"
+      ;;
   esac
-  # Exclude the daemon shapes by the rest of argv.
-  case "$args" in
-    *hermes_cli.main*gateway* | *'hermes gateway'*) return 1 ;; # hermes gateway
-    *'claude --bg-'* | *'claude daemon run'*) return 1 ;;       # Claude bg spare/daemon/pty-host
-    *'codex app-server'*) return 1 ;;                           # Codex app server
+  case "$effective" in
+    claude | codex | hermes) ;;
+    *) return 1 ;; # not an agent process (node, bash, a plain python tool)
   esac
-  return 0
+  # Daemon shapes: an exact match on the flags-position token means a persistent
+  # background daemon, which never loads a skill on its own, so it proceeds.
+  case "$effective" in
+    hermes)
+      [[ $first_arg == "gateway" ]] && return 1
+      ;;
+    claude)
+      case "$first_arg" in
+        --remote-control | --bg-spare | --bg-pty-host | daemon) return 1 ;;
+      esac
+      ;;
+    codex)
+      [[ $first_arg == "app-server" ]] && return 1
+      ;;
+  esac
+  return 0 # a live interactive session -> defer
 }
 
 __update_skills_harness_active() {
-  local args
+  local ps_output args
+  # Fail CLOSED: if ps errors, or yields nothing (it must at minimum list this
+  # very process), treat the world as busy and defer rather than risk swapping
+  # skills under an unreadable process table.
+  if ! ps_output="$(ps -xo args= 2>/dev/null)" || [[ -z $ps_output ]]; then
+    return 0
+  fi
   while IFS= read -r args; do
     [[ -n $args ]] || continue
     __update_skills_is_interactive_harness "$args" && return 0
-  done < <(ps -xo args= 2>/dev/null)
+  done <<<"$ps_output"
   return 1
 }
 
@@ -526,7 +584,7 @@ fi
 # Monday slot the retry budget is spent, so a deferral there alerts LOUDLY rather
 # than failing silent.
 if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
-  log "an interactive harness session (claude/codex/hermes) is using the store; deferring this run"
+  log "a live harness session (claude/codex/hermes) is using the store, or the process table could not be read (fail-closed); deferring this run"
   if [[ "$(date +%H)" == "$UPDATE_SKILLS_LAST_SLOT_HOUR" ]]; then
     log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred — the weekly skills update did not run this week"
     if command -v alerter >/dev/null 2>&1; then

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -789,20 +789,36 @@ __update_skills_acquire_lock() {
   done
   return 1
 }
-if ! __update_skills_acquire_lock; then
-  log "another run in progress; exiting"
-  exit 0
+if [[ $DRYRUN == "--dry-run" ]]; then
+  # A dry run is a READ-ONLY contention check (item 5): it never creates,
+  # deletes, or reclaims lock state, and it tolerates an absent .agents parent.
+  # It only reports whether a live lock would make the real run defer.
+  if [[ -d $LOCKDIR ]]; then
+    dry_lock_owner="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
+    if [[ -n $dry_lock_owner ]] && __update_skills_owner_alive "$dry_lock_owner"; then
+      log "would defer: a live run holds the lock ($dry_lock_owner)"
+    else
+      log "would run: the existing lock has no live owner (stale or ownerless)"
+    fi
+  else
+    log "would run: no lock is held"
+  fi
+else
+  if ! __update_skills_acquire_lock; then
+    log "another run in progress; exiting"
+    exit 0
+  fi
+  # The EXIT trap removes the lock ONLY while we still own it: a later run that
+  # reclaims a dead lock rewrites the owner file, and our trap must never delete
+  # a lock we no longer hold (the three-writer race).
+  __update_skills_release_lock() {
+    local cur
+    cur="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
+    [[ $cur == "$LOCK_MY_TOKEN" ]] && rm -rf "$LOCKDIR"
+    return 0 # never let the EXIT trap's status leak into the script's exit code
+  }
+  trap '__update_skills_release_lock' EXIT
 fi
-# The EXIT trap removes the lock ONLY while we still own it: a later run that
-# reclaims a dead lock rewrites the owner file, and our trap must never delete a
-# lock we no longer hold (the three-writer race).
-__update_skills_release_lock() {
-  local cur
-  cur="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
-  [[ $cur == "$LOCK_MY_TOKEN" ]] && rm -rf "$LOCKDIR"
-  return 0 # never let the EXIT trap's status leak into the script's exit code
-}
-trap '__update_skills_release_lock' EXIT
 
 # weekly success stamp: the four Monday plist slots share one ISO week; once a
 # slot completes a full run this week, the remaining slots are no-ops. A deferral

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -13,7 +13,7 @@
 # ~/.agents/.skills-generations/<id>/home, runs the package-CLI lanes against it
 # under env -i (HOME/XDG/TMPDIR/npm cache pinned inside the candidate), validates
 # the whole candidate, and publishes with ONE atomic renameat2 RENAME_EXCHANGE
-# (gmv --exchange --no-copy -T). Exactly one previous generation is retained.
+# (GNU mv --exchange --no-copy -T). Exactly one previous generation is retained.
 #
 # HONEST GUARANTEE: per-lookup completeness and cross-skill coherence per
 # generation: any path resolution during or after the exchange yields a
@@ -134,7 +134,7 @@ SCHEDULED_WEEK_STAMP="$STATE_DIR/last-scheduled-week" # ISO week of the last SCH
 # ~/.agents/.skill-lock.json is a symlink into .skills-current/.skill-lock.json.
 # Both keep resolving across a publish because .skills-current is a stable PATH
 # whose CONTENTS are swapped by ONE renameat2 RENAME_EXCHANGE
-# (gmv --exchange --no-copy -T), so any lookup during or after the swap yields a
+# (GNU mv --exchange --no-copy -T), so any lookup during or after the swap yields a
 # complete tree from exactly one generation. Candidate generations are built as a
 # fake HOME under .skills-generations/<id>/home, on the SAME device as
 # .skills-current so the same-filesystem exchange works. Exactly one previous
@@ -144,8 +144,15 @@ SKILLS_CURRENT="$AGENTS/.skills-current"
 GENERATIONS="$AGENTS/.skills-generations"
 SKILL_LOCK_LINK="$AGENTS/.skill-lock.json"
 GENERATION_META_NAME="generation.json"
-# GNU coreutils mv (has --exchange; BSD /bin/mv does not). Tests can override.
-GMV="${UPDATE_SKILLS_GMV:-gmv}"
+# The exchange tool (a GNU coreutils mv with a working --exchange; BSD /bin/mv
+# lacks it) is resolved at RUN TIME by __gen_resolve_exchange_tool, never a
+# hardcoded host path: a macOS host carries it as Homebrew's gmv, while the Nix
+# devshell (CI) provides GNU mv as plain mv and has no /opt/homebrew. Candidate
+# order is the UPDATE_SKILLS_GMV override (tests), then gmv, then mv on PATH; a
+# candidate is accepted only when --version says GNU coreutils AND a functional
+# probe swap succeeds. The accepted tool is cached here for the rest of the
+# run; empty means not resolved yet.
+GEN_EXCHANGE_TOOL=""
 # This script's own path, for the env -i re-invocation that runs the build lanes
 # inside a candidate fake HOME (see __gen_run_lanes / --build-lanes).
 UPDATE_SKILLS_SELF="${BASH_SOURCE[0]}"
@@ -304,12 +311,75 @@ __update_skills_stamp_value() {
 # Sortable-by-time is what lets prune keep the newest previous and delete older.
 __gen_new_id() { printf '%s-%s-%s' "$(date +%s)" "$$" "${RANDOM}${RANDOM}"; }
 
-# Two paths are on the same filesystem (required for renameat2 RENAME_EXCHANGE).
+# Two paths are on the same filesystem (renameat2 RENAME_EXCHANGE needs that).
+# %d is the device number, but the flag spelling differs by stat flavor: GNU
+# stat takes -c (its -f means file-SYSTEM status, whose %d is the format code;
+# comparing that reports same-device paths as different); BSD stat takes -f.
+# Probe the GNU spelling first, fall back to BSD. ADVISORY ONLY: callers
+# attempt the exchange regardless and treat its outcome as authoritative; this
+# check only shapes the pre-flight warning.
 __gen_same_device() {
   local a b
-  a="$(stat -f %d "$1" 2>/dev/null)" || return 1
-  b="$(stat -f %d "$2" 2>/dev/null)" || return 1
+  if a="$(stat -c %d "$1" 2>/dev/null)"; then
+    b="$(stat -c %d "$2" 2>/dev/null)" || return 1
+  else
+    a="$(stat -f %d "$1" 2>/dev/null)" || return 1
+    b="$(stat -f %d "$2" 2>/dev/null)" || return 1
+  fi
   [[ -n $a && $a == "$b" ]]
+}
+
+# A candidate exchange tool is capable iff --version says GNU coreutils AND a
+# real probe swap in a private temp dir succeeds (--exchange --no-copy -T with
+# the swapped content verified). The functional probe is the authority: a GNU
+# mv too old for --exchange, or a filesystem without atomic-swap support, both
+# fail here and the candidate is rejected.
+__gen_exchange_tool_capable() {
+  local tool="$1" probe rc=1
+  command -v "$tool" >/dev/null 2>&1 || return 1
+  "$tool" --version 2>/dev/null | head -1 | grep -q 'GNU coreutils' || return 1
+  probe="$(mktemp -d)" || return 1
+  mkdir -p "$probe/a" "$probe/b" || {
+    rm -rf "$probe"
+    return 1
+  }
+  printf 'a' >"$probe/a/marker"
+  printf 'b' >"$probe/b/marker"
+  if "$tool" --exchange --no-copy -T "$probe/a" "$probe/b" 2>/dev/null &&
+    [[ "$(cat "$probe/a/marker" 2>/dev/null)" == "b" &&
+    "$(cat "$probe/b/marker" 2>/dev/null)" == "a" ]]; then
+    rc=0
+  fi
+  rm -rf "$probe"
+  return $rc
+}
+
+# Resolve (and cache for this run) the exchange tool: the UPDATE_SKILLS_GMV
+# override first, then gmv, then mv on PATH. Returns 1 (cache left empty) when
+# no capable tool exists; callers then fail LOUDLY, never partially.
+__gen_resolve_exchange_tool() {
+  [[ -n $GEN_EXCHANGE_TOOL ]] && return 0
+  local candidate
+  for candidate in ${UPDATE_SKILLS_GMV:+"$UPDATE_SKILLS_GMV"} gmv mv; do
+    if __gen_exchange_tool_capable "$candidate"; then
+      GEN_EXCHANGE_TOOL="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# THE atomic swap primitive: renameat2 RENAME_EXCHANGE via the resolved GNU mv.
+# Logs loudly and returns 1 when no capable tool exists. --no-copy guarantees a
+# cross-device attempt fails cleanly instead of degrading to a partial copy, so
+# a non-zero return always means "nothing changed".
+#   __gen_exchange <path-a> <path-b>
+__gen_exchange() {
+  if ! __gen_resolve_exchange_tool; then
+    log "exchange: no GNU coreutils mv with a working --exchange on PATH (tried:${UPDATE_SKILLS_GMV:+ $UPDATE_SKILLS_GMV,} gmv, mv)"
+    return 1
+  fi
+  "$GEN_EXCHANGE_TOOL" --exchange --no-copy -T "$1" "$2" 2>/dev/null
 }
 
 # Write generation.json LAST, as the ready marker. Its presence + matching
@@ -450,16 +520,17 @@ __gen_publish() {
     log "publish: $SKILLS_CURRENT is not a real directory"
     return 1
   }
-  __gen_same_device "$candidate" "$SKILLS_CURRENT" || {
-    log "publish: candidate and .skills-current are on different devices; exchange impossible"
-    return 1
-  }
+  # Pre-flight ADVISORY only: warn on an apparent device mismatch, but let the
+  # exchange itself be the authority (--no-copy makes a cross-device attempt a
+  # clean failure, never a partial operation).
+  __gen_same_device "$candidate" "$SKILLS_CURRENT" ||
+    log "publish: WARN candidate and .skills-current look like different devices; attempting the exchange anyway"
   old_id="$(__gen_meta_field "$SKILLS_CURRENT" id)"
   [[ -n $old_id ]] || old_id="pre-$(__gen_new_id)" # a first-migrated current may predate meta
   # THE atomic publish: renameat2 RENAME_EXCHANGE. After it, .skills-current is
   # the new generation and $candidate holds the complete PREVIOUS generation.
-  if ! "$GMV" --exchange --no-copy -T "$candidate" "$SKILLS_CURRENT" 2>/dev/null; then
-    log "publish: gmv --exchange failed; live generation untouched"
+  if ! __gen_exchange "$candidate" "$SKILLS_CURRENT"; then
+    log "publish: atomic exchange failed; live generation untouched"
     return 1
   fi
   mkdir -p "$GENERATIONS"
@@ -653,8 +724,7 @@ __gen_migrate() {
       }
     else
       # .skills-current exists but is incomplete: exchange it in, garbage the old.
-      if __gen_same_device "$staging" "$SKILLS_CURRENT" &&
-        "$GMV" --exchange --no-copy -T "$staging" "$SKILLS_CURRENT" 2>/dev/null; then
+      if __gen_exchange "$staging" "$SKILLS_CURRENT"; then
         __gen_garbage_destroy "$staging"
       else
         __gen_garbage_destroy "$staging"
@@ -674,8 +744,7 @@ __gen_migrate() {
       link_stub="$STORE/.$name.migrating.$$"
       __gen_garbage_destroy "$link_stub"
       ln -s "../.skills-current/skills/$name" "$link_stub"
-      if __gen_same_device "$link_stub" "$link" &&
-        "$GMV" --exchange --no-copy -T "$link_stub" "$link" 2>/dev/null; then
+      if __gen_exchange "$link_stub" "$link"; then
         __gen_garbage_destroy "$link_stub" # now holds the displaced real dir (garbage)
         log "migration: store/$name -> generation link (legacy dir absorbed)"
       else
@@ -692,8 +761,7 @@ __gen_migrate() {
     link_stub="$AGENTS/.skill-lock.json.migrating.$$"
     __gen_garbage_destroy "$link_stub"
     ln -s ".skills-current/.skill-lock.json" "$link_stub"
-    if __gen_same_device "$link_stub" "$SKILL_LOCK_LINK" &&
-      "$GMV" --exchange --no-copy -T "$link_stub" "$SKILL_LOCK_LINK" 2>/dev/null; then
+    if __gen_exchange "$link_stub" "$SKILL_LOCK_LINK"; then
       __gen_garbage_destroy "$link_stub"
     else
       __gen_garbage_destroy "$link_stub"
@@ -946,7 +1014,7 @@ __gen_do_build_lanes() {
 # Parent side: run the build lanes against a candidate home under env -i, with
 # HOME, every XDG_* dir, TMPDIR, and the npm cache/config pinned INSIDE the
 # candidate, so a lane can only write into the candidate (isolation). PATH is
-# passed through so npx/clawhub/jq/gmv resolve (and tests can prepend stubs).
+# passed through so npx/clawhub/jq/GNU mv resolve (and tests can prepend stubs).
 #   __gen_run_lanes <candidate-home> <id> [additive]
 # A non-empty third argument runs the lanes ADDITIVELY (install-only builds:
 # only skills absent from the candidate are installed; nothing is refreshed).
@@ -963,7 +1031,7 @@ __gen_run_lanes() {
     XDG_STATE_HOME="$home/.local/state" \
     TMPDIR="$home/.tmp" \
     npm_config_cache="$home/.npm" \
-    UPDATE_SKILLS_GMV="$GMV" \
+    UPDATE_SKILLS_GMV="${GEN_EXCHANGE_TOOL:-${UPDATE_SKILLS_GMV:-}}" \
     UPDATE_SKILLS_GEN_ID="$id" \
     UPDATE_SKILLS_LOCK_PATH="$CUSTOM_SKILL_LOCK" \
     UPDATE_SKILLS_LANES_ADDITIVE="$additive" \

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -71,15 +71,14 @@
 #                       phase, and the fork drift-check)
 #   --check-forks-only  run only the fork/vendored upstream drift-check
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
-#      The idle-gate makes this script refuse to swap skill folders while an
-#      INTERACTIVE harness session (claude/codex/hermes) is running, so a skill is
-#      never yanked out from under a live session. Persistent background daemons
-#      (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do NOT
-#      defer it (see __update_skills_harness_active). The weekly run is scheduled
-#      across four Monday slots; a per-week success stamp
+#      The idle-gate (fail-closed) makes this script refuse to swap skill folders
+#      while ANY agent-harness process (claude/codex/hermes) is running, session
+#      OR daemon, so a skill is never yanked out from under a live session (argv
+#      shape cannot prove idleness here; see __update_skills_harness_active). The
+#      weekly run is scheduled across four Monday slots; a per-week success stamp
 #      (~/.local/state/update-skills/last-success) makes the extra slots no-ops
-#      after one succeeds, and the last slot alerts if it still cannot run. FORCE=1
-#      accepts the swap risk for test runs and deliberate manual runs.
+#      after one succeeds, and the last scheduled slot alerts if it still cannot
+#      run. FORCE=1 accepts the swap risk for test runs and deliberate manual runs.
 set -euo pipefail
 
 # This script clones and inspects git repos in temp dirs (fork drift-check). If
@@ -174,99 +173,100 @@ __update_skills_alert() {
   fi
 }
 
-# idle-gate discriminator: is a LIVE interactive agent-harness session using the
-# store right now? Returns 0 (defer, never swap a skill out from under a live
-# session) for a live Claude Code / Codex / hermes session, 1 (proceed) when
-# only persistent background daemons are up.
+# idle-gate discriminator (Wave 3a item 1, fail-closed). Argv SHAPE cannot prove
+# idleness on this machine: every interactive Claude launch carries
+# --remote-control (the bridge is on by default), and Codex `app-server` and the
+# Hermes gateway both host live agent turns in-process. So the old daemon-shape
+# allowlist (which declared those "daemon-shaped" argv idle and swapped skills
+# under them) is DELETED. The gate is now simply: if ANY process whose EFFECTIVE
+# program resolves to exactly claude, codex, or hermes exists, DEFER. This trades
+# occasional deferral for never-swap-under-a-live-session, which the design
+# explicitly tolerates (a deferred run just lands the updates next week).
 #
-# The old gate keyed on argv[0]'s basename and substring-matched daemon phrases
-# against the whole flattened argv. Two proven holes: (a) a hermes session execs
-# a python console script, so argv[0] is `python` and the session was never seen
-# as an agent at all (the gate swapped skills under a live hermes session); (b)
-# prompt free text containing a daemon phrase (a `claude -p "restart the hermes
-# gateway"` one-shot) was substring-matched as a daemon, so a live session was
-# read as a daemon and proceeded. The rewrite keys on the argv EFFECTIVE program
-# and on the single flags-position token, never on free text.
-#
-# Algorithm (Wave 3a conductor ruling), applied to one `ps -xo args=` line:
-#   1. Tokenize argv and find the EFFECTIVE program. When token0's basename is a
-#      python interpreter (python, python3, python3.12, ...): a hermes session
-#      is `python /path/bin/hermes ...` (token1 is the console-script path) and
-#      the gateway is `python -m hermes_cli.main ...` (token1 is -m). So:
-#        - token1 == "-m": effective program = the module's leading identifier
-#          (hermes_cli.main -> hermes), flags-position token = token3;
-#        - otherwise:      effective program = basename(token1), flags-position
-#          token = token2.
-#      For a non-python token0: effective program = basename(token0),
-#      flags-position token = token1.
-#   2. AGENT process iff the effective program is EXACTLY claude, codex, or
-#      hermes; anything else (node, bash, a plain python tool) proceeds.
-#   3. DAEMON iff the flags-position token EXACTLY matches that harness's daemon
-#      shape (never a substring, never free text):
-#        hermes -> gateway
-#        claude -> --remote-control | --bg-spare | --bg-pty-host | daemon
-#        codex  -> app-server
-#      A daemon proceeds; every other agent process is a live session -> defer.
-#
-# Ground truth (dresden, read-only ps, 2026-07-10):
-#   DAEMONS (proceed):
-#     python -m hermes_cli.main gateway run --replace      (hermes gateway)
-#     /opt/homebrew/bin/claude --remote-control            (Remote Control bridge)
-#     .../claude --bg-spare | daemon run | --bg-pty-host   (Claude bg helpers)
-#     codex app-server [--analytics-default-enabled]       (Codex app server)
-#   LIVE SESSIONS (defer):
-#     .../python .../bin/hermes -c <prompt>                (hermes console session)
-#     /opt/homebrew/bin/claude -p <prompt> | resume        (a Claude one-shot/TUI)
-#     codex [resume <id>]                                  (a Codex CLI session)
-#
-# A Remote Control bridge is a daemon by SHAPE (flags-position --remote-control);
-# a session that bridge spawns is a SEPARATE claude process WITHOUT that
-# positional flag, so it defers normally.
-__update_skills_is_interactive_harness() {
-  local args="$1"
+# __update_skills_effective_program resolves one `ps -xo args=` line to its
+# harness name (or empty). It is interpreter-aware (item 2): when the program is
+# an interpreter front (python/python3/python3.NN, node, bun, with an optional
+# leading `env`), it skips the interpreter's OWN options to the module or script
+# operand:
+#   - `-m MOD` -> the module's leading identifier mapped to its harness
+#     (hermes_cli.main -> hermes);
+#   - the arg-taking python/node options -X -W -c -e --eval consume the next
+#     token too;
+#   - `--` ends options, the next token is the script (its basename);
+#   - a bare script path -> its basename (a trailing .js/.mjs/.cjs/.py stripped).
+# node/bun-fronted `claude` (npm-style installs) resolves the same way.
+__update_skills_effective_program() {
   local -a tokens
-  read -ra tokens <<<"$args"
-  [[ ${#tokens[@]} -gt 0 ]] || return 1
-  local base0 effective first_arg module
-  base0="${tokens[0]##*/}"
-  case "$base0" in
-    python | python[0-9]*)
-      if [[ ${tokens[1]:-} == "-m" ]]; then
-        module="${tokens[2]:-}"
-        module="${module%%.*}"    # hermes_cli.main -> hermes_cli
-        effective="${module%%_*}" # hermes_cli -> hermes
-        first_arg="${tokens[3]:-}"
-      else
-        effective="${tokens[1]:-}"
-        effective="${effective##*/}" # basename of the script path
-        first_arg="${tokens[2]:-}"
-      fi
-      ;;
-    *)
-      effective="$base0"
-      first_arg="${tokens[1]:-}"
-      ;;
-  esac
-  case "$effective" in
-    claude | codex | hermes) ;;
-    *) return 1 ;; # not an agent process (node, bash, a plain python tool)
-  esac
-  # Daemon shapes: an exact match on the flags-position token means a persistent
-  # background daemon, which never loads a skill on its own, so it proceeds.
-  case "$effective" in
-    hermes)
-      [[ $first_arg == "gateway" ]] && return 1
-      ;;
-    claude)
-      case "$first_arg" in
-        --remote-control | --bg-spare | --bg-pty-host | daemon) return 1 ;;
+  read -ra tokens <<<"$1"
+  [[ ${#tokens[@]} -gt 0 ]] || return 0
+  local i=0 t base module
+  base="${tokens[0]##*/}"
+  # strip a leading `env` (skip its VAR=val assignments and options; -u/-S take
+  # an argument) to the real command.
+  if [[ $base == "env" ]]; then
+    i=1
+    while [[ $i -lt ${#tokens[@]} ]]; do
+      t="${tokens[$i]}"
+      case "$t" in
+        -u | -S) i=$((i + 1)) ;; # consumes the next token
+        -*) : ;;                 # a lone env option
+        *=*) : ;;                # a VAR=value assignment
+        *) break ;;              # the command
       esac
-      ;;
-    codex)
-      [[ $first_arg == "app-server" ]] && return 1
+      i=$((i + 1))
+    done
+    [[ $i -lt ${#tokens[@]} ]] || return 0
+    base="${tokens[$i]##*/}"
+  fi
+  case "$base" in
+    python | python[0-9] | python[0-9].[0-9]* | node | bun)
+      local j=$((i + 1))
+      while [[ $j -lt ${#tokens[@]} ]]; do
+        t="${tokens[$j]}"
+        case "$t" in
+          -m)
+            module="${tokens[$((j + 1))]:-}"
+            module="${module%%.*}" # hermes_cli.main -> hermes_cli
+            module="${module%%_*}" # hermes_cli -> hermes
+            printf '%s' "$module"
+            return 0
+            ;;
+          --)
+            j=$((j + 1))
+            break
+            ;;
+          -X | -W | -c | -e | --eval)
+            j=$((j + 2)) # option consumes the next token too
+            ;;
+          -*)
+            j=$((j + 1)) # a lone interpreter option
+            ;;
+          *)
+            break # the script operand
+            ;;
+        esac
+      done
+      [[ $j -lt ${#tokens[@]} ]] || return 0
+      base="${tokens[$j]##*/}"
       ;;
   esac
-  return 0 # a live interactive session -> defer
+  # strip a trailing script extension so cli.js / claude.py resolve to the bin name
+  base="${base%.js}"
+  base="${base%.mjs}"
+  base="${base%.cjs}"
+  base="${base%.py}"
+  printf '%s' "$base"
+}
+
+# True (0) for one argv line that resolves to an agent harness (claude/codex/
+# hermes), i.e. the gate must DEFER; 1 otherwise.
+__update_skills_is_interactive_harness() {
+  local effective
+  effective="$(__update_skills_effective_program "$1")"
+  case "$effective" in
+    claude | codex | hermes) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 __update_skills_harness_active() {
@@ -735,16 +735,16 @@ if [[ -z $INSTALL_ONLY ]] && [[ -z $CHECK_FORKS_ONLY ]] && [[ $DRYRUN != "--dry-
   exit 0
 fi
 
-# idle-gate: defer while an INTERACTIVE harness session is using the store, so a
-# skill is never swapped out from under a live session. Persistent background
-# daemons (the hermes gateway, Claude Code's bg helpers, the Codex app-server) do
-# NOT count, blocking on them is what deferred the weekly run forever (see
-# __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests, manual
-# runs). --install-only is EXEMPT: it only ADDS absent skills (never swaps a
-# folder), so it is safe under a live session, this is what lets the fresh-
-# machine bootstrap run --install-only unattended at apply time. On the LAST
-# Monday slot the retry budget is spent, so a deferral there alerts LOUDLY rather
-# than failing silent.
+# idle-gate (fail-closed): defer while ANY agent-harness process (claude/codex/
+# hermes) is running, so a skill is never swapped out from under a live session.
+# Argv shape cannot distinguish a live session from a background daemon here, so
+# the gate errs toward deferral (a deferred run just lands the updates next week;
+# see __update_skills_harness_active). UPDATE_SKILLS_FORCE=1 bypasses (tests,
+# manual runs). --install-only is EXEMPT: it only ADDS absent skills (never swaps
+# a folder), so it is safe under a live session, this is what lets the fresh-
+# machine bootstrap run --install-only unattended at apply time. On the last
+# SCHEDULED slot the retry budget is spent, so a deferral there alerts LOUDLY
+# rather than failing silent.
 if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
   log "a live harness session (claude/codex/hermes) is using the store, or the process table could not be read (fail-closed); deferring this run"
   if __update_skills_is_last_monday_slot; then

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -498,7 +498,20 @@ assert_superpowers_routing() {
   local routing_script="$HOME/.local/bin/assert-hermes-superpowers-routing.sh"
   local relay_script="$HOME/.local/bin/relay.sh"
   local routing_output
-  [[ -x $routing_script ]] || return 0
+  if [[ ! -x $routing_script ]]; then
+    # A non-empty superpowersRouting table with no routing script is a REQUIRED
+    # failure: the hermes mirror's routing patches would silently go un-asserted
+    # (item 4). An empty table (or absent lock) means there is nothing to do.
+    if [[ -f $CUSTOM_SKILL_LOCK ]] && jq -e '(.superpowersRouting // {} | length) > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1; then
+      log "WARN: assert-hermes-superpowers-routing.sh absent but superpowersRouting is non-empty; routing cannot be asserted"
+      record_required_failure "superpowers routing script missing with a non-empty superpowersRouting table"
+      if [[ -x $relay_script ]]; then
+        "$relay_script" --agent update-skills --state prereq-missing --project hermes-superpowers \
+          --detail "the routing-assert script is not deployed but superpowersRouting has entries; the mirror routing may drift" || true
+      fi
+    fi
+    return 0
+  fi
   if [[ $DRYRUN == "--dry-run" ]]; then
     "$routing_script" --dry-run || log "routing re-assert reported issues (continuing)"
     return 0
@@ -587,11 +600,23 @@ assert_codex_overlays() {
 # run).
 update_hermes_registry_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  local relay_script="$HOME/.local/bin/relay.sh"
   if ! command -v hermes >/dev/null 2>&1; then
-    log "hermes not on PATH; skipping the hermes registry-update phase"
+    # A non-empty hermesRegistry table with no hermes binary is a REQUIRED
+    # failure: the hub-owned skills would silently go un-refreshed (item 4). An
+    # empty table means there is nothing to do, so a missing hermes is harmless.
+    if jq -e '(.hermesRegistry // {} | length) > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1; then
+      log "WARN: hermes not on PATH but hermesRegistry is non-empty; the registry-update phase cannot run"
+      record_required_failure "hermes missing with a non-empty hermesRegistry table"
+      if [[ -x $relay_script ]]; then
+        "$relay_script" --agent update-skills --state prereq-missing --project hermes \
+          --detail "hermes is not on PATH but hermesRegistry has hub-owned skills to refresh; they will drift" || true
+      fi
+    else
+      log "hermes not on PATH; skipping the hermes registry-update phase (hermesRegistry is empty)"
+    fi
     return 0
   fi
-  local relay_script="$HOME/.local/bin/relay.sh"
   local profile skill lock_key held update_output
   # Profiles to walk: every profile owning a registry skill — default included
   # (`hermes -p default` addresses Bob's root profile; un-entanglement done).
@@ -856,8 +881,16 @@ install_npx_tracked() {
 install_clawhub_tracked() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
+  local relay_script="$HOME/.local/bin/relay.sh"
   if ! command -v clawhub >/dev/null 2>&1; then
-    log "clawhub not on PATH; skipping the clawhub install pass"
+    # A non-empty clawhubTracked table with no clawhub binary is a REQUIRED
+    # failure: absent skills would silently never install (item 4).
+    log "WARN: clawhub not on PATH but clawhubTracked is non-empty; the install pass cannot run"
+    record_required_failure "clawhub missing with a non-empty clawhubTracked table (install pass)"
+    if [[ -x $relay_script ]]; then
+      "$relay_script" --agent update-skills --state prereq-missing --project clawhub \
+        --detail "clawhub is not on PATH but clawhubTracked has skills to install; the store cannot be completed" || true
+    fi
     return 0
   fi
   local skill slug registry tmp_workdir installed_dir
@@ -914,11 +947,18 @@ install_clawhub_tracked() {
 update_clawhub_tracked() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
+  local relay_script="$HOME/.local/bin/relay.sh"
   if ! command -v clawhub >/dev/null 2>&1; then
-    log "clawhub not on PATH; skipping the clawhub update pass"
+    # A non-empty clawhubTracked table with no clawhub binary is a REQUIRED
+    # failure: the tracked store copies would silently go un-refreshed (item 4).
+    log "WARN: clawhub not on PATH but clawhubTracked is non-empty; the update pass cannot run"
+    record_required_failure "clawhub missing with a non-empty clawhubTracked table (update pass)"
+    if [[ -x $relay_script ]]; then
+      "$relay_script" --agent update-skills --state prereq-missing --project clawhub \
+        --detail "clawhub is not on PATH but clawhubTracked has skills to refresh; they will drift" || true
+    fi
     return 0
   fi
-  local relay_script="$HOME/.local/bin/relay.sh"
   local skill overlay_file update_output retry_output
   # read on fd 3: clawhub may consume stdin
   while IFS= read -r -u3 skill; do

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -60,13 +60,15 @@
 # assert_codex_overlays below).
 #
 # Usage: update-skills [--dry-run] [--install-only] [--check-forks-only]
-#   --dry-run           log what would change, change nothing
-#   --install-only      run only the npx + clawhub install passes for absent
-#                       skills + symlink fan-out + Codex overlay re-assert +
-#                       superpowers routing re-assert (used by tests and
-#                       fresh-machine bootstrap; skips the weekly npx and
-#                       clawhub updates, the hermes registry-update phase, and
-#                       the fork drift-check)
+#   --dry-run           log what would change, write nothing to the filesystem
+#   --install-only      ADDITIVE bootstrap: run only the npx + clawhub install
+#                       passes for absent skills, then the symlink fan-out (which
+#                       here CREATES missing links only, never replacing a
+#                       wrong-target link or removing a stale one), the Codex
+#                       overlay re-assert, and the superpowers routing re-assert
+#                       (used by tests and fresh-machine bootstrap; skips the
+#                       weekly npx and clawhub updates, the hermes registry-update
+#                       phase, and the fork drift-check)
 #   --check-forks-only  run only the fork/vendored upstream drift-check
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
 #      The idle-gate makes this script refuse to swap skill folders while an
@@ -261,16 +263,32 @@ __update_skills_is_owned_link() {
 # Converge one managed dir to a desired {name -> "$prefix/$name"} set:
 #   converge_dir <dir> <target_prefix> <desired_name>...
 # create a missing desired link; REPLACE an updater-owned link whose target
-# differs (wrong-target, incl. dangling — the additive `[[ -e ]] || ln -s`
+# differs (wrong-target, incl. dangling: the additive `[[ -e ]] || ln -s`
 # crashed on a dangling link); REMOVE an updater-owned link no longer desired
 # (stale). A real dir/file (hub-owned/catalog) at a managed name, and any
 # non-store symlink, are left untouched. A no-op convergence is silent.
+#
+# Two run modes narrow that behavior, driven by the globals $DRYRUN and
+# $INSTALL_ONLY:
+#   * --dry-run: make NO filesystem writes at all. Report each action as a
+#     "would create/replace/remove" line and change nothing. A preview must
+#     never mutate live link state.
+#   * --install-only: ADDITIVE only. Create a missing desired link, but NEVER
+#     replace a wrong-target link (leave it + a loud warning) and NEVER remove a
+#     stale one. This is what lets the fresh-machine bootstrap run at apply time,
+#     even under a live agent session, without swapping anything. Destructive
+#     reconciliation (replace/remove) runs solely in the full weekly path behind
+#     the idle gate.
 converge_dir() {
   local dir="$1" prefix="$2"
   shift 2
   local -a desired=("$@")
   local skill target path current name is_desired old_target
-  mkdir -p "$dir"
+  local dry="" additive=""
+  [[ $DRYRUN == "--dry-run" ]] && dry=1
+  [[ -n $INSTALL_ONLY ]] && additive=1
+  # dry-run makes no writes, so it does not even create the managed dir.
+  [[ -n $dry ]] || mkdir -p "$dir"
   # 1) create or repair every desired link
   if [[ ${#desired[@]} -gt 0 ]]; then
     for skill in "${desired[@]}"; do
@@ -280,20 +298,30 @@ converge_dir() {
         current="$(readlink "$path" 2>/dev/null || true)"
         [[ $current == "$target" ]] && continue # already correct
         if __update_skills_is_owned_link "$path"; then
-          ln -sfn "$target" "$path" # replace wrong-target / dangling updater-owned link
-          log "converge: replaced $path (was $current, now $target)"
+          if [[ -n $additive ]]; then
+            log "converge: WARN $path points to $current, not $target; --install-only is additive and leaves it (a full run repairs)"
+          elif [[ -n $dry ]]; then
+            log "converge: would replace $path (currently $current, desired $target)"
+          else
+            ln -sfn "$target" "$path" # replace wrong-target / dangling updater-owned link
+            log "converge: replaced $path (was $current, now $target)"
+          fi
         else
           log "converge: WARN $path is a non-store symlink at a managed name; leaving it (resolve by hand)"
         fi
       elif [[ -e $path ]]; then
-        : # a real dir/file (hub-owned or catalog) at this name — never overwrite
+        : # a real dir/file (hub-owned or catalog) at this name, never overwrite
+      elif [[ -n $dry ]]; then
+        log "converge: would create $path -> $target"
       else
         ln -s "$target" "$path"
         log "converge: created $path -> $target"
       fi
     done
   fi
-  # 2) remove updater-owned links that are no longer desired (stale drift)
+  # 2) remove updater-owned links no longer desired (stale drift). Additive
+  #    --install-only never removes; only the full weekly path reconciles.
+  [[ -n $additive ]] && return 0
   for path in "$dir"/*; do
     [[ -e $path || -L $path ]] || continue # skip the un-globbed literal when the dir is empty
     name="${path##*/}"
@@ -309,8 +337,12 @@ converge_dir() {
     [[ -n $is_desired ]] && continue
     if __update_skills_is_owned_link "$path"; then
       old_target="$(readlink "$path" 2>/dev/null || true)"
-      rm -f "$path"
-      log "converge: removed stale $path (was $old_target)"
+      if [[ -n $dry ]]; then
+        log "converge: would remove stale $path (currently $old_target)"
+      else
+        rm -f "$path"
+        log "converge: removed stale $path (was $old_target)"
+      fi
     fi
   done
 }
@@ -552,7 +584,8 @@ refresh_app_owned_cua_pack() {
   fi
 }
 
-mkdir -p "$STORE" "$CLAUDE" "$HERMES"
+# A dry run makes no filesystem writes, so it does not pre-create these dirs.
+[[ $DRYRUN == "--dry-run" ]] || mkdir -p "$STORE" "$CLAUDE" "$HERMES"
 
 # serialize: one run at a time (mkdir is atomic + system-shipped; flock is absent on macOS)
 if [[ -d $LOCKDIR ]] && find "$LOCKDIR" -prune -mmin +120 2>/dev/null | grep -q .; then rm -rf "$LOCKDIR"; fi # steal stale lock (>2h: crashed run)

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -1580,9 +1580,16 @@ __update_skills_make_cutoff_sentinel() {
   local cutoff sentinel stamp
   cutoff=$(($(date +%s) - IDLE_THRESHOLD_SECONDS))
   sentinel="$(mktemp)" || return 1
-  # date -r <epoch> is BSD (this is a macOS LaunchAgent script); the test's date
-  # stub execs the real date for -r, so this is exercised faithfully.
-  stamp="$(date -r "$cutoff" +%Y%m%d%H%M.%S 2>/dev/null)" || {
+  # Epoch-to-stamp spelling differs by date flavor: GNU date takes -d @<epoch>,
+  # BSD date takes -r <epoch> (and its -d is the kernel DST flag, so the flavor
+  # is detected via --version, which only GNU date supports, instead of by
+  # trying -d). Both render LOCAL time, matching touch -t below.
+  if date --version >/dev/null 2>&1; then
+    stamp="$(date -d "@$cutoff" +%Y%m%d%H%M.%S 2>/dev/null)" || stamp=""
+  else
+    stamp="$(date -r "$cutoff" +%Y%m%d%H%M.%S 2>/dev/null)" || stamp=""
+  fi
+  [[ -n $stamp ]] || {
     rm -f "$sentinel"
     return 1
   }

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -587,13 +587,60 @@ refresh_app_owned_cua_pack() {
 # A dry run makes no filesystem writes, so it does not pre-create these dirs.
 [[ $DRYRUN == "--dry-run" ]] || mkdir -p "$STORE" "$CLAUDE" "$HERMES"
 
-# serialize: one run at a time (mkdir is atomic + system-shipped; flock is absent on macOS)
-if [[ -d $LOCKDIR ]] && find "$LOCKDIR" -prune -mmin +120 2>/dev/null | grep -q .; then rm -rf "$LOCKDIR"; fi # steal stale lock (>2h: crashed run)
+# serialize: one run at a time. mkdir is atomic and system-shipped (macOS ships
+# neither flock(1) nor lockf(1)). We do NOT steal a lock by age: a long but
+# healthy run must never be killed, and age-stealing raced three writers in the
+# audit (the stale-steal removed a live newcomer's lock, then the first run's
+# unconditional trap removed the newcomer's). Instead the lock carries an owner
+# token (PID plus the process start time, a boot-stable discriminator so a
+# recycled PID cannot masquerade as the original owner), and is reclaimed ONLY
+# from a PROVABLY dead owner.
+LOCK_OWNER_FILE="$LOCKDIR/owner"
+__update_skills_proc_start() {
+  # normalized process start time for pid $1 (empty when the pid is gone)
+  ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' | sed 's/^ *//;s/ *$//'
+}
+__update_skills_owner_token() { printf '%s\t%s' "$$" "$(__update_skills_proc_start "$$")"; }
+__update_skills_owner_alive() {
+  # $1 = recorded "PID<TAB>START". Alive iff the pid still exists (kill -0) AND
+  # its start time still matches (not recycled). Anything we cannot PROVE dead is
+  # treated as alive, so a contender never steals from a possibly-live run.
+  local rec="$1" rec_pid rec_start cur_start
+  rec_pid="${rec%%$'\t'*}"
+  rec_start="${rec#*$'\t'}"
+  [[ $rec_pid =~ ^[0-9]+$ ]] || return 0                  # unparseable owner: do not steal
+  [[ -n $rec_start && $rec_start != "$rec" ]] || return 0 # missing start field: do not steal
+  kill -0 "$rec_pid" 2>/dev/null || return 1              # no such process: dead
+  cur_start="$(__update_skills_proc_start "$rec_pid")"
+  [[ -z $cur_start ]] && return 1  # ps lookup empty: dead
+  [[ $cur_start == "$rec_start" ]] # start differs => pid recycled => original dead
+}
 if ! mkdir "$LOCKDIR" 2>/dev/null; then
-  log "another run in progress; exiting"
-  exit 0
+  lock_owner="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
+  if [[ -n $lock_owner ]] && ! __update_skills_owner_alive "$lock_owner"; then
+    log "reclaiming the lock from a dead owner ($lock_owner)"
+    rm -rf "$LOCKDIR"
+    if ! mkdir "$LOCKDIR" 2>/dev/null; then
+      log "another run took the lock while reclaiming; exiting"
+      exit 0
+    fi
+  else
+    log "another run in progress; exiting"
+    exit 0
+  fi
 fi
-trap 'rm -rf "$LOCKDIR"' EXIT
+# Record ownership immediately, then arm a trap that removes the lock ONLY while
+# we still own it: a later run that reclaims a dead lock rewrites the owner file,
+# and our trap must never delete a lock we no longer hold (the three-writer race).
+LOCK_MY_TOKEN="$(__update_skills_owner_token)"
+printf '%s' "$LOCK_MY_TOKEN" >"$LOCK_OWNER_FILE"
+__update_skills_release_lock() {
+  local cur
+  cur="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
+  [[ $cur == "$LOCK_MY_TOKEN" ]] && rm -rf "$LOCKDIR"
+  return 0 # never let the EXIT trap's status leak into the script's exit code
+}
+trap '__update_skills_release_lock' EXIT
 
 # weekly success stamp: the four Monday plist slots share one ISO week; once a
 # slot completes a full run this week, the remaining slots are no-ops. A deferral

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -184,28 +184,106 @@ __update_skills_harness_active() {
   return 1
 }
 
-ensure_symlink() {
-  local skill="$1"
-  [[ -d "$STORE/$skill" ]] || return 0
-  [[ -e "$CLAUDE/$skill" ]] || ln -s "../../.agents/skills/$skill" "$CLAUDE/$skill"
-  ensure_hermes_symlinks "$skill"
+# updater-owned link = a SYMLINK whose literal target points under
+# ~/.agents/skills. The literal readlink target is matched (not a resolved path),
+# so this holds for a DANGLING link too — its string still points into the store.
+# ONLY such links are ever replaced or removed by convergence; real dirs
+# (hub-owned registry dirs, hermes's catalog) and non-store symlinks are never
+# touched, and neither is any name in a profile the lock does not map.
+__update_skills_is_owned_link() {
+  local path="$1" target
+  [[ -L $path ]] || return 1
+  target="$(readlink "$path" 2>/dev/null || true)"
+  case "$target" in
+    *.agents/skills/*) return 0 ;;
+  esac
+  return 1
 }
 
-# Hermes fan-out is profile-driven by the lock's hermesProfiles map: it names
-# the hermes profiles whose skills/ dir carries a store symlink for the skill —
-# "default" is ~/.hermes/skills (Bob), any other name is
-# ~/.hermes/profiles/<name>/skills (created here when absent, so a mapping can
-# land before its profile has been initialized on this machine). A [] mapping —
-# or a missing table — gets no hermes links: the deliberate "not available in
-# hermes from the store" state, not an error. Collision-named skills never fan
-# out regardless: hermes's catalog wins those names (operator ruling), so their
-# store copies serve Claude/Codex only. Claude is not profile-scoped: every
-# store skill keeps its ~/.claude/skills link (tiering there is the settings
-# modify-template's job, not the fan-out's).
-# summarize-pro left this list 2026-07-09: its only hermes copy was the
-# (retired) default-profile hub install, so no catalog copy wins the name —
-# exactly like todoist-cli. It now fans out per hermesProfiles like any other
-# store skill.
+# Converge one managed dir to a desired {name -> "$prefix/$name"} set:
+#   converge_dir <dir> <target_prefix> <desired_name>...
+# create a missing desired link; REPLACE an updater-owned link whose target
+# differs (wrong-target, incl. dangling — the additive `[[ -e ]] || ln -s`
+# crashed on a dangling link); REMOVE an updater-owned link no longer desired
+# (stale). A real dir/file (hub-owned/catalog) at a managed name, and any
+# non-store symlink, are left untouched. A no-op convergence is silent.
+converge_dir() {
+  local dir="$1" prefix="$2"
+  shift 2
+  local -a desired=("$@")
+  local skill target path current name is_desired old_target
+  mkdir -p "$dir"
+  # 1) create or repair every desired link
+  if [[ ${#desired[@]} -gt 0 ]]; then
+    for skill in "${desired[@]}"; do
+      target="$prefix/$skill"
+      path="$dir/$skill"
+      if [[ -L $path ]]; then
+        current="$(readlink "$path" 2>/dev/null || true)"
+        [[ $current == "$target" ]] && continue # already correct
+        if __update_skills_is_owned_link "$path"; then
+          ln -sfn "$target" "$path" # replace wrong-target / dangling updater-owned link
+          log "converge: replaced $path (was $current, now $target)"
+        else
+          log "converge: WARN $path is a non-store symlink at a managed name; leaving it (resolve by hand)"
+        fi
+      elif [[ -e $path ]]; then
+        : # a real dir/file (hub-owned or catalog) at this name — never overwrite
+      else
+        ln -s "$target" "$path"
+        log "converge: created $path -> $target"
+      fi
+    done
+  fi
+  # 2) remove updater-owned links that are no longer desired (stale drift)
+  for path in "$dir"/*; do
+    [[ -e $path || -L $path ]] || continue # skip the un-globbed literal when the dir is empty
+    name="${path##*/}"
+    is_desired=""
+    if [[ ${#desired[@]} -gt 0 ]]; then
+      for skill in "${desired[@]}"; do
+        [[ $skill == "$name" ]] && {
+          is_desired=1
+          break
+        }
+      done
+    fi
+    [[ -n $is_desired ]] && continue
+    if __update_skills_is_owned_link "$path"; then
+      old_target="$(readlink "$path" 2>/dev/null || true)"
+      rm -f "$path"
+      log "converge: removed stale $path (was $old_target)"
+    fi
+  done
+}
+
+# Claude fan-out: every store skill (the full roster) gets a ~/.claude/skills
+# link. Claude is not profile-scoped — tiering there is the settings
+# modify-template's job, not the fan-out's.
+converge_claude_skills() {
+  local -a desired=()
+  local skill_path skill
+  for skill_path in "$STORE"/*; do
+    [[ -d $skill_path || -L $skill_path ]] || continue
+    skill="${skill_path##*/}"
+    desired+=("$skill")
+  done
+  if [[ ${#desired[@]} -gt 0 ]]; then
+    converge_dir "$CLAUDE" "../../.agents/skills" "${desired[@]}"
+  else
+    converge_dir "$CLAUDE" "../../.agents/skills"
+  fi
+}
+
+# Hermes fan-out is profile-driven by the lock's hermesProfiles map. "default" is
+# ~/.hermes/skills (Bob), any other name is ~/.hermes/profiles/<name>/skills
+# (created here when absent, so a mapping can land before its profile exists on
+# this machine). A [] mapping — or a missing table — gets no hermes link: the
+# deliberate "not available in hermes from the store" state, not an error.
+# Collision-named skills (humanizer, hyperframes) never fan out: hermes's catalog
+# wins those names (operator ruling), so a stale store link at such a name IS
+# removed by convergence, but creating one never happens. Only the profiles the
+# lock names are walked — a profile the lock does not map is never touched.
 HERMES_COLLISION_NAMES=(humanizer hyperframes)
 is_hermes_collision_name() {
   local collision_entry
@@ -214,21 +292,36 @@ is_hermes_collision_name() {
   done
   return 1
 }
-ensure_hermes_symlinks() {
-  local skill="$1" profile link_dir target
+converge_hermes_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  is_hermes_collision_name "$skill" && return 0
+  local profile link_dir prefix skill
+  local -a profiles=() desired=()
   while IFS= read -r profile; do
+    [[ -n $profile ]] && profiles+=("$profile")
+  done < <(jq -r '.hermesProfiles // {} | [.[][]?] | unique | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  [[ ${#profiles[@]} -gt 0 ]] || return 0
+  for profile in "${profiles[@]}"; do
     if [[ $profile == "default" ]]; then
       link_dir="$HERMES"
-      target="../../.agents/skills/$skill"
+      prefix="../../.agents/skills"
     else
       link_dir="$HERMES_PROFILES/$profile/skills"
-      target="../../../../.agents/skills/$skill"
+      prefix="../../../../.agents/skills"
     fi
-    mkdir -p "$link_dir"
-    [[ -e "$link_dir/$skill" ]] || ln -s "$target" "$link_dir/$skill"
-  done < <(jq -r --arg skill "$skill" '.hermesProfiles[$skill] // [] | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+    desired=()
+    while IFS= read -r skill; do
+      [[ -n $skill ]] || continue
+      is_hermes_collision_name "$skill" && continue              # collision names never fan out
+      [[ -d "$STORE/$skill" || -L "$STORE/$skill" ]] || continue # only skills present in the store
+      desired+=("$skill")
+    done < <(jq -r --arg p "$profile" '.hermesProfiles // {} | to_entries[]
+      | select((.value // []) | index($p) != null) | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+    if [[ ${#desired[@]} -gt 0 ]]; then
+      converge_dir "$link_dir" "$prefix" "${desired[@]}"
+    else
+      converge_dir "$link_dir" "$prefix"
+    fi
+  done
 }
 
 # Superpowers→hermes routing re-assert: the hand-patched hermes-superpowers
@@ -464,8 +557,7 @@ install_npx_tracked() {
     fi
     if npx --yes skills@latest add "$repo" --skill "$skill" --agent claude-code --agent codex -g -y 2>&1 | tr -d '\r' | tail -3; then
       if [[ -d "$STORE/$skill" ]]; then
-        ensure_symlink "$skill"
-        log "installed: $skill from $repo"
+        log "installed: $skill from $repo" # fan-out is the convergence pass's job (below)
       else
         log "install $skill: npx add reported success but $STORE/$skill is absent (continuing)"
       fi
@@ -515,8 +607,7 @@ install_clawhub_tracked() {
       [[ -d $installed_dir ]] || installed_dir="$tmp_workdir/skills/$skill"
       if [[ -d $installed_dir ]]; then
         mv "$installed_dir" "$STORE/$skill"
-        ensure_symlink "$skill"
-        log "installed: $skill from $slug"
+        log "installed: $skill from $slug" # fan-out is the convergence pass's job (below)
       else
         log "install $skill: clawhub install reported success but produced no skill dir (continuing)"
       fi
@@ -667,7 +758,8 @@ log "clawhub installs (absent skills)"
 install_clawhub_tracked
 
 if [[ -n $INSTALL_ONLY ]]; then
-  for skill_dir in "$STORE"/*/; do [[ -d $skill_dir ]] && ensure_symlink "$(basename "$skill_dir")"; done
+  converge_claude_skills
+  converge_hermes_skills
   assert_codex_overlays
   assert_superpowers_routing
   log "done (install-only)${DRYRUN:+ (dry-run)}"
@@ -692,9 +784,12 @@ update_clawhub_tracked
 #     (see refresh_app_owned_cua_pack above — never a write through the symlink)
 refresh_app_owned_cua_pack
 
-# 2) ensure every store skill is symlinked into Claude, and into exactly the
-#    hermes profile skills dirs its hermesProfiles mapping names
-for skill_dir in "$STORE"/*/; do [[ -d $skill_dir ]] && ensure_symlink "$(basename "$skill_dir")"; done
+# 2) CONVERGE the fan-out: every store skill is symlinked into Claude, and into
+#    exactly the hermes profile skills dirs its hermesProfiles mapping names —
+#    creating missing links, repairing wrong/dangling targets, and removing
+#    updater-owned links that drifted out of the desired set
+converge_claude_skills
+converge_hermes_skills
 
 # 3) re-assert Codex policy overlays for on-demand skills — AFTER the npx
 #    refresh above, which replaces npx-tracked skill folders (overlay and all)

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -1,33 +1,46 @@
 #!/usr/bin/env bash
-# update-skills: keep the canonical skills store (~/.agents/skills) complete and fresh.
+# update-skills: keep the canonical skills store (~/.agents/skills) complete and
+# fresh via the GENERATION-EXCHANGE model.
 #
 # The store holds exactly the roster this repo declares (see
 # ~/.agents/custom-skill-lock.json), so the registered-skill count in the
-# harnesses does not grow when this runs. The roster's provenance kinds, and
-# who refreshes each:
-#   - npx-tracked (npxTracked table): the store copy is installed and refreshed
-#      by the official npx `skills` CLI from an official upstream, latest from
-#      main (no pin). This script INSTALLS any that are absent with
-#      `npx skills add <repo> --skill <name> --agent claude-code --agent codex
-#      -g -y` — the multi-agent form lands the real dir in the store and plants
-#      a relative ~/.claude/skills symlink (no ~/.codex dir; Codex reads the
-#      store natively). The hermes symlinks are planted here. The weekly
-#      `npx skills update -g` pass REFRESHES them all in place.
-#   - clawhub-tracked (clawhubTracked table): the store copy is installed and
-#      refreshed by the `clawhub` CLI from a ClawHub upstream (npx cannot
-#      source ClawHub — `npx skills add` is GitHub-only). This script INSTALLS
-#      any that are absent: `clawhub install @owner/<name>` nests its output as
-#      <dir>/@owner/<name> (v0.23.1, verified live), so the install runs in a
-#      throwaway --workdir and the nested dir is MOVED flat into the store as
-#      <store>/<name> — its .clawhub/origin.json travels with it and pins the
-#      owner, which is what lets the weekly pass refresh IN PLACE with a bare
-#      `clawhub --workdir ~/.agents --dir skills update <name>` (bare-name
-#      update resolves via origin.json even when the name is ambiguous on the
-#      registry). The temp-workdir install also keeps the store's
-#      .clawhub/lock.json free of phantom @owner-keyed entries, whose presence
-#      would make a slug-form update recreate the nested dir. Fan-out (Claude +
-#      hermes symlinks) is planted here, same as the npx lane. See
-#      update_clawhub_tracked for the local-changes refusal ladder.
+# harnesses does not grow when this runs. Every npx- and clawhub-tracked skill
+# lives inside ONE live generation directory, ~/.agents/.skills-current (real
+# dirs under skills/, the npx CLI lock .skill-lock.json, and generation.json as
+# the ready marker); the store names ~/.agents/skills/<name> are stable literal
+# symlinks into it, and ~/.agents/.skill-lock.json is a symlink to its lock.
+# The weekly run builds a CANDIDATE generation as a fake HOME under
+# ~/.agents/.skills-generations/<id>/home, runs the package-CLI lanes against it
+# under env -i (HOME/XDG/TMPDIR/npm cache pinned inside the candidate), validates
+# the whole candidate, and publishes with ONE atomic renameat2 RENAME_EXCHANGE
+# (gmv --exchange --no-copy -T). Exactly one previous generation is retained.
+#
+# HONEST GUARANTEE: per-lookup completeness and cross-skill coherence per
+# generation: any path resolution during or after the exchange yields a
+# complete tree from exactly one generation. A session that cached a CANONICAL
+# (resolved) path keeps a complete previous generation for at least a week (one
+# retained generation); after pruning it gets a clean ENOENT, never partial
+# content. Out-of-band writers (the HyperFrames workflows self-update the store
+# via `npx hyperframes skills update`, upstream-controlled, no supported
+# disable) bypass any local design exactly as they do today; the weekly run
+# detects that drift in recovery and re-absorbs it into the next candidate. OUR
+# updater's own operations are atomic end to end.
+#
+# The roster's provenance kinds, and who refreshes each:
+#   - npx-tracked (npxTracked table): installed and refreshed by the official
+#      npx `skills` CLI from an official upstream, latest from main (no pin).
+#      The build lane runs an explicit `npx skills add <repo> --skill <name>
+#      --agent claude-code --agent codex -g -y` per repo group against the
+#      CANDIDATE (never the bulk `skills update`, whose lock-walk logs some
+#      failures at exit 0), which also reconciles lock-absent roster skills.
+#   - clawhub-tracked (clawhubTracked table): installed and refreshed by the
+#      `clawhub` CLI from a ClawHub upstream (npx cannot source ClawHub;
+#      `npx skills add` is GitHub-only). The lane installs an absent skill in a
+#      throwaway --workdir and moves the CLI's nested @owner/<name> output flat
+#      into the candidate store (its .clawhub/origin.json travels along and
+#      pins the owner), then refreshes present ones in place with a bare
+#      `clawhub --workdir <candidate>/.agents --dir skills update <name>`. See
+#      __gen_lane_clawhub for the local-changes refusal ladder.
 #   - vendored (dot_agents/skills/, committed): third-party copies refreshed by
 #      `chezmoi apply`, never by this script. Two sub-kinds: (a) forks-table
 #      entries whose upstreams the weekly run drift-checks and alerts on — the
@@ -60,23 +73,27 @@
 # assert_codex_overlays below).
 #
 # Usage: update-skills [--dry-run] [--install-only] [--check-forks-only]
-#   --dry-run           log what would change, write nothing to the filesystem
-#   --install-only      ADDITIVE bootstrap: run only the npx + clawhub install
-#                       passes for absent skills, then the symlink fan-out (which
-#                       here CREATES missing links only, never replacing a
-#                       wrong-target link or removing a stale one), the Codex
-#                       overlay re-assert, and the superpowers routing re-assert
-#                       (used by tests and fresh-machine bootstrap; skips the
-#                       weekly npx and clawhub updates, the hermes registry-update
-#                       phase, and the fork drift-check)
+#   --dry-run           read-only preview: NEVER invokes either package CLI (the
+#                       npx CLI treats `update --help` as a real update, observed
+#                       live), zero writes; reports roster-vs-lock and
+#                       roster-vs-generation drift, the fan-out convergence
+#                       preview, and would-run/would-defer
+#   --install-only      ADDITIVE bootstrap: build and publish a candidate whose
+#                       EXISTING skills are byte-clones of current (no updates)
+#                       plus genuinely absent roster skills added; never migrates
+#                       a flat store, never replaces existing store content; the
+#                       fan-out CREATES missing links only (used by tests and the
+#                       fresh-machine apply-time bootstrap)
 #   --check-forks-only  run only the fork/vendored upstream drift-check
 #   --scheduled         mark this as a LaunchAgent (scheduled) run; only a
 #                       scheduled run with no later slot remaining this week
 #                       claims retry-budget exhaustion (a manual run never does)
+#   --build-lanes       INTERNAL: this process is the env -i sub-invocation that
+#                       runs the build lanes inside a candidate fake HOME
 # Env: UPDATE_SKILLS_FORCE=1 bypasses the idle-gate AND the weekly success stamp.
 #      The idle-gate (activity-based, fail-closed) makes this script refuse to
 #      swap skill folders only while a harness (claude/codex/hermes) shows RECENT
-#      activity — the newest mtime among its per-turn activity files is within
+#      activity, meaning the newest mtime among its per-turn activity files is within
 #      IDLE_THRESHOLD (default 15 min). It runs UNATTENDED: an always-up bridge no
 #      longer defers the weekly run forever; a machine quiet for the window
 #      proceeds (see __update_skills_should_defer). Override the window with
@@ -414,12 +431,23 @@ __gen_publish() {
     log "publish: candidate $candidate is not a real directory"
     return 1
   }
-  [[ -d $SKILLS_CURRENT && ! -L $SKILLS_CURRENT ]] || {
-    log "publish: $SKILLS_CURRENT is not a real directory"
-    return 1
-  }
   __gen_is_complete "$candidate" || {
     log "publish: candidate $candidate is not complete (no ready marker)"
+    return 1
+  }
+  # First publish on a machine with no live generation yet (fresh bootstrap):
+  # a plain rename onto the absent path is atomic and there is no previous
+  # generation to retain.
+  if [[ ! -e $SKILLS_CURRENT && ! -L $SKILLS_CURRENT ]]; then
+    mkdir -p "$AGENTS"
+    if mv "$candidate" "$SKILLS_CURRENT" 2>/dev/null; then
+      return 0
+    fi
+    log "publish: could not rename the candidate onto the absent $SKILLS_CURRENT"
+    return 1
+  fi
+  [[ -d $SKILLS_CURRENT && ! -L $SKILLS_CURRENT ]] || {
+    log "publish: $SKILLS_CURRENT is not a real directory"
     return 1
   }
   __gen_same_device "$candidate" "$SKILLS_CURRENT" || {
@@ -484,11 +512,11 @@ __gen_store_link_correct() {
 # ---------------------------------------------------------------------------
 # RECOVERY state table (brief step 1). Runs before the idle gate and stamp
 # logic. Self-heals what it can and records two things the main flow acts on:
-#   GEN_REABSORB[]      — tracked names whose store entry is a REAL DIR where a
+#   GEN_REABSORB[]      = tracked names whose store entry is a REAL DIR where a
 #                         link is expected (a competing writer, e.g. the
 #                         HyperFrames self-updater, or an interrupted migration):
 #                         re-absorb that content into this run's candidate.
-#   GEN_REUSE_CANDIDATE — a complete, unpublished candidate whose generation.json
+#   GEN_REUSE_CANDIDATE = a complete, unpublished candidate whose generation.json
 #                         matches the current desired state: the main flow may
 #                         publish it instead of rebuilding.
 # The self-healed cases: incomplete staging leftovers are garbage-destroyed;
@@ -514,7 +542,7 @@ __gen_recover() {
         cand_agents="$entry/home/.agents"
         if __gen_is_complete "$cand_agents" && __gen_meta_matches_desired "$cand_agents"; then
           # A complete candidate matching desired state: reusable (keep the
-          # newest such by createdAt is overkill — one is enough to publish).
+          # newest such by createdAt is overkill; one is enough to publish).
           [[ -z $GEN_REUSE_CANDIDATE ]] && GEN_REUSE_CANDIDATE="$cand_agents"
           continue
         fi
@@ -555,7 +583,16 @@ __gen_recover() {
         # a tracked skill present in the generation but missing its store link
         if [[ -d "$SKILLS_CURRENT/skills/$name" ]]; then __gen_plant_store_link "$name" || true; fi
       elif [[ -L $link ]] && ! __gen_store_link_correct "$name"; then
-        __gen_plant_store_link "$name" || true
+        # Repair only a link we plausibly own: a stale generation-form target or
+        # a DANGLING link. A RESOLVING foreign symlink (e.g. app-owned content
+        # at a tracked name) is left alone with a WARN, never replanted.
+        local link_target
+        link_target="$(readlink "$link" 2>/dev/null || true)"
+        if [[ $link_target == ../.skills-current/* || ! -e $link ]]; then
+          __gen_plant_store_link "$name" || true
+        else
+          log "recovery: WARN store/$name is a foreign symlink ($link_target); leaving it"
+        fi
       fi
     done < <(__gen_tracked_names)
   fi
@@ -706,6 +743,18 @@ __gen_build_candidate() {
     cp -c -R "$STORE/$reabsorb" "$agents/skills/$reabsorb" 2>/dev/null ||
       cp -R "$STORE/$reabsorb" "$agents/skills/$reabsorb" || return 1
   done
+  # Any tracked store entry that is a REAL DIR and still absent from the clone
+  # (a flat pre-migration store under --install-only, which never migrates) is
+  # byte-cloned in, so it counts as EXISTING: the additive lanes skip it and
+  # validation sees its real content. The store real dir itself stays untouched.
+  local tracked_name
+  while IFS= read -r tracked_name; do
+    [[ -n $tracked_name ]] || continue
+    [[ -e "$agents/skills/$tracked_name" ]] && continue
+    [[ -d "$STORE/$tracked_name" && ! -L "$STORE/$tracked_name" ]] || continue
+    cp -c -R "$STORE/$tracked_name" "$agents/skills/$tracked_name" 2>/dev/null ||
+      cp -R "$STORE/$tracked_name" "$agents/skills/$tracked_name" || return 1
+  done < <(__gen_tracked_names)
   # Seed the npx lock from the current generation (or an empty object).
   if [[ -f "$SKILLS_CURRENT/.skill-lock.json" ]]; then
     cp -c "$SKILLS_CURRENT/.skill-lock.json" "$agents/.skill-lock.json" 2>/dev/null ||
@@ -719,35 +768,56 @@ __gen_build_candidate() {
   return 0
 }
 
+# Per-skill failure capture for the streak accounting (brief step 6). The lanes
+# run inside the env -i sub-invocation, so failed skill names are appended to a
+# file inside the candidate's .agents dir; the parent reads it back before
+# discarding the failed candidate. Never published: a candidate with failures is
+# always discarded, and a clean build removes the file before the ready marker.
+GEN_FAILED_SKILLS_FILE_NAME=".lane-failed-skills"
+record_failed_skill() {
+  printf '%s\n' "$1" >>"$AGENTS/$GEN_FAILED_SKILLS_FILE_NAME" 2>/dev/null || true
+}
+
 # npx lane (brief step 3): explicit `skills add <repo> --skill <name> ...` per
 # npxTracked entry, GROUPED by repo (NOT a bulk `update`, whose lock-walk logs
 # some failures at exit 0). Operating on $STORE, which in --build-lanes mode is
 # the candidate's store (HOME points there). This reconciles lock-absent roster
 # skills too, since `add` installs-or-refreshes every entry. Each failure is a
 # required failure (the whole candidate is discarded on any).
+# Install-only builds (UPDATE_SKILLS_LANES_ADDITIVE=1) narrow every repo group to
+# the skills ABSENT from the candidate store, so existing skills stay the
+# byte-clones of current the candidate started as (no updates, additive only).
 __gen_lane_npx() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  local additive="${UPDATE_SKILLS_LANES_ADDITIVE:-}"
   local -a repos=()
   local repo
   while IFS= read -r repo; do
     [[ -n $repo ]] && repos+=("$repo")
   done < <(jq -r '.npxTracked // {} | [.[].repo] | unique | .[]' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-  local -a skill_args
+  local -a skill_args group_names
   local name
   for repo in "${repos[@]:-}"; do
     [[ -n $repo ]] || continue
     skill_args=()
+    group_names=()
     while IFS= read -r name; do
-      [[ -n $name ]] && skill_args+=(--skill "$name")
+      [[ -n $name ]] || continue
+      if [[ -n $additive && -e "$STORE/$name" ]]; then
+        continue # additive build: keep the existing byte-clone, never refresh
+      fi
+      skill_args+=(--skill "$name")
+      group_names+=("$name")
     done < <(jq -r --arg r "$repo" '.npxTracked // {} | to_entries[]
       | select(.value.repo == $r) | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
     [[ ${#skill_args[@]} -gt 0 ]] || continue
     if npx --yes skills@latest add "$repo" "${skill_args[@]}" \
       --agent claude-code --agent codex -g -y 2>&1 | tr -d '\r' | tail -3; then
-      log "npx add: $repo (${#skill_args[@]} skill arg tokens)"
+      log "npx add: $repo (${#group_names[@]} skills)"
     else
       log "npx add failed: $repo (continuing; candidate will be discarded)"
       record_required_failure "npx add $repo failed"
+      for name in "${group_names[@]}"; do record_failed_skill "$name"; done
     fi
   done
 }
@@ -759,6 +829,7 @@ __gen_lane_npx() {
 __gen_lane_clawhub() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
+  local additive="${UPDATE_SKILLS_LANES_ADDITIVE:-}"
   if ! command -v clawhub >/dev/null 2>&1; then
     log "clawhub not on PATH but clawhubTracked is non-empty; candidate cannot be completed"
     record_required_failure "clawhub missing with a non-empty clawhubTracked table (build lane)"
@@ -780,18 +851,23 @@ __gen_lane_clawhub() {
           log "clawhub install: $skill from $slug"
         else
           record_required_failure "clawhub install $skill produced no store dir"
+          record_failed_skill "$skill"
         fi
       else
         record_required_failure "clawhub install $skill failed"
+        record_failed_skill "$skill"
       fi
       rm -rf "$tmp_workdir"
       continue
     fi
+    # An additive (install-only) build keeps every existing byte-clone untouched.
+    [[ -n $additive ]] && continue
     # present: refresh in place (bare name resolves via origin.json)
     [[ -d "$STORE/$skill" && ! -L "$STORE/$skill" ]] || continue
     rm -f "$STORE/$skill/.DS_Store"
     if ! update_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)"; then
       record_required_failure "clawhub update $skill failed"
+      record_failed_skill "$skill"
       printf '%s\n' "$update_output"
       continue
     fi
@@ -808,6 +884,7 @@ __gen_lane_clawhub() {
         printf '%s\n' "$CODEX_POLICY" >"$overlay_file"
       fi
       record_required_failure "clawhub update $skill refused over local changes"
+      record_failed_skill "$skill"
     fi
   done 3< <(jq -r '.clawhubTracked // {} | to_entries[]
     | [.key, (.value.slug // ""), (.value.registry // "")] | @tsv' \
@@ -847,25 +924,35 @@ __gen_assert_overlays() {
 __gen_do_build_lanes() {
   local id="${UPDATE_SKILLS_GEN_ID:-$(__gen_new_id)}"
   mkdir -p "$STORE"
+  rm -f "$AGENTS/$GEN_FAILED_SKILLS_FILE_NAME"
   log "build lane: npx"
   __gen_lane_npx
   log "build lane: clawhub"
   __gen_lane_clawhub
   log "build lane: codex overlays"
   __gen_assert_overlays
-  # The ready marker goes at .agents/generation.json (one level above skills/).
+  if [[ $REQUIRED_FAILURES -gt 0 ]]; then
+    # No ready marker for a failed build: the candidate is incomplete by
+    # construction and recovery deletes it if the parent crashes first. The
+    # failed-skills file stays for the parent to read before the discard.
+    return 1
+  fi
+  rm -f "$AGENTS/$GEN_FAILED_SKILLS_FILE_NAME"
+  # The ready marker goes at .agents/generation.json (one level above skills/),
+  # written LAST.
   __gen_write_meta "$AGENTS" "$id"
-  [[ $REQUIRED_FAILURES -eq 0 ]]
 }
 
 # Parent side: run the build lanes against a candidate home under env -i, with
 # HOME, every XDG_* dir, TMPDIR, and the npm cache/config pinned INSIDE the
 # candidate, so a lane can only write into the candidate (isolation). PATH is
 # passed through so npx/clawhub/jq/gmv resolve (and tests can prepend stubs).
-#   __gen_run_lanes <candidate-home> <id>
+#   __gen_run_lanes <candidate-home> <id> [additive]
+# A non-empty third argument runs the lanes ADDITIVELY (install-only builds:
+# only skills absent from the candidate are installed; nothing is refreshed).
 # Returns the re-invocation's exit status (non-zero = discard the candidate).
 __gen_run_lanes() {
-  local home="$1" id="$2"
+  local home="$1" id="$2" additive="${3:-}"
   mkdir -p "$home/.cache" "$home/.config" "$home/.local/share" "$home/.local/state" "$home/.tmp" "$home/.npm"
   env -i \
     PATH="$PATH" \
@@ -879,6 +966,7 @@ __gen_run_lanes() {
     UPDATE_SKILLS_GMV="$GMV" \
     UPDATE_SKILLS_GEN_ID="$id" \
     UPDATE_SKILLS_LOCK_PATH="$CUSTOM_SKILL_LOCK" \
+    UPDATE_SKILLS_LANES_ADDITIVE="$additive" \
     UPDATE_SKILLS_BUILD_LANES=1 \
     bash "$UPDATE_SKILLS_SELF" --build-lanes
 }
@@ -887,7 +975,7 @@ __gen_run_lanes() {
 # tracked skill present with a SKILL.md, on-demand overlays in place, expected
 # origin metadata (clawhub skills carry .clawhub/origin.json), the npx lock is
 # valid JSON, and the ready marker is present. Returns 0 valid, 1 invalid (the
-# caller garbage-renames the candidate and records a required failure — never a
+# caller garbage-renames the candidate and records a required failure, never a
 # partial promotion).
 #   __gen_validate_candidate <candidate-agents-dir>
 __gen_validate_candidate() {
@@ -912,10 +1000,12 @@ __gen_validate_candidate() {
     [[ -n $name ]] || continue
     [[ -d "$skills/$name" ]] || {
       log "validate: tracked skill $name is missing from the candidate"
+      record_failed_skill_parent "$name"
       return 1
     }
     [[ -f "$skills/$name/SKILL.md" ]] || {
       log "validate: tracked skill $name has no SKILL.md"
+      record_failed_skill_parent "$name"
       return 1
     }
   done < <(__gen_tracked_names)
@@ -924,6 +1014,7 @@ __gen_validate_candidate() {
     [[ -n $name ]] || continue
     [[ -f "$skills/$name/.clawhub/origin.json" ]] || {
       log "validate: clawhub skill $name is missing .clawhub/origin.json"
+      record_failed_skill_parent "$name"
       return 1
     }
   done < <(jq -r '.clawhubTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
@@ -934,9 +1025,302 @@ __gen_validate_candidate() {
     [[ -d "$skills/$name" ]] || continue
     grep -q 'allow_implicit_invocation: false' "$skills/$name/agents/openai.yaml" 2>/dev/null || {
       log "validate: on-demand skill $name is missing its Codex overlay"
+      record_failed_skill_parent "$name"
       return 1
     }
   done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# RUN ORCHESTRATION (brief steps 5-6): store-link reconcile, live overlay
+# verification, the weekly attempt, the install-only attempt, drift reporting,
+# and per-skill failure streaks.
+# ---------------------------------------------------------------------------
+
+# Post-publish store-link reconciliation for every tracked name present in the
+# live generation. Full runs (additive="") also absorb competing-writer real
+# dirs recorded by recovery (their content is already inside the published
+# generation) and repair stale generation-form or dangling links. Additive runs
+# (install-only) only plant links for names with NO store entry at all, so
+# nothing existing is ever replaced. A resolving foreign symlink is never
+# touched in either mode.
+#   __gen_reconcile_store_links [additive]
+__gen_reconcile_store_links() {
+  local additive="${1:-}" name link target reabsorbed
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    [[ -d "$SKILLS_CURRENT/skills/$name" ]] || continue
+    link="$STORE/$name"
+    if [[ ! -e $link && ! -L $link ]]; then
+      __gen_plant_store_link "$name" || record_required_failure "store link for $name could not be planted"
+      continue
+    fi
+    [[ -n $additive ]] && continue # additive: never replace anything existing
+    if [[ -d $link && ! -L $link ]]; then
+      # A competing-writer real dir recorded by recovery was absorbed into the
+      # published generation; return the store name to link topology.
+      reabsorbed=""
+      local n
+      for n in "${GEN_REABSORB[@]:-}"; do
+        if [[ -n $n && $n == "$name" ]]; then reabsorbed=1; fi
+      done
+      if [[ -n $reabsorbed ]]; then
+        __gen_absorb_store_link "$name" || record_required_failure "store/$name could not be re-absorbed"
+      else
+        log "WARN: store/$name is a real dir not seen by recovery; leaving it (next run re-absorbs)"
+      fi
+      continue
+    fi
+    if [[ -L $link ]] && ! __gen_store_link_correct "$name"; then
+      target="$(readlink "$link" 2>/dev/null || true)"
+      if [[ $target == ../.skills-current/* || ! -e $link ]]; then
+        __gen_plant_store_link "$name" || record_required_failure "store link for $name could not be repaired"
+      else
+        log "WARN: store/$name is a foreign symlink ($target); leaving it"
+      fi
+    fi
+  done < <(__gen_tracked_names)
+}
+
+# Live-pass Codex overlay handling (brief step 3, overlays): tier overlays are
+# ASSERTED in the candidate only; the live pass VERIFIES them through the store
+# links and records a required failure when one is missing; it never writes
+# through a store link. A vendored on-demand skill (a real store dir outside the
+# generation) still gets the old write-if-missing assert (additive, chezmoi owns
+# the committed copy). App-owned store symlinks (not generation links) carry no
+# overlay by documented asymmetry.
+__gen_verify_live_overlays() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
+  local skill overlay_file
+  while IFS= read -r skill; do
+    [[ -n $skill ]] || continue
+    if [[ -L "$STORE/$skill" ]]; then
+      __gen_store_link_correct "$skill" || continue # app-owned/foreign link: never through it
+      overlay_file="$STORE/$skill/agents/openai.yaml"
+      if ! grep -q 'allow_implicit_invocation: false' "$overlay_file" 2>/dev/null; then
+        log "OVERLAY MISSING: on-demand skill $skill has no Codex overlay in the live generation (never written through store links; the next candidate re-asserts it)"
+        record_required_failure "live overlay missing for $skill"
+        record_failed_skill_parent "$skill"
+      fi
+      continue
+    fi
+    [[ -d "$STORE/$skill" ]] || continue
+    # vendored real dir: keep the additive write-if-missing assert
+    overlay_file="$STORE/$skill/agents/openai.yaml"
+    if [[ -f $overlay_file ]] && grep -q 'allow_implicit_invocation: false' "$overlay_file"; then
+      continue
+    fi
+    if ! mkdir -p "$STORE/$skill/agents"; then
+      record_required_failure "codex overlay dir for $skill could not be created"
+      continue
+    fi
+    if [[ -f $overlay_file ]]; then
+      if printf '\n%s\n' "$CODEX_POLICY" >>"$overlay_file"; then
+        log "appended codex overlay policy to upstream openai.yaml: $skill"
+      else
+        record_required_failure "codex overlay append for $skill failed"
+      fi
+    elif printf '%s\n' "$CODEX_POLICY" >"$overlay_file"; then
+      log "asserted codex overlay: $skill"
+    else
+      record_required_failure "codex overlay write for $skill failed"
+    fi
+  done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+}
+
+# Parent-side per-skill failure capture (validation failures, live overlay
+# verification, migration exchanges). The lanes' subprocess failures arrive via
+# the candidate's failed-skills file and are merged in the weekly attempt.
+GEN_FAILED_SKILLS=()
+record_failed_skill_parent() { GEN_FAILED_SKILLS+=("$1"); }
+__gen_merge_lane_failures() {
+  local file="$1" name
+  [[ -f $file ]] || return 0
+  while IFS= read -r name; do
+    [[ -n $name ]] && GEN_FAILED_SKILLS+=("$name")
+  done <"$file"
+}
+
+# --dry-run drift report (brief Modes): NEVER invokes either package CLI (the
+# npx CLI treats `update --help` as a real update, observed live). Reports
+# roster-vs-lock drift (npx-tracked roster skills absent from the npx CLI lock)
+# and roster-vs-generation drift (tracked roster skills absent from the live
+# generation, or no generation at all: migration pending). Zero writes.
+__gen_dryrun_drift_report() {
+  [[ -f $CUSTOM_SKILL_LOCK ]] || {
+    log "drift: no custom-skill-lock.json; nothing to compare"
+    return 0
+  }
+  local name
+  if [[ -f $SKILL_LOCK_LINK ]]; then
+    while IFS= read -r name; do
+      [[ -n $name ]] || continue
+      jq -e --arg n "$name" '.skills | has($n)' "$SKILL_LOCK_LINK" >/dev/null 2>&1 ||
+        log "drift: roster skill $name is absent from the npx lock (the explicit per-repo add reconciles it)"
+    done < <(jq -r '.npxTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  else
+    log "drift: no npx lock present"
+  fi
+  if __gen_is_complete "$SKILLS_CURRENT"; then
+    while IFS= read -r name; do
+      [[ -n $name ]] || continue
+      [[ -d "$SKILLS_CURRENT/skills/$name" ]] ||
+        log "drift: roster skill $name is absent from the live generation (the next full run adds it)"
+    done < <(__gen_tracked_names)
+  else
+    log "drift: no live generation yet; the next full run migrates the flat store"
+  fi
+}
+
+# Per-skill failure streaks (brief step 6): {last_failed_week,
+# consecutive_failed_weeks} per skill in one JSON map, incremented at most once
+# per ISO WEEK (not per hourly slot), reset on verified success, escalated alert
+# wording at 2 consecutive weeks. Convergence never stops: streaks only change
+# the alert wording, never gate a retry.
+STREAK_FILE="$STATE_DIR/skill-failure-streaks.json"
+__gen_update_failure_streaks() {
+  [[ ${#GEN_FAILED_SKILLS[@]} -gt 0 ]] || return 0
+  local week name streaks entry_week entry_count
+  week="$(date +%G-%V)"
+  mkdir -p "$STATE_DIR" 2>/dev/null || return 0
+  streaks="$(cat "$STREAK_FILE" 2>/dev/null || true)"
+  jq -e . <<<"$streaks" >/dev/null 2>&1 || streaks='{}'
+  local -a escalated=()
+  local -a seen=()
+  local dup
+  for name in "${GEN_FAILED_SKILLS[@]}"; do
+    [[ -n $name ]] || continue
+    dup=""
+    local s
+    for s in "${seen[@]:-}"; do
+      if [[ -n $s && $s == "$name" ]]; then dup=1; fi
+    done
+    if [[ -n $dup ]]; then continue; fi
+    seen+=("$name")
+    entry_week="$(jq -r --arg n "$name" '.[$n].last_failed_week // ""' <<<"$streaks")"
+    entry_count="$(jq -r --arg n "$name" '.[$n].consecutive_failed_weeks // 0' <<<"$streaks")"
+    [[ $entry_count =~ ^[0-9]+$ ]] || entry_count=0
+    if [[ $entry_week == "$week" ]]; then
+      : # already counted this week (a later hourly slot); no double increment
+    else
+      entry_count=$((entry_count + 1))
+      streaks="$(jq --arg n "$name" --arg w "$week" --argjson c "$entry_count" \
+        '.[$n] = {last_failed_week: $w, consecutive_failed_weeks: $c}' <<<"$streaks")"
+    fi
+    if [[ $entry_count -ge 2 ]]; then
+      escalated+=("$name ($entry_count weeks)")
+      log "STREAK: skill $name has failed $entry_count consecutive weekly cycles"
+    fi
+  done
+  printf '%s\n' "$streaks" >"$STREAK_FILE" 2>/dev/null || true
+  if [[ ${#escalated[@]} -gt 0 ]]; then
+    __update_skills_alert "Weekly skills update: still failing after multiple weeks for ${escalated[*]}. The updater keeps retrying weekly, but these skills need eyes (~/.local/log/skills/)."
+  fi
+}
+__gen_reset_failure_streaks() {
+  if [[ -f $STREAK_FILE ]]; then
+    printf '{}\n' >"$STREAK_FILE" 2>/dev/null || true
+  fi
+}
+
+# The full-run weekly attempt (brief steps 2-5): reuse a recovered complete
+# matching candidate, or build one; run the lanes; validate; publish with the
+# atomic exchange; reconcile the store links. ANY failure discards the WHOLE
+# candidate (no partial promotion), records a required failure (loud + relay),
+# and leaves the live generation untouched; the next slot retries.
+__gen_weekly_attempt() {
+  local relay_script="$HOME/.local/bin/relay.sh"
+  local id candidate_home candidate_agents id_dir
+  if [[ -n $GEN_REUSE_CANDIDATE ]] && __gen_validate_candidate "$GEN_REUSE_CANDIDATE"; then
+    candidate_agents="$GEN_REUSE_CANDIDATE"
+    id_dir="$(dirname "$(dirname "$candidate_agents")")"
+    log "reusing the recovered complete candidate at $candidate_agents"
+    if __gen_publish "$candidate_agents"; then
+      __gen_garbage_destroy "$id_dir"
+      __gen_reconcile_store_links
+      __gen_plant_lock_link || record_required_failure "lock link could not be planted after publish"
+      return 0
+    fi
+    record_required_failure "publish of the recovered candidate failed"
+    __gen_garbage_destroy "$id_dir"
+    return 1
+  fi
+  id="$(__gen_new_id)"
+  if ! __gen_build_candidate "$id"; then
+    record_required_failure "candidate build failed"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  candidate_home="$GEN_CANDIDATE_HOME"
+  candidate_agents="$GEN_CANDIDATE_AGENTS"
+  if ! __gen_run_lanes "$candidate_home" "$id"; then
+    __gen_merge_lane_failures "$candidate_agents/$GEN_FAILED_SKILLS_FILE_NAME"
+    record_required_failure "build lanes failed; the whole candidate is discarded (no partial promotion)"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    if [[ -x $relay_script ]]; then
+      "$relay_script" --agent update-skills --state build-failed --project skills \
+        --detail "the weekly candidate build lanes failed; the live generation is untouched and the next slot retries" || true
+    fi
+    return 1
+  fi
+  if ! __gen_validate_candidate "$candidate_agents"; then
+    record_required_failure "candidate validation failed; the whole candidate is discarded (no partial promotion)"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    if [[ -x $relay_script ]]; then
+      "$relay_script" --agent update-skills --state validation-failed --project skills \
+        --detail "the weekly candidate failed validation; the live generation is untouched and the next slot retries" || true
+    fi
+    return 1
+  fi
+  if ! __gen_publish "$candidate_agents"; then
+    record_required_failure "publish failed; the live generation is untouched"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  __gen_garbage_destroy "$GENERATIONS/$id" # the emptied build workspace shell
+  __gen_reconcile_store_links
+  __gen_plant_lock_link || record_required_failure "lock link could not be planted after publish"
+  return 0
+}
+
+# The install-only attempt (brief Modes): builds and publishes a candidate whose
+# EXISTING skills are byte-clones of current (no updates) plus genuinely absent
+# roster skills added. Never migrates a flat store, never replaces existing
+# store content: link planting is additive (absent names only).
+__gen_install_only_attempt() {
+  local id candidate_home candidate_agents
+  id="$(__gen_new_id)"
+  if ! __gen_build_candidate "$id"; then
+    record_required_failure "install-only candidate build failed"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  candidate_home="$GEN_CANDIDATE_HOME"
+  candidate_agents="$GEN_CANDIDATE_AGENTS"
+  if ! __gen_run_lanes "$candidate_home" "$id" additive; then
+    __gen_merge_lane_failures "$candidate_agents/$GEN_FAILED_SKILLS_FILE_NAME"
+    record_required_failure "install-only lanes failed; candidate discarded"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  if ! __gen_validate_candidate "$candidate_agents"; then
+    record_required_failure "install-only candidate failed validation; candidate discarded"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  if ! __gen_publish "$candidate_agents"; then
+    record_required_failure "install-only publish failed; live state untouched"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  __gen_garbage_destroy "$GENERATIONS/$id"
+  __gen_reconcile_store_links additive
+  # The lock link is planted only when nothing exists at the path (a flat lock
+  # file is migration's job, and install-only never migrates).
+  if [[ ! -e $SKILL_LOCK_LINK && ! -L $SKILL_LOCK_LINK ]]; then
+    __gen_plant_lock_link || true
+  fi
   return 0
 }
 
@@ -970,12 +1354,12 @@ fi
 # harness, PROCEED (fast path, evidence never probed); (2) if a harness process
 # exists, probe every harness PRESENT on the machine for recent file activity and
 # DEFER only while at least one is fresh (within IDLE_THRESHOLD); (3) fail closed
-# — an unreadable process table or a probe error counts as ACTIVE. This is the
+# (an unreadable process table or a probe error counts as ACTIVE). This is the
 # UNATTENDED norm: the weekly run proceeds whenever the machine has been quiet for
 # IDLE_THRESHOLD, even with a bridge up.
 #
 # PR-facing tradeoff: the gate reads mtimes, not a lock the harnesses hold, so
-# there is a narrow race — a session that starts writing in the millisecond after
+# there is a narrow race: a session that starts writing in the millisecond after
 # the probe scans could have a skill folder swapped mid-turn. The window is tiny
 # and the blast radius is one weekly run; the design accepts it as the unattended
 # tradeoff. FOLLOW-UP (a task exists): the durable fix is a versioned skills store
@@ -1072,7 +1456,7 @@ __update_skills_is_interactive_harness() {
 # Enumerate the process table for agent-harness processes. Returns:
 #   0 = at least one agent-harness process (claude/codex/hermes) is running
 #   1 = ps read cleanly and NO harness process exists (the fast-path signal)
-#   2 = ps could not be read (or yielded nothing — it must at minimum list this
+#   2 = ps could not be read (or yielded nothing; it must at minimum list this
 #       very process): FAIL CLOSED, the caller must defer.
 __update_skills_harness_active() {
   local ps_output args
@@ -1088,11 +1472,11 @@ __update_skills_harness_active() {
 
 # Recent-activity probe for one harness's activity dir, against a cutoff SENTINEL
 # file whose mtime is (now - IDLE_THRESHOLD). Returns:
-#   0 = ACTIVE  — a file newer than the sentinel exists, OR the probe errored
+#   0 = ACTIVE  = a file newer than the sentinel exists, OR the probe errored
 #                 (unreadable dir / scan failure): fail closed and treat as active
-#   1 = STALE   — the dir is present and readable but its newest file is older
+#   1 = STALE   = the dir is present and readable but its newest file is older
 #                 than the window
-#   2 = ABSENT  — the dir does not exist: this harness is not installed, so it
+#   2 = ABSENT  = the dir does not exist: this harness is not installed, so it
 #                 contributes NO evidence and must not block
 #
 # The sentinel + POSIX `-newer` is deliberate: macOS's BSD `/usr/bin/find` does
@@ -1103,13 +1487,13 @@ __update_skills_harness_active() {
 # non-zero on a scan error (e.g. an unreadable subtree), which we treat as ACTIVE.
 #
 # Empirically verified per-turn activity sources on this machine (2026-07-11):
-#   Claude Code: ~/.claude/projects/**/<session>.jsonl — the transcript is
+#   Claude Code: ~/.claude/projects/**/<session>.jsonl, the transcript that is
 #     appended per turn; the FILE mtime is the signal (directory mtimes do NOT
 #     propagate on append: verified live, newest file mtime == wall clock during
 #     an active turn while the enclosing dir mtime lagged ~45s).
-#   Codex: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl — the per-turn rollout
+#   Codex: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl, the per-turn rollout
 #     transcript (verified: mtimes advance per turn, stale while idle).
-#   Hermes: ~/.hermes/logs/agent.log (and siblings) — the gateway's per-run/turn
+#   Hermes: ~/.hermes/logs/agent.log (and siblings), the gateway's per-run/turn
 #     log (verified: agent.log mtime advances while the gateway serves a turn).
 __update_skills_activity_state() {
   local dir="$1" sentinel="$2" newer
@@ -1442,55 +1826,6 @@ assert_superpowers_routing() {
   fi
 }
 
-# Codex policy overlays: every skill the lock's tiers table marks "on-demand"
-# must carry agents/openai.yaml with allow_implicit_invocation disabled, so
-# Codex loads it only on an explicit $name invocation
-# (developers.openai.com/codex/skills). Chezmoi commits the overlay for vendored
-# skills, but an npx-tracked skill loses it whenever the npx add/update replaces
-# the folder wholesale, and cua-driver's folder is app-owned — so every run
-# re-asserts the overlay from the tiers table for any on-demand skill present in
-# the store. Additive by construction: the only path ever written is
-# agents/openai.yaml, a file that already carries the policy line is left
-# untouched (keeps chezmoi-managed copies drift-free), and when the upstream
-# skill ships its own agents/openai.yaml (the official hyperframes-keyframes
-# carries an interface: block there) the policy block is APPENDED so upstream
-# metadata survives — never a whole-file overwrite.
-assert_codex_overlays() {
-  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  local skill overlay_file
-  local policy="$CODEX_POLICY"
-  while IFS= read -r skill; do
-    [[ -d "$STORE/$skill" ]] || continue
-    # Never write through a store symlink (e.g. cua-driver -> ~/.cua-driver):
-    # the target is app-owned content this repo must not modify. Such skills
-    # simply carry no Codex overlay — documented asymmetry, not an oversight.
-    [[ -L "$STORE/$skill" ]] && continue
-    overlay_file="$STORE/$skill/agents/openai.yaml"
-    if [[ -f $overlay_file ]] && grep -q 'allow_implicit_invocation: false' "$overlay_file"; then
-      continue
-    fi
-    if [[ $DRYRUN == "--dry-run" ]]; then
-      log "would assert codex overlay: $skill"
-      continue
-    fi
-    if ! mkdir -p "$STORE/$skill/agents"; then
-      record_required_failure "codex overlay dir for $skill could not be created"
-      continue
-    fi
-    if [[ -f $overlay_file ]]; then
-      if printf '\n%s\n' "$policy" >>"$overlay_file"; then
-        log "appended codex overlay policy to upstream openai.yaml: $skill"
-      else
-        record_required_failure "codex overlay append for $skill failed"
-      fi
-    elif printf '%s\n' "$policy" >"$overlay_file"; then
-      log "asserted codex overlay: $skill"
-    else
-      record_required_failure "codex overlay write for $skill failed"
-    fi
-  done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-}
-
 # Weekly hermes registry-update phase: for each specialist profile, update every
 # skill the lock's hermesRegistry table marks hermes-owned for it — keyed by the
 # entry's lockKey (never a list name: ClawHub slugs differ from frontmatter
@@ -1725,6 +2060,13 @@ else
     return 0 # never let the EXIT trap's status leak into the script's exit code
   }
   trap '__update_skills_release_lock' EXIT
+  # RECOVERY (brief step 1) runs under the lock, BEFORE the stamp early-exit and
+  # the idle gate, so a crash-window leftover self-heals even on a slot that
+  # then early-exits. It deletes incomplete staging, marks a reusable complete
+  # candidate, repairs the stable store/lock links, records competing-writer
+  # real dirs for re-absorption, and prunes generation garbage. Dry runs never
+  # reach here (the dry branch above is read-only).
+  __gen_recover
 fi
 
 # weekly success stamp: the 24 Monday plist slots share one stamp; once a slot
@@ -1742,7 +2084,7 @@ if [[ -z $INSTALL_ONLY ]] && [[ -z $CHECK_FORKS_ONLY ]] && [[ $DRYRUN != "--dry-
 fi
 
 # idle-gate (activity-based, fail-closed): defer only while a harness shows
-# RECENT activity (within IDLE_THRESHOLD), so the weekly run is UNATTENDED — an
+# RECENT activity (within IDLE_THRESHOLD), so the weekly run is UNATTENDED; an
 # always-up bridge no longer defers it forever. A machine quiet for the window
 # proceeds and swaps skills; a live turn defers to next slot. FAIL CLOSED: an
 # unreadable process table or a probe error counts as active. UPDATE_SKILLS_FORCE=1
@@ -1760,181 +2102,6 @@ if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN
   fi
   exit 0
 fi
-
-# 0) npx installs: any npx-tracked skill absent from the store is installed from
-#    its upstream via the official npx `skills` CLI (latest from main). The
-#    multi-agent form lands the real dir in ~/.agents/skills and plants the
-#    relative Claude symlink; the weekly `npx skills update` pass below refreshes
-#    present ones — this pass is install-only.
-install_npx_tracked() {
-  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  local skill repo
-  # read on fd 3: npx may consume stdin
-  while IFS= read -r -u3 skill; do
-    [[ -e "$STORE/$skill" ]] && continue # install only what's absent; refresh is the npx update pass's job
-    repo="$(jq -r --arg skill "$skill" '.npxTracked[$skill].repo' "$CUSTOM_SKILL_LOCK")"
-    if [[ -z $repo || $repo == "null" ]]; then
-      log "install $skill: no npxTracked.repo recorded; skipping"
-      continue
-    fi
-    if [[ $DRYRUN == "--dry-run" ]]; then
-      log "would install via npx: $skill from $repo"
-      continue
-    fi
-    if npx --yes skills@latest add "$repo" --skill "$skill" --agent claude-code --agent codex -g -y 2>&1 | tr -d '\r' | tail -3; then
-      if [[ -d "$STORE/$skill" ]]; then
-        log "installed: $skill from $repo" # fan-out is the convergence pass's job (below)
-      else
-        log "install $skill: npx add reported success but $STORE/$skill is absent (continuing)"
-        record_required_failure "npx install $skill produced no store dir"
-      fi
-    else
-      log "install $skill: npx add failed ($repo) (continuing)"
-      record_required_failure "npx install $skill failed"
-    fi
-  done 3< <(jq -r '.npxTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-}
-
-# 0b) clawhub installs: any clawhub-tracked skill absent from the store is
-#     installed from ClawHub. The CLI nests installs as <dir>/@owner/<name>
-#     (v0.23.1), so each install runs in a throwaway --workdir and the nested
-#     dir is moved FLAT into the store as <store>/<name>. The moved dir keeps
-#     its .clawhub/origin.json (slug + ownerHandle + fingerprint), which is
-#     what makes the weekly bare-name in-place update below deterministic even
-#     for names several ClawHub users publish. Installing outside the store
-#     workdir also keeps the store's .clawhub/lock.json free of @owner-keyed
-#     phantom entries (a slug-form update against such an entry recreates the
-#     nested dir instead of updating the flat one — verified live).
-install_clawhub_tracked() {
-  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
-  local relay_script="$HOME/.local/bin/relay.sh"
-  if ! command -v clawhub >/dev/null 2>&1; then
-    # A non-empty clawhubTracked table with no clawhub binary is a REQUIRED
-    # failure: absent skills would silently never install (item 4).
-    log "WARN: clawhub not on PATH but clawhubTracked is non-empty; the install pass cannot run"
-    record_required_failure "clawhub missing with a non-empty clawhubTracked table (install pass)"
-    if [[ -x $relay_script ]]; then
-      "$relay_script" --agent update-skills --state prereq-missing --project clawhub \
-        --detail "clawhub is not on PATH but clawhubTracked has skills to install; the store cannot be completed" || true
-    fi
-    return 0
-  fi
-  local skill slug registry tmp_workdir installed_dir
-  local -a clawhub_cmd
-  # read on fd 3: clawhub may consume stdin
-  while IFS=$'\t' read -r -u3 skill slug registry; do
-    [[ -e "$STORE/$skill" ]] && continue # install only what's absent; refresh is the update pass's job
-    if [[ -z $slug ]]; then
-      log "install $skill: no clawhubTracked.slug recorded; skipping"
-      continue
-    fi
-    if [[ $DRYRUN == "--dry-run" ]]; then
-      log "would install via clawhub: $skill from $slug"
-      continue
-    fi
-    tmp_workdir="$(mktemp -d)"
-    clawhub_cmd=(clawhub --no-input --workdir "$tmp_workdir" --dir skills)
-    [[ -n $registry ]] && clawhub_cmd+=(--registry "$registry")
-    if "${clawhub_cmd[@]}" install "$slug" 2>&1 | tail -2; then
-      # Nested @owner layout today; tolerate a flat layout should a future CLI
-      # version stop nesting.
-      installed_dir="$tmp_workdir/skills/$slug"
-      [[ -d $installed_dir ]] || installed_dir="$tmp_workdir/skills/$skill"
-      if [[ -d $installed_dir ]]; then
-        mv "$installed_dir" "$STORE/$skill"
-        log "installed: $skill from $slug" # fan-out is the convergence pass's job (below)
-      else
-        log "install $skill: clawhub install reported success but produced no skill dir (continuing)"
-        record_required_failure "clawhub install $skill produced no store dir"
-      fi
-    else
-      log "install $skill: clawhub install failed ($slug) (continuing)"
-      record_required_failure "clawhub install $skill failed"
-    fi
-    rm -rf "$tmp_workdir"
-  done 3< <(jq -r '.clawhubTracked // {} | to_entries[]
-    | [.key, (.value.slug // ""), (.value.registry // "")] | @tsv' \
-    "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-}
-
-# Weekly clawhub update pass: refresh every clawhub-tracked store copy in
-# place — per skill, by its bare store-dir name, with the store as the CLI's
-# workdir (origin.json pins the owner, so bare names resolve deterministically).
-# Two mechanical realities handled up front (both verified live on v0.23.1):
-# Finder .DS_Store litter breaks the CLI's fingerprint match, so it is scrubbed
-# first; and the repo-asserted Codex overlay (agents/openai.yaml) is a local
-# file the published fingerprint cannot know, so the CLI refuses with "local
-# changes". When the refusal is over EXACTLY that file — byte-equal to the
-# policy this script asserts — the file is set aside and the update retried
-# once (assert_codex_overlays re-creates it later in the same run). Any other
-# local change is a loud WARN (relayed), never overwritten: automation never
-# passes --force (and never --force-install, ClawHub's scan bypass — bypassing
-# a security scan needs per-invocation operator confirmation).
-update_clawhub_tracked() {
-  [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  jq -e '.clawhubTracked // {} | length > 0' "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 || return 0
-  local relay_script="$HOME/.local/bin/relay.sh"
-  if ! command -v clawhub >/dev/null 2>&1; then
-    # A non-empty clawhubTracked table with no clawhub binary is a REQUIRED
-    # failure: the tracked store copies would silently go un-refreshed (item 4).
-    log "WARN: clawhub not on PATH but clawhubTracked is non-empty; the update pass cannot run"
-    record_required_failure "clawhub missing with a non-empty clawhubTracked table (update pass)"
-    if [[ -x $relay_script ]]; then
-      "$relay_script" --agent update-skills --state prereq-missing --project clawhub \
-        --detail "clawhub is not on PATH but clawhubTracked has skills to refresh; they will drift" || true
-    fi
-    return 0
-  fi
-  local skill overlay_file update_output retry_output
-  # read on fd 3: clawhub may consume stdin
-  while IFS= read -r -u3 skill; do
-    # Only real store dirs: absent skills are the install pass's job, and a
-    # symlinked entry would be app-owned content this script must not touch.
-    [[ -d "$STORE/$skill" && ! -L "$STORE/$skill" ]] || continue
-    if [[ $DRYRUN == "--dry-run" ]]; then
-      log "would update via clawhub: $skill"
-      continue
-    fi
-    rm -f "$STORE/$skill/.DS_Store"
-    if ! update_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)"; then
-      log "WARN: clawhub update $skill failed (continuing)"
-      record_required_failure "clawhub update $skill failed"
-      printf '%s\n' "$update_output"
-      if [[ -x $relay_script ]]; then
-        "$relay_script" --agent update-skills --state clawhub-update-failed --project "$skill" \
-          --detail "clawhub update exited non-zero; run it by hand to see why" || true
-      fi
-      continue
-    fi
-    if ! printf '%s\n' "$update_output" | grep -q 'local changes'; then
-      log "clawhub $skill: ok"
-      continue
-    fi
-    # Refusal ladder: only when the sole local change is our own overlay.
-    overlay_file="$STORE/$skill/agents/openai.yaml"
-    if [[ -f $overlay_file && "$(<"$overlay_file")" == "$CODEX_POLICY" ]]; then
-      rm "$overlay_file"
-      rmdir "$STORE/$skill/agents" 2>/dev/null || true
-      if retry_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)" &&
-        ! printf '%s\n' "$retry_output" | grep -q 'local changes'; then
-        log "clawhub $skill: ok (repo-asserted Codex overlay set aside; re-asserted below)"
-        continue
-      fi
-      printf '%s\n' "$retry_output"
-      # Not just our overlay after all — put it back and surface the refusal.
-      mkdir -p "$STORE/$skill/agents"
-      printf '%s\n' "$CODEX_POLICY" >"$overlay_file"
-    fi
-    log "WARN: clawhub $skill update refused over local changes (continuing; never --force from automation)"
-    record_required_failure "clawhub update $skill refused over local changes"
-    printf '%s\n' "$update_output"
-    if [[ -x $relay_script ]]; then
-      "$relay_script" --agent update-skills --state clawhub-blocked --project "$skill" \
-        --detail "clawhub update refused over local changes beyond the repo's own Codex overlay; reconcile by hand (never --force from automation)" || true
-    fi
-  done 3< <(jq -r '.clawhubTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
-}
 
 # fork/vendored upstream drift-check: for each lock forks entry, fetch the
 # upstream and compare the recorded skill path's current git hash (tree hash for
@@ -1998,71 +2165,85 @@ if [[ -n $CHECK_FORKS_ONLY ]]; then
   exit 0
 fi
 
-log "npx installs (absent skills)"
-install_npx_tracked
-
-log "clawhub installs (absent skills)"
-install_clawhub_tracked
-
-if [[ -n $INSTALL_ONLY ]]; then
+# --dry-run (brief Modes): a read-only preview that NEVER invokes either package
+# CLI (the npx CLI treats `update --help` as a real update, observed live) and
+# makes ZERO writes. It reports roster-vs-lock and roster-vs-generation drift,
+# the fan-out convergence preview (would create/replace/remove, pure readlink
+# logic), and the would-run/would-defer lock preview printed above.
+if [[ $DRYRUN == "--dry-run" ]]; then
+  __gen_dryrun_drift_report
   converge_claude_skills
   converge_hermes_skills
-  assert_codex_overlays
+  refresh_app_owned_cua_pack    # its dry branch logs the would-run line only
+  assert_superpowers_routing    # --dry-run probe of the routing script (read-only)
+  update_hermes_registry_skills # its dry branch logs would-update lines only
+  check_fork_drift              # its dry branch logs would-drift-check lines only
+  log "done (dry-run)"
+  exit 0
+fi
+
+# --install-only (brief Modes): build and publish an ADDITIVE candidate whose
+# existing skills are byte-clones of the current generation plus genuinely
+# absent roster skills added. Never migrates a flat store, never replaces
+# existing store content. Safe under a live session (nothing existing is
+# swapped), which is what lets the fresh-machine bootstrap run at apply time.
+if [[ -n $INSTALL_ONLY ]]; then
+  __gen_install_only_attempt || true
+  converge_claude_skills
+  converge_hermes_skills
+  __gen_verify_live_overlays
   assert_superpowers_routing
-  log "done (install-only)${DRYRUN:+ (dry-run)}"
+  log "done (install-only)"
   # Signal any required-phase failure to the caller (the first-install
-  # chezmoiscript keys its retry marker on this non-zero exit). A dry run only
-  # reports, so it never fails.
-  if [[ $DRYRUN != "--dry-run" && $REQUIRED_FAILURES -gt 0 ]]; then
+  # chezmoiscript keys its retry marker on this non-zero exit).
+  if [[ $REQUIRED_FAILURES -gt 0 ]]; then
     log "install-only finished with $REQUIRED_FAILURES required-phase failure(s)"
     exit 1
   fi
   exit 0
 fi
 
-# 1) refresh every npx-tracked store skill in place from its upstream
-if [[ $DRYRUN == "--dry-run" ]]; then
-  log "would run: npx skills update --global"
-else
-  log "npx skills update --global"
-  if ! npx --yes skills@latest update --global -y 2>&1 | tr -d '\r' | tail -3; then
-    log "npx update reported issues (continuing)"
-    record_required_failure "npx skills update failed"
-  fi
+# FULL WEEKLY RUN (brief steps 1-6), the generation-exchange path:
+# 1) Migration: first run on a machine with the old flat store converts every
+#    tracked real dir to a stable store symlink into a freshly built
+#    .skills-current generation (per-entry atomic exchange; idle-gated full
+#    runs only, never --install-only).
+if __gen_migration_needed; then
+  log "migrating the flat store to the generation layout"
+  __gen_migrate || record_required_failure "flat-store migration failed"
+  # Recovery ran before the generation existed; re-run it so a reusable
+  # candidate or competing-writer drift is assessed against the migrated state.
+  __gen_recover
 fi
 
-# 1b) refresh every clawhub-tracked store skill in place from its ClawHub
-#     upstream (see update_clawhub_tracked above — bare store names, refusal
-#     ladder for the repo-asserted overlay, never --force)
-log "clawhub updates (tracked skills)"
-update_clawhub_tracked
+# 2-5) Build the candidate generation (a fake HOME under .skills-generations),
+#      run the npx + clawhub + overlay lanes against it under env -i, validate
+#      the WHOLE candidate, and publish with ONE atomic exchange. Any failure
+#      discards the whole candidate; the live generation is untouched.
+log "weekly generation attempt"
+__gen_weekly_attempt || log "the weekly generation attempt failed; the live generation is unchanged (a later slot retries)"
 
-# 1c) refresh the app-owned cua-driver skill pack via the app's own updater
-#     (see refresh_app_owned_cua_pack above — never a write through the symlink)
+# Post-publish live passes (never write through store links):
 refresh_app_owned_cua_pack
 
-# 2) CONVERGE the fan-out: every store skill is symlinked into Claude, and into
-#    exactly the hermes profile skills dirs its hermesProfiles mapping names,
-#    creating missing links, repairing wrong/dangling targets, and removing
-#    updater-owned links that drifted out of the desired set
+# CONVERGE the fan-out: every store skill is symlinked into Claude, and into
+# exactly the hermes profile skills dirs its hermesProfiles mapping names.
 converge_claude_skills
 converge_hermes_skills
 
-# 3) re-assert Codex policy overlays for on-demand skills — AFTER the npx
-#    refresh above, which replaces npx-tracked skill folders (overlay and all)
-assert_codex_overlays
+# VERIFY the Codex overlays through the store links (asserted in the candidate;
+# a missing one here is a required failure, never an in-place write); vendored
+# real dirs keep the additive write-if-missing assert.
+__gen_verify_live_overlays
 
-# 4) re-assert the superpowers→hermes routing patches on the hermes mirror —
-#    like the Codex overlays, a property that must survive anything replacing
-#    files wholesale (here: a superpowers re-mirror)
+# re-assert the superpowers->hermes routing patches on the hermes mirror
 assert_superpowers_routing
 
-# 5) hermes registry-update phase — after the store refresh, so the run
-#    summary reflects final state for both lanes (independent sources)
+# hermes registry-update phase (hub-owned skills, independent source)
 log "hermes registry updates"
 update_hermes_registry_skills
 
-# 6) watch the vendored/fork upstreams (alert-only; see the function above)
+# watch the vendored/fork upstreams (alert-only)
 log "fork drift-check"
 check_fork_drift
 
@@ -2081,8 +2262,14 @@ if [[ $DRYRUN != "--dry-run" ]]; then
   if [[ $REQUIRED_FAILURES -eq 0 ]]; then
     mkdir -p "$STATE_DIR"
     __update_skills_stamp_value >"$SUCCESS_STAMP"
+    # A verified success resets every per-skill failure streak.
+    __gen_reset_failure_streaks
   else
     log "WITHHOLDING the weekly success stamp: $REQUIRED_FAILURES required-phase failure(s) this run; a later scheduled slot will retry"
+    # Per-skill failure streaks: incremented at most once per ISO week (not per
+    # hourly slot); a skill at 2+ consecutive failed weeks escalates the alert
+    # wording. Convergence never stops: the next slot always retries.
+    __gen_update_failure_streaks
     if __update_skills_scheduled_budget_exhausted; then
       log "EXHAUSTED: required-phase failures on the last scheduled slot for this week; the weekly skills update did not fully succeed this week"
       __update_skills_alert "Weekly skills update finished with $REQUIRED_FAILURES required-phase failure(s) and no scheduled slot remains this week. Check ~/.local/log/skills/."

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -669,14 +669,20 @@ refresh_app_owned_cua_pack() {
 # A dry run makes no filesystem writes, so it does not pre-create these dirs.
 [[ $DRYRUN == "--dry-run" ]] || mkdir -p "$STORE" "$CLAUDE" "$HERMES"
 
-# serialize: one run at a time. mkdir is atomic and system-shipped (macOS ships
-# neither flock(1) nor lockf(1)). We do NOT steal a lock by age: a long but
-# healthy run must never be killed, and age-stealing raced three writers in the
-# audit (the stale-steal removed a live newcomer's lock, then the first run's
-# unconditional trap removed the newcomer's). Instead the lock carries an owner
-# token (PID plus the process start time, a boot-stable discriminator so a
-# recycled PID cannot masquerade as the original owner), and is reclaimed ONLY
-# from a PROVABLY dead owner.
+# serialize: one run at a time. macOS ships no dependable rename-onto-existing
+# primitive from the shell (`mv` onto an existing dir moves INTO it, and macOS
+# ships neither flock(1) nor a lockf(1) we depend on), so acquisition builds a
+# STAGING lock dir with the owner token already inside it and publishes it via a
+# rename that is a single-winner move onto the FINAL path: if the final lockdir
+# is absent the staging dir renames onto it atomically (we win, token already
+# inside); if the final lockdir already exists `mv` drops our staging INSIDE it,
+# which we detect and clean up (we lost). This closes three defects the audit
+# found: (a) two contenders cannot both validate one dead token and both proceed
+# (reclaim is a single-winner move-aside); (b) a kill -0 success followed by a
+# failed/empty ps is NOT declared dead (only a successful ps proving absence or a
+# different start time is); (c) there is never a window where the lockdir exists
+# without its owner token, so an ownerless lock can only be a legacy/corrupt one
+# and is reclaimable, never a permanent wedge. We never steal by age.
 LOCK_OWNER_FILE="$LOCKDIR/owner"
 __update_skills_proc_start() {
   # normalized process start time for pid $1 (empty when the pid is gone)
@@ -684,38 +690,87 @@ __update_skills_proc_start() {
 }
 __update_skills_owner_token() { printf '%s\t%s' "$$" "$(__update_skills_proc_start "$$")"; }
 __update_skills_owner_alive() {
-  # $1 = recorded "PID<TAB>START". Alive iff the pid still exists (kill -0) AND
-  # its start time still matches (not recycled). Anything we cannot PROVE dead is
-  # treated as alive, so a contender never steals from a possibly-live run.
-  local rec="$1" rec_pid rec_start cur_start
+  # $1 = recorded "PID<TAB>START". PROVABLY dead requires positive confirmation;
+  # anything we cannot prove dead is treated as ALIVE so a contender never steals
+  # from a possibly-live run.
+  local rec="$1" rec_pid rec_start raw cur_start listing pid_line
   rec_pid="${rec%%$'\t'*}"
   rec_start="${rec#*$'\t'}"
   [[ $rec_pid =~ ^[0-9]+$ ]] || return 0                  # unparseable owner: do not steal
   [[ -n $rec_start && $rec_start != "$rec" ]] || return 0 # missing start field: do not steal
-  kill -0 "$rec_pid" 2>/dev/null || return 1              # no such process: dead
-  cur_start="$(__update_skills_proc_start "$rec_pid")"
-  [[ -z $cur_start ]] && return 1  # ps lookup empty: dead
-  [[ $cur_start == "$rec_start" ]] # start differs => pid recycled => original dead
-}
-if ! mkdir "$LOCKDIR" 2>/dev/null; then
-  lock_owner="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
-  if [[ -n $lock_owner ]] && ! __update_skills_owner_alive "$lock_owner"; then
-    log "reclaiming the lock from a dead owner ($lock_owner)"
-    rm -rf "$LOCKDIR"
-    if ! mkdir "$LOCKDIR" 2>/dev/null; then
-      log "another run took the lock while reclaiming; exiting"
-      exit 0
-    fi
-  else
-    log "another run in progress; exiting"
-    exit 0
+  if kill -0 "$rec_pid" 2>/dev/null; then
+    # The pid exists. Only a SUCCESSFUL ps that returns a DIFFERENT start time
+    # proves a recycle (original dead). A failed OR empty lstart lookup cannot
+    # prove death, so we treat it as alive (fixes defect b).
+    raw="$(ps -o lstart= -p "$rec_pid" 2>/dev/null)" || return 0
+    cur_start="$(printf '%s' "$raw" | tr -s ' ' | sed 's/^ *//;s/ *$//')"
+    [[ -n $cur_start ]] || return 0
+    [[ $cur_start == "$rec_start" ]] # same start => alive (0); differs => recycled => dead (1)
+    return
   fi
-fi
-# Record ownership immediately, then arm a trap that removes the lock ONLY while
-# we still own it: a later run that reclaims a dead lock rewrites the owner file,
-# and our trap must never delete a lock we no longer hold (the three-writer race).
+  # kill -0 failed (possibly dead, or EPERM for a foreign owner). Confirm with a
+  # full listing that exits 0 whether or not the pid is present; if ps ITSELF
+  # errors we cannot prove death, so treat as alive (fail safe).
+  listing="$(ps -ax -o pid= 2>/dev/null)" || return 0
+  while IFS= read -r pid_line; do
+    pid_line="${pid_line//[[:space:]]/}"
+    [[ $pid_line == "$rec_pid" ]] && return 0 # present after all: alive
+  done <<<"$listing"
+  return 1 # kill -0 failed AND ps ran and the pid is absent: provably dead
+}
+# Publish a fully-populated STAGING lock dir onto the final path. Return 0 iff we
+# won (LOCKDIR is now our staging, owner token inside); 1 if the lock was held
+# (mv dropped our staging inside it, or renaming onto a non-empty dir failed).
+__update_skills_publish_lock() {
+  local staging="$1" base
+  base="${staging##*/}"
+  if mv "$staging" "$LOCKDIR" 2>/dev/null; then
+    if [[ -d "$LOCKDIR/$base" ]]; then
+      rm -rf "${LOCKDIR:?}/${base:?}" # our staging was moved INSIDE a held lock: we lost
+      return 1
+    fi
+    return 0
+  fi
+  rm -rf "$staging"
+  return 1
+}
+# Move a stale lockdir aside to a unique name; the rename onto an absent target
+# is a single-winner move, so exactly one reclaimer succeeds and then retries
+# acquisition. The moved-aside dir is discarded.
+__update_skills_reclaim_dead_lock() {
+  local aside="${LOCKDIR}.dead.$$.${RANDOM}"
+  if mv "$LOCKDIR" "$aside" 2>/dev/null; then
+    rm -rf "$aside"
+    return 0
+  fi
+  return 1
+}
 LOCK_MY_TOKEN="$(__update_skills_owner_token)"
-printf '%s' "$LOCK_MY_TOKEN" >"$LOCK_OWNER_FILE"
+__update_skills_acquire_lock() {
+  local staging owner
+  for _ in 1 2 3 4 5; do
+    staging="$(mktemp -d "${LOCKDIR}.stage.XXXXXX")" || return 1
+    printf '%s' "$LOCK_MY_TOKEN" >"$staging/owner"
+    __update_skills_publish_lock "$staging" && return 0
+    # The lock is held. Reclaim only from a dead or ownerless (legacy/corrupt)
+    # owner; a live owner means another run is genuinely in progress.
+    owner="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"
+    if [[ -z $owner ]] || ! __update_skills_owner_alive "$owner"; then
+      log "reclaiming the lock from a dead or ownerless owner (${owner:-<none>})"
+      __update_skills_reclaim_dead_lock || true # lost the move-aside: just retry
+      continue
+    fi
+    return 1 # held by a live owner
+  done
+  return 1
+}
+if ! __update_skills_acquire_lock; then
+  log "another run in progress; exiting"
+  exit 0
+fi
+# The EXIT trap removes the lock ONLY while we still own it: a later run that
+# reclaims a dead lock rewrites the owner file, and our trap must never delete a
+# lock we no longer hold (the three-writer race).
 __update_skills_release_lock() {
   local cur
   cur="$(cat "$LOCK_OWNER_FILE" 2>/dev/null || true)"

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -134,6 +134,46 @@ done
 
 log() { printf '[update-skills] %s\n' "$*"; }
 
+# Required-phase failure accounting. REQUIRED phases (npx/clawhub installs and
+# updates, hermes registry updates, Codex overlay re-assert, fan-out
+# convergence, superpowers routing assert) keep continue-on-failure behavior
+# WITHIN a run, but every failure is RECORDED here. ADVISORY phases (fork
+# drift-watch, the cua-driver pack refresh) only inform and are never recorded.
+# The weekly success stamp is written ONLY when zero required failures occurred,
+# so a transient failure leaves the stamp absent and a later Monday slot retries.
+REQUIRED_FAILURES=0
+record_required_failure() {
+  REQUIRED_FAILURES=$((REQUIRED_FAILURES + 1))
+  log "REQUIRED-FAILURE: $*"
+}
+
+# True when now is Monday at or after the last retry slot hour, i.e. no further
+# scheduled slot remains this week to retry a failed or deferred run. date +%u
+# is 1 for Monday; the hour is stripped of a leading zero so 08 is not read as
+# an invalid octal in the arithmetic compare.
+__update_skills_is_last_monday_slot() {
+  local dow hour
+  dow="$(date +%u)"
+  hour="$(date +%H)"
+  hour="${hour#0}"
+  [[ $dow == "1" ]] || return 1
+  [[ -n $hour ]] || hour=0
+  [[ $hour -ge $UPDATE_SKILLS_LAST_SLOT_HOUR ]]
+}
+
+# Loud alert on both channels the brief names: a local alerter notification and
+# a relay push. Best-effort; a missing tool or relay never fails the run.
+__update_skills_alert() {
+  local detail="$1"
+  if command -v alerter >/dev/null 2>&1; then
+    alerter --timeout 30 --title "update-skills" --message "$detail" --sound default >/dev/null 2>&1 || true
+  fi
+  local relay_script="$HOME/.local/bin/relay.sh"
+  if [[ -x $relay_script ]]; then
+    "$relay_script" --agent update-skills --state exhausted --project skills --detail "$detail" || true
+  fi
+}
+
 # idle-gate discriminator: is a LIVE interactive agent-harness session using the
 # store right now? Returns 0 (defer, never swap a skill out from under a live
 # session) for a live Claude Code / Codex / hermes session, 1 (proceed) when
@@ -303,8 +343,11 @@ converge_dir() {
           elif [[ -n $dry ]]; then
             log "converge: would replace $path (currently $current, desired $target)"
           else
-            ln -sfn "$target" "$path" # replace wrong-target / dangling updater-owned link
-            log "converge: replaced $path (was $current, now $target)"
+            if ln -sfn "$target" "$path"; then # replace wrong-target / dangling updater-owned link
+              log "converge: replaced $path (was $current, now $target)"
+            else
+              record_required_failure "converge could not replace $path"
+            fi
           fi
         else
           log "converge: WARN $path is a non-store symlink at a managed name; leaving it (resolve by hand)"
@@ -313,9 +356,10 @@ converge_dir() {
         : # a real dir/file (hub-owned or catalog) at this name, never overwrite
       elif [[ -n $dry ]]; then
         log "converge: would create $path -> $target"
-      else
-        ln -s "$target" "$path"
+      elif ln -s "$target" "$path"; then
         log "converge: created $path -> $target"
+      else
+        record_required_failure "converge could not create $path"
       fi
     done
   fi
@@ -339,9 +383,10 @@ converge_dir() {
       old_target="$(readlink "$path" 2>/dev/null || true)"
       if [[ -n $dry ]]; then
         log "converge: would remove stale $path (currently $old_target)"
-      else
-        rm -f "$path"
+      elif rm -f "$path"; then
         log "converge: removed stale $path (was $old_target)"
+      else
+        record_required_failure "converge could not remove stale $path"
       fi
     fi
   done
@@ -446,6 +491,7 @@ assert_superpowers_routing() {
   else
     printf '%s\n' "$routing_output"
     log "routing re-assert FAILED (continuing)"
+    record_required_failure "superpowers routing re-assert failed"
   fi
 }
 
@@ -480,13 +526,20 @@ assert_codex_overlays() {
       log "would assert codex overlay: $skill"
       continue
     fi
-    mkdir -p "$STORE/$skill/agents"
+    if ! mkdir -p "$STORE/$skill/agents"; then
+      record_required_failure "codex overlay dir for $skill could not be created"
+      continue
+    fi
     if [[ -f $overlay_file ]]; then
-      printf '\n%s\n' "$policy" >>"$overlay_file"
-      log "appended codex overlay policy to upstream openai.yaml: $skill"
-    else
-      printf '%s\n' "$policy" >"$overlay_file"
+      if printf '\n%s\n' "$policy" >>"$overlay_file"; then
+        log "appended codex overlay policy to upstream openai.yaml: $skill"
+      else
+        record_required_failure "codex overlay append for $skill failed"
+      fi
+    elif printf '%s\n' "$policy" >"$overlay_file"; then
       log "asserted codex overlay: $skill"
+    else
+      record_required_failure "codex overlay write for $skill failed"
     fi
   done < <(jq -r '.tiers // {} | to_entries[] | select(.value == "on-demand") | .key' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
 }
@@ -533,6 +586,7 @@ update_hermes_registry_skills() {
       if update_output="$(hermes -p "$profile" skills update "$lock_key" 2>&1)"; then
         if printf '%s\n' "$update_output" | grep -qiE 'blocked|refused'; then
           log "WARN: hermes $profile/$lock_key update was blocked/refused (continuing; never --force from automation)"
+          record_required_failure "hermes $profile/$lock_key update blocked/refused"
           printf '%s\n' "$update_output"
           if [[ -x $relay_script ]]; then
             "$relay_script" --agent update-skills --state hermes-blocked --project "$profile/$lock_key" \
@@ -543,6 +597,7 @@ update_hermes_registry_skills() {
         fi
       else
         log "WARN: hermes $profile/$lock_key update failed (continuing)"
+        record_required_failure "hermes $profile/$lock_key update failed"
         printf '%s\n' "$update_output"
         if [[ -x $relay_script ]]; then
           "$relay_script" --agent update-skills --state hermes-update-failed --project "$profile/$lock_key" \
@@ -665,13 +720,9 @@ fi
 # than failing silent.
 if [[ -z $INSTALL_ONLY ]] && [[ ${UPDATE_SKILLS_FORCE:-} != "1" ]] && [[ $DRYRUN != "--dry-run" ]] && __update_skills_harness_active; then
   log "a live harness session (claude/codex/hermes) is using the store, or the process table could not be read (fail-closed); deferring this run"
-  if [[ "$(date +%H)" == "$UPDATE_SKILLS_LAST_SLOT_HOUR" ]]; then
-    log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred — the weekly skills update did not run this week"
-    if command -v alerter >/dev/null 2>&1; then
-      alerter --timeout 30 --title "update-skills" \
-        --message "Weekly skills update deferred every Monday slot — an agent session was always active. Run it by hand when idle (~/.local/bin/update-skills.sh)." \
-        --sound default >/dev/null 2>&1 || true
-    fi
+  if __update_skills_is_last_monday_slot; then
+    log "EXHAUSTED: the last Monday retry slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00) still deferred; the weekly skills update did not run this week"
+    __update_skills_alert "Weekly skills update deferred on every Monday slot (an agent session was always active). Run it by hand when idle (~/.local/bin/update-skills.sh)."
   fi
   exit 0
 fi
@@ -701,9 +752,11 @@ install_npx_tracked() {
         log "installed: $skill from $repo" # fan-out is the convergence pass's job (below)
       else
         log "install $skill: npx add reported success but $STORE/$skill is absent (continuing)"
+        record_required_failure "npx install $skill produced no store dir"
       fi
     else
       log "install $skill: npx add failed ($repo) (continuing)"
+      record_required_failure "npx install $skill failed"
     fi
   done 3< <(jq -r '.npxTracked // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
 }
@@ -751,9 +804,11 @@ install_clawhub_tracked() {
         log "installed: $skill from $slug" # fan-out is the convergence pass's job (below)
       else
         log "install $skill: clawhub install reported success but produced no skill dir (continuing)"
+        record_required_failure "clawhub install $skill produced no store dir"
       fi
     else
       log "install $skill: clawhub install failed ($slug) (continuing)"
+      record_required_failure "clawhub install $skill failed"
     fi
     rm -rf "$tmp_workdir"
   done 3< <(jq -r '.clawhubTracked // {} | to_entries[]
@@ -795,6 +850,7 @@ update_clawhub_tracked() {
     rm -f "$STORE/$skill/.DS_Store"
     if ! update_output="$(clawhub --no-input --workdir "$AGENTS" --dir skills update "$skill" 2>&1)"; then
       log "WARN: clawhub update $skill failed (continuing)"
+      record_required_failure "clawhub update $skill failed"
       printf '%s\n' "$update_output"
       if [[ -x $relay_script ]]; then
         "$relay_script" --agent update-skills --state clawhub-update-failed --project "$skill" \
@@ -822,6 +878,7 @@ update_clawhub_tracked() {
       printf '%s\n' "$CODEX_POLICY" >"$overlay_file"
     fi
     log "WARN: clawhub $skill update refused over local changes (continuing; never --force from automation)"
+    record_required_failure "clawhub update $skill refused over local changes"
     printf '%s\n' "$update_output"
     if [[ -x $relay_script ]]; then
       "$relay_script" --agent update-skills --state clawhub-blocked --project "$skill" \
@@ -904,6 +961,13 @@ if [[ -n $INSTALL_ONLY ]]; then
   assert_codex_overlays
   assert_superpowers_routing
   log "done (install-only)${DRYRUN:+ (dry-run)}"
+  # Signal any required-phase failure to the caller (the first-install
+  # chezmoiscript keys its retry marker on this non-zero exit). A dry run only
+  # reports, so it never fails.
+  if [[ $DRYRUN != "--dry-run" && $REQUIRED_FAILURES -gt 0 ]]; then
+    log "install-only finished with $REQUIRED_FAILURES required-phase failure(s)"
+    exit 1
+  fi
   exit 0
 fi
 
@@ -912,7 +976,10 @@ if [[ $DRYRUN == "--dry-run" ]]; then
   log "would run: npx skills update --global"
 else
   log "npx skills update --global"
-  npx --yes skills@latest update --global -y 2>&1 | tr -d '\r' | tail -3 || log "npx update reported issues (continuing)"
+  if ! npx --yes skills@latest update --global -y 2>&1 | tr -d '\r' | tail -3; then
+    log "npx update reported issues (continuing)"
+    record_required_failure "npx skills update failed"
+  fi
 fi
 
 # 1b) refresh every clawhub-tracked store skill in place from its ClawHub
@@ -950,11 +1017,27 @@ update_hermes_registry_skills
 log "fork drift-check"
 check_fork_drift
 
-# record this week's success so the remaining Monday slots no-op — the run used
-# to defer forever with no stamp and no bounded retry budget (audit Fix 1)
+# Record this week's success ONLY when zero required phases failed. The stamp is
+# an ISO year-week key (date +%G-%V): %G is the ISO week-numbering YEAR and %V is
+# the ISO week (01-53), so the four Monday slots share one key and a slot no-ops
+# once one has fully succeeded this week. %G (not %Y) is what keeps a year-
+# boundary week correct: the days of ISO week 01 that fall in late December carry
+# the NEXT year's %G, and the late-December days of week 52/53 carry the current
+# %G, so the key never collides or splits across the boundary (52/53/01 verified).
+# When a required phase failed we WITHHOLD the stamp, so a later Monday slot
+# retries; and if no slot remains this Monday we alert (the retry budget is
+# spent). A dry run records nothing.
 if [[ $DRYRUN != "--dry-run" ]]; then
-  mkdir -p "$STATE_DIR"
-  date +%G-%V >"$SUCCESS_STAMP"
+  if [[ $REQUIRED_FAILURES -eq 0 ]]; then
+    mkdir -p "$STATE_DIR"
+    date +%G-%V >"$SUCCESS_STAMP"
+  else
+    log "WITHHOLDING the weekly success stamp: $REQUIRED_FAILURES required-phase failure(s) this run; a later Monday slot will retry"
+    if __update_skills_is_last_monday_slot; then
+      log "EXHAUSTED: required-phase failures on the last Monday slot (${UPDATE_SKILLS_LAST_SLOT_HOUR}:00); the weekly skills update did not fully succeed this week"
+      __update_skills_alert "Weekly skills update finished with $REQUIRED_FAILURES required-phase failure(s) and no Monday slot remains. Check ~/.local/log/skills/."
+    fi
+  fi
 fi
 
 log "done${DRYRUN:+ (dry-run)}"

--- a/test/fixtures/exchange-tool.lib.sh
+++ b/test/fixtures/exchange-tool.lib.sh
@@ -1,0 +1,28 @@
+# shellcheck shell=bash
+# exchange-tool.lib.sh: shared test helper that resolves the generation-exchange
+# tool the same way the updater does at run time. The host userland differs by
+# environment: a macOS host carries GNU mv as Homebrew's gmv (plain mv is BSD),
+# while the Nix devshell (what CI runs) provides GNU coreutils mv as plain mv
+# and has no /opt/homebrew. A candidate is accepted only when --version says
+# GNU coreutils AND a functional probe performs a real --exchange --no-copy -T
+# swap in a private temp dir. Prints the accepted tool name; returns 1 when no
+# capable tool exists on PATH.
+resolve_exchange_tool() {
+  local candidate probe
+  for candidate in ${UPDATE_SKILLS_GMV:+"$UPDATE_SKILLS_GMV"} gmv mv; do
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    "$candidate" --version 2>/dev/null | head -1 | grep -q 'GNU coreutils' || continue
+    probe="$(mktemp -d)" || return 1
+    mkdir -p "$probe/a" "$probe/b"
+    printf 'a' >"$probe/a/marker"
+    printf 'b' >"$probe/b/marker"
+    if "$candidate" --exchange --no-copy -T "$probe/a" "$probe/b" 2>/dev/null &&
+      [[ "$(cat "$probe/a/marker" 2>/dev/null)" == "b" ]]; then
+      rm -rf "$probe"
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    rm -rf "$probe"
+  done
+  return 1
+}

--- a/test/update-skills-competing-writer.sh
+++ b/test/update-skills-competing-writer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-competing-writer.sh — proves competing-writer drift is re-absorbed
+# update-skills-competing-writer.sh proves competing-writer drift is re-absorbed
 # (Wave 3a fix4 hostile test). A store link is replaced with a REAL DIR mid-state
 # (as the HyperFrames self-updater or an interrupted migration would leave it).
 # The next run detects it, re-absorbs its content into the candidate, and the
@@ -73,7 +73,9 @@ printf 'COMPETING-MARKER' >"$STORE/mover/competing.txt"
 # The full-run orchestration for the re-absorption path.
 __gen_recover
 recorded=""
-for n in "${GEN_REABSORB[@]:-}"; do [[ $n == mover ]] && recorded=1; done
+for n in "${GEN_REABSORB[@]:-}"; do
+  if [[ $n == mover ]]; then recorded=1; fi
+done
 [[ -n $recorded ]] || fail "recovery did not record the competing-writer real dir for re-absorption"
 
 id="$(__gen_new_id)"

--- a/test/update-skills-competing-writer.sh
+++ b/test/update-skills-competing-writer.sh
@@ -10,12 +10,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-competing-writer.sh
+++ b/test/update-skills-competing-writer.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# update-skills-competing-writer.sh — proves competing-writer drift is re-absorbed
+# (Wave 3a fix4 hostile test). A store link is replaced with a REAL DIR mid-state
+# (as the HyperFrames self-updater or an interrupted migration would leave it).
+# The next run detects it, re-absorbs its content into the candidate, and the
+# store returns to link topology with the content preserved (or refreshed).
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"tiers":{"mover":"core"},"npxTracked":{"mover":{"repo":"x/mover"}},"clawhubTracked":{}}
+EOF
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+# The npx stub refreshes SKILL.md but leaves any other files in place (a real
+# add does not purge sibling files), so an absorbed competing file survives.
+cat >"$stub/npx" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+mode=""; prev=""; skills=()
+for a in "$@"; do
+  case "$a" in add) mode=add ;; esac
+  [[ $prev == --skill ]] && skills+=("$a")
+  prev="$a"
+done
+if [[ $mode == add ]]; then
+  for s in "${skills[@]}"; do
+    mkdir -p "$HOME/.agents/skills/$s"
+    printf -- '---\nname: %s\n---\n# refreshed\n' "$s" >"$HOME/.agents/skills/$s/SKILL.md"
+  done
+fi
+STUB
+chmod +x "$stub/npx"
+export PATH="$stub:$PATH"
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# Seed a published generation with mover as a store symlink.
+mkdir -p "$SKILLS_CURRENT/skills/mover"
+printf -- '---\nname: mover\n---\n# original\n' >"$SKILLS_CURRENT/skills/mover/SKILL.md"
+printf '{}' >"$SKILLS_CURRENT/.skill-lock.json"
+__gen_write_meta "$SKILLS_CURRENT" "live-1-1"
+__gen_plant_store_link mover
+__gen_plant_lock_link
+[[ -L "$STORE/mover" ]] || fail "precondition: store/mover should be a symlink"
+
+# A competing writer replaces the store link with a REAL DIR carrying updated
+# content plus a unique marker file.
+rm -f "$STORE/mover"
+mkdir -p "$STORE/mover"
+printf -- '---\nname: mover\n---\n# COMPETING WRITER version\n' >"$STORE/mover/SKILL.md"
+printf 'COMPETING-MARKER' >"$STORE/mover/competing.txt"
+
+# The full-run orchestration for the re-absorption path.
+__gen_recover
+recorded=""
+for n in "${GEN_REABSORB[@]:-}"; do [[ $n == mover ]] && recorded=1; done
+[[ -n $recorded ]] || fail "recovery did not record the competing-writer real dir for re-absorption"
+
+id="$(__gen_new_id)"
+__gen_build_candidate "$id" || fail "candidate build failed"
+# The candidate must have absorbed the competing writer's content BEFORE the lanes.
+[[ -f "$GEN_CANDIDATE_AGENTS/skills/mover/competing.txt" ]] ||
+  fail "the candidate did not absorb the competing-writer content"
+__gen_run_lanes "$GEN_CANDIDATE_HOME" "$id" >/dev/null 2>&1 || fail "lanes failed"
+__gen_validate_candidate "$GEN_CANDIDATE_AGENTS" || fail "candidate failed validation"
+__gen_publish "$GEN_CANDIDATE_AGENTS" || fail "publish failed"
+# Post-publish: reconcile the re-absorbed store name back to link topology.
+for n in "${GEN_REABSORB[@]:-}"; do __gen_absorb_store_link "$n"; done
+
+# The store is back to a link that resolves, and the absorbed content survived.
+[[ -L "$STORE/mover" ]] || fail "store/mover did not return to link topology after re-absorption"
+[[ "$(readlink "$STORE/mover")" == "../.skills-current/skills/mover" ]] ||
+  fail "store/mover points at the wrong target after re-absorption"
+[[ -f "$STORE/mover/SKILL.md" ]] || fail "store/mover does not resolve to a skill"
+[[ "$(cat "$STORE/mover/competing.txt" 2>/dev/null)" == "COMPETING-MARKER" ]] ||
+  fail "the competing-writer content was lost (not preserved through re-absorption)"
+
+echo "update-skills-competing-writer: OK"

--- a/test/update-skills-converge.sh
+++ b/test/update-skills-converge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-converge.sh — the symlink fan-out must CONVERGE each managed dir
+# update-skills-converge.sh, the symlink fan-out must CONVERGE each managed dir
 # to the lock's desired set, not just add missing links. The additive
 # `[[ -e ]] || ln -s` left stale links behind, never fixed a wrong target, and
 # crashed on a DANGLING link (`[[ -e ]]` is false for it, so `ln -s` then failed
@@ -17,7 +17,7 @@
 #   * NEVER touch a real directory (hub-owned registry dir, catalog), a
 #     non-store symlink, or anything in a profile the lock does not map.
 # "updater-owned" = a symlink whose literal target points under ~/.agents/skills
-# (works for dangling links too — the string still points there).
+# (works for dangling links too, the string still points there).
 #
 # The real script runs unmodified in a sandbox: FORCE bypasses the idle-gate and
 # the weekly stamp, offline stubs neutralize the network passes, and the FULL run
@@ -52,7 +52,7 @@ for s in keeper mover revived demoted humanizer dualname; do
 done
 
 # Fixture lock. humanizer is a catalog-collision name mapped to default ON
-# PURPOSE — convergence must still refuse to create it hermes-side and must
+# PURPOSE, convergence must still refuse to create it hermes-side and must
 # remove a stale one. dualname is hermes-OWNED (hermesProfiles [] + a
 # hermesRegistry entry): hermes keeps a real hub dir of that name, untouchable.
 cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
@@ -86,14 +86,14 @@ ln -s "../../.agents/skills/keeper" "$CLAUDE/keeper"
 ln -s "../../.agents/skills/gone" "$CLAUDE/gone" # stale: gone not in store
 
 # Hermes default drift:
-#   keeper   — absent            → created (missing)
-#   mover    — wrong target      → replaced
-#   revived  — DANGLING target   → replaced (the old ln -s crashed here)
-#   demoted  — correct target but hermesProfiles [] → removed (stale)
-#   humanizer— collision name    → removed, never re-created
-#   dualname — REAL hub dir      → untouched
-#   external — non-store symlink  → untouched
-#   hermes-superpowers — real dir → untouched
+#   keeper, absent            → created (missing)
+#   mover, wrong target      → replaced
+#   revived, DANGLING target   → replaced (the old ln -s crashed here)
+#   demoted, correct target but hermesProfiles [] → removed (stale)
+#   humanizer, collision name    → removed, never re-created
+#   dualname, REAL hub dir      → untouched
+#   external, non-store symlink  → untouched
+#   hermes-superpowers, real dir → untouched
 ln -s "../../.agents/skills/WRONGTARGET" "$HERMES/mover"
 ln -s "../../.agents/skills/revived-old" "$HERMES/revived" # dangling (revived-old absent)
 ln -s "../../.agents/skills/demoted" "$HERMES/demoted"

--- a/test/update-skills-converge.sh
+++ b/test/update-skills-converge.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# update-skills-converge.sh — the symlink fan-out must CONVERGE each managed dir
+# to the lock's desired set, not just add missing links. The additive
+# `[[ -e ]] || ln -s` left stale links behind, never fixed a wrong target, and
+# crashed on a DANGLING link (`[[ -e ]]` is false for it, so `ln -s` then failed
+# on the existing name). The audit found 29 store links vs 13 declared in the
+# hermes default profile.
+#
+# Desired set (from the lock): Claude = the full store roster; each hermes
+# profile = exactly its hermesProfiles entries, minus the catalog-collision
+# names (humanizer, hyperframes) which hermes serves from its own catalog and
+# which must NEVER be symlinked from the store. Convergence per managed dir:
+#   * create a missing desired link;
+#   * REPLACE an updater-owned link whose target differs (wrong-target, incl.
+#     dangling);
+#   * REMOVE an updater-owned link no longer desired (stale);
+#   * NEVER touch a real directory (hub-owned registry dir, catalog), a
+#     non-store symlink, or anything in a profile the lock does not map.
+# "updater-owned" = a symlink whose literal target points under ~/.agents/skills
+# (works for dangling links too — the string still points there).
+#
+# The real script runs unmodified in a sandbox: FORCE bypasses the idle-gate,
+# --install-only runs the install passes (no-op here — empty npx/clawhub tables)
+# then the fan-out convergence.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+STORE="$HOME/.agents/skills"
+CLAUDE="$HOME/.claude/skills"
+HERMES="$HOME/.hermes/skills"
+mkdir -p "$STORE" "$CLAUDE" "$HERMES"
+
+# Fixture store: six real skill dirs.
+for s in keeper mover revived demoted humanizer dualname; do
+  mkdir -p "$STORE/$s"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "$s" >"$STORE/$s/SKILL.md"
+done
+
+# Fixture lock. humanizer is a catalog-collision name mapped to default ON
+# PURPOSE — convergence must still refuse to create it hermes-side and must
+# remove a stale one. dualname is hermes-OWNED (hermesProfiles [] + a
+# hermesRegistry entry): hermes keeps a real hub dir of that name, untouchable.
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {
+    "keeper": "core", "mover": "core", "revived": "core",
+    "demoted": "core", "humanizer": "core", "dualname": "on-demand"
+  },
+  "hermesProfiles": {
+    "keeper": ["default"],
+    "mover": ["default"],
+    "revived": ["default"],
+    "demoted": [],
+    "humanizer": ["default"],
+    "dualname": []
+  },
+  "hermesRegistry": {
+    "dualname": {"profiles": ["default"], "source": "clawhub", "identifier": "clawhub/dualname", "lockKey": "dualname"}
+  },
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+# ── Pre-existing drift ─────────────────────────────────────────────────────
+# Claude: one correct link (kept), one stale updater-owned link to a skill that
+# left the store (removed). Every other store skill is missing (created).
+ln -s "../../.agents/skills/keeper" "$CLAUDE/keeper"
+ln -s "../../.agents/skills/gone" "$CLAUDE/gone" # stale: gone not in store
+
+# Hermes default drift:
+#   keeper   — absent            → created (missing)
+#   mover    — wrong target      → replaced
+#   revived  — DANGLING target   → replaced (the old ln -s crashed here)
+#   demoted  — correct target but hermesProfiles [] → removed (stale)
+#   humanizer— collision name    → removed, never re-created
+#   dualname — REAL hub dir      → untouched
+#   external — non-store symlink  → untouched
+#   hermes-superpowers — real dir → untouched
+ln -s "../../.agents/skills/WRONGTARGET" "$HERMES/mover"
+ln -s "../../.agents/skills/revived-old" "$HERMES/revived" # dangling (revived-old absent)
+ln -s "../../.agents/skills/demoted" "$HERMES/demoted"
+ln -s "../../.agents/skills/humanizer" "$HERMES/humanizer"
+mkdir -p "$HERMES/dualname"
+printf -- '---\nname: dualname\ndescription: hub-owned\n---\n' >"$HERMES/dualname/SKILL.md"
+ln -s "/tmp/external-target" "$HERMES/external"
+mkdir -p "$HERMES/hermes-superpowers"
+printf 'mirror\n' >"$HERMES/hermes-superpowers/marker"
+
+# ── RED gate: capture whether the current script even survives the dangling
+#    link. It is informational; the assertions below are the contract.
+run() { UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only 2>&1; }
+output="$(run)" || fail "update-skills --install-only exited non-zero (a dangling link must not crash the fan-out): $output"
+
+# ── Claude convergence ─────────────────────────────────────────────────────
+for s in keeper mover revived demoted humanizer dualname; do
+  [[ -L "$CLAUDE/$s" ]] || fail "Claude link missing for store skill: $s"
+  [[ "$(readlink "$CLAUDE/$s")" == "../../.agents/skills/$s" ]] ||
+    fail "Claude link for $s has wrong target: $(readlink "$CLAUDE/$s")"
+done
+[[ ! -e "$CLAUDE/gone" && ! -L "$CLAUDE/gone" ]] ||
+  fail "stale updater-owned Claude link 'gone' was not removed"
+
+# ── Hermes default convergence ─────────────────────────────────────────────
+# created (was missing)
+[[ -L "$HERMES/keeper" && "$(readlink "$HERMES/keeper")" == "../../.agents/skills/keeper" ]] ||
+  fail "hermes 'keeper' link was not created with the right target"
+# replaced (wrong target)
+[[ -L "$HERMES/mover" && "$(readlink "$HERMES/mover")" == "../../.agents/skills/mover" ]] ||
+  fail "hermes 'mover' wrong-target link was not replaced: $(readlink "$HERMES/mover" 2>/dev/null)"
+# replaced (dangling) and now resolves
+[[ -L "$HERMES/revived" && "$(readlink "$HERMES/revived")" == "../../.agents/skills/revived" ]] ||
+  fail "hermes 'revived' dangling link was not replaced: $(readlink "$HERMES/revived" 2>/dev/null)"
+[[ -e "$HERMES/revived/SKILL.md" ]] || fail "hermes 'revived' link does not resolve after convergence"
+# removed (stale updater-owned, no longer desired)
+[[ ! -e "$HERMES/demoted" && ! -L "$HERMES/demoted" ]] ||
+  fail "stale updater-owned hermes link 'demoted' (hermesProfiles []) was not removed"
+# removed (collision name), never re-created
+[[ ! -e "$HERMES/humanizer" && ! -L "$HERMES/humanizer" ]] ||
+  fail "collision-name hermes link 'humanizer' was not removed / was re-created"
+# untouched: hub-owned real dir
+[[ -d "$HERMES/dualname" && ! -L "$HERMES/dualname" ]] ||
+  fail "hub-owned real dir 'dualname' was altered by convergence"
+[[ -e "$HERMES/dualname/SKILL.md" ]] || fail "hub-owned 'dualname' content was disturbed"
+# untouched: non-store symlink
+[[ -L "$HERMES/external" && "$(readlink "$HERMES/external")" == "/tmp/external-target" ]] ||
+  fail "non-store symlink 'external' was altered by convergence"
+# untouched: real mirror dir
+[[ -d "$HERMES/hermes-superpowers" && -e "$HERMES/hermes-superpowers/marker" ]] ||
+  fail "the hermes-superpowers mirror dir was disturbed by convergence"
+
+# ── Idempotence: a second run changes nothing and stays quiet about convergence.
+second="$(run)" || fail "second --install-only run exited non-zero: $second"
+if printf '%s\n' "$second" | grep -qiE 'converge: (created|replaced|removed)'; then
+  fail "a no-op convergence run still logged create/replace/remove actions: $second"
+fi
+
+echo "update-skills-converge: OK"

--- a/test/update-skills-converge.sh
+++ b/test/update-skills-converge.sh
@@ -19,9 +19,10 @@
 # "updater-owned" = a symlink whose literal target points under ~/.agents/skills
 # (works for dangling links too — the string still points there).
 #
-# The real script runs unmodified in a sandbox: FORCE bypasses the idle-gate,
-# --install-only runs the install passes (no-op here — empty npx/clawhub tables)
-# then the fan-out convergence.
+# The real script runs unmodified in a sandbox: FORCE bypasses the idle-gate and
+# the weekly stamp, offline stubs neutralize the network passes, and the FULL run
+# exercises destructive convergence (replace/remove), which the additive
+# --install-only bootstrap deliberately never does.
 set -euo pipefail
 
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
@@ -103,10 +104,24 @@ ln -s "/tmp/external-target" "$HERMES/external"
 mkdir -p "$HERMES/hermes-superpowers"
 printf 'mirror\n' >"$HERMES/hermes-superpowers/marker"
 
+# Destructive reconciliation (replace wrong-target links, remove stale ones)
+# runs only on the FULL weekly path, never under the additive --install-only
+# bootstrap, so this test exercises a FULL run. Offline stubs stand in for the
+# network passes a full run would otherwise make (npx update; the hermes
+# registry phase for the dualname hub entry). FORCE bypasses the idle-gate and
+# the weekly stamp, so the second (idempotence) run reconverges instead of
+# early-exiting on the stamp.
+stub_dir="$tmp/stubs"
+mkdir -p "$stub_dir"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub_dir/npx"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub_dir/hermes"
+chmod +x "$stub_dir"/*
+export PATH="$stub_dir:$PATH"
+
 # ── RED gate: capture whether the current script even survives the dangling
 #    link. It is informational; the assertions below are the contract.
-run() { UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only 2>&1; }
-output="$(run)" || fail "update-skills --install-only exited non-zero (a dangling link must not crash the fan-out): $output"
+run() { UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1; }
+output="$(run)" || fail "update-skills full run exited non-zero (a dangling link must not crash the fan-out): $output"
 
 # ── Claude convergence ─────────────────────────────────────────────────────
 for s in keeper mover revived demoted humanizer dualname; do

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-defer.sh — the weekly idle-gate must distinguish a LIVE
+# update-skills-defer.sh, the weekly idle-gate must distinguish a LIVE
 # interactive agent-harness session (defer, never swap skills under a live
 # session) from a persistent BACKGROUND daemon (proceed, a daemon never loads a
 # skill from the store on its own, so blocking on it defers the weekly run
@@ -7,12 +7,12 @@
 # its flags-position token, never on free prompt text.
 #
 # Ground truth (dresden, read-only ps, 2026-07-10):
-#   DAEMONS — must NOT block the run (proceed):
+#   DAEMONS, must NOT block the run (proceed):
 #     python -m hermes_cli.main gateway run --replace        (hermes gateway)
 #     .../claude --remote-control                            (Remote Control bridge)
 #     .../claude --bg-spare | daemon run | --bg-pty-host     (Claude bg helpers)
 #     codex app-server [--analytics-default-enabled]         (Codex app server)
-#   LIVE SESSIONS — must block the run (defer):
+#   LIVE SESSIONS, must block the run (defer):
 #     .../python .../bin/hermes -c <prompt>                  (hermes console-script session)
 #     /opt/homebrew/bin/claude -p <prompt>                   (a Claude one-shot)
 #     codex resume <id> | plain codex                        (a Codex CLI session)
@@ -24,7 +24,7 @@
 # substring-matched as a daemon and let a live session proceed. The new gate
 # also fails CLOSED when ps cannot be read.
 #
-# The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE — that
+# The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE, that
 # bypasses the gate). PATH shims present a controllable process world (ps, which
 # can also simulate a read failure), record alerter invocations, and pin the
 # clock (date) so the "last retry slot" branch is deterministic. A minimal lock
@@ -32,7 +32,7 @@
 # runs clean to its final `[update-skills] done`.
 set -euo pipefail
 
-# git hooks (this runs under pre-commit) leak GIT_DIR/GIT_INDEX_FILE — unset so
+# git hooks (this runs under pre-commit) leak GIT_DIR/GIT_INDEX_FILE, unset so
 # no child git command reaches the outer repo.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
@@ -72,7 +72,7 @@ NPX_LOG="$tmp/npx.log"
 : >"$ALERTER_LOG"
 
 # ps stub: prints the simulated process world ($FAKE_PS), or simulates a read
-# failure (exit non-zero) when FAKE_PS_FAIL is set — the gate must fail closed.
+# failure (exit non-zero) when FAKE_PS_FAIL is set, the gate must fail closed.
 cat >"$stub_dir/ps" <<'EOF'
 #!/usr/bin/env bash
 if [[ -n ${FAKE_PS_FAIL:-} ]]; then
@@ -112,7 +112,7 @@ chmod +x "$stub_dir"/*
 export PATH="$stub_dir:$PATH"
 export FAKE_WEEK="2026-28"
 
-# run_gate <fake_ps> [fake_hour] [fake_ps_fail] — reset per-run state, run the
+# run_gate <fake_ps> [fake_hour] [fake_ps_fail], reset per-run state, run the
 # real script with the given world, capture combined output. No FORCE: the gate
 # is under test.
 GATE_OUTPUT=""
@@ -129,7 +129,7 @@ deferred() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'deferring'; }
 early_exited() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'already succeeded'; }
 alerted() { [[ -s $ALERTER_LOG ]]; }
 
-# argv fixtures — real dresden shapes.
+# argv fixtures, real dresden shapes.
 HERMES_GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace'
 HERMES_SESSION='/Users/x/.hermes/hermes-agent/venv/bin/python /Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
 CLAUDE_REMOTE='/opt/homebrew/bin/claude --remote-control'
@@ -147,13 +147,13 @@ UNRELATED_PYTHON='/usr/bin/python3 /usr/local/bin/some-tool.py --flag'
 #    -c, not the gateway daemon shape). This is hole (a).
 run_gate "$HERMES_SESSION"
 deferred || fail "python-console hermes session did not defer (hole a): $GATE_OUTPUT"
-proceeded && fail "python-console hermes session proceeded — a live session must defer: $GATE_OUTPUT"
+proceeded && fail "python-console hermes session proceeded, a live session must defer: $GATE_OUTPUT"
 
 # 2) hermes gateway (python -m hermes_cli.main gateway) → PROCEED (module maps
 #    to hermes, flags token is exactly `gateway`).
 run_gate "$HERMES_GATEWAY"
 proceeded || fail "hermes gateway daemon did not proceed: $GATE_OUTPUT"
-deferred && fail "hermes gateway daemon deferred — a daemon must not block: $GATE_OUTPUT"
+deferred && fail "hermes gateway daemon deferred, a daemon must not block: $GATE_OUTPUT"
 
 # 3) claude -p with the daemon phrase in the PROMPT free text → DEFER (the
 #    flags-position token is -p; free text is never matched). This is hole (b).
@@ -189,7 +189,7 @@ proceeded || fail "unrelated python process did not proceed: $GATE_OUTPUT"
 #     app-server) → PROCEEDS. None is a live session.
 run_gate "$(printf '%s\n%s\n%s\n%s\n%s' "$HERMES_GATEWAY" "$CLAUDE_REMOTE" "$CLAUDE_BG" "$CLAUDE_DAEMON" "$CODEX_SERVER")"
 proceeded || fail "daemons-only world did not proceed: $GATE_OUTPUT"
-deferred && fail "daemons-only world deferred — background daemons must not block the run: $GATE_OUTPUT"
+deferred && fail "daemons-only world deferred, background daemons must not block the run: $GATE_OUTPUT"
 
 # 8c) A live session hiding among daemons → DEFER.
 run_gate "$(printf '%s\n%s' "$CODEX_SERVER" "$CODEX_SESSION")" 04
@@ -199,7 +199,7 @@ deferred || fail "a live codex session among daemons did not defer: $GATE_OUTPUT
 # 2) A non-last slot deferral must NOT fire the LOUD alert.
 run_gate "$CODEX_PLAIN" 04
 deferred || fail "interactive session did not defer: $GATE_OUTPUT"
-alerted && fail "a non-last slot (04:00) fired the LOUD alert — only the last slot should: $(cat "$ALERTER_LOG")"
+alerted && fail "a non-last slot (04:00) fired the LOUD alert, only the last slot should: $(cat "$ALERTER_LOG")"
 
 # 3) Weekly success stamp present → EARLY-EXIT before any work.
 mkdir -p "$HOME/.local/state/update-skills"

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -103,17 +103,21 @@ chmod +x "$stub_dir"/*
 export PATH="$stub_dir:$PATH"
 export FAKE_WEEK="2026-28"
 
-# run_gate <fake_ps> [fake_hour] [fake_ps_fail], reset per-run state, run the
-# real script with the given world, capture combined output. No FORCE: the gate
-# is under test.
+# run_gate <fake_ps> [fake_hour] [fake_ps_fail] [fake_dow] [sched], reset per-run
+# state, run the real script with the given world, capture combined output. No
+# FORCE: the gate is under test. The 5th arg, when "--scheduled", marks the run
+# as a LaunchAgent (scheduled) run; otherwise the run is manual.
 GATE_OUTPUT=""
 run_gate() {
-  local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}" fake_dow="${4:-1}"
+  local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}" fake_dow="${4:-1}" sched="${5:-}"
+  local -a run_args=()
+  [[ $sched == "--scheduled" ]] && run_args=(--scheduled)
   rm -rf "$HOME/.local/state"
   : >"$ALERTER_LOG"
-  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" FAKE_PS_FAIL="$fake_ps_fail" FAKE_DOW="$fake_dow" bash "$SCRIPT" 2>&1)" ||
+  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" FAKE_PS_FAIL="$fake_ps_fail" FAKE_DOW="$fake_dow" bash "$SCRIPT" "${run_args[@]}" 2>&1)" ||
     fail "script exited non-zero (gate should always exit 0): $GATE_OUTPUT"
 }
+run_gate_sched() { run_gate "$1" "${2:-04}" "${3:-}" "${4:-1}" --scheduled; }
 
 proceeded() { printf '%s\n' "$GATE_OUTPUT" | grep -qF '[update-skills] done'; }
 deferred() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'deferring'; }
@@ -198,24 +202,46 @@ run_gate "$UNRELATED_PYTHON" 04
 [[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
   fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
 
-# 4) Last retry slot (Monday 16:00) still deferring → LOUD alerter notification +
-#    log line (the weekly budget is exhausted).
-run_gate "$CODEX_PLAIN" 16 "" 1
-deferred || fail "last-slot world did not defer: $GATE_OUTPUT"
-alerted || fail "last slot (Monday 16:00) deferral did not fire the LOUD alerter notification: (empty log)"
-grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||
-  fail "last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
+# ── Item 6: slot-aware exhaustion via the --scheduled marker ─────────────────
+# Exhaustion is claimed ONLY for a SCHEDULED run with no later slot remaining
+# this week; a manual run never claims scheduled-budget exhaustion.
 
-# 4b) Same hour (16:00) but NOT Monday (a manual run on another day) → DEFERS but
-#     does NOT claim exhaustion (no future slot to reason about; slot-aware).
+# 4) SCHEDULED last Monday slot (16:00) still deferring → LOUD alert + log line.
+run_gate_sched "$CODEX_PLAIN" 16 "" 1
+deferred || fail "scheduled last-slot world did not defer: $GATE_OUTPUT"
+alerted || fail "a scheduled last slot (Monday 16:00) deferral did not fire the LOUD alerter notification"
+grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||
+  fail "scheduled last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
+[[ -f "$HOME/.local/state/update-skills/last-scheduled-week" ]] ||
+  fail "a scheduled run did not record its ISO week in the scheduled-attempt state file"
+
+# 4a) SCHEDULED EARLY Monday slot (04:00) deferring → NO alert (later slots remain).
+run_gate_sched "$CODEX_PLAIN" 04 "" 1
+deferred || fail "scheduled early-slot world did not defer: $GATE_OUTPUT"
+alerted && fail "an early scheduled slot (04:00) claimed exhaustion; later slots remain: $(cat "$ALERTER_LOG")"
+
+# 4b) SCHEDULED coalesced catch-up on a LATER weekday (Wed 10:00) → alert (the
+#     Monday slots are spent; launchd delivered the missed event late).
+run_gate_sched "$CODEX_PLAIN" 10 "" 3
+deferred || fail "scheduled catch-up world did not defer: $GATE_OUTPUT"
+alerted || fail "a scheduled catch-up on a later day did not claim exhaustion (no later slot this week): $GATE_OUTPUT"
+
+# 4c) MANUAL run on Monday 16:00 → DEFERS but NEVER claims scheduled-budget
+#     exhaustion (a manual run is not part of the scheduled cycle).
+run_gate "$CODEX_PLAIN" 16 "" 1
+deferred || fail "manual Monday-16:00 world did not defer: $GATE_OUTPUT"
+alerted && fail "a manual Monday-16:00 run claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
+
+# 4d) MANUAL non-Monday run → DEFERS, no alert (unchanged).
 run_gate "$CODEX_PLAIN" 16 "" 3
-deferred || fail "non-Monday 16:00 world did not defer: $GATE_OUTPUT"
-alerted && fail "a non-Monday 16:00 deferral fired the exhaustion alert (slot-awareness lost): $(cat "$ALERTER_LOG")"
+deferred || fail "manual non-Monday world did not defer: $GATE_OUTPUT"
+alerted && fail "a manual non-Monday deferral alerted: $(cat "$ALERTER_LOG")"
 
 # 5) The plist declares EXACTLY four Monday retry slots, each a full
-#    {Weekday=1, Hour in 4/8/12/16, Minute=0} tuple. Parse the rendered plist as
-#    real plist data (plutil -> json -> jq) so dropping Weekday or Minute (which
-#    launchd then treats as a wildcard, firing far more often) fails this test.
+#    {Weekday=1, Hour in 4/8/12/16, Minute=0} tuple, AND passes --scheduled in
+#    ProgramArguments. Parse the rendered plist as real plist data (plutil ->
+#    json -> jq) so dropping Weekday or Minute (which launchd then treats as a
+#    wildcard, firing far more often) fails this test.
 PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl"
 rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
   fail "chezmoi execute-template failed on the update-skills plist"
@@ -231,5 +257,8 @@ non_conforming="$(jq '[.StartCalendarInterval[] | select(.Weekday != 1 or .Minut
 slot_hours="$(jq -c '[.StartCalendarInterval[].Hour] | sort' "$plist_json")"
 [[ $slot_hours == "[4,8,12,16]" ]] ||
   fail "slot hours are not exactly 4/8/12/16: $slot_hours"
+prog_scheduled="$(jq -r '[.ProgramArguments[] | select(. == "--scheduled")] | length' "$plist_json")"
+[[ $prog_scheduled == "1" ]] ||
+  fail "the plist ProgramArguments does not pass exactly one --scheduled marker (slot-aware exhaustion needs it)"
 
 echo "update-skills-defer: OK"

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -1,29 +1,32 @@
 #!/usr/bin/env bash
-# update-skills-defer.sh — the weekly idle-gate must distinguish an ACTIVE agent
-# harness session (defer — never swap skills under a live session) from a
-# persistent BACKGROUND daemon (proceed — a daemon never loads a skill from the
-# store on its own, so blocking on it defers the weekly run forever).
+# update-skills-defer.sh — the weekly idle-gate must distinguish a LIVE
+# interactive agent-harness session (defer, never swap skills under a live
+# session) from a persistent BACKGROUND daemon (proceed, a daemon never loads a
+# skill from the store on its own, so blocking on it defers the weekly run
+# forever). The discriminator keys strictly on the argv EFFECTIVE program and
+# its flags-position token, never on free prompt text.
 #
 # Ground truth (dresden, read-only ps, 2026-07-10):
-#   DAEMONS — must NOT block the run:
+#   DAEMONS — must NOT block the run (proceed):
 #     python -m hermes_cli.main gateway run --replace        (hermes gateway)
+#     .../claude --remote-control                            (Remote Control bridge)
 #     .../claude --bg-spare | daemon run | --bg-pty-host     (Claude bg helpers)
 #     codex app-server [--analytics-default-enabled]         (Codex app server)
-#   INTERACTIVE SESSIONS — must block the run:
-#     /opt/homebrew/bin/claude --remote-control              (a Claude Code TUI)
-#     codex resume <id>                                      (a Codex CLI session)
-#     .../hermes -c <prompt> | hermes -p <profile>           (an interactive hermes run)
+#   LIVE SESSIONS — must block the run (defer):
+#     .../python .../bin/hermes -c <prompt>                  (hermes console-script session)
+#     /opt/homebrew/bin/claude -p <prompt>                   (a Claude one-shot)
+#     codex resume <id> | plain codex                        (a Codex CLI session)
 #
-# NOTE on the brief's premise: on this machine `pgrep -x hermes` matches NOTHING
-# (the gateway's comm is `python`, not `hermes`); the real persistent matcher of
-# the OLD gate is `claude --remote-control` bridges that linger for days. The
-# defect (defer-forever) is real regardless of which harness triggers it, and
-# the stub world below models the pre-fix gate's view (`pgrep -x hermes` matching
-# the gateway) so the RED is meaningful against the shipped script.
+# Two holes the pre-fix gate had, both covered below: (a) a hermes session's
+# argv starts with `python` (console script), so the old first-word gate never
+# saw it as an agent and swapped skills under it; (b) prompt free text that
+# merely CONTAINS a daemon phrase (`claude -p "restart the hermes gateway"`) was
+# substring-matched as a daemon and let a live session proceed. The new gate
+# also fails CLOSED when ps cannot be read.
 #
 # The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE — that
-# bypasses the gate). PATH shims present a controllable process world (ps),
-# replicate the pre-fix gate (pgrep), record alerter invocations, and pin the
+# bypasses the gate). PATH shims present a controllable process world (ps, which
+# can also simulate a read failure), record alerter invocations, and pin the
 # clock (date) so the "last retry slot" branch is deterministic. A minimal lock
 # with empty tables makes every network pass a no-op, so a proceeding full run
 # runs clean to its final `[update-skills] done`.
@@ -68,25 +71,15 @@ ALERTER_LOG="$tmp/alerter.log"
 NPX_LOG="$tmp/npx.log"
 : >"$ALERTER_LOG"
 
-# ps stub: prints the simulated process world ($FAKE_PS), whatever flags it gets.
+# ps stub: prints the simulated process world ($FAKE_PS), or simulates a read
+# failure (exit non-zero) when FAKE_PS_FAIL is set — the gate must fail closed.
 cat >"$stub_dir/ps" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n ${FAKE_PS_FAIL:-} ]]; then
+  echo "ps: simulated read failure" >&2
+  exit 1
+fi
 printf '%s\n' "${FAKE_PS:-}"
-EOF
-
-# pgrep stub: models the PRE-FIX gate. `-x hermes` matches the persistent gateway
-# (the defer-forever bug the audit found); `-x claude`/`-x codex` match only when
-# an interactive line for that harness is present in $FAKE_PS.
-cat >"$stub_dir/pgrep" <<'EOF'
-#!/usr/bin/env bash
-pat=""
-for a in "$@"; do case "$a" in -*) ;; *) pat="$a" ;; esac; done
-case "$pat" in
-  hermes) printf '%s\n' "${FAKE_PS:-}" | grep -q 'hermes' && exit 0 ;;
-  claude) printf '%s\n' "${FAKE_PS:-}" | grep -Eq '(^|/| )claude( |$)' && exit 0 ;;
-  codex) printf '%s\n' "${FAKE_PS:-}" | grep -Eq '(^|/| )codex( |$)' && exit 0 ;;
-esac
-exit 1
 EOF
 
 # alerter stub: record every invocation so the "last slot" LOUD-alert path is
@@ -118,14 +111,15 @@ chmod +x "$stub_dir"/*
 export PATH="$stub_dir:$PATH"
 export FAKE_WEEK="2026-28"
 
-# run_gate <fake_ps> <fake_hour> — reset per-run state, run the real script with
-# the given world, capture combined output. No FORCE: the gate is under test.
+# run_gate <fake_ps> [fake_hour] [fake_ps_fail] — reset per-run state, run the
+# real script with the given world, capture combined output. No FORCE: the gate
+# is under test.
 GATE_OUTPUT=""
 run_gate() {
-  local fake_ps="$1" fake_hour="$2"
+  local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}"
   rm -rf "$HOME/.local/state"
   : >"$ALERTER_LOG"
-  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" bash "$SCRIPT" 2>&1)" ||
+  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" FAKE_PS_FAIL="$fake_ps_fail" bash "$SCRIPT" 2>&1)" ||
     fail "script exited non-zero (gate should always exit 0): $GATE_OUTPUT"
 }
 
@@ -134,66 +128,98 @@ deferred() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'deferring'; }
 early_exited() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'already succeeded'; }
 alerted() { [[ -s $ALERTER_LOG ]]; }
 
-GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace'
+# argv fixtures — real dresden shapes.
+HERMES_GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace'
+HERMES_SESSION='/Users/x/.hermes/hermes-agent/venv/bin/python /Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
+CLAUDE_REMOTE='/opt/homebrew/bin/claude --remote-control'
 CLAUDE_BG='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude --bg-spare /tmp/x.sock'
 CLAUDE_DAEMON='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude daemon run --origin transient'
+CLAUDE_PROMPT_TRAP='/opt/homebrew/bin/claude -p restart the hermes gateway'
 CODEX_SERVER='/Applications/Codex.app/Contents/Resources/codex app-server --analytics-default-enabled'
-CLAUDE_TUI='/opt/homebrew/bin/claude --remote-control'
 CODEX_SESSION='codex resume 019f4a8f-c990-7441-b02f-086e4bd16e87'
-HERMES_RUN='/Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
+CODEX_PLAIN='codex'
+UNRELATED_PYTHON='/usr/bin/python3 /usr/local/bin/some-tool.py --flag'
 
-# 1) Gateway-only world → PROCEEDS. The persistent hermes gateway is a daemon,
-#    not a session; blocking on it is the defer-forever bug. (RED against the
-#    pre-fix script, whose pgrep -x hermes matches the gateway and defers.)
-run_gate "$GATEWAY" 04
-proceeded || fail "gateway-only world did not proceed (defer-forever bug): $GATE_OUTPUT"
-deferred && fail "gateway-only world deferred — a persistent daemon must not block the run: $GATE_OUTPUT"
+# ── Hostile-argv discriminator table ───────────────────────────────────────
+# 1) python console-script hermes session → DEFER (argv starts with python, but
+#    the effective program is the hermes console script, and the flags token is
+#    -c, not the gateway daemon shape). This is hole (a).
+run_gate "$HERMES_SESSION"
+deferred || fail "python-console hermes session did not defer (hole a): $GATE_OUTPUT"
+proceeded && fail "python-console hermes session proceeded — a live session must defer: $GATE_OUTPUT"
 
-# 1b) Daemons-only world (gateway + Claude bg helpers + Codex app-server) →
-#     PROCEEDS. None of these is an interactive session.
-run_gate "$(printf '%s\n%s\n%s\n%s' "$GATEWAY" "$CLAUDE_BG" "$CLAUDE_DAEMON" "$CODEX_SERVER")" 04
+# 2) hermes gateway (python -m hermes_cli.main gateway) → PROCEED (module maps
+#    to hermes, flags token is exactly `gateway`).
+run_gate "$HERMES_GATEWAY"
+proceeded || fail "hermes gateway daemon did not proceed: $GATE_OUTPUT"
+deferred && fail "hermes gateway daemon deferred — a daemon must not block: $GATE_OUTPUT"
+
+# 3) claude -p with the daemon phrase in the PROMPT free text → DEFER (the
+#    flags-position token is -p; free text is never matched). This is hole (b).
+run_gate "$CLAUDE_PROMPT_TRAP"
+deferred || fail "claude -p with 'hermes gateway' in the prompt did not defer (hole b): $GATE_OUTPUT"
+
+# 4) claude --remote-control (Remote Control bridge, daemon by shape) → PROCEED.
+run_gate "$CLAUDE_REMOTE"
+proceeded || fail "claude --remote-control bridge did not proceed (daemon by shape): $GATE_OUTPUT"
+
+# 5) codex app-server → PROCEED.
+run_gate "$CODEX_SERVER"
+proceeded || fail "codex app-server daemon did not proceed: $GATE_OUTPUT"
+
+# 6) plain codex (interactive) → DEFER.
+run_gate "$CODEX_PLAIN"
+deferred || fail "plain codex session did not defer: $GATE_OUTPUT"
+
+# 6b) codex resume <id> → DEFER (flags token is `resume`, not `app-server`).
+run_gate "$CODEX_SESSION"
+deferred || fail "codex resume session did not defer: $GATE_OUTPUT"
+
+# 7) ps read failure → DEFER (fail closed).
+run_gate "$HERMES_GATEWAY" 04 1
+deferred || fail "ps read failure did not fail closed (must defer): $GATE_OUTPUT"
+
+# 8) unrelated python process → PROCEED (effective program is the script name,
+#    not an agent binary).
+run_gate "$UNRELATED_PYTHON"
+proceeded || fail "unrelated python process did not proceed: $GATE_OUTPUT"
+
+# 8b) Daemons-only world (gateway + Claude bg helpers + Claude bridge + Codex
+#     app-server) → PROCEEDS. None is a live session.
+run_gate "$(printf '%s\n%s\n%s\n%s\n%s' "$HERMES_GATEWAY" "$CLAUDE_REMOTE" "$CLAUDE_BG" "$CLAUDE_DAEMON" "$CODEX_SERVER")"
 proceeded || fail "daemons-only world did not proceed: $GATE_OUTPUT"
 deferred && fail "daemons-only world deferred — background daemons must not block the run: $GATE_OUTPUT"
 
-# 2) Interactive Claude TUI → DEFERS (never swap skills under a live session).
-run_gate "$CLAUDE_TUI" 04
-deferred || fail "interactive claude session did not defer: $GATE_OUTPUT"
-proceeded && fail "interactive claude session proceeded — a live session must defer: $GATE_OUTPUT"
+# 8c) A live session hiding among daemons → DEFER.
+run_gate "$(printf '%s\n%s' "$CODEX_SERVER" "$CODEX_SESSION")" 04
+deferred || fail "a live codex session among daemons did not defer: $GATE_OUTPUT"
+
+# ── Weekly success stamp + alert (last-slot) ────────────────────────────────
+# 2) A non-last slot deferral must NOT fire the LOUD alert.
+run_gate "$CODEX_PLAIN" 04
+deferred || fail "interactive session did not defer: $GATE_OUTPUT"
 alerted && fail "a non-last slot (04:00) fired the LOUD alert — only the last slot should: $(cat "$ALERTER_LOG")"
 
-# 2b) Interactive Codex session → DEFERS (proves the discriminator excludes the
-#     Codex app-server daemon but catches an interactive `codex resume`).
-run_gate "$(printf '%s\n%s' "$CODEX_SERVER" "$CODEX_SESSION")" 04
-deferred || fail "interactive codex session did not defer despite an app-server-only exclusion: $GATE_OUTPUT"
-
-# 2c) Interactive hermes run → DEFERS (the gateway is excluded, but an
-#     interactive `hermes -c` counts).
-run_gate "$(printf '%s\n%s' "$GATEWAY" "$HERMES_RUN")" 04
-deferred || fail "interactive hermes run did not defer despite a gateway-only exclusion: $GATE_OUTPUT"
-
-# 3) Weekly success stamp present → EARLY-EXIT before any work (extra Monday
-#    slots are no-ops once one slot succeeded this week). (RED against the
-#    pre-fix script, which has no stamp and would proceed.)
+# 3) Weekly success stamp present → EARLY-EXIT before any work.
 mkdir -p "$HOME/.local/state/update-skills"
 printf '%s' "$FAKE_WEEK" >"$HOME/.local/state/update-skills/last-success"
 : >"$ALERTER_LOG"
-GATE_OUTPUT="$(FAKE_PS="$GATEWAY" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
+GATE_OUTPUT="$(FAKE_PS="$HERMES_GATEWAY" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
   fail "stamped run exited non-zero: $GATE_OUTPUT"
 early_exited || fail "a run whose week already succeeded did not early-exit: $GATE_OUTPUT"
 proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $GATE_OUTPUT"
 rm -rf "$HOME/.local/state"
 
 # 3b) A proceeding full run WRITES the week stamp (so the next slot early-exits).
-run_gate "$GATEWAY" 04
+run_gate "$HERMES_GATEWAY" 04
 [[ -f "$HOME/.local/state/update-skills/last-success" ]] ||
   fail "a successful full run did not write the weekly success stamp"
 [[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
   fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
 
 # 4) Last retry slot (16:00) still deferring → LOUD alerter notification + log
-#    line (the weekly budget is exhausted). (RED against the pre-fix script,
-#    which never calls alerter.)
-run_gate "$CLAUDE_TUI" 16
+#    line (the weekly budget is exhausted).
+run_gate "$CODEX_PLAIN" 16
 deferred || fail "last-slot world did not defer: $GATE_OUTPUT"
 alerted || fail "last slot (16:00) deferral did not fire the LOUD alerter notification: (empty log)"
 grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -89,12 +89,13 @@ cat >"$stub_dir/alerter" <<EOF
 printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
 EOF
 
-# date stub: pin the ISO week and the hour; everything else falls through to the
-# real date.
+# date stub: pin the ISO week, the hour, and the weekday (1 = Monday) so the
+# slot-aware alert branch is deterministic; everything else falls through.
 cat >"$stub_dir/date" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%u) printf '%s\n' "${FAKE_DOW:-1}" ;;
   +%G-%V) printf '%s\n' "${FAKE_WEEK:-2026-28}" ;;
   *) exec /bin/date "$@" ;;
 esac
@@ -116,10 +117,10 @@ export FAKE_WEEK="2026-28"
 # is under test.
 GATE_OUTPUT=""
 run_gate() {
-  local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}"
+  local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}" fake_dow="${4:-1}"
   rm -rf "$HOME/.local/state"
   : >"$ALERTER_LOG"
-  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" FAKE_PS_FAIL="$fake_ps_fail" bash "$SCRIPT" 2>&1)" ||
+  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" FAKE_PS_FAIL="$fake_ps_fail" FAKE_DOW="$fake_dow" bash "$SCRIPT" 2>&1)" ||
     fail "script exited non-zero (gate should always exit 0): $GATE_OUTPUT"
 }
 
@@ -217,25 +218,38 @@ run_gate "$HERMES_GATEWAY" 04
 [[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
   fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
 
-# 4) Last retry slot (16:00) still deferring → LOUD alerter notification + log
-#    line (the weekly budget is exhausted).
-run_gate "$CODEX_PLAIN" 16
+# 4) Last retry slot (Monday 16:00) still deferring → LOUD alerter notification +
+#    log line (the weekly budget is exhausted).
+run_gate "$CODEX_PLAIN" 16 "" 1
 deferred || fail "last-slot world did not defer: $GATE_OUTPUT"
-alerted || fail "last slot (16:00) deferral did not fire the LOUD alerter notification: (empty log)"
+alerted || fail "last slot (Monday 16:00) deferral did not fire the LOUD alerter notification: (empty log)"
 grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||
   fail "last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
 
-# 5) The plist declares FOUR Monday retry slots (04:00/08:00/12:00/16:00) instead
-#    of the single 04:00 that could defer forever. Render it and count them.
+# 4b) Same hour (16:00) but NOT Monday (a manual run on another day) → DEFERS but
+#     does NOT claim exhaustion (no future slot to reason about; slot-aware).
+run_gate "$CODEX_PLAIN" 16 "" 3
+deferred || fail "non-Monday 16:00 world did not defer: $GATE_OUTPUT"
+alerted && fail "a non-Monday 16:00 deferral fired the exhaustion alert (slot-awareness lost): $(cat "$ALERTER_LOG")"
+
+# 5) The plist declares EXACTLY four Monday retry slots, each a full
+#    {Weekday=1, Hour in 4/8/12/16, Minute=0} tuple. Parse the rendered plist as
+#    real plist data (plutil -> json -> jq) so dropping Weekday or Minute (which
+#    launchd then treats as a wildcard, firing far more often) fails this test.
 PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl"
 rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
   fail "chezmoi execute-template failed on the update-skills plist"
-hour_lines="$(printf '%s\n' "$rendered_plist" | grep -c '<key>Hour</key>')"
-[[ $hour_lines -eq 4 ]] ||
-  fail "expected 4 Monday retry slots in the plist, found $hour_lines"
-for slot_hour in 4 8 12 16; do
-  printf '%s\n' "$rendered_plist" | grep -A1 '<key>Hour</key>' | grep -qF "<integer>${slot_hour}</integer>" ||
-    fail "plist is missing the Monday ${slot_hour}:00 retry slot"
-done
+plist_json="$tmp/plist.json"
+printf '%s' "$rendered_plist" | plutil -convert json -o "$plist_json" - 2>/dev/null ||
+  fail "rendered plist did not parse as a plist"
+slot_count="$(jq '.StartCalendarInterval | length' "$plist_json")"
+[[ $slot_count -eq 4 ]] ||
+  fail "expected exactly 4 StartCalendarInterval tuples, got $slot_count"
+non_conforming="$(jq '[.StartCalendarInterval[] | select(.Weekday != 1 or .Minute != 0)] | length' "$plist_json")"
+[[ $non_conforming -eq 0 ]] ||
+  fail "a slot is missing Weekday=1 or Minute=0 (launchd would treat the missing key as a wildcard)"
+slot_hours="$(jq -c '[.StartCalendarInterval[].Hour] | sort' "$plist_json")"
+[[ $slot_hours == "[4,8,12,16]" ]] ||
+  fail "slot hours are not exactly 4/8/12/16: $slot_hours"
 
 echo "update-skills-defer: OK"

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# update-skills-defer.sh — the weekly idle-gate must distinguish an ACTIVE agent
+# harness session (defer — never swap skills under a live session) from a
+# persistent BACKGROUND daemon (proceed — a daemon never loads a skill from the
+# store on its own, so blocking on it defers the weekly run forever).
+#
+# Ground truth (dresden, read-only ps, 2026-07-10):
+#   DAEMONS — must NOT block the run:
+#     python -m hermes_cli.main gateway run --replace        (hermes gateway)
+#     .../claude --bg-spare | daemon run | --bg-pty-host     (Claude bg helpers)
+#     codex app-server [--analytics-default-enabled]         (Codex app server)
+#   INTERACTIVE SESSIONS — must block the run:
+#     /opt/homebrew/bin/claude --remote-control              (a Claude Code TUI)
+#     codex resume <id>                                      (a Codex CLI session)
+#     .../hermes -c <prompt> | hermes -p <profile>           (an interactive hermes run)
+#
+# NOTE on the brief's premise: on this machine `pgrep -x hermes` matches NOTHING
+# (the gateway's comm is `python`, not `hermes`); the real persistent matcher of
+# the OLD gate is `claude --remote-control` bridges that linger for days. The
+# defect (defer-forever) is real regardless of which harness triggers it, and
+# the stub world below models the pre-fix gate's view (`pgrep -x hermes` matching
+# the gateway) so the RED is meaningful against the shipped script.
+#
+# The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE — that
+# bypasses the gate). PATH shims present a controllable process world (ps),
+# replicate the pre-fix gate (pgrep), record alerter invocations, and pin the
+# clock (date) so the "last retry slot" branch is deterministic. A minimal lock
+# with empty tables makes every network pass a no-op, so a proceeding full run
+# runs clean to its final `[update-skills] done`.
+set -euo pipefail
+
+# git hooks (this runs under pre-commit) leak GIT_DIR/GIT_INDEX_FILE — unset so
+# no child git command reaches the outer repo.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+
+# Minimal lock: every table empty, so install/update/hermes/fork passes no-op
+# and a proceeding full run reaches `[update-skills] done`.
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {},
+  "hermesProfiles": {},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+stub_dir="$tmp/stubs"
+mkdir -p "$stub_dir"
+ALERTER_LOG="$tmp/alerter.log"
+NPX_LOG="$tmp/npx.log"
+: >"$ALERTER_LOG"
+
+# ps stub: prints the simulated process world ($FAKE_PS), whatever flags it gets.
+cat >"$stub_dir/ps" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_PS:-}"
+EOF
+
+# pgrep stub: models the PRE-FIX gate. `-x hermes` matches the persistent gateway
+# (the defer-forever bug the audit found); `-x claude`/`-x codex` match only when
+# an interactive line for that harness is present in $FAKE_PS.
+cat >"$stub_dir/pgrep" <<'EOF'
+#!/usr/bin/env bash
+pat=""
+for a in "$@"; do case "$a" in -*) ;; *) pat="$a" ;; esac; done
+case "$pat" in
+  hermes) printf '%s\n' "${FAKE_PS:-}" | grep -q 'hermes' && exit 0 ;;
+  claude) printf '%s\n' "${FAKE_PS:-}" | grep -Eq '(^|/| )claude( |$)' && exit 0 ;;
+  codex) printf '%s\n' "${FAKE_PS:-}" | grep -Eq '(^|/| )codex( |$)' && exit 0 ;;
+esac
+exit 1
+EOF
+
+# alerter stub: record every invocation so the "last slot" LOUD-alert path is
+# observable.
+cat >"$stub_dir/alerter" <<EOF
+#!/usr/bin/env bash
+printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
+EOF
+
+# date stub: pin the ISO week and the hour; everything else falls through to the
+# real date.
+cat >"$stub_dir/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%G-%V) printf '%s\n' "${FAKE_WEEK:-2026-28}" ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+
+# npx stub: a proceeding full run runs `npx skills update`; log and succeed.
+cat >"$stub_dir/npx" <<EOF
+#!/usr/bin/env bash
+printf 'npx %s\n' "\$*" >>"$NPX_LOG"
+echo "stub npx"
+EOF
+
+chmod +x "$stub_dir"/*
+export PATH="$stub_dir:$PATH"
+export FAKE_WEEK="2026-28"
+
+# run_gate <fake_ps> <fake_hour> — reset per-run state, run the real script with
+# the given world, capture combined output. No FORCE: the gate is under test.
+GATE_OUTPUT=""
+run_gate() {
+  local fake_ps="$1" fake_hour="$2"
+  rm -rf "$HOME/.local/state"
+  : >"$ALERTER_LOG"
+  GATE_OUTPUT="$(FAKE_PS="$fake_ps" FAKE_HOUR="$fake_hour" bash "$SCRIPT" 2>&1)" ||
+    fail "script exited non-zero (gate should always exit 0): $GATE_OUTPUT"
+}
+
+proceeded() { printf '%s\n' "$GATE_OUTPUT" | grep -qF '[update-skills] done'; }
+deferred() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'deferring'; }
+early_exited() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'already succeeded'; }
+alerted() { [[ -s $ALERTER_LOG ]]; }
+
+GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace'
+CLAUDE_BG='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude --bg-spare /tmp/x.sock'
+CLAUDE_DAEMON='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude daemon run --origin transient'
+CODEX_SERVER='/Applications/Codex.app/Contents/Resources/codex app-server --analytics-default-enabled'
+CLAUDE_TUI='/opt/homebrew/bin/claude --remote-control'
+CODEX_SESSION='codex resume 019f4a8f-c990-7441-b02f-086e4bd16e87'
+HERMES_RUN='/Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
+
+# 1) Gateway-only world → PROCEEDS. The persistent hermes gateway is a daemon,
+#    not a session; blocking on it is the defer-forever bug. (RED against the
+#    pre-fix script, whose pgrep -x hermes matches the gateway and defers.)
+run_gate "$GATEWAY" 04
+proceeded || fail "gateway-only world did not proceed (defer-forever bug): $GATE_OUTPUT"
+deferred && fail "gateway-only world deferred — a persistent daemon must not block the run: $GATE_OUTPUT"
+
+# 1b) Daemons-only world (gateway + Claude bg helpers + Codex app-server) →
+#     PROCEEDS. None of these is an interactive session.
+run_gate "$(printf '%s\n%s\n%s\n%s' "$GATEWAY" "$CLAUDE_BG" "$CLAUDE_DAEMON" "$CODEX_SERVER")" 04
+proceeded || fail "daemons-only world did not proceed: $GATE_OUTPUT"
+deferred && fail "daemons-only world deferred — background daemons must not block the run: $GATE_OUTPUT"
+
+# 2) Interactive Claude TUI → DEFERS (never swap skills under a live session).
+run_gate "$CLAUDE_TUI" 04
+deferred || fail "interactive claude session did not defer: $GATE_OUTPUT"
+proceeded && fail "interactive claude session proceeded — a live session must defer: $GATE_OUTPUT"
+alerted && fail "a non-last slot (04:00) fired the LOUD alert — only the last slot should: $(cat "$ALERTER_LOG")"
+
+# 2b) Interactive Codex session → DEFERS (proves the discriminator excludes the
+#     Codex app-server daemon but catches an interactive `codex resume`).
+run_gate "$(printf '%s\n%s' "$CODEX_SERVER" "$CODEX_SESSION")" 04
+deferred || fail "interactive codex session did not defer despite an app-server-only exclusion: $GATE_OUTPUT"
+
+# 2c) Interactive hermes run → DEFERS (the gateway is excluded, but an
+#     interactive `hermes -c` counts).
+run_gate "$(printf '%s\n%s' "$GATEWAY" "$HERMES_RUN")" 04
+deferred || fail "interactive hermes run did not defer despite a gateway-only exclusion: $GATE_OUTPUT"
+
+# 3) Weekly success stamp present → EARLY-EXIT before any work (extra Monday
+#    slots are no-ops once one slot succeeded this week). (RED against the
+#    pre-fix script, which has no stamp and would proceed.)
+mkdir -p "$HOME/.local/state/update-skills"
+printf '%s' "$FAKE_WEEK" >"$HOME/.local/state/update-skills/last-success"
+: >"$ALERTER_LOG"
+GATE_OUTPUT="$(FAKE_PS="$GATEWAY" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
+  fail "stamped run exited non-zero: $GATE_OUTPUT"
+early_exited || fail "a run whose week already succeeded did not early-exit: $GATE_OUTPUT"
+proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $GATE_OUTPUT"
+rm -rf "$HOME/.local/state"
+
+# 3b) A proceeding full run WRITES the week stamp (so the next slot early-exits).
+run_gate "$GATEWAY" 04
+[[ -f "$HOME/.local/state/update-skills/last-success" ]] ||
+  fail "a successful full run did not write the weekly success stamp"
+[[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
+  fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
+
+# 4) Last retry slot (16:00) still deferring → LOUD alerter notification + log
+#    line (the weekly budget is exhausted). (RED against the pre-fix script,
+#    which never calls alerter.)
+run_gate "$CLAUDE_TUI" 16
+deferred || fail "last-slot world did not defer: $GATE_OUTPUT"
+alerted || fail "last slot (16:00) deferral did not fire the LOUD alerter notification: (empty log)"
+grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||
+  fail "last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
+
+# 5) The plist declares FOUR Monday retry slots (04:00/08:00/12:00/16:00) instead
+#    of the single 04:00 that could defer forever. Render it and count them.
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl"
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi execute-template failed on the update-skills plist"
+hour_lines="$(printf '%s\n' "$rendered_plist" | grep -c '<key>Hour</key>')"
+[[ $hour_lines -eq 4 ]] ||
+  fail "expected 4 Monday retry slots in the plist, found $hour_lines"
+for slot_hour in 4 8 12 16; do
+  printf '%s\n' "$rendered_plist" | grep -A1 '<key>Hour</key>' | grep -qF "<integer>${slot_hour}</integer>" ||
+    fail "plist is missing the Monday ${slot_hour}:00 retry slot"
+done
+
+echo "update-skills-defer: OK"

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
-# update-skills-defer.sh, the weekly idle-gate FAILS CLOSED: it defers whenever
-# ANY process whose argv EFFECTIVE program resolves to an agent harness (claude,
-# codex, or hermes) is running, live session or background daemon alike. Argv
-# shape cannot prove idleness here (every interactive Claude launch carries
-# --remote-control; Codex app-server and the Hermes gateway host live agent
-# turns in-process), so the old daemon-shape allowlist was DELETED: a busy
-# machine could present only daemon-shaped argv and get its skills swapped under
-# a live session. The gate now errs toward deferral, which the design tolerates
-# (a deferred run just lands the updates next week). Only a machine with NO agent
-# process proceeds.
+# update-skills-defer.sh: the weekly idle-gate judges recent ACTIVITY, not mere
+# process existence, so the updater runs UNATTENDED. On the daily driver a
+# `claude --remote-control` bridge is always up; the round-2 gate deferred on any
+# such process forever and forced a manual run. The gate now works in two steps:
 #
-# The discriminator keys on the argv EFFECTIVE program, resolved through any
-# interpreter front (python/node/bun, optional `env` prefix), skipping the
-# interpreter's own options to find the -m module or script operand. Free prompt
-# text is never matched.
+#   1. If NO process resolves to an agent harness (claude/codex/hermes) — the
+#      existing effective-program logic, resolved through any interpreter front —
+#      PROCEED (unchanged fast path; evidence probes are never touched).
+#   2. If an agent process exists, judge idleness by ACTIVITY. Every harness
+#      PRESENT on the machine (its activity dir exists) is probed for the newest
+#      file mtime; if EVERY present harness is older than IDLE_THRESHOLD, PROCEED;
+#      if ANY is fresh, DEFER as before.
+#   3. Fail closed: an unreadable process table, or an activity probe that errors
+#      (unreadable dir), counts as ACTIVE and DEFERS.
+#   4. UPDATE_SKILLS_FORCE=1 still bypasses everything (not re-tested here; the
+#      other suites cover it).
 #
-# The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE, that
-# bypasses the gate). PATH shims present a controllable process world (ps, which
-# can also simulate a read failure), record alerter invocations, and pin the
-# clock (date) so the "last retry slot" branch is deterministic. A minimal lock
-# with empty tables makes every network pass a no-op, so a proceeding full run
-# runs clean to its final `[update-skills] done`.
+# The gate is exercised through the REAL script (no FORCE, that bypasses the
+# gate). PATH shims present a controllable process world (ps, which can also
+# simulate a read failure) and pin the clock (date) so the slot-aware exhaustion
+# branch is deterministic; the activity evidence is stubbed as real files with
+# controlled mtimes inside the tmp HOME, pointed at via the env vars the script
+# reads with sane $HOME-relative defaults. A minimal lock with empty tables makes
+# every network pass a no-op, so a proceeding full run reaches the final
+# `[update-skills] done`.
 set -euo pipefail
 
 # git hooks (this runs under pre-commit) leak GIT_DIR/GIT_INDEX_FILE, unset so
@@ -36,7 +39,11 @@ fail() {
 }
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+cleanup() {
+  chmod -R u+rwx "$tmp" 2>/dev/null || true # an unreadable-dir test may leave a 000 dir
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
 
 HOME="$tmp/home"
 export HOME
@@ -81,7 +88,8 @@ printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
 EOF
 
 # date stub: pin the ISO week, the hour, and the weekday (1 = Monday) so the
-# slot-aware alert branch is deterministic; everything else falls through.
+# slot-aware alert branch is deterministic; everything else (notably the +%s the
+# activity probe reads) falls through to the real date.
 cat >"$stub_dir/date" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
@@ -103,10 +111,54 @@ chmod +x "$stub_dir"/*
 export PATH="$stub_dir:$PATH"
 export FAKE_WEEK="2026-28"
 
+# ── Activity evidence surface. The three probe dirs are pointed at the tmp HOME
+#    via the env vars the script reads (defaults are $HOME/.claude/projects,
+#    $HOME/.codex/sessions, $HOME/.hermes/logs). Threshold default 900s; tests
+#    override it for the boundary case. ────────────────────────────────────────
+ACT_CLAUDE="$HOME/act/claude"
+ACT_CODEX="$HOME/act/codex"
+ACT_HERMES="$HOME/act/hermes"
+export UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR="$ACT_CLAUDE"
+export UPDATE_SKILLS_CODEX_ACTIVITY_DIR="$ACT_CODEX"
+export UPDATE_SKILLS_HERMES_ACTIVITY_DIR="$ACT_HERMES"
+export UPDATE_SKILLS_IDLE_THRESHOLD=900
+
+# harness evidence-state helpers, each on one probe dir.
+reset_activity() {
+  chmod -R u+rwx "$HOME/act" 2>/dev/null || true
+  rm -rf "$HOME/act"
+}
+harness_absent() { rm -rf "$1"; } # no dir at all → not installed
+harness_active() {                # a file whose mtime is NOW → within the window
+  mkdir -p "$1"
+  : >"$1/live.jsonl"
+}
+harness_stale() { # a file aged well past the window → no recent activity
+  local age_ago
+  age_ago="$(/bin/date -r "$(($(/bin/date +%s) - 3600))" +%Y%m%d%H%M.%S)"
+  mkdir -p "$1"
+  : >"$1/old.jsonl"
+  touch -t "$age_ago" "$1/old.jsonl"
+}
+harness_unreadable() { # present but unreadable → probe error → fail closed
+  mkdir -p "$1"
+  : >"$1/x.jsonl"
+  chmod 000 "$1"
+}
+# a file aged a controlled NUMBER of seconds into the past (boundary test).
+harness_file_aged() {
+  local dir="$1" seconds="$2" ts
+  ts="$(/bin/date -r "$(($(/bin/date +%s) - seconds))" +%Y%m%d%H%M.%S)"
+  mkdir -p "$dir"
+  : >"$dir/f.jsonl"
+  touch -t "$ts" "$dir/f.jsonl"
+}
+
 # run_gate <fake_ps> [fake_hour] [fake_ps_fail] [fake_dow] [sched], reset per-run
 # state, run the real script with the given world, capture combined output. No
 # FORCE: the gate is under test. The 5th arg, when "--scheduled", marks the run
-# as a LaunchAgent (scheduled) run; otherwise the run is manual.
+# as a LaunchAgent (scheduled) run; otherwise the run is manual. The activity
+# evidence is whatever the caller staged on disk beforehand.
 GATE_OUTPUT=""
 run_gate() {
   local fake_ps="$1" fake_hour="${2:-04}" fake_ps_fail="${3:-}" fake_dow="${4:-1}" sched="${5:-}"
@@ -129,15 +181,14 @@ HERMES_GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main
 HERMES_SESSION='/Users/x/.hermes/hermes-agent/venv/bin/python /Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
 CLAUDE_REMOTE='/opt/homebrew/bin/claude --remote-control'
 CLAUDE_BG='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude --bg-spare /tmp/x.sock'
-CLAUDE_DAEMON='/opt/homebrew/Caskroom/claude-code@latest/2.1.200/claude daemon run --origin transient'
-CLAUDE_PROMPT_TRAP='/opt/homebrew/bin/claude -p restart the hermes gateway'
 CODEX_SERVER='/Applications/Codex.app/Contents/Resources/codex app-server --analytics-default-enabled'
 CODEX_SESSION='codex resume 019f4a8f-c990-7441-b02f-086e4bd16e87'
 CODEX_PLAIN='codex'
 UNRELATED_PYTHON='/usr/bin/python3 /usr/local/bin/some-tool.py --flag'
-# Hostile interpreter-front bypasses (item 2): options between the interpreter
-# and the -m module / script operand must be skipped, and `env`/node fronts
-# resolved. Each still resolves to an agent harness and MUST defer.
+# Hostile interpreter-front bypasses: options between the interpreter and the -m
+# module / script operand must be skipped, and `env`/node fronts resolved. Each
+# still resolves to an agent harness and, paired with a fresh evidence file,
+# MUST defer.
 HERMES_U='/Users/x/venv/bin/python3 -u /Users/x/venv/bin/hermes -c go'
 HERMES_I_M='/Users/x/venv/bin/python3 -I -m hermes_cli.main gateway run'
 HERMES_X_M='/Users/x/venv/bin/python3 -X utf8 -m hermes_cli.main gateway run'
@@ -145,46 +196,122 @@ HERMES_DASHDASH='/Users/x/venv/bin/python3 -- /Users/x/venv/bin/hermes -c go'
 HERMES_ENV='/usr/bin/env python3 -m hermes_cli.main gateway run'
 CLAUDE_NODE='/opt/homebrew/bin/node /Users/x/.local/share/npm/bin/claude --remote-control'
 
-# ── Item 1: fail-closed idle gate. ANY agent process (session OR daemon) DEFERS;
-#    only a machine with no agent process proceeds. ──────────────────────────
-# The nine real dresden shapes all DEFER now (the daemon-shape allowlist is gone).
-for world in "$HERMES_GATEWAY" "$HERMES_SESSION" "$CLAUDE_REMOTE" "$CLAUDE_BG" \
-  "$CLAUDE_DAEMON" "$CLAUDE_PROMPT_TRAP" "$CODEX_SERVER" "$CODEX_SESSION" "$CODEX_PLAIN"; do
-  run_gate "$world"
-  deferred || fail "an agent process did not defer (fail-closed gate): [$world]: $GATE_OUTPUT"
-  proceeded && fail "an agent process proceeded (must never swap under a live/daemon agent): [$world]: $GATE_OUTPUT"
-done
+# ── Item 1 of the brief: bridge process present + ALL evidence stale → PROCEED.
+#    This is the unattended headline: the always-up `claude --remote-control`
+#    bridge no longer defers the weekly run when nothing has happened lately. ───
+reset_activity
+harness_stale "$ACT_CLAUDE"
+harness_stale "$ACT_CODEX"
+harness_stale "$ACT_HERMES"
+run_gate "$CLAUDE_REMOTE"
+proceeded || fail "bridge present + all evidence stale did not PROCEED (unattended run): $GATE_OUTPUT"
+deferred && fail "bridge present + all evidence stale wrongly deferred: $GATE_OUTPUT"
 
-# ── Item 2: hostile interpreter-front resolution. Each resolves to an agent and
-#    must DEFER. ───────────────────────────────────────────────────────────
-for world in "$HERMES_U" "$HERMES_I_M" "$HERMES_X_M" "$HERMES_DASHDASH" "$HERMES_ENV" "$CLAUDE_NODE"; do
-  run_gate "$world"
-  deferred || fail "an interpreter-fronted agent did not resolve/defer: [$world]: $GATE_OUTPUT"
-done
+# Bridge present + ALL evidence dirs absent (no transcripts at all) → PROCEED:
+# a harness with no install contributes no evidence and does not block.
+reset_activity
+run_gate "$CLAUDE_REMOTE"
+proceeded || fail "bridge present + no evidence dirs did not PROCEED (absent = no block): $GATE_OUTPUT"
 
-# A non-agent interpreter process (a plain python tool) → PROCEED.
+# ── Item 2: bridge process present + ONE harness active (fresh mtime) → DEFER.
+#    Cross-harness: the fresh harness need not be the one whose process is up. ──
+reset_activity
+harness_stale "$ACT_CLAUDE"
+harness_stale "$ACT_CODEX"
+harness_active "$ACT_HERMES" # a live hermes turn, while the claude bridge idles
+run_gate "$CLAUDE_REMOTE"
+deferred || fail "bridge present + one harness active did not DEFER: $GATE_OUTPUT"
+proceeded && fail "bridge present + one harness active wrongly proceeded: $GATE_OUTPUT"
+
+# The active harness matching its own process also defers.
+reset_activity
+harness_active "$ACT_CLAUDE"
+run_gate "$CLAUDE_REMOTE"
+deferred || fail "an active claude session did not DEFER: $GATE_OUTPUT"
+
+# ── Item 3: NO agent process → PROCEED without touching evidence probes. Prove
+#    it by staging ALL dirs ACTIVE yet still expecting PROCEED (the fast path
+#    short-circuits before any probe). ─────────────────────────────────────────
+reset_activity
+harness_active "$ACT_CLAUDE"
+harness_active "$ACT_CODEX"
+harness_active "$ACT_HERMES"
 run_gate "$UNRELATED_PYTHON"
-proceeded || fail "unrelated python process did not proceed: $GATE_OUTPUT"
+proceeded || fail "an agent-free world did not PROCEED even with fresh evidence (fast path): $GATE_OUTPUT"
 
-# ps read failure → DEFER (fail closed).
+# ── Item 4: evidence probe error (unreadable dir) → DEFER (fail closed). ───────
+reset_activity
+harness_stale "$ACT_CLAUDE"
+harness_unreadable "$ACT_CODEX" # chmod 000 → find errors → ACTIVE
+run_gate "$CLAUDE_REMOTE"
+chmod 755 "$ACT_CODEX" 2>/dev/null || true
+deferred || fail "an unreadable activity dir did not fail closed (must DEFER): $GATE_OUTPUT"
+proceeded && fail "an unreadable activity dir wrongly proceeded: $GATE_OUTPUT"
+
+# ── Item 5: harness absent (no evidence dir) does not block. A present-but-stale
+#    harness alongside two ABSENT ones → PROCEED. ──────────────────────────────
+reset_activity
+harness_stale "$ACT_CLAUDE"
+harness_absent "$ACT_CODEX"
+harness_absent "$ACT_HERMES"
+run_gate "$CLAUDE_REMOTE"
+proceeded || fail "stale-plus-absent harnesses did not PROCEED (absent must not block): $GATE_OUTPUT"
+
+# ── Item 6: threshold boundary. With a small window, a file just INSIDE the
+#    window is ACTIVE (DEFER) and one just OUTSIDE is STALE (PROCEED). ──────────
+export UPDATE_SKILLS_IDLE_THRESHOLD=100
+reset_activity
+harness_file_aged "$ACT_CLAUDE" 40 # 40s old, inside the 100s window → ACTIVE
+run_gate "$CLAUDE_REMOTE"
+deferred || fail "a file just inside IDLE_THRESHOLD did not DEFER: $GATE_OUTPUT"
+reset_activity
+harness_file_aged "$ACT_CLAUDE" 400 # 400s old, well outside 100s → STALE
+run_gate "$CLAUDE_REMOTE"
+proceeded || fail "a file just outside IDLE_THRESHOLD did not PROCEED: $GATE_OUTPUT"
+export UPDATE_SKILLS_IDLE_THRESHOLD=900
+
+# ── ps read failure → DEFER (fail closed): an unreadable process table means we
+#    cannot prove idleness, so we never swap. ──────────────────────────────────
+reset_activity # even with no evidence, a ps failure must defer
 run_gate "$HERMES_GATEWAY" 04 1
 deferred || fail "ps read failure did not fail closed (must defer): $GATE_OUTPUT"
 
-# A world with NO agent process (only an unrelated python tool) → PROCEED.
+# ── Interpreter-front recognition, under the new semantics: each resolves to an
+#    agent harness, so paired with a fresh evidence file it MUST defer. A NON-
+#    harness front paired with the same fresh file PROCEEDS (proving the front is
+#    what is recognized, not the file). ────────────────────────────────────────
+for world in "$HERMES_U" "$HERMES_I_M" "$HERMES_X_M" "$HERMES_DASHDASH" "$HERMES_ENV" \
+  "$CLAUDE_NODE" "$HERMES_GATEWAY" "$HERMES_SESSION" "$CLAUDE_BG" "$CODEX_SERVER" \
+  "$CODEX_SESSION" "$CODEX_PLAIN"; do
+  reset_activity
+  harness_active "$ACT_CLAUDE"
+  run_gate "$world"
+  deferred || fail "an interpreter-fronted agent + fresh evidence did not DEFER: [$world]: $GATE_OUTPUT"
+done
+# The non-harness python front is NOT recognized: same fresh file, but PROCEED.
+reset_activity
+harness_active "$ACT_CLAUDE"
 run_gate "$UNRELATED_PYTHON"
-proceeded || fail "an agent-free world did not proceed: $GATE_OUTPUT"
+proceeded || fail "unrelated python front was treated as a harness: $GATE_OUTPUT"
 
-# A live agent hiding among unrelated processes → DEFER.
+# A live agent hiding among unrelated processes, with fresh evidence → DEFER.
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate "$(printf '%s\n%s' "$UNRELATED_PYTHON" "$CODEX_SESSION")" 04
 deferred || fail "a live agent among unrelated processes did not defer: $GATE_OUTPUT"
 
-# ── Weekly success stamp + alert (last-slot) ────────────────────────────────
-# 2) A non-last slot deferral must NOT fire the LOUD alert.
+# ── Weekly success stamp + alert (last-slot). These semantics are unchanged; the
+#    deferral they rest on is now activity-driven, so each stages a fresh
+#    harness. ──────────────────────────────────────────────────────────────────
+# A non-last slot deferral must NOT fire the LOUD alert.
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate "$CODEX_PLAIN" 04
-deferred || fail "interactive session did not defer: $GATE_OUTPUT"
+deferred || fail "an active session did not defer: $GATE_OUTPUT"
 alerted && fail "a non-last slot (04:00) fired the LOUD alert, only the last slot should: $(cat "$ALERTER_LOG")"
 
-# 3) Weekly success stamp present → EARLY-EXIT before any work.
+# Weekly success stamp present → EARLY-EXIT before any work (no evidence needed).
+reset_activity
 mkdir -p "$HOME/.local/state/update-skills"
 printf '%s' "$FAKE_WEEK" >"$HOME/.local/state/update-skills/last-success"
 : >"$ALERTER_LOG"
@@ -194,54 +321,65 @@ early_exited || fail "a run whose week already succeeded did not early-exit: $GA
 proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $GATE_OUTPUT"
 rm -rf "$HOME/.local/state"
 
-# 3b) A proceeding full run (agent-free world) WRITES the week stamp (so the next
-#     slot early-exits).
+# A proceeding full run (agent-free world) WRITES the week stamp (so the next
+# slot early-exits).
+reset_activity
 run_gate "$UNRELATED_PYTHON" 04
 [[ -f "$HOME/.local/state/update-skills/last-success" ]] ||
   fail "a successful full run did not write the weekly success stamp"
 [[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
   fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
 
-# ── Item 6: slot-aware exhaustion via the --scheduled marker ─────────────────
-# Exhaustion is claimed ONLY for a SCHEDULED run with no later slot remaining
-# this week; a manual run never claims scheduled-budget exhaustion.
-
-# 4) SCHEDULED last Monday slot (16:00) still deferring → LOUD alert + log line.
+# ── Slot-aware exhaustion via the --scheduled marker. Exhaustion is claimed ONLY
+#    for a SCHEDULED run with no later slot remaining this week, and now means
+#    "the machine had agent activity at every scheduled slot". Each stages a
+#    fresh harness so the run defers. ──────────────────────────────────────────
+# SCHEDULED last Monday slot (16:00) still deferring → LOUD alert + log line.
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate_sched "$CODEX_PLAIN" 16 "" 1
 deferred || fail "scheduled last-slot world did not defer: $GATE_OUTPUT"
 alerted || fail "a scheduled last slot (Monday 16:00) deferral did not fire the LOUD alerter notification"
-grep -qiE 'exhaust|budget|last' <<<"$GATE_OUTPUT" ||
+grep -qiE 'exhaust|budget|last|activity' <<<"$GATE_OUTPUT" ||
   fail "scheduled last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
 [[ -f "$HOME/.local/state/update-skills/last-scheduled-week" ]] ||
   fail "a scheduled run did not record its ISO week in the scheduled-attempt state file"
 
-# 4a) SCHEDULED EARLY Monday slot (04:00) deferring → NO alert (later slots remain).
+# SCHEDULED EARLY Monday slot (04:00) deferring → NO alert (later slots remain).
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate_sched "$CODEX_PLAIN" 04 "" 1
 deferred || fail "scheduled early-slot world did not defer: $GATE_OUTPUT"
 alerted && fail "an early scheduled slot (04:00) claimed exhaustion; later slots remain: $(cat "$ALERTER_LOG")"
 
-# 4b) SCHEDULED coalesced catch-up on a LATER weekday (Wed 10:00) → alert (the
-#     Monday slots are spent; launchd delivered the missed event late).
+# SCHEDULED coalesced catch-up on a LATER weekday (Wed 10:00) → alert (the Monday
+# slots are spent; launchd delivered the missed event late).
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate_sched "$CODEX_PLAIN" 10 "" 3
 deferred || fail "scheduled catch-up world did not defer: $GATE_OUTPUT"
 alerted || fail "a scheduled catch-up on a later day did not claim exhaustion (no later slot this week): $GATE_OUTPUT"
 
-# 4c) MANUAL run on Monday 16:00 → DEFERS but NEVER claims scheduled-budget
-#     exhaustion (a manual run is not part of the scheduled cycle).
+# MANUAL run on Monday 16:00 → DEFERS but NEVER claims scheduled-budget
+# exhaustion (a manual run is not part of the scheduled cycle).
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate "$CODEX_PLAIN" 16 "" 1
 deferred || fail "manual Monday-16:00 world did not defer: $GATE_OUTPUT"
 alerted && fail "a manual Monday-16:00 run claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
 
-# 4d) MANUAL non-Monday run → DEFERS, no alert (unchanged).
+# MANUAL non-Monday run → DEFERS, no alert (unchanged).
+reset_activity
+harness_active "$ACT_CODEX"
 run_gate "$CODEX_PLAIN" 16 "" 3
 deferred || fail "manual non-Monday world did not defer: $GATE_OUTPUT"
 alerted && fail "a manual non-Monday deferral alerted: $(cat "$ALERTER_LOG")"
 
-# 5) The plist declares EXACTLY four Monday retry slots, each a full
+# ── The plist declares EXACTLY four Monday retry slots, each a full
 #    {Weekday=1, Hour in 4/8/12/16, Minute=0} tuple, AND passes --scheduled in
 #    ProgramArguments. Parse the rendered plist as real plist data (plutil ->
 #    json -> jq) so dropping Weekday or Minute (which launchd then treats as a
-#    wildcard, firing far more often) fails this test.
+#    wildcard, firing far more often) fails this test. ─────────────────────────
 PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl"
 rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
   fail "chezmoi execute-template failed on the update-skills plist"

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -4,8 +4,8 @@
 # `claude --remote-control` bridge is always up; the round-2 gate deferred on any
 # such process forever and forced a manual run. The gate now works in two steps:
 #
-#   1. If NO process resolves to an agent harness (claude/codex/hermes) — the
-#      existing effective-program logic, resolved through any interpreter front —
+#   1. If NO process resolves to an agent harness (claude/codex/hermes) via the
+#      existing effective-program logic, resolved through any interpreter front,
 #      PROCEED (unchanged fast path; evidence probes are never touched).
 #   2. If an agent process exists, judge idleness by ACTIVITY. Every harness
 #      PRESENT on the machine (its activity dir exists) is probed for the newest

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -1,28 +1,19 @@
 #!/usr/bin/env bash
-# update-skills-defer.sh, the weekly idle-gate must distinguish a LIVE
-# interactive agent-harness session (defer, never swap skills under a live
-# session) from a persistent BACKGROUND daemon (proceed, a daemon never loads a
-# skill from the store on its own, so blocking on it defers the weekly run
-# forever). The discriminator keys strictly on the argv EFFECTIVE program and
-# its flags-position token, never on free prompt text.
+# update-skills-defer.sh, the weekly idle-gate FAILS CLOSED: it defers whenever
+# ANY process whose argv EFFECTIVE program resolves to an agent harness (claude,
+# codex, or hermes) is running, live session or background daemon alike. Argv
+# shape cannot prove idleness here (every interactive Claude launch carries
+# --remote-control; Codex app-server and the Hermes gateway host live agent
+# turns in-process), so the old daemon-shape allowlist was DELETED: a busy
+# machine could present only daemon-shaped argv and get its skills swapped under
+# a live session. The gate now errs toward deferral, which the design tolerates
+# (a deferred run just lands the updates next week). Only a machine with NO agent
+# process proceeds.
 #
-# Ground truth (dresden, read-only ps, 2026-07-10):
-#   DAEMONS, must NOT block the run (proceed):
-#     python -m hermes_cli.main gateway run --replace        (hermes gateway)
-#     .../claude --remote-control                            (Remote Control bridge)
-#     .../claude --bg-spare | daemon run | --bg-pty-host     (Claude bg helpers)
-#     codex app-server [--analytics-default-enabled]         (Codex app server)
-#   LIVE SESSIONS, must block the run (defer):
-#     .../python .../bin/hermes -c <prompt>                  (hermes console-script session)
-#     /opt/homebrew/bin/claude -p <prompt>                   (a Claude one-shot)
-#     codex resume <id> | plain codex                        (a Codex CLI session)
-#
-# Two holes the pre-fix gate had, both covered below: (a) a hermes session's
-# argv starts with `python` (console script), so the old first-word gate never
-# saw it as an agent and swapped skills under it; (b) prompt free text that
-# merely CONTAINS a daemon phrase (`claude -p "restart the hermes gateway"`) was
-# substring-matched as a daemon and let a live session proceed. The new gate
-# also fails CLOSED when ps cannot be read.
+# The discriminator keys on the argv EFFECTIVE program, resolved through any
+# interpreter front (python/node/bun, optional `env` prefix), skipping the
+# interpreter's own options to find the -m module or script operand. Free prompt
+# text is never matched.
 #
 # The gate is exercised through the REAL script (no UPDATE_SKILLS_FORCE, that
 # bypasses the gate). PATH shims present a controllable process world (ps, which
@@ -129,7 +120,7 @@ deferred() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'deferring'; }
 early_exited() { printf '%s\n' "$GATE_OUTPUT" | grep -qiF 'already succeeded'; }
 alerted() { [[ -s $ALERTER_LOG ]]; }
 
-# argv fixtures, real dresden shapes.
+# argv fixtures, real dresden shapes plus hostile interpreter fronts.
 HERMES_GATEWAY='/Users/x/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace'
 HERMES_SESSION='/Users/x/.hermes/hermes-agent/venv/bin/python /Users/x/.hermes/hermes-agent/venv/bin/hermes -c Do a thing'
 CLAUDE_REMOTE='/opt/homebrew/bin/claude --remote-control'
@@ -140,60 +131,48 @@ CODEX_SERVER='/Applications/Codex.app/Contents/Resources/codex app-server --anal
 CODEX_SESSION='codex resume 019f4a8f-c990-7441-b02f-086e4bd16e87'
 CODEX_PLAIN='codex'
 UNRELATED_PYTHON='/usr/bin/python3 /usr/local/bin/some-tool.py --flag'
+# Hostile interpreter-front bypasses (item 2): options between the interpreter
+# and the -m module / script operand must be skipped, and `env`/node fronts
+# resolved. Each still resolves to an agent harness and MUST defer.
+HERMES_U='/Users/x/venv/bin/python3 -u /Users/x/venv/bin/hermes -c go'
+HERMES_I_M='/Users/x/venv/bin/python3 -I -m hermes_cli.main gateway run'
+HERMES_X_M='/Users/x/venv/bin/python3 -X utf8 -m hermes_cli.main gateway run'
+HERMES_DASHDASH='/Users/x/venv/bin/python3 -- /Users/x/venv/bin/hermes -c go'
+HERMES_ENV='/usr/bin/env python3 -m hermes_cli.main gateway run'
+CLAUDE_NODE='/opt/homebrew/bin/node /Users/x/.local/share/npm/bin/claude --remote-control'
 
-# ── Hostile-argv discriminator table ───────────────────────────────────────
-# 1) python console-script hermes session → DEFER (argv starts with python, but
-#    the effective program is the hermes console script, and the flags token is
-#    -c, not the gateway daemon shape). This is hole (a).
-run_gate "$HERMES_SESSION"
-deferred || fail "python-console hermes session did not defer (hole a): $GATE_OUTPUT"
-proceeded && fail "python-console hermes session proceeded, a live session must defer: $GATE_OUTPUT"
+# ── Item 1: fail-closed idle gate. ANY agent process (session OR daemon) DEFERS;
+#    only a machine with no agent process proceeds. ──────────────────────────
+# The nine real dresden shapes all DEFER now (the daemon-shape allowlist is gone).
+for world in "$HERMES_GATEWAY" "$HERMES_SESSION" "$CLAUDE_REMOTE" "$CLAUDE_BG" \
+  "$CLAUDE_DAEMON" "$CLAUDE_PROMPT_TRAP" "$CODEX_SERVER" "$CODEX_SESSION" "$CODEX_PLAIN"; do
+  run_gate "$world"
+  deferred || fail "an agent process did not defer (fail-closed gate): [$world]: $GATE_OUTPUT"
+  proceeded && fail "an agent process proceeded (must never swap under a live/daemon agent): [$world]: $GATE_OUTPUT"
+done
 
-# 2) hermes gateway (python -m hermes_cli.main gateway) → PROCEED (module maps
-#    to hermes, flags token is exactly `gateway`).
-run_gate "$HERMES_GATEWAY"
-proceeded || fail "hermes gateway daemon did not proceed: $GATE_OUTPUT"
-deferred && fail "hermes gateway daemon deferred, a daemon must not block: $GATE_OUTPUT"
+# ── Item 2: hostile interpreter-front resolution. Each resolves to an agent and
+#    must DEFER. ───────────────────────────────────────────────────────────
+for world in "$HERMES_U" "$HERMES_I_M" "$HERMES_X_M" "$HERMES_DASHDASH" "$HERMES_ENV" "$CLAUDE_NODE"; do
+  run_gate "$world"
+  deferred || fail "an interpreter-fronted agent did not resolve/defer: [$world]: $GATE_OUTPUT"
+done
 
-# 3) claude -p with the daemon phrase in the PROMPT free text → DEFER (the
-#    flags-position token is -p; free text is never matched). This is hole (b).
-run_gate "$CLAUDE_PROMPT_TRAP"
-deferred || fail "claude -p with 'hermes gateway' in the prompt did not defer (hole b): $GATE_OUTPUT"
-
-# 4) claude --remote-control (Remote Control bridge, daemon by shape) → PROCEED.
-run_gate "$CLAUDE_REMOTE"
-proceeded || fail "claude --remote-control bridge did not proceed (daemon by shape): $GATE_OUTPUT"
-
-# 5) codex app-server → PROCEED.
-run_gate "$CODEX_SERVER"
-proceeded || fail "codex app-server daemon did not proceed: $GATE_OUTPUT"
-
-# 6) plain codex (interactive) → DEFER.
-run_gate "$CODEX_PLAIN"
-deferred || fail "plain codex session did not defer: $GATE_OUTPUT"
-
-# 6b) codex resume <id> → DEFER (flags token is `resume`, not `app-server`).
-run_gate "$CODEX_SESSION"
-deferred || fail "codex resume session did not defer: $GATE_OUTPUT"
-
-# 7) ps read failure → DEFER (fail closed).
-run_gate "$HERMES_GATEWAY" 04 1
-deferred || fail "ps read failure did not fail closed (must defer): $GATE_OUTPUT"
-
-# 8) unrelated python process → PROCEED (effective program is the script name,
-#    not an agent binary).
+# A non-agent interpreter process (a plain python tool) → PROCEED.
 run_gate "$UNRELATED_PYTHON"
 proceeded || fail "unrelated python process did not proceed: $GATE_OUTPUT"
 
-# 8b) Daemons-only world (gateway + Claude bg helpers + Claude bridge + Codex
-#     app-server) → PROCEEDS. None is a live session.
-run_gate "$(printf '%s\n%s\n%s\n%s\n%s' "$HERMES_GATEWAY" "$CLAUDE_REMOTE" "$CLAUDE_BG" "$CLAUDE_DAEMON" "$CODEX_SERVER")"
-proceeded || fail "daemons-only world did not proceed: $GATE_OUTPUT"
-deferred && fail "daemons-only world deferred, background daemons must not block the run: $GATE_OUTPUT"
+# ps read failure → DEFER (fail closed).
+run_gate "$HERMES_GATEWAY" 04 1
+deferred || fail "ps read failure did not fail closed (must defer): $GATE_OUTPUT"
 
-# 8c) A live session hiding among daemons → DEFER.
-run_gate "$(printf '%s\n%s' "$CODEX_SERVER" "$CODEX_SESSION")" 04
-deferred || fail "a live codex session among daemons did not defer: $GATE_OUTPUT"
+# A world with NO agent process (only an unrelated python tool) → PROCEED.
+run_gate "$UNRELATED_PYTHON"
+proceeded || fail "an agent-free world did not proceed: $GATE_OUTPUT"
+
+# A live agent hiding among unrelated processes → DEFER.
+run_gate "$(printf '%s\n%s' "$UNRELATED_PYTHON" "$CODEX_SESSION")" 04
+deferred || fail "a live agent among unrelated processes did not defer: $GATE_OUTPUT"
 
 # ── Weekly success stamp + alert (last-slot) ────────────────────────────────
 # 2) A non-last slot deferral must NOT fire the LOUD alert.
@@ -205,14 +184,15 @@ alerted && fail "a non-last slot (04:00) fired the LOUD alert, only the last slo
 mkdir -p "$HOME/.local/state/update-skills"
 printf '%s' "$FAKE_WEEK" >"$HOME/.local/state/update-skills/last-success"
 : >"$ALERTER_LOG"
-GATE_OUTPUT="$(FAKE_PS="$HERMES_GATEWAY" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
+GATE_OUTPUT="$(FAKE_PS="$UNRELATED_PYTHON" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
   fail "stamped run exited non-zero: $GATE_OUTPUT"
 early_exited || fail "a run whose week already succeeded did not early-exit: $GATE_OUTPUT"
 proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $GATE_OUTPUT"
 rm -rf "$HOME/.local/state"
 
-# 3b) A proceeding full run WRITES the week stamp (so the next slot early-exits).
-run_gate "$HERMES_GATEWAY" 04
+# 3b) A proceeding full run (agent-free world) WRITES the week stamp (so the next
+#     slot early-exits).
+run_gate "$UNRELATED_PYTHON" 04
 [[ -f "$HOME/.local/state/update-skills/last-success" ]] ||
   fail "a successful full run did not write the weekly success stamp"
 [[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||

--- a/test/update-skills-defer.sh
+++ b/test/update-skills-defer.sh
@@ -311,14 +311,26 @@ deferred || fail "an active session did not defer: $GATE_OUTPUT"
 alerted && fail "a non-last slot (04:00) fired the LOUD alert, only the last slot should: $(cat "$ALERTER_LOG")"
 
 # Weekly success stamp present → EARLY-EXIT before any work (no evidence needed).
+# The stamp is <week> <custom-lock-hash> <updater-hash>; the early-exit only
+# fires when all three match the current desired state, so the fixture stamp is
+# built from the real hashes (a roster or updater change un-stamps the week).
 reset_activity
 mkdir -p "$HOME/.local/state/update-skills"
-printf '%s' "$FAKE_WEEK" >"$HOME/.local/state/update-skills/last-success"
+lock_hash="$(shasum -a 256 "$HOME/.agents/custom-skill-lock.json" | awk '{print $1}')"
+updater_hash="$(shasum -a 256 "$SCRIPT" | awk '{print $1}')"
+printf '%s %s %s' "$FAKE_WEEK" "$lock_hash" "$updater_hash" >"$HOME/.local/state/update-skills/last-success"
 : >"$ALERTER_LOG"
 GATE_OUTPUT="$(FAKE_PS="$UNRELATED_PYTHON" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
   fail "stamped run exited non-zero: $GATE_OUTPUT"
 early_exited || fail "a run whose week already succeeded did not early-exit: $GATE_OUTPUT"
 proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $GATE_OUTPUT"
+
+# A stamp for the same week but a DIFFERENT roster hash must NOT early-exit (a
+# roster change un-stamps the week).
+printf '%s %s %s' "$FAKE_WEEK" "deadbeef" "$updater_hash" >"$HOME/.local/state/update-skills/last-success"
+GATE_OUTPUT="$(FAKE_PS="$UNRELATED_PYTHON" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
+  fail "roster-changed run exited non-zero: $GATE_OUTPUT"
+early_exited && fail "a stamp with a stale roster hash early-exited instead of rebuilding: $GATE_OUTPUT"
 rm -rf "$HOME/.local/state"
 
 # A proceeding full run (agent-free world) WRITES the week stamp (so the next
@@ -327,19 +339,19 @@ reset_activity
 run_gate "$UNRELATED_PYTHON" 04
 [[ -f "$HOME/.local/state/update-skills/last-success" ]] ||
   fail "a successful full run did not write the weekly success stamp"
-[[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK" ]] ||
-  fail "the success stamp is not the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
+[[ "$(<"$HOME/.local/state/update-skills/last-success")" == "$FAKE_WEEK "* ]] ||
+  fail "the success stamp does not begin with the current ISO week: $(<"$HOME/.local/state/update-skills/last-success")"
 
 # ── Slot-aware exhaustion via the --scheduled marker. Exhaustion is claimed ONLY
 #    for a SCHEDULED run with no later slot remaining this week, and now means
 #    "the machine had agent activity at every scheduled slot". Each stages a
 #    fresh harness so the run defers. ──────────────────────────────────────────
-# SCHEDULED last Monday slot (16:00) still deferring → LOUD alert + log line.
+# SCHEDULED last Monday slot (23:00) still deferring → LOUD alert + log line.
 reset_activity
 harness_active "$ACT_CODEX"
-run_gate_sched "$CODEX_PLAIN" 16 "" 1
+run_gate_sched "$CODEX_PLAIN" 23 "" 1
 deferred || fail "scheduled last-slot world did not defer: $GATE_OUTPUT"
-alerted || fail "a scheduled last slot (Monday 16:00) deferral did not fire the LOUD alerter notification"
+alerted || fail "a scheduled last slot (Monday 23:00) deferral did not fire the LOUD alerter notification"
 grep -qiE 'exhaust|budget|last|activity' <<<"$GATE_OUTPUT" ||
   fail "scheduled last-slot deferral did not emit an exhausted-budget log line: $GATE_OUTPUT"
 [[ -f "$HOME/.local/state/update-skills/last-scheduled-week" ]] ||
@@ -360,26 +372,27 @@ run_gate_sched "$CODEX_PLAIN" 10 "" 3
 deferred || fail "scheduled catch-up world did not defer: $GATE_OUTPUT"
 alerted || fail "a scheduled catch-up on a later day did not claim exhaustion (no later slot this week): $GATE_OUTPUT"
 
-# MANUAL run on Monday 16:00 → DEFERS but NEVER claims scheduled-budget
-# exhaustion (a manual run is not part of the scheduled cycle).
+# MANUAL run on Monday 23:00 (the last slot hour) → DEFERS but NEVER claims
+# scheduled-budget exhaustion (a manual run is not part of the scheduled cycle).
 reset_activity
 harness_active "$ACT_CODEX"
-run_gate "$CODEX_PLAIN" 16 "" 1
-deferred || fail "manual Monday-16:00 world did not defer: $GATE_OUTPUT"
-alerted && fail "a manual Monday-16:00 run claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
+run_gate "$CODEX_PLAIN" 23 "" 1
+deferred || fail "manual Monday-23:00 world did not defer: $GATE_OUTPUT"
+alerted && fail "a manual Monday-23:00 run claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
 
 # MANUAL non-Monday run → DEFERS, no alert (unchanged).
 reset_activity
 harness_active "$ACT_CODEX"
-run_gate "$CODEX_PLAIN" 16 "" 3
+run_gate "$CODEX_PLAIN" 23 "" 3
 deferred || fail "manual non-Monday world did not defer: $GATE_OUTPUT"
 alerted && fail "a manual non-Monday deferral alerted: $(cat "$ALERTER_LOG")"
 
-# ── The plist declares EXACTLY four Monday retry slots, each a full
-#    {Weekday=1, Hour in 4/8/12/16, Minute=0} tuple, AND passes --scheduled in
+# ── The plist declares EXACTLY 24 hourly Monday retry slots, each a full
+#    {Weekday=1, Hour in 0..23, Minute=0} tuple, AND passes --scheduled in
 #    ProgramArguments. Parse the rendered plist as real plist data (plutil ->
 #    json -> jq) so dropping Weekday or Minute (which launchd then treats as a
-#    wildcard, firing far more often) fails this test. ─────────────────────────
+#    wildcard, firing far more often) fails this test. The expected hour set is
+#    generated programmatically (0..23) rather than hand-listed. ───────────────
 PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl"
 rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
   fail "chezmoi execute-template failed on the update-skills plist"
@@ -387,14 +400,15 @@ plist_json="$tmp/plist.json"
 printf '%s' "$rendered_plist" | plutil -convert json -o "$plist_json" - 2>/dev/null ||
   fail "rendered plist did not parse as a plist"
 slot_count="$(jq '.StartCalendarInterval | length' "$plist_json")"
-[[ $slot_count -eq 4 ]] ||
-  fail "expected exactly 4 StartCalendarInterval tuples, got $slot_count"
+[[ $slot_count -eq 24 ]] ||
+  fail "expected exactly 24 StartCalendarInterval tuples, got $slot_count"
 non_conforming="$(jq '[.StartCalendarInterval[] | select(.Weekday != 1 or .Minute != 0)] | length' "$plist_json")"
 [[ $non_conforming -eq 0 ]] ||
   fail "a slot is missing Weekday=1 or Minute=0 (launchd would treat the missing key as a wildcard)"
 slot_hours="$(jq -c '[.StartCalendarInterval[].Hour] | sort' "$plist_json")"
-[[ $slot_hours == "[4,8,12,16]" ]] ||
-  fail "slot hours are not exactly 4/8/12/16: $slot_hours"
+expected_hours="$(jq -cn '[range(0;24)]')"
+[[ $slot_hours == "$expected_hours" ]] ||
+  fail "slot hours are not exactly 0..23: $slot_hours"
 prog_scheduled="$(jq -r '[.ProgramArguments[] | select(. == "--scheduled")] | length' "$plist_json")"
 [[ $prog_scheduled == "1" ]] ||
   fail "the plist ProgramArguments does not pass exactly one --scheduled marker (slot-aware exhaustion needs it)"

--- a/test/update-skills-dryrun-additive.sh
+++ b/test/update-skills-dryrun-additive.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# update-skills-dryrun-additive.sh — two convergence guarantees the audit found
+# violated:
+#   * --dry-run makes ZERO filesystem writes. The old convergence still ran
+#     mkdir/ln/rm under --dry-run, so a "preview" mutated live links. A dry run
+#     must leave link state byte-identical.
+#   * --install-only is truly ADDITIVE. It may create a missing store install
+#     and create an absent symlink, but it must NEVER replace a wrong-target
+#     link or remove a stale one. Destructive reconciliation belongs only to the
+#     full weekly path behind the idle gate. A wrong-target link under
+#     --install-only is left untouched and a loud warning is logged.
+#
+# The real script runs unmodified in a sandbox. Fixture store = three real skill
+# dirs; the Claude fan-out desired set is the full store roster. Pre-existing
+# Claude drift covers all three convergence actions:
+#   keep   — correct link            → kept
+#   wrongt — wrong-target owned link → full run replaces; dry/install-only leave
+#   miss   — absent                  → created
+#   ghost  — stale owned link        → full run removes; dry/install-only leave
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+STORE="$HOME/.agents/skills"
+CLAUDE="$HOME/.claude/skills"
+mkdir -p "$STORE" "$CLAUDE" "$HOME/.hermes/skills"
+
+for s in keep wrongt miss; do
+  mkdir -p "$STORE/$s"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "$s" >"$STORE/$s/SKILL.md"
+done
+
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"keep": "core", "wrongt": "core", "miss": "core"},
+  "hermesProfiles": {"keep": [], "wrongt": [], "miss": []},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+# Pre-existing Claude drift.
+ln -s "../../.agents/skills/keep" "$CLAUDE/keep"
+ln -s "../../.agents/skills/WRONG" "$CLAUDE/wrongt" # owned, wrong target
+ln -s "../../.agents/skills/ghost" "$CLAUDE/ghost"  # owned, stale (not in store)
+
+snapshot() {
+  local d="$1" p
+  {
+    for p in "$d"/*; do
+      [[ -e $p || -L $p ]] || continue
+      if [[ -L $p ]]; then
+        printf '%s -> %s\n' "${p##*/}" "$(readlink "$p")"
+      else
+        printf '%s [real]\n' "${p##*/}"
+      fi
+    done
+  } | sort
+}
+
+# ── --dry-run: byte-identical link state, but it must REPORT every action. ───
+before="$(snapshot "$CLAUDE")"
+dry_out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" || fail "--dry-run exited non-zero: $dry_out"
+after="$(snapshot "$CLAUDE")"
+[[ $before == "$after" ]] ||
+  fail "--dry-run mutated Claude link state:
+--- before ---
+$before
+--- after ---
+$after"
+printf '%s\n' "$dry_out" | grep -qi 'would create.*miss' ||
+  fail "--dry-run did not report the missing link it would create: $dry_out"
+printf '%s\n' "$dry_out" | grep -qi 'would replace.*wrongt' ||
+  fail "--dry-run did not report the wrong-target link it would replace: $dry_out"
+printf '%s\n' "$dry_out" | grep -qi 'would remove.*ghost' ||
+  fail "--dry-run did not report the stale link it would remove: $dry_out"
+
+# ── --install-only (additive): create missing, LEAVE wrong-target (+ warn),
+#    LEAVE stale. ──────────────────────────────────────────────────────────
+io_out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only 2>&1)" || fail "--install-only exited non-zero: $io_out"
+# created the missing link
+[[ -L "$CLAUDE/miss" && "$(readlink "$CLAUDE/miss")" == "../../.agents/skills/miss" ]] ||
+  fail "--install-only did not create the absent link 'miss'"
+# LEFT the wrong-target link untouched
+[[ -L "$CLAUDE/wrongt" && "$(readlink "$CLAUDE/wrongt")" == "../../.agents/skills/WRONG" ]] ||
+  fail "--install-only replaced a wrong-target link (must be additive-only): $(readlink "$CLAUDE/wrongt" 2>/dev/null)"
+# and logged a loud warning about it
+printf '%s\n' "$io_out" | grep -i 'warn' | grep -q 'wrongt' ||
+  fail "--install-only did not log a loud warning about the wrong-target link it left: $io_out"
+# LEFT the stale link (no removal under additive mode)
+[[ -L "$CLAUDE/ghost" ]] ||
+  fail "--install-only removed a stale link (must be additive-only, never remove)"
+
+# ── full run (FORCE, no --install-only): destructive reconciliation runs. ────
+UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/dev/null 2>&1 || fail "full run exited non-zero"
+[[ -L "$CLAUDE/wrongt" && "$(readlink "$CLAUDE/wrongt")" == "../../.agents/skills/wrongt" ]] ||
+  fail "full run did not repair the wrong-target link"
+[[ ! -e "$CLAUDE/ghost" && ! -L "$CLAUDE/ghost" ]] ||
+  fail "full run did not remove the stale link"
+
+echo "update-skills-dryrun-additive: OK"

--- a/test/update-skills-dryrun-additive.sh
+++ b/test/update-skills-dryrun-additive.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-dryrun-additive.sh — two convergence guarantees the audit found
+# update-skills-dryrun-additive.sh, two convergence guarantees the audit found
 # violated:
 #   * --dry-run makes ZERO filesystem writes. The old convergence still ran
 #     mkdir/ln/rm under --dry-run, so a "preview" mutated live links. A dry run
@@ -13,10 +13,10 @@
 # The real script runs unmodified in a sandbox. Fixture store = three real skill
 # dirs; the Claude fan-out desired set is the full store roster. Pre-existing
 # Claude drift covers all three convergence actions:
-#   keep   — correct link            → kept
-#   wrongt — wrong-target owned link → full run replaces; dry/install-only leave
-#   miss   — absent                  → created
-#   ghost  — stale owned link        → full run removes; dry/install-only leave
+#   keep, correct link            → kept
+#   wrongt, wrong-target owned link → full run replaces; dry/install-only leave
+#   miss, absent                  → created
+#   ghost, stale owned link        → full run removes; dry/install-only leave
 set -euo pipefail
 
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR

--- a/test/update-skills-dryrun-readonly.sh
+++ b/test/update-skills-dryrun-readonly.sh
@@ -22,12 +22,15 @@ tmp="$(mktemp -d)"
 # remove everything.
 trap 'chmod -R u+w "$tmp" 2>/dev/null || true; rm -rf "$tmp"' EXIT
 
-# Offline npx stub (a dry run still logs "would run: npx ..." but never calls it;
-# keep PATH sane regardless).
+# Recording npx + clawhub stubs: a dry run must NEVER invoke either package CLI
+# (the npx CLI treats `update --help` as a real update, observed live), so any
+# entry in these logs is a failure asserted at the end.
 stub="$tmp/stub"
 mkdir -p "$stub"
-printf '#!/usr/bin/env bash\necho stub\n' >"$stub/npx"
-chmod +x "$stub/npx"
+CLI_LOG="$tmp/cli-invocations.log"
+printf '#!/usr/bin/env bash\nprintf "npx %%s\\n" "$*" >>"%s"\necho stub\n' "$CLI_LOG" >"$stub/npx"
+printf '#!/usr/bin/env bash\nprintf "clawhub %%s\\n" "$*" >>"%s"\necho stub\n' "$CLI_LOG" >"$stub/clawhub"
+chmod +x "$stub/npx" "$stub/clawhub"
 export PATH="$stub:$PATH"
 
 snapshot() { find "$1" 2>/dev/null | sort; }
@@ -89,18 +92,21 @@ grep -qi 'would defer' <<<"$out" || fail "--dry-run did not preview 'would defer
 kill "$live_pid" 2>/dev/null || true
 wait "$live_pid" 2>/dev/null || true
 
-# ── 4) read-only home → dry-run writes nothing, exits 0 ─────────────────────
+# ── 4) read-only home → dry-run writes nothing, exits 0. The roster is
+#      NON-EMPTY here (an absent npx skill and an absent clawhub skill a full
+#      run would install), so the never-invokes-a-package-CLI assertion at the
+#      end is load-bearing, not vacuous. ──────────────────────────────────────
 HOME4="$tmp/home4"
 export HOME="$HOME4"
 mkdir -p "$HOME4/.agents/skills"
 cat >"$HOME4/.agents/custom-skill-lock.json" <<'EOF'
 {
   "version": 2,
-  "tiers": {},
-  "hermesProfiles": {},
+  "tiers": {"wanted": "core", "clawwanted": "core"},
+  "hermesProfiles": {"wanted": [], "clawwanted": []},
   "hermesRegistry": {},
-  "npxTracked": {},
-  "clawhubTracked": {},
+  "npxTracked": {"wanted": {"repo": "fixture/wanted"}},
+  "clawhubTracked": {"clawwanted": {"slug": "@fixture/clawwanted", "registry": "https://clawhub.example"}},
   "superpowersRouting": {},
   "forks": {}
 }
@@ -116,5 +122,10 @@ $before
 --- after ---
 $after"
 chmod -R u+w "$HOME4/.agents"
+
+# ── 5) across ALL the dry runs above: neither package CLI was ever invoked ────
+if [[ -s $CLI_LOG ]]; then
+  fail "--dry-run invoked a package CLI (npx/clawhub must never run in a dry run): $(cat "$CLI_LOG")"
+fi
 
 echo "update-skills-dryrun-readonly: OK"

--- a/test/update-skills-dryrun-readonly.sh
+++ b/test/update-skills-dryrun-readonly.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# update-skills-dryrun-readonly.sh, --dry-run is a READ-ONLY contention check
+# (Wave 3a item 5). The audit found dry-run still created the lock dir and could
+# delete a dead lock, and on a fresh home with .agents absent it failed as false
+# contention. A dry run must create nothing, delete nothing, tolerate an absent
+# .agents parent, and leave the filesystem byte-identical while still previewing
+# whether it would run or defer.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+# Some cases chmod a dir read-only; restore write before cleanup so the trap can
+# remove everything.
+trap 'chmod -R u+w "$tmp" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+# Offline npx stub (a dry run still logs "would run: npx ..." but never calls it;
+# keep PATH sane regardless).
+stub="$tmp/stub"
+mkdir -p "$stub"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub/npx"
+chmod +x "$stub/npx"
+export PATH="$stub:$PATH"
+
+snapshot() { find "$1" 2>/dev/null | sort; }
+
+# ── 1) absent .agents parent → preview, no false contention, nothing created ─
+HOME1="$tmp/home1"
+export HOME="$HOME1"
+mkdir -p "$HOME1" # .agents deliberately absent
+before="$(snapshot "$HOME1")"
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" ||
+  fail "--dry-run on an absent-.agents home exited non-zero: $out"
+after="$(snapshot "$HOME1")"
+[[ $before == "$after" ]] || fail "--dry-run mutated a fresh home:
+--- before ---
+$before
+--- after ---
+$after"
+[[ ! -d "$HOME1/.agents/.update-skills.lock.d" ]] ||
+  fail "--dry-run created a lock dir on a fresh home (false contention path)"
+grep -qiE 'another run in progress' <<<"$out" &&
+  fail "--dry-run on a fresh home reported false contention: $out"
+grep -qi 'would run' <<<"$out" || fail "--dry-run did not preview 'would run': $out"
+
+# ── 2) existing DEAD lock → dry-run must not delete it, previews would-run ────
+HOME2="$tmp/home2"
+export HOME="$HOME2"
+mkdir -p "$HOME2/.agents/skills"
+LOCKDIR2="$HOME2/.agents/.update-skills.lock.d"
+mkdir -p "$LOCKDIR2"
+printf '%s\t%s' "999999" "Sat Jan  1 00:00:00 2000" >"$LOCKDIR2/owner" # dead owner
+before="$(snapshot "$HOME2")"
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" ||
+  fail "--dry-run with a dead lock exited non-zero: $out"
+after="$(snapshot "$HOME2")"
+[[ $before == "$after" ]] || fail "--dry-run mutated lock state around a dead lock:
+--- before ---
+$before
+--- after ---
+$after"
+[[ -d $LOCKDIR2 && -f "$LOCKDIR2/owner" ]] ||
+  fail "--dry-run deleted a dead lock (must never mutate lock state)"
+grep -qi 'would run' <<<"$out" || fail "--dry-run did not preview 'would run' past a dead lock: $out"
+
+# ── 3) existing LIVE lock → dry-run previews would-defer, changes nothing ─────
+HOME3="$tmp/home3"
+export HOME="$HOME3"
+mkdir -p "$HOME3/.agents/skills"
+LOCKDIR3="$HOME3/.agents/.update-skills.lock.d"
+mkdir -p "$LOCKDIR3"
+sleep 60 &
+live_pid=$!
+printf '%s\t%s' "$live_pid" "$(ps -o lstart= -p "$live_pid" 2>/dev/null | tr -s ' ' | sed 's/^ *//;s/ *$//')" >"$LOCKDIR3/owner"
+before="$(snapshot "$HOME3")"
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" ||
+  fail "--dry-run with a live lock exited non-zero: $out"
+after="$(snapshot "$HOME3")"
+[[ $before == "$after" ]] || fail "--dry-run mutated state around a live lock"
+grep -qi 'would defer' <<<"$out" || fail "--dry-run did not preview 'would defer' under a live lock: $out"
+kill "$live_pid" 2>/dev/null || true
+wait "$live_pid" 2>/dev/null || true
+
+# ── 4) read-only home → dry-run writes nothing, exits 0 ─────────────────────
+HOME4="$tmp/home4"
+export HOME="$HOME4"
+mkdir -p "$HOME4/.agents/skills"
+cat >"$HOME4/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {},
+  "hermesProfiles": {},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "superpowersRouting": {},
+  "forks": {}
+}
+EOF
+chmod -R a-w "$HOME4/.agents" # read-only tree
+before="$(snapshot "$HOME4")"
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" ||
+  fail "--dry-run under a read-only home exited non-zero: $out"
+after="$(snapshot "$HOME4")"
+[[ $before == "$after" ]] || fail "--dry-run wrote to a read-only home:
+--- before ---
+$before
+--- after ---
+$after"
+chmod -R u+w "$HOME4/.agents"
+
+echo "update-skills-dryrun-readonly: OK"

--- a/test/update-skills-exchange-publish.sh
+++ b/test/update-skills-exchange-publish.sh
@@ -18,14 +18,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
 
-command -v "$GMV_BIN" >/dev/null 2>&1 || fail "GNU coreutils gmv not found at $GMV_BIN"
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-exchange-publish.sh
+++ b/test/update-skills-exchange-publish.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# update-skills-exchange-publish.sh — proves the generation-exchange publish is
+# update-skills-exchange-publish.sh proves the generation-exchange publish is
 # atomic and per-lookup complete (Wave 3a fix4 acceptance points 2 and 3).
 #
 # A reader loop resolves the store during 100 publish cycles. Each pass resolves
 # ONE physical generation (as a running session that cached a canonical path
 # would) and reads two sibling skills' recorded generation id from it. The
 # guarantee under test: any resolution yields a COMPLETE tree from EXACTLY ONE
-# generation — the reader never sees a missing path, and two siblings resolved
+# generation: the reader never sees a missing path, and two siblings resolved
 # from one pass never disagree on the generation id (no mixed-generation pair).
 #
 # The machinery is exercised in isolation by sourcing the real script with
@@ -66,12 +66,12 @@ READER_LOG="$tmp/reader.log"
 : >"$READER_LOG"
 
 # The reader models a running session that cached a RESOLVED path. Each pass
-# pins its cwd to the physical generation directory (via the store symlink) —
+# pins its cwd to the physical generation directory (via the store symlink);
 # the cwd fd is the cache, so an atomic exchange of the .skills-current entry
 # does not move this reader off the generation it pinned. It then reads both
 # siblings RELATIVE to that pinned cwd, so the two reads land in ONE generation.
-# Violations: exactly one sibling missing (a PARTIAL tree — never allowed); both
-# present but their generation ids disagree (a MIXED pair — never allowed). Both
+# Violations: exactly one sibling missing (a PARTIAL tree, never allowed); both
+# present but their generation ids disagree (a MIXED pair, never allowed). Both
 # siblings missing is a clean ENOENT of a since-pruned generation (allowed by the
 # per-lookup-completeness guarantee) and is NOT a violation.
 reader() {

--- a/test/update-skills-exchange-publish.sh
+++ b/test/update-skills-exchange-publish.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# update-skills-exchange-publish.sh — proves the generation-exchange publish is
+# atomic and per-lookup complete (Wave 3a fix4 acceptance points 2 and 3).
+#
+# A reader loop resolves the store during 100 publish cycles. Each pass resolves
+# ONE physical generation (as a running session that cached a canonical path
+# would) and reads two sibling skills' recorded generation id from it. The
+# guarantee under test: any resolution yields a COMPLETE tree from EXACTLY ONE
+# generation — the reader never sees a missing path, and two siblings resolved
+# from one pass never disagree on the generation id (no mixed-generation pair).
+#
+# The machinery is exercised in isolation by sourcing the real script with
+# UPDATE_SKILLS_LIB_ONLY=1 and calling __gen_publish, so the test drives the
+# exact publish primitive the weekly run uses.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v "$GMV_BIN" >/dev/null 2>&1 || fail "GNU coreutils gmv not found at $GMV_BIN"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"npxTracked":{"alpha":{"repo":"x/a"},"beta":{"repo":"x/b"}},"clawhubTracked":{}}
+EOF
+
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# Build a complete generation dir holding both siblings, each carrying gen.txt =
+# the generation id, plus the npx lock and the ready marker.
+build_generation() {
+  local dir="$1" id="$2" skill
+  mkdir -p "$dir/skills"
+  for skill in alpha beta; do
+    mkdir -p "$dir/skills/$skill"
+    printf -- '---\nname: %s\n---\n' "$skill" >"$dir/skills/$skill/SKILL.md"
+    printf '%s' "$id" >"$dir/skills/$skill/gen.txt"
+  done
+  printf '{}\n' >"$dir/.skill-lock.json"
+  __gen_write_meta "$dir" "$id"
+}
+
+# Seed the live generation and the stable store + lock links.
+build_generation "$SKILLS_CURRENT" "gen-000"
+__gen_plant_store_link alpha
+__gen_plant_store_link beta
+__gen_plant_lock_link
+
+READER_LOG="$tmp/reader.log"
+: >"$READER_LOG"
+
+# The reader models a running session that cached a RESOLVED path. Each pass
+# pins its cwd to the physical generation directory (via the store symlink) —
+# the cwd fd is the cache, so an atomic exchange of the .skills-current entry
+# does not move this reader off the generation it pinned. It then reads both
+# siblings RELATIVE to that pinned cwd, so the two reads land in ONE generation.
+# Violations: exactly one sibling missing (a PARTIAL tree — never allowed); both
+# present but their generation ids disagree (a MIXED pair — never allowed). Both
+# siblings missing is a clean ENOENT of a since-pruned generation (allowed by the
+# per-lookup-completeness guarantee) and is NOT a violation.
+reader() {
+  local passes=0 result
+  while [[ -f "$tmp/reader.run" ]]; do
+    passes=$((passes + 1))
+    result="$(
+      # Physical cd (-P) follows the store symlink to the real generation dir
+      # and pins the process cwd to that inode; a logical cd would collapse
+      # alpha/.. textually and leave us re-resolving .skills-current per read.
+      if ! { cd -P "$STORE/alpha" && cd -P ..; } 2>/dev/null; then
+        printf 'MISSING-STORE'
+        exit 0
+      fi
+      # cwd is now pinned to one generation's skills inode.
+      a=""
+      b=""
+      [[ -f alpha/gen.txt ]] && a="$(cat alpha/gen.txt 2>/dev/null || true)"
+      [[ -f beta/gen.txt ]] && b="$(cat beta/gen.txt 2>/dev/null || true)"
+      if [[ -z $a && -z $b ]]; then
+        printf 'PRUNED'
+      elif [[ -z $a || -z $b ]]; then
+        printf 'PARTIAL a=%s b=%s' "$a" "$b"
+      elif [[ $a != "$b" ]]; then
+        printf 'MIXED a=%s b=%s' "$a" "$b"
+      else
+        printf 'OK'
+      fi
+    )"
+    case "$result" in
+      MISSING-STORE) printf 'MISSING store/alpha at pass %s\n' "$passes" >>"$READER_LOG" ;;
+      PARTIAL*) printf 'PARTIAL at pass %s (%s)\n' "$passes" "$result" >>"$READER_LOG" ;;
+      MIXED*) printf 'MIXED at pass %s (%s)\n' "$passes" "$result" >>"$READER_LOG" ;;
+    esac
+  done
+  printf 'passes=%s\n' "$passes" >>"$READER_LOG"
+}
+
+touch "$tmp/reader.run"
+reader &
+reader_pid=$!
+
+# 100 publish cycles: build a fresh candidate under the generations tree and
+# publish it with the atomic exchange the weekly run uses.
+cycles=100
+for i in $(seq 1 "$cycles"); do
+  cand="$GENERATIONS/build-$i/home/.agents"
+  build_generation "$cand" "gen-$(printf '%03d' "$i")"
+  __gen_publish "$cand" >>"$tmp/publish.log" 2>&1 ||
+    fail "publish cycle $i failed: $(tail -3 "$tmp/publish.log")"
+done
+
+rm -f "$tmp/reader.run"
+wait "$reader_pid" 2>/dev/null || true
+
+# The live generation must be the last one published.
+final_id="$(__gen_meta_field "$SKILLS_CURRENT" id)"
+[[ $final_id == "gen-$(printf '%03d' "$cycles")" ]] ||
+  fail "final live generation id is $final_id, expected gen-$(printf '%03d' "$cycles")"
+
+# Exactly one previous generation is retained (durable-not-destructive bar).
+retained_count="$(find "$GENERATIONS" -maxdepth 1 -type d -name '*-*' \
+  \! -name '*.garbage.*' -exec test -f '{}/generation.json' \; -print 2>/dev/null | wc -l | tr -d ' ')"
+[[ $retained_count -le 1 ]] ||
+  fail "expected at most one retained previous generation, found $retained_count"
+
+# The reader must have run and logged ZERO violations.
+grep -qE 'MISSING|MIXED|EMPTY' "$READER_LOG" &&
+  fail "reader observed a violation: $(grep -E 'MISSING|MIXED|EMPTY' "$READER_LOG" | head -5)"
+passes="$(sed -n 's/^passes=//p' "$READER_LOG")"
+[[ ${passes:-0} -ge 1 ]] || fail "reader loop did not run (passes=$passes)"
+
+echo "update-skills-exchange-publish: OK ($cycles cycles, reader $passes passes, 0 violations)"

--- a/test/update-skills-exchange-tool.sh
+++ b/test/update-skills-exchange-tool.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# update-skills-exchange-tool.sh: the generation-exchange tool is resolved at
+# RUN TIME on PATH, never hardcoded to a host location (/opt/homebrew/bin/gmv
+# broke the Nix devshell, whose GNU coreutils mv is plain mv). Contract:
+#   1. Resolution order is gmv then mv; a candidate is accepted only when
+#      --version says GNU coreutils AND a functional probe performs a real
+#      --exchange --no-copy -T swap. A non-GNU binary named gmv is skipped in
+#      favor of a capable mv, so publishes succeed on a GNU-mv-only userland.
+#   2. The resolved tool is cached per run: repeated publishes probe once.
+#   3. With NO capable tool on PATH, a publish is a LOUD no-op: it fails with a
+#      clear message and both the live generation and the candidate stay
+#      complete (never a partial operation).
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+REAL_TOOL="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
+REAL_TOOL_PATH="$(command -v "$REAL_TOOL")"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"npxTracked":{"alpha":{"repo":"x/a"}},"clawhubTracked":{}}
+EOF
+unset UPDATE_SKILLS_GMV
+
+# Each case runs in its own interpreter (fresh per-run tool cache) with a
+# sandbox dir PREPENDED to PATH so its gmv/mv shadow the real ones. The driver
+# sources the script lib-only, seeds a live generation, builds a candidate,
+# publishes, and reports the resolved tool plus the live generation id.
+driver="$tmp/driver.sh"
+cat >"$driver" <<DRIVER
+#!/usr/bin/env bash
+set -euo pipefail
+cycles="\${DRIVER_CYCLES:-1}"
+set -- # the sourced script parses \$@; it must see no arguments
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+build_generation() {
+  local dir="\$1" id="\$2"
+  mkdir -p "\$dir/skills/alpha"
+  printf -- '---\nname: alpha\n---\n' >"\$dir/skills/alpha/SKILL.md"
+  printf '{}\n' >"\$dir/.skill-lock.json"
+  __gen_write_meta "\$dir" "\$id"
+}
+rm -rf "\$SKILLS_CURRENT" "\$GENERATIONS"
+build_generation "\$SKILLS_CURRENT" gen-live
+for i in \$(seq 1 "\$cycles"); do
+  cand="\$GENERATIONS/build-\$i/home/.agents"
+  build_generation "\$cand" "gen-\$i"
+  if ! __gen_publish "\$cand"; then
+    printf 'publish-rc=1\n'
+    exit 0
+  fi
+done
+printf 'publish-rc=0\n'
+printf 'resolved=%s\n' "\$GEN_EXCHANGE_TOOL"
+printf 'live-id=%s\n' "\$(__gen_meta_field "\$SKILLS_CURRENT" id)"
+DRIVER
+chmod +x "$driver"
+
+# ── 1. a non-GNU gmv is skipped; the capable mv is picked ──────────────────
+sandbox1="$tmp/sandbox1"
+mkdir -p "$sandbox1"
+cat >"$sandbox1/gmv" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+  echo "fake mv 1.0 (not coreutils)"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$sandbox1/gmv"
+ln -s "$REAL_TOOL_PATH" "$sandbox1/mv"
+out="$(PATH="$sandbox1:$PATH" DRIVER_CYCLES=1 bash "$driver")" || fail "case 1 driver failed: $out"
+grep -q 'publish-rc=0' <<<"$out" || fail "case 1: publish failed with a capable mv on PATH: $out"
+grep -q 'resolved=mv' <<<"$out" ||
+  fail "case 1: resolution did not skip the non-GNU gmv in favor of mv: $out"
+grep -q 'live-id=gen-1' <<<"$out" || fail "case 1: the live generation was not published: $out"
+
+# ── 2. the resolved tool is cached: 3 publishes probe --version once ───────
+sandbox2="$tmp/sandbox2"
+mkdir -p "$sandbox2"
+version_calls="$tmp/version-calls"
+: >"$version_calls"
+cat >"$sandbox2/gmv" <<EOF
+#!/usr/bin/env bash
+if [[ \${1:-} == --version ]]; then
+  printf 'v\n' >>"$version_calls"
+fi
+exec "$REAL_TOOL_PATH" "\$@"
+EOF
+chmod +x "$sandbox2/gmv"
+out="$(PATH="$sandbox2:$PATH" DRIVER_CYCLES=3 bash "$driver")" || fail "case 2 driver failed: $out"
+grep -q 'publish-rc=0' <<<"$out" || fail "case 2: publishes failed: $out"
+grep -q 'live-id=gen-3' <<<"$out" || fail "case 2: the last generation is not live: $out"
+probe_count="$(wc -l <"$version_calls" | tr -d ' ')"
+[[ $probe_count -eq 1 ]] ||
+  fail "case 2: expected exactly 1 --version probe across 3 publishes (per-run cache); got $probe_count"
+
+# ── 3. no capable tool: publish is a loud no-op, nothing partial ───────────
+sandbox3="$tmp/sandbox3"
+mkdir -p "$sandbox3"
+for name in gmv mv; do
+  cat >"$sandbox3/$name" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${1:-} == --version ]]; then
+  echo "stub mv 1.0 (not coreutils)"
+  exit 0
+fi
+for arg in "$@"; do
+  [[ $arg == --exchange ]] && exit 1
+done
+exec /bin/mv "$@"
+EOF
+  chmod +x "$sandbox3/$name"
+done
+out="$(PATH="$sandbox3:$PATH" DRIVER_CYCLES=1 bash "$driver" 2>&1)" || fail "case 3 driver crashed: $out"
+grep -q 'publish-rc=1' <<<"$out" || fail "case 3: publish claimed success with no capable exchange tool: $out"
+grep -q 'no GNU coreutils mv with a working --exchange' <<<"$out" ||
+  fail "case 3: the missing exchange tool was not reported loudly: $out"
+# No partial operation: the live generation and the candidate are both complete.
+[[ -f "$HOME/.agents/.skills-current/skills/alpha/SKILL.md" ]] ||
+  fail "case 3: the live generation lost content on a failed publish"
+live_id="$(jq -r '.id' "$HOME/.agents/.skills-current/generation.json")"
+[[ $live_id == gen-live ]] || fail "case 3: the live generation changed on a failed publish (id=$live_id)"
+[[ -f "$HOME/.agents/.skills-generations/build-1/home/.agents/skills/alpha/SKILL.md" ]] ||
+  fail "case 3: the candidate was partially consumed by a failed publish"
+
+echo "update-skills-exchange-tool: OK (resolution, per-run cache, loud no-op)"

--- a/test/update-skills-first-install-retry.sh
+++ b/test/update-skills-first-install-retry.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-first-install-retry.sh — a failed first-install pass must stay
+# update-skills-first-install-retry.sh, a failed first-install pass must stay
 # RETRYABLE across applies without ever aborting the apply, and the retry marker
 # must never be able to inject shell into the rendered chezmoiscript.
 #

--- a/test/update-skills-first-install-retry.sh
+++ b/test/update-skills-first-install-retry.sh
@@ -37,8 +37,12 @@ grep -q 'regexFind "\^\[0-9\]+"' "$TMPL" ||
   fail "the chezmoiscript does not sanitize the marker to digits with regexFind"
 grep -q 'first-install-pending' "$TMPL" ||
   fail "the chezmoiscript does not reference the pending-marker file"
-grep -q 'output "cat"' "$TMPL" ||
-  fail "the chezmoiscript does not interpolate the marker via output"
+# The marker is read through a shell guard (cat ... || true) so an unreadable
+# (mode-000) marker yields the safe zero path instead of a render abort.
+grep -q 'output "sh"' "$TMPL" ||
+  fail "the chezmoiscript does not read the marker via a guarded output call"
+grep -q '10#' "$TMPL" ||
+  fail "the chezmoiscript does not force base-10 on the retry counter"
 
 # Sandbox home; render the runner against it (marker path resolves under here).
 sbox="$tmp/home"
@@ -73,6 +77,35 @@ FAKE_UPDATER_RC=1 HOME="$sbox" bash "$runner" || fail "runner aborted on the sec
 # ── 4. success after failure -> marker removed. ─────────────────────────────
 FAKE_UPDATER_RC=0 HOME="$sbox" bash "$runner" || fail "runner exited non-zero clearing the marker"
 [[ ! -e $MARKER ]] || fail "the pending marker was not removed after a success"
+
+# ── 4a. base-10: a leading-zero marker (08) must NOT abort with an octal error;
+#     it routes through the failure branch and increments to 9. ─────────────
+mkdir -p "$(dirname "$MARKER")"
+printf '08\n' >"$MARKER"
+FAKE_UPDATER_RC=1 HOME="$sbox" bash "$runner" ||
+  fail "an '08' marker aborted the failure branch (octal arithmetic bug: value too great for base)"
+[[ "$(<"$MARKER")" == "9" ]] || fail "base-10 bump of '08' did not yield 9: $(<"$MARKER")"
+
+# ── 4b. a multiline marker is inert: only the leading digits count, the second
+#     line never executes, and the counter still increments off the first line.
+sentinel2="$tmp/PWNED2"
+rm -f "$sentinel2"
+printf '5\ntouch %s\n' "$sentinel2" >"$MARKER"
+FAKE_UPDATER_RC=1 HOME="$sbox" bash "$runner" ||
+  fail "a multiline marker aborted the failure branch"
+[[ ! -e $sentinel2 ]] || fail "a multiline marker executed its injected second line at run time"
+[[ "$(<"$MARKER")" == "6" ]] || fail "a multiline marker did not increment off its leading digit: $(<"$MARKER")"
+rm -f "$MARKER"
+
+# ── 4c. render tolerates an UNREADABLE (mode-000) marker: no template abort,
+#     the safe zero path is taken. ────────────────────────────────────────
+mkdir -p "$(dirname "$MARKER")"
+printf '3\n' >"$MARKER"
+chmod 000 "$MARKER"
+mode000_runner="$tmp/mode000.sh"
+render "$mode000_runner" || fail "rendering with a mode-000 marker aborted the render (output of cat errored)"
+chmod 644 "$MARKER"
+rm -f "$MARKER"
 
 # ── 5. SECURITY: a hostile marker must not inject shell. ────────────────────
 sentinel="$tmp/PWNED"

--- a/test/update-skills-first-install-retry.sh
+++ b/test/update-skills-first-install-retry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# update-skills-first-install-retry.sh — a failed first-install pass must stay
+# RETRYABLE across applies without ever aborting the apply, and the retry marker
+# must never be able to inject shell into the rendered chezmoiscript.
+#
+# The runner is exercised by RENDERING the chezmoiscript (chezmoi
+# execute-template, with .chezmoi.homeDir pointed at a sandbox via $HOME) and
+# then EXECUTING the rendered bytes with a stubbed updater on PATH. Assertions:
+#   1. updater success  -> no marker, exit 0;
+#   2. updater failure  -> a monotonic marker is created, exit 0 (NOT aborted);
+#   3. repeated failure  -> the marker counter increments;
+#   4. success after failure -> the marker is removed;
+#   5. SECURITY: a hostile marker (a digit then a second shell line) renders as a
+#      digits-only comment and neither executes nor aborts the render/apply;
+#   6. template-content: the digits-only marker interpolation exists in the .tmpl;
+#   7. mutating the UPDATER copy (not just the lock) changes the rendered
+#      trigger content (the updater-hash line), so run_onchange re-fires on an
+#      installer change too.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPL="$REPO_ROOT/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl"
+UPDATER_SRC="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# ── 6. template-content: the digits-only sanitizer is present in the source. ──
+grep -q 'regexFind "\^\[0-9\]+"' "$TMPL" ||
+  fail "the chezmoiscript does not sanitize the marker to digits with regexFind"
+grep -q 'first-install-pending' "$TMPL" ||
+  fail "the chezmoiscript does not reference the pending-marker file"
+grep -q 'output "cat"' "$TMPL" ||
+  fail "the chezmoiscript does not interpolate the marker via output"
+
+# Sandbox home; render the runner against it (marker path resolves under here).
+sbox="$tmp/home"
+mkdir -p "$sbox/.local/bin"
+MARKER="$sbox/.local/state/skills/first-install-pending"
+
+# A stub updater whose exit code we control via FAKE_UPDATER_RC.
+cat >"$sbox/.local/bin/update-skills.sh" <<'EOF'
+#!/usr/bin/env bash
+exit "${FAKE_UPDATER_RC:-0}"
+EOF
+chmod +x "$sbox/.local/bin/update-skills.sh"
+
+render() { HOME="$sbox" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$TMPL" >"$1"; }
+runner="$tmp/runner.sh"
+render "$runner" || fail "rendering the chezmoiscript failed"
+
+# ── 1. updater success -> no marker, exit 0. ────────────────────────────────
+rm -rf "$sbox/.local/state"
+FAKE_UPDATER_RC=0 HOME="$sbox" bash "$runner" || fail "runner exited non-zero on updater success"
+[[ ! -e $MARKER ]] || fail "a marker was created on updater success"
+
+# ── 2. updater failure -> marker created (count 1), exit 0. ─────────────────
+FAKE_UPDATER_RC=1 HOME="$sbox" bash "$runner" || fail "runner aborted the apply on updater failure (must exit 0)"
+[[ -f $MARKER ]] || fail "no pending marker was created on updater failure"
+[[ "$(<"$MARKER")" == "1" ]] || fail "first failure did not record attempt 1: $(<"$MARKER")"
+
+# ── 3. repeated failure -> counter increments. ──────────────────────────────
+FAKE_UPDATER_RC=1 HOME="$sbox" bash "$runner" || fail "runner aborted on the second failure"
+[[ "$(<"$MARKER")" == "2" ]] || fail "second failure did not bump the counter to 2: $(<"$MARKER")"
+
+# ── 4. success after failure -> marker removed. ─────────────────────────────
+FAKE_UPDATER_RC=0 HOME="$sbox" bash "$runner" || fail "runner exited non-zero clearing the marker"
+[[ ! -e $MARKER ]] || fail "the pending marker was not removed after a success"
+
+# ── 5. SECURITY: a hostile marker must not inject shell. ────────────────────
+sentinel="$tmp/PWNED"
+rm -f "$sentinel"
+mkdir -p "$(dirname "$MARKER")"
+printf '5\ntouch %s\n' "$sentinel" >"$MARKER" # digit then an injected command
+hostile_runner="$tmp/hostile.sh"
+render "$hostile_runner" || fail "rendering with a hostile marker aborted the render"
+# The injected command must not appear as a live (uncommented) line.
+if grep -Eq '^[[:space:]]*touch ' "$hostile_runner"; then
+  fail "the hostile marker injected a live 'touch' line into the rendered runner"
+fi
+# The digit still lands, but only inside the comment line.
+grep -Eq '^# pending retry: 5$' "$hostile_runner" ||
+  fail "the sanitized digit did not land in the pending-retry comment: $(grep -i 'pending retry' "$hostile_runner")"
+# Executing the rendered runner must not run the injection.
+FAKE_UPDATER_RC=0 HOME="$sbox" bash "$hostile_runner" || fail "the hostile-marker runner exited non-zero"
+[[ ! -e $sentinel ]] || fail "the hostile marker executed injected shell (sentinel created)"
+
+# ── 7. mutating the UPDATER copy changes the rendered trigger content. ───────
+fix="$tmp/fixture_src"
+mkdir -p "$fix/.chezmoiscripts" "$fix/dot_local/bin" "$fix/dot_agents"
+cp "$TMPL" "$fix/.chezmoiscripts/$(basename "$TMPL")"
+cp "$UPDATER_SRC" "$fix/dot_local/bin/executable_update-skills.sh"
+printf '{"version":2,"tiers":{}}\n' >"$fix/dot_agents/custom-skill-lock.json"
+render_fix() { CI=1 chezmoi --source "$fix" execute-template --no-tty <"$fix/.chezmoiscripts/$(basename "$TMPL")"; }
+before="$(render_fix | grep 'updater hash:')" || fail "fixture render A failed"
+printf '\n# a change to the installer\n' >>"$fix/dot_local/bin/executable_update-skills.sh"
+after="$(render_fix | grep 'updater hash:')" || fail "fixture render B failed"
+[[ $before != "$after" ]] ||
+  fail "the rendered updater-hash line did not change when the updater copy changed (run_onchange would miss installer edits)"
+
+echo "update-skills-first-install-retry: OK"

--- a/test/update-skills-first-install.sh
+++ b/test/update-skills-first-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# update-skills-first-install.sh — a fresh machine must reproduce the full skills
+# update-skills-first-install.sh, a fresh machine must reproduce the full skills
 # store at apply time, not wait for the weekly Monday LaunchAgent (RunAtLoad is
-# false, so the agent's first chance is Monday — or never, given the idle-gate).
+# false, so the agent's first chance is Monday, or never, given the idle-gate).
 #
 # Asserts:
 #   1. the run_onchange chezmoiscript invokes the DEPLOYED updater with
@@ -9,7 +9,7 @@
 #   2. its rendered content re-hashes when the lock changes, so run_onchange
 #      re-fires on any roster edit;
 #   3. --install-only against an empty HOME installs ABSENT skills and skips
-#      present ones — and it runs even while an agent session is live, because
+#      present ones, and it runs even while an agent session is live, because
 #      --install-only only ADDS absent skills (never swaps a folder) and is
 #      therefore exempt from the idle-gate.
 set -euo pipefail

--- a/test/update-skills-first-install.sh
+++ b/test/update-skills-first-install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# update-skills-first-install.sh — a fresh machine must reproduce the full skills
+# store at apply time, not wait for the weekly Monday LaunchAgent (RunAtLoad is
+# false, so the agent's first chance is Monday — or never, given the idle-gate).
+#
+# Asserts:
+#   1. the run_onchange chezmoiscript invokes the DEPLOYED updater with
+#      --install-only;
+#   2. its rendered content re-hashes when the lock changes, so run_onchange
+#      re-fires on any roster edit;
+#   3. --install-only against an empty HOME installs ABSENT skills and skips
+#      present ones — and it runs even while an agent session is live, because
+#      --install-only only ADDS absent skills (never swaps a folder) and is
+#      therefore exempt from the idle-gate.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_TMPL="$REPO_ROOT/.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl"
+UPDATER="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# ── 1. the chezmoiscript renders and invokes the deployed updater --install-only.
+[[ -f $SCRIPT_TMPL ]] || fail "first-install chezmoiscript not found: $SCRIPT_TMPL"
+# --source pins the render to this checkout (hermetic; mirrors treefmt.nix).
+rendered="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT_TMPL")" ||
+  fail "chezmoi execute-template failed on the first-install script"
+printf '%s\n' "$rendered" | grep -q 'update-skills\.sh' ||
+  fail "the first-install script does not reference the deployed updater update-skills.sh: $rendered"
+printf '%s\n' "$rendered" | grep -q -- '--install-only' ||
+  fail "the first-install script does not pass --install-only to the updater: $rendered"
+
+# ── 2. content re-hashes when the lock changes (so run_onchange re-fires). Build
+#      a minimal fixture source with the script + updater + a lock, render twice
+#      with different locks, and require the rendered bytes to differ.
+fixture_src="$(mktemp -d)"
+mkdir -p "$fixture_src/.chezmoiscripts" "$fixture_src/dot_agents" "$fixture_src/dot_local/bin"
+tmpl_name="$(basename "$SCRIPT_TMPL")"
+cp "$SCRIPT_TMPL" "$fixture_src/.chezmoiscripts/$tmpl_name"
+cp "$UPDATER" "$fixture_src/dot_local/bin/executable_update-skills.sh"
+render_fixture() {
+  CI=1 chezmoi --source "$fixture_src" execute-template --no-tty <"$fixture_src/.chezmoiscripts/$tmpl_name"
+}
+printf '{"version":2,"tiers":{"alpha":"core"}}\n' >"$fixture_src/dot_agents/custom-skill-lock.json"
+render_a="$(render_fixture)" || fail "fixture render A failed"
+printf '{"version":2,"tiers":{"bravo":"core"}}\n' >"$fixture_src/dot_agents/custom-skill-lock.json"
+render_b="$(render_fixture)" || fail "fixture render B failed"
+rm -rf "$fixture_src"
+[[ $render_a != "$render_b" ]] ||
+  fail "the rendered first-install script did not change when the lock changed (run_onchange would not re-fire)"
+
+# ── 3. empty HOME: --install-only installs absent, skips present, under a live
+#      session (the idle-gate must not block a swap-free install pass).
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills/already"
+printf -- '---\nname: already\ndescription: present\n---\n' >"$HOME/.agents/skills/already/SKILL.md"
+touch "$HOME/.agents/skills/already/local.marker"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"freshskill": "core", "already": "core"},
+  "hermesProfiles": {"freshskill": [], "already": []},
+  "hermesRegistry": {},
+  "npxTracked": {
+    "freshskill": {"repo": "fixture/freshskill"},
+    "already": {"repo": "fixture/already"}
+  },
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+NPX_LOG="$tmp/npx.log"
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npx %s\n' "\$*" >>"$NPX_LOG"
+mode=""
+skill=""
+prev=""
+for arg in "\$@"; do
+  case "\$arg" in add) mode="add" ;; esac
+  [[ \$prev == "--skill" ]] && skill="\$arg"
+  prev="\$arg"
+done
+if [[ \$mode == "add" && -n \$skill ]]; then
+  mkdir -p "\$HOME/.agents/skills/\$skill"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "\$skill" >"\$HOME/.agents/skills/\$skill/SKILL.md"
+fi
+echo "stub npx"
+EOF
+# ps stub: an ACTIVE Claude session. Proves --install-only runs anyway (exempt).
+cat >"$stub/ps" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '/opt/homebrew/bin/claude --remote-control'
+EOF
+# alerter/date stubs: keep any gate path (pre-fix) from firing a real
+# notification and pin the hour off the last slot.
+cat >"$stub/alerter" <<'EOF'
+#!/usr/bin/env bash
+:
+EOF
+cat >"$stub/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) echo 04 ;;
+  +%G-%V) echo 2026-28 ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+# No UPDATE_SKILLS_FORCE: the swap-free install pass must run despite the active
+# claude stub (a fresh machine is often provisioned from a live session).
+out="$(bash "$UPDATER" --install-only 2>&1)" ||
+  fail "--install-only exited non-zero under an active session: $out"
+[[ -f "$HOME/.agents/skills/freshskill/SKILL.md" ]] ||
+  fail "absent skill freshskill was not installed by the first-install pass (idle-gate blocked --install-only?): $out"
+[[ -f "$HOME/.agents/skills/already/local.marker" ]] ||
+  fail "present skill 'already' was reinstalled by the install pass (marker lost)"
+grep -q 'add fixture/freshskill' "$NPX_LOG" ||
+  fail "npx add was not invoked for the absent skill: $(cat "$NPX_LOG" 2>/dev/null)"
+if grep -q 'add fixture/already' "$NPX_LOG"; then
+  fail "npx add was invoked for an already-present skill (install pass must skip present skills)"
+fi
+
+echo "update-skills-first-install: OK"

--- a/test/update-skills-generation-lanes.sh
+++ b/test/update-skills-generation-lanes.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# update-skills-generation-lanes.sh — proves the candidate build, the env -i
+# isolated lanes, validation, and sibling-path resolution (Wave 3a fix4 brief
+# steps 2-4 and the isolation + sibling-path hostile tests).
+#
+#   1. Happy path: clone the current generation, run the npx + clawhub + overlay
+#      lanes inside a candidate fake HOME, validate, and publish. The published
+#      generation carries every roster skill (with SKILL.md), the on-demand
+#      overlay, and clawhub origin metadata.
+#   2. Isolation (hostile): the lanes run under env -i with HOME / XDG_* / TMPDIR
+#      / npm cache pinned inside the candidate. A DECOY real HOME laid out with
+#      sentinel XDG and npm dirs is byte-identical after the run — a lane can
+#      only write into the candidate.
+#   3. Sibling-path resolution: from inside a RESOLVED workflow skill, the
+#      relative sibling reference ../core reaches the SAME generation's core.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "tiers": {"workflow": "on-demand", "core": "on-demand", "claw": "core"},
+  "npxTracked": {"workflow": {"repo": "x/hf"}, "core": {"repo": "x/hf"}},
+  "clawhubTracked": {"claw": {"slug": "@o/claw", "registry": "https://c.example"}}
+}
+EOF
+
+# --- Stubs. The npx stub deliberately references HOME, XDG_CACHE_HOME,
+#     npm_config_cache and TMPDIR to write breadcrumbs, so the isolation
+#     assertion is meaningful: if __gen_run_lanes failed to pin one of them the
+#     breadcrumb would land in the decoy real HOME.
+stub="$tmp/stub"
+mkdir -p "$stub"
+cat >"$stub/npx" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+mode=""; prev=""; skills=()
+for a in "$@"; do
+  case "$a" in add) mode=add ;; update) mode=update ;; esac
+  [[ $prev == --skill ]] && skills+=("$a")
+  prev="$a"
+done
+if [[ $mode == add ]]; then
+  for s in "${skills[@]}"; do
+    mkdir -p "$HOME/.agents/skills/$s"
+    printf -- '---\nname: %s\n---\n# %s\n' "$s" "$s" >"$HOME/.agents/skills/$s/SKILL.md"
+  done
+  # environment breadcrumbs (must all resolve inside the candidate):
+  : >"$HOME/.agents/.skill-lock.json"
+  printf '{"updated":true}\n' >"$HOME/.agents/.skill-lock.json"
+  mkdir -p "$XDG_CACHE_HOME" "$npm_config_cache" "$TMPDIR"
+  : >"$XDG_CACHE_HOME/npx-ran"
+  : >"$npm_config_cache/npm-ran"
+fi
+STUB
+cat >"$stub/clawhub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+wd=""; dir="skills"; mode=""; prev=""
+for a in "$@"; do
+  case "$prev" in --workdir) wd="$a" ;; --dir) dir="$a" ;; esac
+  case "$a" in install) mode=install ;; update) mode=update ;; esac
+  prev="$a"
+done
+args=("$@"); slug="${args[${#args[@]} - 1]}"
+if [[ $mode == install ]]; then
+  dest="$wd/$dir/$slug"; mkdir -p "$dest/.clawhub"
+  printf -- '---\nname: %s\n---\n' "$(basename "$slug")" >"$dest/SKILL.md"
+  printf '{"slug":"%s"}\n' "$(basename "$slug")" >"$dest/.clawhub/origin.json"
+fi
+STUB
+chmod +x "$stub/npx" "$stub/clawhub"
+export PATH="$stub:$PATH"
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+
+# --- Decoy real HOME with sentinel XDG + npm dirs (must stay byte-identical).
+decoy="$tmp/decoy"
+mkdir -p "$decoy/.cache" "$decoy/.config" "$decoy/.npm" "$decoy/.local/share" "$decoy/.agents/skills"
+printf 'SENTINEL' >"$decoy/.cache/keep"
+printf 'SENTINEL' >"$decoy/.npm/keep"
+printf 'SENTINEL' >"$decoy/.agents/keep"
+decoy_before="$(find "$decoy" -type f -exec shasum {} \; | sort)"
+
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# Seed the current generation (as if migrated): workflow, core, claw.
+seed() {
+  local name="$1"
+  mkdir -p "$SKILLS_CURRENT/skills/$name"
+  printf -- '---\nname: %s\n---\n' "$name" >"$SKILLS_CURRENT/skills/$name/SKILL.md"
+}
+seed workflow
+seed core
+mkdir -p "$SKILLS_CURRENT/skills/claw/.clawhub"
+printf -- '---\nname: claw\n---\n' >"$SKILLS_CURRENT/skills/claw/SKILL.md"
+printf '{"slug":"claw"}\n' >"$SKILLS_CURRENT/skills/claw/.clawhub/origin.json"
+printf '{}' >"$SKILLS_CURRENT/.skill-lock.json"
+__gen_write_meta "$SKILLS_CURRENT" "cur-1-1"
+__gen_plant_store_link workflow
+__gen_plant_store_link core
+__gen_plant_store_link claw
+__gen_plant_lock_link
+
+# --- Build + lanes + validate + publish.
+__gen_recover
+id="$(__gen_new_id)"
+__gen_build_candidate "$id" || fail "candidate build failed"
+__gen_run_lanes "$GEN_CANDIDATE_HOME" "$id" >/dev/null 2>&1 || fail "lanes returned non-zero"
+__gen_validate_candidate "$GEN_CANDIDATE_AGENTS" || fail "candidate failed validation"
+
+# 2) Isolation: the breadcrumbs landed in the candidate, and the decoy is intact.
+[[ -f "$GEN_CANDIDATE_HOME/.cache/npx-ran" ]] ||
+  fail "isolation: XDG_CACHE_HOME breadcrumb did not land in the candidate"
+[[ -f "$GEN_CANDIDATE_HOME/.npm/npm-ran" ]] ||
+  fail "isolation: npm cache breadcrumb did not land in the candidate"
+decoy_after="$(find "$decoy" -type f -exec shasum {} \; | sort)"
+[[ $decoy_before == "$decoy_after" ]] ||
+  fail "isolation: the decoy real HOME was modified by the staged lanes"
+
+__gen_publish "$GEN_CANDIDATE_AGENTS" || fail "publish failed"
+
+# 1) Published generation carries every roster skill + overlay + origin metadata.
+for name in workflow core claw; do
+  [[ -f "$STORE/$name/SKILL.md" ]] || fail "published store/$name/SKILL.md does not resolve"
+done
+grep -q 'allow_implicit_invocation: false' "$STORE/workflow/agents/openai.yaml" ||
+  fail "published on-demand skill workflow has no Codex overlay"
+[[ -f "$STORE/claw/.clawhub/origin.json" ]] || fail "published claw lost its origin metadata"
+
+# 3) Sibling-path resolution: from inside the resolved workflow skill, ../core
+#    reaches the SAME generation's core (both physically under one generation).
+sibling="$(cd -P "$STORE/workflow" && cd -P ../core && pwd -P)"
+workflow_gen="$(cd -P "$STORE/workflow" && cd -P .. && pwd -P)"
+[[ $sibling == "$workflow_gen/core" ]] ||
+  fail "sibling ../core did not resolve within the workflow skill's own generation ($sibling vs $workflow_gen/core)"
+[[ -f "$sibling/SKILL.md" ]] || fail "sibling ../core does not resolve to a real skill"
+
+echo "update-skills-generation-lanes: OK"

--- a/test/update-skills-generation-lanes.sh
+++ b/test/update-skills-generation-lanes.sh
@@ -19,12 +19,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-generation-lanes.sh
+++ b/test/update-skills-generation-lanes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-generation-lanes.sh — proves the candidate build, the env -i
+# update-skills-generation-lanes.sh proves the candidate build, the env -i
 # isolated lanes, validation, and sibling-path resolution (Wave 3a fix4 brief
 # steps 2-4 and the isolation + sibling-path hostile tests).
 #
@@ -9,7 +9,7 @@
 #      overlay, and clawhub origin metadata.
 #   2. Isolation (hostile): the lanes run under env -i with HOME / XDG_* / TMPDIR
 #      / npm cache pinned inside the candidate. A DECOY real HOME laid out with
-#      sentinel XDG and npm dirs is byte-identical after the run — a lane can
+#      sentinel XDG and npm dirs is byte-identical after the run; a lane can
 #      only write into the candidate.
 #   3. Sibling-path resolution: from inside a RESOLVED workflow skill, the
 #      relative sibling reference ../core reaches the SAME generation's core.

--- a/test/update-skills-generation-run.sh
+++ b/test/update-skills-generation-run.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# update-skills-generation-run.sh: end-to-end proof that the generation path IS
+# the default weekly run (Wave 3a fix4 cutover). A machine with the old flat
+# store runs one plain full run and comes out in the generation topology:
+#   1. Migration: tracked flat real dirs become stable store symlinks into a
+#      complete ~/.agents/.skills-current generation; the flat .skill-lock.json
+#      becomes a symlink into it; vendored dirs and foreign links untouched.
+#   2. The weekly attempt built a candidate, ran the lanes (per-repo explicit
+#      `skills add`, never bulk update), validated, and published: store content
+#      is the lanes' refreshed copy.
+#   3. Post-publish: Claude + hermes fan-out resolve through the store links,
+#      the on-demand overlay is present through the store path, the lock link
+#      resolves, and the roster-aware weekly stamp was written.
+#   4. No staging leftovers; exactly one retained previous generation at most.
+#   5. A second run is green and leaves the topology intact.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"alpha": "on-demand", "claw": "core"},
+  "hermesProfiles": {"alpha": ["default"], "claw": []},
+  "hermesRegistry": {},
+  "npxTracked": {"alpha": {"repo": "fixture/alpha"}},
+  "clawhubTracked": {"claw": {"slug": "@fixture/claw", "registry": "https://clawhub.example"}},
+  "forks": {}
+}
+EOF
+
+# The old flat store: tracked real dirs + a vendored dir + the flat npx lock.
+mkdir -p "$HOME/.agents/skills/alpha"
+printf -- '---\nname: alpha\n---\n# flat legacy\n' >"$HOME/.agents/skills/alpha/SKILL.md"
+printf 'LEGACY' >"$HOME/.agents/skills/alpha/local.txt"
+mkdir -p "$HOME/.agents/skills/claw/.clawhub"
+printf -- '---\nname: claw\n---\n' >"$HOME/.agents/skills/claw/SKILL.md"
+printf '{"slug":"claw"}\n' >"$HOME/.agents/skills/claw/.clawhub/origin.json"
+mkdir -p "$HOME/.agents/skills/vendored"
+printf 'VENDORED' >"$HOME/.agents/skills/vendored/keep.txt"
+printf '{"skills":{"alpha":{}}}\n' >"$HOME/.agents/.skill-lock.json"
+
+# Stubs. npx refreshes SKILL.md (leaves other files); logs argv for the
+# per-repo-add / never-bulk-update assertions.
+stub="$tmp/stub"
+mkdir -p "$stub"
+NPX_LOG="$tmp/npx.log"
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npx %s\n' "\$*" >>"$NPX_LOG"
+mode=""; prev=""; skills=()
+for a in "\$@"; do
+  case "\$a" in add) mode=add ;; update) mode=update ;; esac
+  [[ \$prev == --skill ]] && skills+=("\$a")
+  prev="\$a"
+done
+if [[ \$mode == add ]]; then
+  for s in "\${skills[@]}"; do
+    mkdir -p "\$HOME/.agents/skills/\$s"
+    printf -- '---\nname: %s\n---\n# refreshed by lane\n' "\$s" >"\$HOME/.agents/skills/\$s/SKILL.md"
+  done
+fi
+EOF
+cat >"$stub/clawhub" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'clawhub %s\n' "\$*" >>"$tmp/clawhub.log"
+echo "stub: up to date"
+EOF
+chmod +x "$stub/npx" "$stub/clawhub"
+export PATH="$stub:$PATH"
+
+run() { UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1; }
+out="$(run)" || fail "full run exited non-zero: $out"
+
+AGENTS="$HOME/.agents"
+CURRENT="$AGENTS/.skills-current"
+
+# 1) Generation topology after one plain full run.
+[[ -d $CURRENT && ! -L $CURRENT ]] || fail "no live .skills-current generation after the full run"
+[[ -f "$CURRENT/generation.json" ]] || fail "the live generation has no ready marker"
+for name in alpha claw; do
+  [[ -L "$AGENTS/skills/$name" ]] || fail "store/$name is not a symlink after the full run"
+  [[ "$(readlink "$AGENTS/skills/$name")" == "../.skills-current/skills/$name" ]] ||
+    fail "store/$name points at the wrong target: $(readlink "$AGENTS/skills/$name")"
+  [[ -f "$AGENTS/skills/$name/SKILL.md" ]] || fail "store/$name does not resolve"
+done
+[[ -d "$AGENTS/skills/vendored" && ! -L "$AGENTS/skills/vendored" ]] ||
+  fail "the vendored dir was converted (must stay outside the generation)"
+[[ "$(cat "$AGENTS/skills/vendored/keep.txt")" == "VENDORED" ]] || fail "vendored content changed"
+[[ -L "$AGENTS/.skill-lock.json" ]] || fail ".skill-lock.json is not a symlink after the full run"
+grep -q '"alpha"' "$AGENTS/.skill-lock.json" || fail "the lock symlink does not resolve to lock content"
+
+# 2) The lanes refreshed the content (per-repo explicit add), and migration
+#    preserved the legacy sibling file through the clone.
+grep -q '# refreshed by lane' "$AGENTS/skills/alpha/SKILL.md" ||
+  fail "the npx lane did not refresh alpha (store content is not the lane's copy)"
+[[ "$(cat "$AGENTS/skills/alpha/local.txt")" == "LEGACY" ]] ||
+  fail "the legacy sibling file did not survive migration + lanes"
+grep -qE 'skills@latest add fixture/alpha .*--skill alpha' "$NPX_LOG" ||
+  fail "the npx lane did not run an explicit per-repo add: $(cat "$NPX_LOG")"
+if grep -qE 'update (--global|-g)' "$NPX_LOG"; then
+  fail "the run invoked the bulk npx update (forbidden; per-repo add only): $(cat "$NPX_LOG")"
+fi
+
+# 3) Fan-out + overlay + stamp.
+[[ -L "$HOME/.claude/skills/alpha" && -f "$HOME/.claude/skills/alpha/SKILL.md" ]] ||
+  fail "Claude fan-out for alpha does not resolve"
+[[ -L "$HOME/.hermes/skills/alpha" && -f "$HOME/.hermes/skills/alpha/SKILL.md" ]] ||
+  fail "hermes default fan-out for alpha does not resolve"
+grep -q 'allow_implicit_invocation: false' "$AGENTS/skills/alpha/agents/openai.yaml" ||
+  fail "the on-demand overlay is missing through the store path"
+stamp="$HOME/.local/state/update-skills/last-success"
+[[ -f $stamp ]] || fail "a fully successful run did not write the weekly stamp"
+[[ "$(wc -w <"$stamp" | tr -d ' ')" == "3" ]] ||
+  fail "the stamp is not <week> <lock-hash> <updater-hash>: $(cat "$stamp")"
+
+# 4) No staging leftovers; at most one retained previous generation.
+shopt -s nullglob
+staging=("$AGENTS/.skills-generations"/*/home)
+garbage=("$AGENTS/.skills-generations"/*.garbage.* "$AGENTS/skills"/*.garbage.* "$AGENTS/skills"/.*.migrating.*)
+shopt -u nullglob
+[[ ${#staging[@]} -eq 0 ]] || fail "staging leftovers survived the run: ${staging[*]}"
+[[ ${#garbage[@]} -eq 0 ]] || fail "garbage leftovers survived the run: ${garbage[*]}"
+retained="$(find "$AGENTS/.skills-generations" -maxdepth 2 -name generation.json 2>/dev/null | wc -l | tr -d ' ')"
+[[ $retained -le 1 ]] || fail "more than one previous generation retained: $retained"
+
+# 5) A second run is green and the topology holds (FORCE bypasses the stamp).
+out2="$(run)" || fail "second full run exited non-zero: $out2"
+[[ "$(readlink "$AGENTS/skills/alpha")" == "../.skills-current/skills/alpha" ]] ||
+  fail "store/alpha drifted on the second run"
+[[ -f "$AGENTS/skills/alpha/SKILL.md" ]] || fail "store/alpha stopped resolving on the second run"
+
+echo "update-skills-generation-run: OK"

--- a/test/update-skills-hermes-phase.sh
+++ b/test/update-skills-hermes-phase.sh
@@ -22,7 +22,9 @@
 #      updates re-apply the install gate, and a block must reach the operator.
 #   7. --install-only never reaches the phase (it is network-dependent).
 #   8. --dry-run prints would-update lines and invokes hermes zero times.
-#   9. A machine without hermes on PATH skips the phase gracefully (exit 0).
+#   9. A machine without hermes on PATH but a NON-EMPTY hermesRegistry records a
+#      REQUIRED failure (item 4: a missing prerequisite with work to do is not a
+#      silent success), warns loudly, and still exits 0.
 set -euo pipefail
 
 # When git runs a hook such as pre-commit (this test runs under one via
@@ -157,8 +159,9 @@ dry_output="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)" || fail "--d
 [[ ! -s $hermes_log ]] || fail "--dry-run invoked hermes: $(cat "$hermes_log")"
 printf '%s\n' "$dry_output" | grep -q "would update" || fail "--dry-run did not report would-update lines: $dry_output"
 
-# 9) hermes off PATH: the phase is a graceful skip, not a failure. The
-#    stripped PATH keeps npx (stub), jq, and git so only hermes is missing.
+# 9) hermes off PATH with a NON-EMPTY hermesRegistry: a REQUIRED failure (item
+#    4), warned loudly, run still exits 0. The stripped PATH keeps npx (stub),
+#    jq, and git so only hermes is missing.
 no_hermes_dir="$scratch_dir/no-hermes"
 mkdir -p "$no_hermes_dir"
 cp "$stub_dir/npx" "$no_hermes_dir/npx"
@@ -166,7 +169,9 @@ ln -s "$(command -v jq)" "$no_hermes_dir/jq"
 ln -s "$(command -v git)" "$no_hermes_dir/git"
 missing_output="$(UPDATE_SKILLS_FORCE=1 PATH="$no_hermes_dir:/usr/bin:/bin" bash "$SCRIPT" 2>&1)" ||
   fail "run without hermes on PATH exited non-zero: $missing_output"
-printf '%s\n' "$missing_output" | grep -qi "hermes.*skip" ||
-  fail "missing hermes was not reported as a skip: $missing_output"
+printf '%s\n' "$missing_output" | grep -qi "REQUIRED-FAILURE.*hermes" ||
+  fail "missing hermes with a non-empty hermesRegistry did not record a required failure: $missing_output"
+printf '%s\n' "$missing_output" | grep -qi "WITHHOLDING" ||
+  fail "missing hermes prerequisite did not withhold the weekly stamp: $missing_output"
 
 echo "update-skills-hermes-phase: OK"

--- a/test/update-skills-launchagent-path.sh
+++ b/test/update-skills-launchagent-path.sh
@@ -22,7 +22,10 @@ fail() {
 [[ -f $PLIST ]] || fail "plist template not found: $PLIST"
 
 # Render the template so {{ .chezmoi.homeDir }} etc. resolve exactly as at apply time.
-rendered="$(CI=1 chezmoi execute-template --no-tty <"$PLIST")" ||
+# --source pins the render to THIS checkout (hermetic): bare chezmoi reads the machine's
+# configured sourceDir, so the test would break whenever that live checkout is on a
+# different branch or holds stray state (mirrors treefmt.nix's rendered-template calls).
+rendered="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
   fail "chezmoi execute-template failed on the plist"
 
 # Pull the PATH string: the <string> immediately after the <key>PATH</key> line.
@@ -30,7 +33,7 @@ path_value="$(printf '%s\n' "$rendered" |
   awk '/<key>PATH<\/key>/{getline; gsub(/^[[:space:]]*<string>/,""); gsub(/<\/string>[[:space:]]*$/,""); print; exit}')"
 [[ -n $path_value ]] || fail "no PATH EnvironmentVariable found in the rendered plist"
 
-home_dir="$(chezmoi execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
 
 # Every dir the script's bare-name tools live in must be on the launchd PATH.
 for required_dir in "$home_dir/.local/bin" "/opt/homebrew/bin"; do

--- a/test/update-skills-lock-symlink.sh
+++ b/test/update-skills-lock-symlink.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-lock-symlink.sh — proves the npx CLI reads and writes the npx
+# update-skills-lock-symlink.sh proves the npx CLI reads and writes the npx
 # lock THROUGH the ~/.agents/.skill-lock.json symlink into the live generation
 # (Wave 3a fix4 lock-symlink test). POSIX open() follows the symlink, so a CLI
 # that opens ~/.agents/.skill-lock.json transparently reads and updates the

--- a/test/update-skills-lock-symlink.sh
+++ b/test/update-skills-lock-symlink.sh
@@ -10,12 +10,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-lock-symlink.sh
+++ b/test/update-skills-lock-symlink.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# update-skills-lock-symlink.sh — proves the npx CLI reads and writes the npx
+# lock THROUGH the ~/.agents/.skill-lock.json symlink into the live generation
+# (Wave 3a fix4 lock-symlink test). POSIX open() follows the symlink, so a CLI
+# that opens ~/.agents/.skill-lock.json transparently reads and updates the
+# generation's real lock. Encoded here with the npx stub.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"npxTracked":{"alpha":{"repo":"x/a"}},"clawhubTracked":{}}
+EOF
+
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# A published generation with the lock symlink planted.
+mkdir -p "$SKILLS_CURRENT/skills/alpha"
+printf -- '---\nname: alpha\n---\n' >"$SKILLS_CURRENT/skills/alpha/SKILL.md"
+printf '{"initial":true}\n' >"$SKILLS_CURRENT/.skill-lock.json"
+__gen_write_meta "$SKILLS_CURRENT" "live-1-1"
+__gen_plant_store_link alpha
+__gen_plant_lock_link
+[[ -L $SKILL_LOCK_LINK ]] || fail "precondition: the lock link was not planted as a symlink"
+
+# A CLI reads the lock through the symlink.
+read_via_link="$(cat "$SKILL_LOCK_LINK")"
+[[ $read_via_link == '{"initial":true}' ]] ||
+  fail "reading through the lock symlink did not return the generation's lock content: $read_via_link"
+
+# A CLI (npx stub) opens ~/.agents/.skill-lock.json for WRITE and updates it; the
+# write must land in the generation's real lock, not clobber the symlink.
+stub="$tmp/stub"
+mkdir -p "$stub"
+cat >"$stub/npx" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+# Simulate the CLI persisting an updated lock through the well-known path.
+printf '{"updatedByCli":true}\n' >"\$HOME/.agents/.skill-lock.json"
+echo "stub npx: lock rewritten"
+STUB
+chmod +x "$stub/npx"
+PATH="$stub:$PATH" npx skills update >/dev/null 2>&1 || fail "stub npx run failed"
+
+# The symlink itself must still be a symlink (not clobbered into a file).
+[[ -L $SKILL_LOCK_LINK ]] ||
+  fail "the write clobbered the lock symlink into a regular file (open should follow it)"
+# The write landed in the generation's real lock.
+[[ "$(cat "$SKILLS_CURRENT/.skill-lock.json")" == '{"updatedByCli":true}' ]] ||
+  fail "the CLI write did not land in the generation's real lock through the symlink"
+# Reading through the link reflects the update.
+[[ "$(cat "$SKILL_LOCK_LINK")" == '{"updatedByCli":true}' ]] ||
+  fail "reading through the symlink does not reflect the CLI update"
+
+echo "update-skills-lock-symlink: OK"

--- a/test/update-skills-lock.sh
+++ b/test/update-skills-lock.sh
@@ -99,5 +99,99 @@ wait "$run_pid"
 [[ -d $LOCKDIR ]] || fail "the EXIT trap removed a lock it no longer owned (hijacked token)"
 [[ "$(cat "$LOCKDIR/owner" 2>/dev/null)" == "424242"* ]] ||
   fail "the hijacked owner token was clobbered by the finishing run"
+rm -rf "$LOCKDIR"
+
+# Reset npx to the fast non-blocking stub for the remaining cases.
+cat >"$stub/npx" <<'EOF'
+#!/usr/bin/env bash
+echo stub
+EOF
+chmod +x "$stub/npx"
+
+# ── 4) ownerless lock (crash between mkdir and token write) → reclaimable ────
+# Item 3(c): a lock dir with NO owner token must not wedge every later run
+# forever; a run must reclaim it and proceed.
+mkdir -p "$LOCKDIR" # no owner file written at all
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+  fail "script exited non-zero on an ownerless lock: $out"
+printf '%s\n' "$out" | grep -qi 'reclaim' ||
+  fail "an ownerless lock (no token) was not reclaimed (wedge-forever bug): $out"
+printf '%s\n' "$out" | grep -qF '[update-skills] done' ||
+  fail "did not proceed after reclaiming an ownerless lock: $out"
+[[ ! -d $LOCKDIR ]] || fail "a successful run left its own lock behind after an ownerless reclaim"
+
+# ── 5) live owner but a FAILING ps lookup → treated ALIVE (defer) ────────────
+# Item 3(b): kill -0 succeeds, but if ps errors we cannot prove the owner dead,
+# so we must NOT steal. A ps stub that always fails simulates an unreadable
+# process table for the owner-liveness lookup.
+psfail="$tmp/psfail"
+mkdir -p "$psfail"
+cat >"$psfail/ps" <<'EOF'
+#!/usr/bin/env bash
+echo "ps: simulated failure" >&2
+exit 1
+EOF
+chmod +x "$psfail/ps"
+sleep 300 &
+live_pid2=$!
+mkdir -p "$LOCKDIR"
+printf '%s\t%s' "$live_pid2" "$(proc_start "$live_pid2")" >"$LOCKDIR/owner"
+out="$(PATH="$psfail:$PATH" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+  fail "script exited non-zero on a failed-ps liveness check: $out"
+printf '%s\n' "$out" | grep -qi 'another run in progress' ||
+  fail "a live owner with a failing ps lookup was stolen (must treat unprovable death as ALIVE): $out"
+[[ -d $LOCKDIR ]] || fail "a live owner's lock was removed under a failing ps lookup"
+[[ "$(cat "$LOCKDIR/owner" 2>/dev/null)" == "$live_pid2"* ]] ||
+  fail "a live owner's token was clobbered under a failing ps lookup"
+kill "$live_pid2" 2>/dev/null || true
+wait "$live_pid2" 2>/dev/null || true
+rm -rf "$LOCKDIR"
+
+# ── 6) two simultaneous reclaimers of a dead lock → EXACTLY one proceeds ─────
+# Item 3(a): the reclaim must be a single-winner move-aside, never two runs both
+# validating the same dead token and both proceeding. A blocking npx holds the
+# winner's lock while the loser resolves.
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+while [[ ! -e "$tmp/go2" ]]; do sleep 0.02; done
+echo stub
+EOF
+chmod +x "$stub/npx"
+rm -f "$tmp/go2"
+mkdir -p "$LOCKDIR"
+printf '%s\t%s' "999999" "Sat Jan  1 00:00:00 2000" >"$LOCKDIR/owner" # dead owner
+o1="$tmp/o1.log"
+o2="$tmp/o2.log"
+(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >"$o1" 2>&1) &
+r1=$!
+(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >"$o2" 2>&1) &
+r2=$!
+# Wait until one contender has parked on the blocking npx (it now owns the lock
+# with a LIVE token) and the other has resolved. Bounded wait.
+for _ in $(seq 1 200); do
+  live_token="$(cat "$LOCKDIR/owner" 2>/dev/null || true)"
+  live_owner_pid="${live_token%%$'\t'*}"
+  [[ $live_owner_pid =~ ^[0-9]+$ ]] && kill -0 "$live_owner_pid" 2>/dev/null && break
+  sleep 0.02
+done
+# Let the parked winner finish.
+touch "$tmp/go2"
+wait "$r1" 2>/dev/null || true
+wait "$r2" 2>/dev/null || true
+proceed_count=0
+grep -qF '[update-skills] done' "$o1" && proceed_count=$((proceed_count + 1))
+grep -qF '[update-skills] done' "$o2" && proceed_count=$((proceed_count + 1))
+[[ $proceed_count -eq 1 ]] ||
+  fail "two reclaimers of a dead lock: expected exactly one to proceed, got $proceed_count
+--- o1 ---
+$(cat "$o1")
+--- o2 ---
+$(cat "$o2")"
+defer_count=0
+grep -qi 'another run in progress' "$o1" && defer_count=$((defer_count + 1))
+grep -qi 'another run in progress' "$o2" && defer_count=$((defer_count + 1))
+[[ $defer_count -eq 1 ]] ||
+  fail "two reclaimers: expected exactly one to defer with 'another run in progress', got $defer_count"
+[[ ! -d $LOCKDIR ]] || fail "the winning reclaimer left its lock behind"
 
 echo "update-skills-lock: OK"

--- a/test/update-skills-lock.sh
+++ b/test/update-skills-lock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-lock.sh — the serialize lock must NEVER steal from a live run by
+# update-skills-lock.sh, the serialize lock must NEVER steal from a live run by
 # age; it reclaims ONLY from a provably dead owner, and its EXIT trap removes
 # only a lock it still owns. This closes the three-writer race the audit found:
 # the old lock removed any dir older than 120 min (killing a long healthy run),

--- a/test/update-skills-lock.sh
+++ b/test/update-skills-lock.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# update-skills-lock.sh — the serialize lock must NEVER steal from a live run by
+# age; it reclaims ONLY from a provably dead owner, and its EXIT trap removes
+# only a lock it still owns. This closes the three-writer race the audit found:
+# the old lock removed any dir older than 120 min (killing a long healthy run),
+# and its unconditional `trap rm -rf` then deleted a newcomer's lock.
+#
+# macOS ships neither flock(1) nor lockf(1), so the lock stays a mkdir lock, but
+# it now carries an owner token: PID plus the process start time (a boot-stable
+# discriminator, so a recycled PID cannot masquerade as the original owner).
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+LOCKDIR="$HOME/.agents/.update-skills.lock.d"
+
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {},
+  "hermesProfiles": {},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+# Offline stubs so a proceeding full run is fast and never hits the network.
+stub="$tmp/stub"
+mkdir -p "$stub"
+cat >"$stub/npx" <<'EOF'
+#!/usr/bin/env bash
+echo stub
+EOF
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+proc_start() { ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' | sed 's/^ *//;s/ *$//'; }
+
+# ── 1) live owner, even with an OLD lock dir → contender must NOT steal ──────
+# (The old age-gate would `rm -rf` this lock because its mtime is > 120 min,
+# killing a live run. The new lock reclaims only from a dead owner.)
+sleep 300 &
+live_pid=$!
+mkdir -p "$LOCKDIR"
+printf '%s\t%s' "$live_pid" "$(proc_start "$live_pid")" >"$LOCKDIR/owner"
+touch -t 200001010000 "$LOCKDIR" # make the dir look ancient
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" || fail "script exited non-zero on contention: $out"
+printf '%s\n' "$out" | grep -qi 'another run in progress' ||
+  fail "contender did not defer to a live owner (age-steal bug?): $out"
+[[ -d $LOCKDIR ]] || fail "contender removed a live owner's lock dir (age-steal)"
+[[ "$(cat "$LOCKDIR/owner" 2>/dev/null)" == "$live_pid"* ]] ||
+  fail "contender overwrote a live owner's token"
+kill "$live_pid" 2>/dev/null || true
+wait "$live_pid" 2>/dev/null || true
+rm -rf "$LOCKDIR"
+
+# ── 2) dead owner → reclaim and proceed ─────────────────────────────────────
+mkdir -p "$LOCKDIR"
+printf '%s\t%s' "999999" "Sat Jan  1 00:00:00 2000" >"$LOCKDIR/owner" # pid 999999 is dead
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+  fail "script exited non-zero reclaiming a dead lock: $out"
+printf '%s\n' "$out" | grep -qi 'reclaim' || fail "did not reclaim a dead owner's lock: $out"
+printf '%s\n' "$out" | grep -qF '[update-skills] done' || fail "did not proceed after reclaiming: $out"
+[[ ! -d $LOCKDIR ]] || fail "a successful run left its own lock behind (trap did not release)"
+
+# ── 3) EXIT trap must not remove a lock it no longer owns (hijack) ───────────
+# The npx stub blocks until we release it, so we can rewrite the owner token
+# mid-run (simulating a reclaim by a later run). The trap must see the mismatch
+# and leave the lock alone.
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+while [[ ! -e "$tmp/go" ]]; do sleep 0.05; done
+echo stub
+EOF
+chmod +x "$stub/npx"
+rm -f "$tmp/go"
+(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/dev/null 2>&1) &
+run_pid=$!
+until [[ -f "$LOCKDIR/owner" ]]; do sleep 0.05; done
+printf '%s\t%s' "424242" "Hijacked start" >"$LOCKDIR/owner" # a foreign owner
+touch "$tmp/go"
+wait "$run_pid"
+[[ -d $LOCKDIR ]] || fail "the EXIT trap removed a lock it no longer owned (hijacked token)"
+[[ "$(cat "$LOCKDIR/owner" 2>/dev/null)" == "424242"* ]] ||
+  fail "the hijacked owner token was clobbered by the finishing run"
+
+echo "update-skills-lock: OK"

--- a/test/update-skills-migration.sh
+++ b/test/update-skills-migration.sh
@@ -121,11 +121,21 @@ shopt -u nullglob
 [[ ${#leftovers[@]} -eq 0 ]] ||
   fail "migration left in-flight leftovers: ${leftovers[*]}"
 
-# 6) Idempotence.
-before="$(find "$STORE" "$SKILLS_CURRENT" -exec stat -f '%N %m %Z' {} \; | sort)"
+# 6) Idempotence. The snapshot spelling differs by stat flavor: GNU stat takes
+# -c (its -f means file-system status and misreads the format as a path, and
+# the free-block counts it then prints drift between snapshots, a false
+# "mutated"); BSD stat takes -f.
+snapshot_tree() {
+  if stat -c %n . >/dev/null 2>&1; then
+    find "$STORE" "$SKILLS_CURRENT" -exec stat -c '%n %Y %Z' {} \; | sort
+  else
+    find "$STORE" "$SKILLS_CURRENT" -exec stat -f '%N %m %Z' {} \; | sort
+  fi
+}
+before="$(snapshot_tree)"
 __gen_migration_needed && fail "migration still reported as needed after a successful migrate"
 __gen_migrate || fail "second migrate run returned non-zero"
-after="$(find "$STORE" "$SKILLS_CURRENT" -exec stat -f '%N %m %Z' {} \; | sort)"
+after="$(snapshot_tree)"
 [[ $before == "$after" ]] || fail "second migrate run mutated the tree (not idempotent)"
 for name in alpha beta claw; do
   [[ "$(readlink "$STORE/$name")" == "../.skills-current/skills/$name" ]] ||

--- a/test/update-skills-migration.sh
+++ b/test/update-skills-migration.sh
@@ -19,12 +19,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-migration.sh
+++ b/test/update-skills-migration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-migration.sh — proves the flat-store -> generation migration
+# update-skills-migration.sh proves the flat-store -> generation migration
 # (Wave 3a fix4 brief "Migration"). A machine with the old flat store
 # (~/.agents/skills/<name> real dirs + a real ~/.agents/.skill-lock.json) is
 # migrated: every tracked store entry becomes a stable symlink into a real

--- a/test/update-skills-migration.sh
+++ b/test/update-skills-migration.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# update-skills-migration.sh — proves the flat-store -> generation migration
+# (Wave 3a fix4 brief "Migration"). A machine with the old flat store
+# (~/.agents/skills/<name> real dirs + a real ~/.agents/.skill-lock.json) is
+# migrated: every tracked store entry becomes a stable symlink into a real
+# .skills-current generation whose content is a clone of the legacy dirs, and
+# the lock becomes a symlink. Asserted:
+#   1. .skills-current is built from the legacy real dirs (content preserved).
+#   2. Each tracked store entry is now a symlink into the generation.
+#   3. Vendored real dirs and app-owned symlinks (NOT tracked) are untouched.
+#   4. The .skill-lock.json symlink resolves to the original lock content.
+#   5. Per-entry atomicity: every store name resolves (never dangling) and no
+#      *.migrating.* / *.garbage.* leftovers survive.
+#   6. Idempotence: a second migrate run is a no-op (content byte-identical, no
+#      dangling links, no new generations).
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+# alpha/beta npx-tracked, claw clawhub-tracked; vendored + app not tracked.
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "npxTracked": {"alpha": {"repo": "x/a"}, "beta": {"repo": "x/b"}},
+  "clawhubTracked": {"claw": {"slug": "@o/claw", "registry": "https://c.example"}}
+}
+EOF
+
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# Build the flat legacy store.
+seed_skill() {
+  local name="$1"
+  mkdir -p "$STORE/$name"
+  printf -- '---\nname: %s\n---\n# %s\n' "$name" "$name" >"$STORE/$name/SKILL.md"
+  printf 'LEGACY-%s' "$name" >"$STORE/$name/content.txt"
+}
+seed_skill alpha
+seed_skill beta
+seed_skill claw
+# A vendored real dir NOT in the tracked tables.
+mkdir -p "$STORE/vendored"
+printf 'VENDORED' >"$STORE/vendored/content.txt"
+# An app-owned symlink NOT in the tracked tables.
+mkdir -p "$tmp/app/appskill"
+printf 'APP' >"$tmp/app/appskill/content.txt"
+ln -s "$tmp/app/appskill" "$STORE/appskill"
+# The legacy real npx lock.
+printf '{"legacy":true}\n' >"$SKILL_LOCK_LINK"
+
+[[ ! -e $SKILLS_CURRENT ]] || fail "precondition: .skills-current should not exist yet"
+__gen_migration_needed || fail "migration should be reported as needed on a flat store"
+
+# Migrate.
+__gen_migrate || fail "migration returned non-zero"
+
+# 1) .skills-current built from the legacy dirs, content preserved.
+__gen_is_complete "$SKILLS_CURRENT" || fail "migration did not produce a complete .skills-current"
+for name in alpha beta claw; do
+  [[ -f "$SKILLS_CURRENT/skills/$name/content.txt" ]] ||
+    fail "generation is missing $name content"
+  [[ "$(cat "$SKILLS_CURRENT/skills/$name/content.txt")" == "LEGACY-$name" ]] ||
+    fail "generation $name content was not the legacy clone"
+done
+
+# 2) Each tracked store entry is now a correct symlink into the generation.
+for name in alpha beta claw; do
+  [[ -L "$STORE/$name" ]] || fail "store/$name is not a symlink after migration"
+  [[ "$(readlink "$STORE/$name")" == "../.skills-current/skills/$name" ]] ||
+    fail "store/$name points at the wrong target: $(readlink "$STORE/$name")"
+  [[ "$(cat "$STORE/$name/content.txt")" == "LEGACY-$name" ]] ||
+    fail "store/$name does not resolve to the legacy content"
+done
+
+# 3) Vendored real dir and app-owned symlink untouched.
+[[ -d "$STORE/vendored" && ! -L "$STORE/vendored" ]] ||
+  fail "vendored real dir was converted (must stay outside the generation)"
+[[ "$(cat "$STORE/vendored/content.txt")" == "VENDORED" ]] || fail "vendored content changed"
+[[ -L "$STORE/appskill" ]] || fail "app-owned symlink was replaced"
+[[ "$(readlink "$STORE/appskill")" == "$tmp/app/appskill" ]] ||
+  fail "app-owned symlink target changed"
+
+# 4) The lock is now a symlink resolving to the original content.
+[[ -L $SKILL_LOCK_LINK ]] || fail ".skill-lock.json is not a symlink after migration"
+[[ "$(readlink "$SKILL_LOCK_LINK")" == ".skills-current/.skill-lock.json" ]] ||
+  fail ".skill-lock.json symlink points at the wrong target"
+grep -q '"legacy":true' "$SKILL_LOCK_LINK" ||
+  fail "the lock symlink does not resolve to the original legacy lock content"
+
+# 5) Per-entry atomicity: every store name resolves; no in-flight leftovers.
+for entry in "$STORE"/*; do
+  name="${entry##*/}"
+  [[ -e $entry ]] || fail "store/$name is dangling after migration (per-entry atomicity broken)"
+done
+shopt -s nullglob
+leftovers=("$STORE"/.*.migrating.* "$STORE"/*.garbage.* "$AGENTS"/.*.migrating.*)
+shopt -u nullglob
+[[ ${#leftovers[@]} -eq 0 ]] ||
+  fail "migration left in-flight leftovers: ${leftovers[*]}"
+
+# 6) Idempotence.
+before="$(find "$STORE" "$SKILLS_CURRENT" -exec stat -f '%N %m %Z' {} \; | sort)"
+__gen_migration_needed && fail "migration still reported as needed after a successful migrate"
+__gen_migrate || fail "second migrate run returned non-zero"
+after="$(find "$STORE" "$SKILLS_CURRENT" -exec stat -f '%N %m %Z' {} \; | sort)"
+[[ $before == "$after" ]] || fail "second migrate run mutated the tree (not idempotent)"
+for name in alpha beta claw; do
+  [[ "$(readlink "$STORE/$name")" == "../.skills-current/skills/$name" ]] ||
+    fail "store/$name drifted after the idempotent second run"
+done
+
+echo "update-skills-migration: OK"

--- a/test/update-skills-profile-universe.sh
+++ b/test/update-skills-profile-universe.sh
@@ -79,7 +79,7 @@ ln -sfn "../../../../.agents/skills/beta" "$SPEC/beta"  # owned, desired
 ln -sfn "../../../../.agents/skills/gone" "$SPEC/stale" # owned, stale
 plant_foreign "$SPEC"
 
-UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/tmp/pu1.log 2>&1 || fail "run 1 exited non-zero: $(cat /tmp/pu1.log)"
+UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >"$tmp/pu1.log" 2>&1 || fail "run 1 exited non-zero: $(cat "$tmp/pu1.log")"
 
 for d in "$HERMES" "$SPEC"; do
   [[ -L "$d/foreign-abs" && "$(readlink "$d/foreign-abs")" == "/tmp/foreign-root/.agents/skills/evil" ]] ||
@@ -96,7 +96,7 @@ done
 #    profile is still walked (its dir exists) and its owned links are reaped,
 #    foreign entries still survive. ────────────────────────────────────────
 write_lock '[]' '[]'
-UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/tmp/pu2.log 2>&1 || fail "run 2 exited non-zero: $(cat /tmp/pu2.log)"
+UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >"$tmp/pu2.log" 2>&1 || fail "run 2 exited non-zero: $(cat "$tmp/pu2.log")"
 
 [[ ! -e "$HERMES/alpha" ]] ||
   fail "de-mapped default profile was not walked: owned link 'alpha' survived"

--- a/test/update-skills-profile-universe.sh
+++ b/test/update-skills-profile-universe.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-profile-universe.sh — two convergence-scope guarantees:
+# update-skills-profile-universe.sh, two convergence-scope guarantees:
 #
 #   Item 6 (ownership): a link is updater-owned ONLY when its target resolves to
 #   THIS user's store followed by a single skill basename. A foreign symlink
@@ -70,7 +70,7 @@ plant_foreign() {
   printf 'keep me\n' >"$dir/notes.txt"
 }
 
-# ── Part 1: item 6 — default is WALKED (alpha mapped), and its foreign links
+# ── Part 1: item 6, default is WALKED (alpha mapped), and its foreign links
 #    survive; a stale owned link in spec is reaped. ─────────────────────────
 write_lock '["default"]' '["spec"]'
 ln -sfn "../../.agents/skills/alpha" "$HERMES/alpha" # owned, desired
@@ -92,7 +92,7 @@ done
 [[ -L "$SPEC/beta" ]] || fail "the desired spec link 'beta' was removed"
 [[ ! -e "$SPEC/stale" ]] || fail "a stale owned link in spec was not reaped"
 
-# ── Part 2: item 7 — de-map the sole skill of BOTH default and spec; each
+# ── Part 2: item 7, de-map the sole skill of BOTH default and spec; each
 #    profile is still walked (its dir exists) and its owned links are reaped,
 #    foreign entries still survive. ────────────────────────────────────────
 write_lock '[]' '[]'

--- a/test/update-skills-profile-universe.sh
+++ b/test/update-skills-profile-universe.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# update-skills-profile-universe.sh — two convergence-scope guarantees:
+#
+#   Item 6 (ownership): a link is updater-owned ONLY when its target resolves to
+#   THIS user's store followed by a single skill basename. A foreign symlink
+#   whose target merely CONTAINS ".agents/skills/" under some other root must
+#   survive convergence untouched (the old substring match would unlink it).
+#
+#   Item 7 (profile universe): convergence walks every EXISTING hermes skills
+#   dir (default and each profile), not just the profiles the lock still maps.
+#   So a profile whose LAST mapped skill is de-mapped is still walked and its
+#   stale updater-owned links are reaped, while foreign files there survive.
+#
+# The real script runs unmodified in a sandbox: a FULL run (offline stubs) so
+# destructive convergence happens, FORCE to bypass the idle-gate.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+STORE="$HOME/.agents/skills"
+HERMES="$HOME/.hermes/skills"
+SPEC="$HOME/.hermes/profiles/spec/skills"
+mkdir -p "$STORE" "$HOME/.claude/skills" "$HERMES" "$SPEC"
+
+for s in alpha beta; do
+  mkdir -p "$STORE/$s"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "$s" >"$STORE/$s/SKILL.md"
+done
+
+write_lock() { # $1 = default mapping for alpha, $2 = spec mapping for beta (json arrays)
+  cat >"$HOME/.agents/custom-skill-lock.json" <<EOF
+{
+  "version": 2,
+  "tiers": {"alpha": "core", "beta": "core"},
+  "hermesProfiles": {"alpha": $1, "beta": $2},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+}
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub/npx"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub/hermes"
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+# Foreign links whose targets CONTAIN .agents/skills/ but under foreign roots,
+# plus a plain foreign file. None is updater-owned; all must survive.
+plant_foreign() {
+  local dir="$1"
+  ln -sfn "/tmp/foreign-root/.agents/skills/evil" "$dir/foreign-abs"
+  ln -sfn "/Users/someone-else/.agents/skills/evil" "$dir/foreign-user"
+  printf 'keep me\n' >"$dir/notes.txt"
+}
+
+# ── Part 1: item 6 — default is WALKED (alpha mapped), and its foreign links
+#    survive; a stale owned link in spec is reaped. ─────────────────────────
+write_lock '["default"]' '["spec"]'
+ln -sfn "../../.agents/skills/alpha" "$HERMES/alpha" # owned, desired
+plant_foreign "$HERMES"
+ln -sfn "../../../../.agents/skills/beta" "$SPEC/beta"  # owned, desired
+ln -sfn "../../../../.agents/skills/gone" "$SPEC/stale" # owned, stale
+plant_foreign "$SPEC"
+
+UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/tmp/pu1.log 2>&1 || fail "run 1 exited non-zero: $(cat /tmp/pu1.log)"
+
+for d in "$HERMES" "$SPEC"; do
+  [[ -L "$d/foreign-abs" && "$(readlink "$d/foreign-abs")" == "/tmp/foreign-root/.agents/skills/evil" ]] ||
+    fail "a foreign /tmp .agents/skills link in $d was unlinked (ownership false positive)"
+  [[ -L "$d/foreign-user" && "$(readlink "$d/foreign-user")" == "/Users/someone-else/.agents/skills/evil" ]] ||
+    fail "a foreign /Users .agents/skills link in $d was unlinked (ownership false positive)"
+  [[ -f "$d/notes.txt" ]] || fail "a foreign plain file in $d was removed"
+done
+[[ -L "$HERMES/alpha" ]] || fail "the desired default link 'alpha' was removed"
+[[ -L "$SPEC/beta" ]] || fail "the desired spec link 'beta' was removed"
+[[ ! -e "$SPEC/stale" ]] || fail "a stale owned link in spec was not reaped"
+
+# ── Part 2: item 7 — de-map the sole skill of BOTH default and spec; each
+#    profile is still walked (its dir exists) and its owned links are reaped,
+#    foreign entries still survive. ────────────────────────────────────────
+write_lock '[]' '[]'
+UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" >/tmp/pu2.log 2>&1 || fail "run 2 exited non-zero: $(cat /tmp/pu2.log)"
+
+[[ ! -e "$HERMES/alpha" ]] ||
+  fail "de-mapped default profile was not walked: owned link 'alpha' survived"
+[[ ! -e "$SPEC/beta" ]] ||
+  fail "de-mapped spec profile was not walked: owned link 'beta' survived"
+for d in "$HERMES" "$SPEC"; do
+  [[ -L "$d/foreign-abs" ]] || fail "a foreign link in $d was reaped during de-map convergence"
+  [[ -L "$d/foreign-user" ]] || fail "a foreign user link in $d was reaped during de-map convergence"
+  [[ -f "$d/notes.txt" ]] || fail "a foreign file in $d was removed during de-map convergence"
+done
+
+echo "update-skills-profile-universe: OK"

--- a/test/update-skills-recovery.sh
+++ b/test/update-skills-recovery.sh
@@ -17,12 +17,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/test/update-skills-recovery.sh
+++ b/test/update-skills-recovery.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-recovery.sh — proves the recovery state table (Wave 3a fix4
+# update-skills-recovery.sh proves the recovery state table (Wave 3a fix4
 # brief step 1). Each crash-window state is fabricated, then __gen_recover is
 # invoked (via UPDATE_SKILLS_LIB_ONLY sourcing) and the self-heal is asserted:
 #   1. incomplete staging leftover        -> deleted
@@ -111,7 +111,9 @@ __gen_recover
 
 # 4) competing-writer real dir recorded for re-absorption; content preserved.
 recorded=""
-for n in "${GEN_REABSORB[@]:-}"; do [[ $n == beta ]] && recorded=1; done
+for n in "${GEN_REABSORB[@]:-}"; do
+  if [[ $n == beta ]]; then recorded=1; fi
+done
 [[ -n $recorded ]] || fail "state 4: competing-writer real dir 'beta' not recorded in GEN_REABSORB"
 [[ -d "$STORE/beta" && ! -L "$STORE/beta" ]] ||
   fail "state 4: recovery must not destroy the competing-writer real dir before re-absorption"

--- a/test/update-skills-recovery.sh
+++ b/test/update-skills-recovery.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# update-skills-recovery.sh — proves the recovery state table (Wave 3a fix4
+# brief step 1). Each crash-window state is fabricated, then __gen_recover is
+# invoked (via UPDATE_SKILLS_LIB_ONLY sourcing) and the self-heal is asserted:
+#   1. incomplete staging leftover        -> deleted
+#   2. complete unpublished candidate that MATCHES desired state  -> reusable
+#   2b. complete candidate that does NOT match desired state      -> deleted
+#   3. published generation, stale store link / lock link         -> repaired
+#   4. store entry is a REAL DIR where a link is expected          -> recorded
+#      for re-absorption (GEN_REABSORB), links otherwise intact
+#   5. partial-prune *.garbage.* leftover                          -> swept
+#   6. multiple retained generations                              -> newest kept,
+#                                                                     older pruned
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"npxTracked":{"alpha":{"repo":"x/a"},"beta":{"repo":"x/b"}},"clawhubTracked":{}}
+EOF
+
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+build_generation() {
+  local dir="$1" id="$2" skill
+  mkdir -p "$dir/skills"
+  for skill in alpha beta; do
+    mkdir -p "$dir/skills/$skill"
+    printf -- '---\nname: %s\n---\n' "$skill" >"$dir/skills/$skill/SKILL.md"
+  done
+  printf '{}\n' >"$dir/.skill-lock.json"
+  __gen_write_meta "$dir" "$id"
+}
+
+# A published live generation is the baseline for every state.
+build_generation "$SKILLS_CURRENT" "live-1-1"
+__gen_plant_store_link alpha
+__gen_plant_store_link beta
+__gen_plant_lock_link
+
+# --- State 1: incomplete staging leftover (no ready marker) ------------------
+mkdir -p "$GENERATIONS/incomplete-9-9/home/.agents/skills/alpha"
+# (no .skill-lock.json, no generation.json -> incomplete)
+
+# --- State 2: complete candidate matching desired state ----------------------
+build_generation "$GENERATIONS/goodcand-8-8/home/.agents" "goodcand-8-8"
+
+# --- State 2b: complete candidate NOT matching desired (bogus hashes) --------
+mkdir -p "$GENERATIONS/stalecand-7-7/home/.agents/skills/alpha"
+printf '{}\n' >"$GENERATIONS/stalecand-7-7/home/.agents/.skill-lock.json"
+cat >"$GENERATIONS/stalecand-7-7/home/.agents/generation.json" <<'EOF'
+{"id":"stalecand-7-7","createdAt":"2020-01-01T00:00:00Z","customLockHash":"deadbeef","updaterHash":"deadbeef"}
+EOF
+
+# --- State 3: stale store link + stale lock link -----------------------------
+ln -sfn "../.skills-current/skills/WRONG" "$STORE/alpha" # wrong target
+ln -sfn ".skills-current/WRONG-lock" "$SKILL_LOCK_LINK"  # wrong lock target
+
+# --- State 4: store entry is a REAL DIR where a link is expected (beta) -------
+rm -f "$STORE/beta"
+mkdir -p "$STORE/beta"
+printf 'competing-writer content\n' >"$STORE/beta/SKILL.md"
+
+# --- State 5: partial-prune garbage leftover ---------------------------------
+mkdir -p "$GENERATIONS/old-3-3.garbage.123.456/skills"
+
+# --- State 6: two retained generations (bare <id> dirs) ----------------------
+build_generation "$GENERATIONS/1000000000-1-1" "1000000000-1-1" # older
+build_generation "$GENERATIONS/2000000000-2-2" "2000000000-2-2" # newer
+
+# Run recovery.
+__gen_recover
+
+# 1) incomplete staging deleted.
+[[ ! -d "$GENERATIONS/incomplete-9-9" ]] ||
+  fail "state 1: incomplete staging leftover was not deleted"
+
+# 2) matching candidate recorded as reusable.
+[[ $GEN_REUSE_CANDIDATE == "$GENERATIONS/goodcand-8-8/home/.agents" ]] ||
+  fail "state 2: complete matching candidate not marked reusable (got '$GEN_REUSE_CANDIDATE')"
+[[ -d "$GENERATIONS/goodcand-8-8/home/.agents" ]] ||
+  fail "state 2: reusable candidate was destroyed"
+
+# 2b) stale candidate deleted.
+[[ ! -d "$GENERATIONS/stalecand-7-7" ]] ||
+  fail "state 2b: stale (non-matching) candidate was not deleted"
+
+# 3) store link + lock link repaired.
+[[ "$(readlink "$STORE/alpha")" == "../.skills-current/skills/alpha" ]] ||
+  fail "state 3: stale store link for alpha was not repaired (got '$(readlink "$STORE/alpha")')"
+[[ "$(readlink "$SKILL_LOCK_LINK")" == ".skills-current/.skill-lock.json" ]] ||
+  fail "state 3: stale lock link was not repaired (got '$(readlink "$SKILL_LOCK_LINK")')"
+
+# 4) competing-writer real dir recorded for re-absorption; content preserved.
+recorded=""
+for n in "${GEN_REABSORB[@]:-}"; do [[ $n == beta ]] && recorded=1; done
+[[ -n $recorded ]] || fail "state 4: competing-writer real dir 'beta' not recorded in GEN_REABSORB"
+[[ -d "$STORE/beta" && ! -L "$STORE/beta" ]] ||
+  fail "state 4: recovery must not destroy the competing-writer real dir before re-absorption"
+grep -q 'competing-writer content' "$STORE/beta/SKILL.md" ||
+  fail "state 4: competing-writer content was lost"
+
+# 5) partial-prune garbage swept.
+[[ ! -d "$GENERATIONS/old-3-3.garbage.123.456" ]] ||
+  fail "state 5: partial-prune garbage was not swept"
+
+# 6) newest retained generation kept, older pruned.
+[[ -d "$GENERATIONS/2000000000-2-2" ]] ||
+  fail "state 6: newest retained generation was pruned"
+[[ ! -d "$GENERATIONS/1000000000-1-1" ]] ||
+  fail "state 6: older retained generation was not pruned"
+
+# Idempotence: a second recovery run changes nothing and finds no new drift.
+prev_reuse="$GEN_REUSE_CANDIDATE"
+__gen_recover
+[[ $GEN_REUSE_CANDIDATE == "$prev_reuse" ]] ||
+  fail "recovery is not idempotent: reusable candidate changed on the second run"
+[[ "$(readlink "$STORE/alpha")" == "../.skills-current/skills/alpha" ]] ||
+  fail "recovery is not idempotent: store link drifted on the second run"
+
+echo "update-skills-recovery: OK"

--- a/test/update-skills-refresh-scope.sh
+++ b/test/update-skills-refresh-scope.sh
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
-# update-skills-refresh-scope.sh — the store refresh is npx-native: it runs
-# `npx skills update` and NEVER git-clones a skill to install it. The git-pin
-# supply-chain machinery (clone -> checkout pin -> tree-hash -> swap) is gone,
-# so a full run's only legitimate git use is the fork/vendored upstream
-# drift-check — and with no forks entries there is nothing to clone at all.
+# update-skills-refresh-scope.sh: the store refresh is npx-native and runs in
+# the GENERATION build lanes: an explicit per-repo `npx skills add ... --skill
+# <name>` against the candidate (NEVER the bulk `npx skills update`, whose
+# lock-walk logs some failures at exit 0), and NEVER a git clone to install a
+# skill. The git-pin supply-chain machinery (clone -> checkout pin -> tree-hash
+# -> swap) is gone, so a full run's only legitimate git use is the fork/vendored
+# upstream drift-check, and with no forks entries there is nothing to clone.
 #
 # Setup: a scratch HOME with a lock whose one npx-tracked skill is already
-# present in the store (so the install pass has nothing to add) and no forks,
+# present in the store (a flat real dir the run migrates into the generation),
 # plus PATH shims for git and npx that log every invocation instead of touching
-# the network. Assertions: a full (non --install-only) run still calls
-# `npx skills update`, and never invokes git — proving no residual git-pin
-# install path and no clone of any retired upstream.
+# the network. Assertions: a full run refreshes via the explicit per-repo add,
+# never invokes the bulk update, and never invokes git.
 #
-# The clawhub update pass rides the same full run: two clawhub-tracked skills
-# are already present in the store, so the pass must per-skill `clawhub update`
-# them in the store workdir (--workdir $HOME/.agents --dir skills, bare store
-# name — never install, never --force), scrub Finder .DS_Store litter first
+# The clawhub lane rides the same candidate build: two clawhub-tracked skills
+# are already present, so the lane must per-skill `clawhub update` them in the
+# CANDIDATE workdir (--workdir <candidate>/.agents --dir skills, bare store
+# name, never install, never --force), scrub Finder .DS_Store litter first
 # (it breaks the CLI's fingerprint match), and when the CLI refuses with
 # "local changes" because of the repo-asserted Codex overlay (the one local
 # file this repo writes into tracked skill dirs), set exactly that file aside
-# and retry once — the overlay assert re-creates it later in the same run.
+# and retry once; the candidate overlay assert re-creates it in the same build.
 set -euo pipefail
 
 # When git runs a hook such as pre-commit (this test runs under one via
@@ -51,11 +52,13 @@ mkdir -p "$HOME/.agents/skills"
 # updater must set exactly that file aside and retry once.
 mkdir -p "$HOME/.agents/skills/tracked-skill"
 printf -- '---\nname: tracked-skill\ndescription: present\n---\n' >"$HOME/.agents/skills/tracked-skill/SKILL.md"
-mkdir -p "$HOME/.agents/skills/tracked-claw"
+mkdir -p "$HOME/.agents/skills/tracked-claw/.clawhub"
 printf -- '---\nname: tracked-claw\ndescription: present\n---\n' >"$HOME/.agents/skills/tracked-claw/SKILL.md"
+printf '{"slug":"tracked-claw"}\n' >"$HOME/.agents/skills/tracked-claw/.clawhub/origin.json"
 touch "$HOME/.agents/skills/tracked-claw/.DS_Store"
-mkdir -p "$HOME/.agents/skills/refused-claw/agents"
+mkdir -p "$HOME/.agents/skills/refused-claw/agents" "$HOME/.agents/skills/refused-claw/.clawhub"
 printf -- '---\nname: refused-claw\ndescription: present\n---\n' >"$HOME/.agents/skills/refused-claw/SKILL.md"
+printf '{"slug":"refused-claw"}\n' >"$HOME/.agents/skills/refused-claw/.clawhub/origin.json"
 printf 'policy:\n  allow_implicit_invocation: false' >"$HOME/.agents/skills/refused-claw/agents/openai.yaml"
 cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
 {
@@ -109,9 +112,13 @@ export PATH="$shim_dir:$PATH"
 # Full run (NOT --install-only): exercises every refresh pass.
 output="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" || fail "full run exited non-zero: $output"
 
-# 1) The npx-native refresh is alive.
-grep -q 'skills@latest update' "$scratch_dir/npx.log" 2>/dev/null ||
-  fail "full run never invoked 'npx skills update' (npx-tracked refresh lost)"
+# 1) The npx-native refresh is alive: an explicit per-repo add against the
+#    candidate, never the bulk update (its lock-walk logs failures at exit 0).
+grep -qE 'skills@latest add fixture/tracked-skill .*--skill tracked-skill' "$scratch_dir/npx.log" 2>/dev/null ||
+  fail "full run never invoked the explicit per-repo 'npx skills add' (npx-tracked refresh lost): $(cat "$scratch_dir/npx.log" 2>/dev/null)"
+if grep -qE 'skills@latest update' "$scratch_dir/npx.log" 2>/dev/null; then
+  fail "full run invoked the bulk 'npx skills update' (forbidden; per-repo add only): $(cat "$scratch_dir/npx.log")"
+fi
 
 # 2) The install pass never git-clones (the git-pin machinery is gone), and
 #    with no forks entries the drift-check clones nothing either — so git is
@@ -131,16 +138,21 @@ done
 # 4) The clawhub update pass refreshes each tracked skill IN the store: bare
 #    store name, --workdir $HOME/.agents --dir skills, per-skill (never --all),
 #    and — both skills being present — never an install.
-grep -q -- "--workdir $HOME/.agents --dir skills update tracked-claw" "$scratch_dir/clawhub.log" 2>/dev/null ||
-  fail "full run never invoked 'clawhub update tracked-claw' against the store workdir: $(cat "$scratch_dir/clawhub.log" 2>/dev/null)"
+grep -qE -- "--workdir [^ ]+/.agents --dir skills update tracked-claw" "$scratch_dir/clawhub.log" 2>/dev/null ||
+  fail "full run never invoked 'clawhub update tracked-claw' against a store-shaped workdir: $(cat "$scratch_dir/clawhub.log" 2>/dev/null)"
+# ... and never against the REAL store: the update must run inside the candidate.
+if grep -q -- "--workdir $HOME/.agents " "$scratch_dir/clawhub.log" 2>/dev/null; then
+  fail "the clawhub lane ran against the REAL store workdir (must run inside the candidate): $(cat "$scratch_dir/clawhub.log")"
+fi
 if grep -qE '(^| )install( |$)' "$scratch_dir/clawhub.log"; then
   fail "the clawhub pass ran an install for a present skill: $(cat "$scratch_dir/clawhub.log")"
 fi
 
 # 5) Finder litter is scrubbed before the update: .DS_Store breaks the real
-#    CLI's fingerprint match, so the pass removes it first.
+#    CLI's fingerprint match, so the lane removes it in the candidate; after
+#    publish the store path (now a generation link) must not show it.
 [[ ! -e "$HOME/.agents/skills/tracked-claw/.DS_Store" ]] ||
-  fail "tracked-claw's .DS_Store survived the update pass (it breaks clawhub's fingerprint match)"
+  fail "tracked-claw's .DS_Store survived the update lane (it breaks clawhub's fingerprint match)"
 
 # 6) The refusal ladder: the repo-asserted overlay makes the CLI refuse with
 #    "local changes"; the pass sets exactly that file aside and retries once —
@@ -153,7 +165,7 @@ if grep -q -- '--force' "$scratch_dir/clawhub.log"; then
   fail "the clawhub pass passed a --force flag (automation must never force): $(cat "$scratch_dir/clawhub.log")"
 fi
 overlay="$HOME/.agents/skills/refused-claw/agents/openai.yaml"
-[[ -f $overlay ]] || fail "refused-claw's Codex overlay was not re-asserted after the update pass set it aside"
+[[ -f $overlay ]] || fail "refused-claw's Codex overlay was not re-asserted after the update lane set it aside"
 grep -q 'allow_implicit_invocation: false' "$overlay" ||
   fail "refused-claw's re-asserted overlay has wrong content: $(<"$overlay")"
 

--- a/test/update-skills-required-prereq.sh
+++ b/test/update-skills-required-prereq.sh
@@ -28,6 +28,9 @@ fail() {
   exit 1
 }
 
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -44,9 +47,19 @@ STAMP="$HOME/.local/state/update-skills/last-success"
 sbin="$tmp/sbin"
 mkdir -p "$sbin"
 ln -s "$(command -v jq)" "$sbin/jq"
-# gmv (GNU coreutils) is the generation-exchange publish primitive; like jq it
-# lives outside the hermetic PATH, so symlink the real binary in.
-ln -s "$(command -v gmv)" "$sbin/gmv"
+# The generation-exchange publish primitive is a GNU coreutils mv resolved at
+# run time (gmv on a Homebrew host, plain mv in the Nix devshell); like jq it
+# lives outside the hermetic PATH, so bring it in as gmv. An exec WRAPPER, not
+# a symlink: Nix ships coreutils as one multi-call binary that dispatches on
+# argv[0], so a symlink named gmv would not behave as mv.
+exchange_tool="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
+exchange_tool_path="$(command -v "$exchange_tool")"
+cat >"$sbin/gmv" <<EOF
+#!/usr/bin/env bash
+exec "$exchange_tool_path" "\$@"
+EOF
+chmod +x "$sbin/gmv"
 cat >"$sbin/npx" <<'EOF'
 #!/usr/bin/env bash
 echo stub

--- a/test/update-skills-required-prereq.sh
+++ b/test/update-skills-required-prereq.sh
@@ -44,6 +44,9 @@ STAMP="$HOME/.local/state/update-skills/last-success"
 sbin="$tmp/sbin"
 mkdir -p "$sbin"
 ln -s "$(command -v jq)" "$sbin/jq"
+# gmv (GNU coreutils) is the generation-exchange publish primitive; like jq it
+# lives outside the hermetic PATH, so symlink the real binary in.
+ln -s "$(command -v gmv)" "$sbin/gmv"
 cat >"$sbin/npx" <<'EOF'
 #!/usr/bin/env bash
 echo stub
@@ -120,8 +123,9 @@ fi
 
 # ── E) control: non-empty tables but prerequisites PRESENT → no required failure,
 #      stamp IS written. ───────────────────────────────────────────────────
-mkdir -p "$STORE/foo" # clawhub skill already present, so the install pass skips it
+mkdir -p "$STORE/foo/.clawhub" # clawhub skill already present, so the install pass skips it
 printf -- '---\nname: foo\ndescription: fixture\n---\n' >"$STORE/foo/SKILL.md"
+printf '{"slug":"foo"}\n' >"$STORE/foo/.clawhub/origin.json" # real installs carry origin metadata; validation requires it
 cat >"$sbin/clawhub" <<'EOF'
 #!/usr/bin/env bash
 echo "ok"

--- a/test/update-skills-required-prereq.sh
+++ b/test/update-skills-required-prereq.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# update-skills-required-prereq.sh, a missing REQUIRED prerequisite is a REQUIRED
+# FAILURE, not a silent success (Wave 3a item 4). The audit found: with a
+# non-empty lock table but its prerequisite binary absent, the phase returned
+# success, so the weekly stamp was written and the first-install retry marker was
+# removed while the skills stayed absent. For each required phase whose lock
+# table is non-empty and whose prerequisite command is missing, the run must
+# record a required failure, WITHHOLD the weekly success stamp, and let
+# --install-only exit non-zero (which preserves the first-install retry marker).
+#
+#   clawhub    -> clawhubTracked (install AND update passes)
+#   hermes     -> hermesRegistry (weekly registry-update phase)
+#   routing    -> superpowersRouting (assert-hermes-superpowers-routing.sh)
+#
+# The run is a FULL run under UPDATE_SKILLS_FORCE=1 (idle-gate bypassed) with a
+# HERMETIC PATH: a sandbox bin holding only the tools the script needs, so the
+# real clawhub/hermes (both installed on this host) are absent unless the case
+# explicitly stubs them.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+STORE="$HOME/.agents/skills"
+mkdir -p "$STORE"
+STAMP="$HOME/.local/state/update-skills/last-success"
+
+# Hermetic sandbox bin: symlink jq (only in /opt/homebrew/bin, alongside the real
+# clawhub) into it, and stub npx/date/alerter. The real clawhub/hermes live in
+# dirs we deliberately keep OFF this PATH, so command -v fails for them unless a
+# case adds a stub here.
+sbin="$tmp/sbin"
+mkdir -p "$sbin"
+ln -s "$(command -v jq)" "$sbin/jq"
+cat >"$sbin/npx" <<'EOF'
+#!/usr/bin/env bash
+echo stub
+EOF
+cat >"$sbin/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%u) printf '%s\n' "${FAKE_DOW:-1}" ;;
+  +%G-%V) printf '%s\n' "${FAKE_WEEK:-2026-28}" ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+cat >"$sbin/alerter" <<'EOF'
+#!/usr/bin/env bash
+:
+EOF
+chmod +x "$sbin"/npx "$sbin"/date "$sbin"/alerter
+HPATH="$sbin:/usr/bin:/bin"
+
+write_lock() { # $1 = claw json, $2 = registry json, $3 = routing json
+  cat >"$HOME/.agents/custom-skill-lock.json" <<EOF
+{
+  "version": 2,
+  "tiers": {},
+  "hermesProfiles": {},
+  "hermesRegistry": $2,
+  "npxTracked": {},
+  "clawhubTracked": $1,
+  "superpowersRouting": $3,
+  "forks": {}
+}
+EOF
+}
+
+CLAW_ONE='{"foo": {"slug": "@o/foo", "registry": "https://clawhub.ai"}}'
+REG_ONE='{"bar": {"profiles": ["default"], "source": "clawhub", "identifier": "c/bar", "lockKey": "bar"}}'
+ROUTING_ONE='{"map": {"a": "b"}}'
+EMPTY='{}'
+
+run_full() {
+  rm -rf "$HOME/.local/state"
+  OUT="$(PATH="$HPATH" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+    fail "full run exited non-zero (a required failure must not abort the run): $OUT"
+}
+
+# ── A) clawhubTracked non-empty, clawhub ABSENT → required failure, no stamp ──
+write_lock "$CLAW_ONE" "$EMPTY" "$EMPTY"
+run_full
+grep -qi 'REQUIRED-FAILURE.*clawhub' <<<"$OUT" ||
+  fail "a missing clawhub with a non-empty clawhubTracked did not record a required failure: $OUT"
+grep -qi 'WITHHOLDING' <<<"$OUT" || fail "clawhub-absent run did not withhold the stamp: $OUT"
+[[ ! -f $STAMP ]] || fail "the weekly stamp was written despite an absent clawhub with work to do"
+
+# ── B) hermesRegistry non-empty, hermes ABSENT → required failure, no stamp ──
+write_lock "$EMPTY" "$REG_ONE" "$EMPTY"
+run_full
+grep -qi 'REQUIRED-FAILURE.*hermes' <<<"$OUT" ||
+  fail "a missing hermes with a non-empty hermesRegistry did not record a required failure: $OUT"
+[[ ! -f $STAMP ]] || fail "the weekly stamp was written despite an absent hermes with work to do"
+
+# ── C) superpowersRouting non-empty, routing script ABSENT → required failure ─
+write_lock "$EMPTY" "$EMPTY" "$ROUTING_ONE"
+run_full
+grep -qi 'REQUIRED-FAILURE.*routing' <<<"$OUT" ||
+  fail "a missing routing script with a non-empty superpowersRouting did not record a required failure: $OUT"
+[[ ! -f $STAMP ]] || fail "the weekly stamp was written despite an absent routing script with work to do"
+
+# ── D) --install-only exits NON-ZERO when clawhub is absent (marker preserved) ─
+write_lock "$CLAW_ONE" "$EMPTY" "$EMPTY"
+if PATH="$HPATH" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only >/dev/null 2>&1; then
+  fail "--install-only returned success with a required prerequisite (clawhub) absent; the first-install marker would be wrongly cleared"
+fi
+
+# ── E) control: non-empty tables but prerequisites PRESENT → no required failure,
+#      stamp IS written. ───────────────────────────────────────────────────
+mkdir -p "$STORE/foo" # clawhub skill already present, so the install pass skips it
+printf -- '---\nname: foo\ndescription: fixture\n---\n' >"$STORE/foo/SKILL.md"
+cat >"$sbin/clawhub" <<'EOF'
+#!/usr/bin/env bash
+echo "ok"
+EOF
+cat >"$sbin/hermes" <<'EOF'
+#!/usr/bin/env bash
+echo "ok"
+EOF
+mkdir -p "$HOME/.local/bin"
+cat >"$HOME/.local/bin/assert-hermes-superpowers-routing.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$sbin/clawhub" "$sbin/hermes" "$HOME/.local/bin/assert-hermes-superpowers-routing.sh"
+write_lock "$CLAW_ONE" "$REG_ONE" "$ROUTING_ONE"
+run_full
+grep -qi 'REQUIRED-FAILURE' <<<"$OUT" &&
+  fail "a run with all prerequisites present recorded a spurious required failure: $OUT"
+[[ -f $STAMP ]] || fail "a clean run with present prerequisites did not write the weekly stamp: $OUT"
+
+echo "update-skills-required-prereq: OK"

--- a/test/update-skills-stamp.sh
+++ b/test/update-skills-stamp.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# update-skills-stamp.sh — the weekly success stamp must be written ONLY when a
+# run had zero REQUIRED-phase failures. A required failure (here: an npx install
+# that fails) leaves the stamp absent so a later Monday slot retries, and — only
+# when no future slot remains this Monday — fires the loud exhaustion alert. A
+# failure on any other day withholds the stamp but claims no exhaustion.
+#
+# The real script runs unmodified in a sandbox. FORCE bypasses the idle-gate (so
+# the run proceeds), an npx stub is made to FAIL the install of a tracked skill,
+# and date/alerter are stubbed so the slot-aware branch and the alert are
+# observable.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+STAMP="$HOME/.local/state/update-skills/last-success"
+
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"flaky": "core"},
+  "hermesProfiles": {"flaky": []},
+  "hermesRegistry": {},
+  "npxTracked": {"flaky": {"repo": "fixture/flaky"}},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+ALERTER_LOG="$tmp/alerter.log"
+
+# npx stub: FAILS `add` when FAKE_NPX_ADD_FAIL is set (a required install
+# failure); otherwise materialises the store dir. `update` always succeeds.
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+mode=""
+skill=""
+prev=""
+for a in "\$@"; do
+  case "\$a" in add) mode=add ;; update) mode=update ;; esac
+  [[ \$prev == "--skill" ]] && skill="\$a"
+  prev="\$a"
+done
+if [[ \$mode == "add" ]]; then
+  if [[ -n \${FAKE_NPX_ADD_FAIL:-} ]]; then echo "npx add boom" >&2; exit 1; fi
+  mkdir -p "\$HOME/.agents/skills/\$skill"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "\$skill" >"\$HOME/.agents/skills/\$skill/SKILL.md"
+fi
+echo stub
+EOF
+cat >"$stub/alerter" <<EOF
+#!/usr/bin/env bash
+printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
+EOF
+cat >"$stub/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%u) printf '%s\n' "${FAKE_DOW:-1}" ;;
+  +%G-%V) printf '%s\n' "${FAKE_WEEK:-2026-28}" ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+run() {
+  rm -rf "$HOME/.local/state"
+  : >"$ALERTER_LOG"
+  OUT="$(FAKE_NPX_ADD_FAIL="$1" FAKE_HOUR="$2" FAKE_DOW="$3" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+    fail "run exited non-zero (a required failure must not abort the run): $OUT"
+}
+
+# 1) Required failure on the last Monday slot → no stamp, loud exhaustion alert.
+run 1 16 1
+[[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure"
+grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a required failure did not log a stamp-withhold: $OUT"
+grep -qi 'EXHAUSTED' <<<"$OUT" || fail "a required failure on the last Monday slot did not log exhaustion: $OUT"
+[[ -s $ALERTER_LOG ]] || fail "a required failure on the last Monday slot did not fire the alerter"
+
+# 2) Required failure on a NON-Monday → no stamp, but NO exhaustion alert.
+run 1 16 3
+[[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure (non-Monday)"
+grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a non-Monday required failure did not log a stamp-withhold: $OUT"
+[[ ! -s $ALERTER_LOG ]] || fail "a non-Monday required failure claimed exhaustion / alerted: $(cat "$ALERTER_LOG")"
+
+# 3) Zero required failures → the stamp IS written.
+run "" 16 1
+[[ -f $STAMP ]] || fail "a clean run did not write the success stamp"
+[[ "$(<"$STAMP")" == "2026-28" ]] || fail "the stamp is not the pinned ISO week: $(<"$STAMP")"
+
+echo "update-skills-stamp: OK"

--- a/test/update-skills-stamp.sh
+++ b/test/update-skills-stamp.sh
@@ -80,28 +80,41 @@ EOF
 chmod +x "$stub"/*
 export PATH="$stub:$PATH"
 
+# run <npx_add_fail> <hour> <dow> [sched], the 4th arg "--scheduled" marks a
+# LaunchAgent run; otherwise the run is manual (never claims exhaustion).
 run() {
+  local -a run_args=()
+  [[ ${4:-} == "--scheduled" ]] && run_args=(--scheduled)
   rm -rf "$HOME/.local/state"
   : >"$ALERTER_LOG"
-  OUT="$(FAKE_NPX_ADD_FAIL="$1" FAKE_HOUR="$2" FAKE_DOW="$3" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+  OUT="$(FAKE_NPX_ADD_FAIL="$1" FAKE_HOUR="$2" FAKE_DOW="$3" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" "${run_args[@]}" 2>&1)" ||
     fail "run exited non-zero (a required failure must not abort the run): $OUT"
 }
 
-# 1) Required failure on the last Monday slot → no stamp, loud exhaustion alert.
-run 1 16 1
+# 1) Required failure on the last SCHEDULED Monday slot → no stamp, loud
+#    exhaustion alert.
+run 1 16 1 --scheduled
 [[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure"
 grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a required failure did not log a stamp-withhold: $OUT"
-grep -qi 'EXHAUSTED' <<<"$OUT" || fail "a required failure on the last Monday slot did not log exhaustion: $OUT"
-[[ -s $ALERTER_LOG ]] || fail "a required failure on the last Monday slot did not fire the alerter"
+grep -qi 'EXHAUSTED' <<<"$OUT" || fail "a required failure on the last scheduled slot did not log exhaustion: $OUT"
+[[ -s $ALERTER_LOG ]] || fail "a required failure on the last scheduled slot did not fire the alerter"
 
-# 2) Required failure on a NON-Monday → no stamp, but NO exhaustion alert.
-run 1 16 3
-[[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure (non-Monday)"
-grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a non-Monday required failure did not log a stamp-withhold: $OUT"
-[[ ! -s $ALERTER_LOG ]] || fail "a non-Monday required failure claimed exhaustion / alerted: $(cat "$ALERTER_LOG")"
+# 2) Required failure on a NON-Monday SCHEDULED catch-up → no stamp; a later day
+#    means the Monday budget is spent, so exhaustion IS claimed.
+run 1 16 3 --scheduled
+[[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure (catch-up)"
+grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a catch-up required failure did not log a stamp-withhold: $OUT"
+[[ -s $ALERTER_LOG ]] || fail "a scheduled catch-up required failure did not claim exhaustion: $(cat "$ALERTER_LOG")"
+
+# 2b) Required failure on a MANUAL last-Monday-slot run → no stamp, but NO
+#     exhaustion alert (a manual run never claims scheduled-budget exhaustion).
+run 1 16 1
+[[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure (manual)"
+grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a manual required failure did not log a stamp-withhold: $OUT"
+[[ ! -s $ALERTER_LOG ]] || fail "a manual required failure claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
 
 # 3) Zero required failures → the stamp IS written.
-run "" 16 1
+run "" 16 1 --scheduled
 [[ -f $STAMP ]] || fail "a clean run did not write the success stamp"
 [[ "$(<"$STAMP")" == "2026-28" ]] || fail "the stamp is not the pinned ISO week: $(<"$STAMP")"
 

--- a/test/update-skills-stamp.sh
+++ b/test/update-skills-stamp.sh
@@ -45,8 +45,9 @@ stub="$tmp/stub"
 mkdir -p "$stub"
 ALERTER_LOG="$tmp/alerter.log"
 
-# npx stub: FAILS `add` when FAKE_NPX_ADD_FAIL is set (a required install
-# failure); otherwise materialises the store dir. `update` always succeeds.
+# npx stub: FAILS `add` while the marker file $tmp/npx-add-fail exists (a
+# required install failure); otherwise materialises the store dir. A FILE, not
+# an env var: the build lanes run under env -i, which strips test variables.
 cat >"$stub/npx" <<EOF
 #!/usr/bin/env bash
 mode=""
@@ -58,7 +59,7 @@ for a in "\$@"; do
   prev="\$a"
 done
 if [[ \$mode == "add" ]]; then
-  if [[ -n \${FAKE_NPX_ADD_FAIL:-} ]]; then echo "npx add boom" >&2; exit 1; fi
+  if [[ -e "$tmp/npx-add-fail" ]]; then echo "npx add boom" >&2; exit 1; fi
   mkdir -p "\$HOME/.agents/skills/\$skill"
   printf -- '---\nname: %s\ndescription: fixture\n---\n' "\$skill" >"\$HOME/.agents/skills/\$skill/SKILL.md"
 fi
@@ -87,7 +88,8 @@ run() {
   [[ ${4:-} == "--scheduled" ]] && run_args=(--scheduled)
   rm -rf "$HOME/.local/state"
   : >"$ALERTER_LOG"
-  OUT="$(FAKE_NPX_ADD_FAIL="$1" FAKE_HOUR="$2" FAKE_DOW="$3" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" "${run_args[@]}" 2>&1)" ||
+  if [[ -n $1 ]]; then touch "$tmp/npx-add-fail"; else rm -f "$tmp/npx-add-fail"; fi
+  OUT="$(FAKE_HOUR="$2" FAKE_DOW="$3" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" "${run_args[@]}" 2>&1)" ||
     fail "run exited non-zero (a required failure must not abort the run): $OUT"
 }
 

--- a/test/update-skills-stamp.sh
+++ b/test/update-skills-stamp.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# update-skills-stamp.sh — the weekly success stamp must be written ONLY when a
+# update-skills-stamp.sh, the weekly success stamp must be written ONLY when a
 # run had zero REQUIRED-phase failures. A required failure (here: an npx install
-# that fails) leaves the stamp absent so a later Monday slot retries, and — only
-# when no future slot remains this Monday — fires the loud exhaustion alert. A
+# that fails) leaves the stamp absent so a later Monday slot retries, and, only
+# when no future slot remains this Monday, fires the loud exhaustion alert. A
 # failure on any other day withholds the stamp but claims no exhaustion.
 #
 # The real script runs unmodified in a sandbox. FORCE bypasses the idle-gate (so

--- a/test/update-skills-stamp.sh
+++ b/test/update-skills-stamp.sh
@@ -91,9 +91,9 @@ run() {
     fail "run exited non-zero (a required failure must not abort the run): $OUT"
 }
 
-# 1) Required failure on the last SCHEDULED Monday slot → no stamp, loud
+# 1) Required failure on the last SCHEDULED Monday slot (23:00) → no stamp, loud
 #    exhaustion alert.
-run 1 16 1 --scheduled
+run 1 23 1 --scheduled
 [[ ! -f $STAMP ]] || fail "the success stamp was written despite a required-phase failure"
 grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a required failure did not log a stamp-withhold: $OUT"
 grep -qi 'EXHAUSTED' <<<"$OUT" || fail "a required failure on the last scheduled slot did not log exhaustion: $OUT"
@@ -113,9 +113,12 @@ run 1 16 1
 grep -qi 'WITHHOLDING' <<<"$OUT" || fail "a manual required failure did not log a stamp-withhold: $OUT"
 [[ ! -s $ALERTER_LOG ]] || fail "a manual required failure claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
 
-# 3) Zero required failures → the stamp IS written.
+# 3) Zero required failures → the stamp IS written (ISO week plus the custom-lock
+#    and updater hashes, so a roster or updater change un-stamps the week).
 run "" 16 1 --scheduled
 [[ -f $STAMP ]] || fail "a clean run did not write the success stamp"
-[[ "$(<"$STAMP")" == "2026-28" ]] || fail "the stamp is not the pinned ISO week: $(<"$STAMP")"
+[[ "$(<"$STAMP")" == "2026-28 "* ]] || fail "the stamp does not begin with the pinned ISO week: $(<"$STAMP")"
+stamp_fields="$(wc -w <"$STAMP" | tr -d ' ')"
+[[ $stamp_fields -eq 3 ]] || fail "the stamp is not <week> <lock-hash> <updater-hash> (got $stamp_fields fields): $(<"$STAMP")"
 
 echo "update-skills-stamp: OK"

--- a/test/update-skills-streaks.sh
+++ b/test/update-skills-streaks.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# update-skills-streaks.sh: per-skill failure streaks (Wave 3a fix4 brief step
+# 6): {last_failed_week, consecutive_failed_weeks} per skill, incremented at
+# most once per ISO WEEK (not per hourly slot), reset on verified success,
+# escalated alert wording at 2 consecutive weeks. Convergence never stops: the
+# failing run still exits 0 and the next slot retries.
+#
+# The real script runs unmodified in a sandbox: an npx stub whose add fails
+# while a marker file exists (file-based: the lanes run under env -i, which
+# strips test env vars), a pinned date stub for the ISO week, and an alerter
+# stub capturing the wording.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+STREAKS="$HOME/.local/state/update-skills/skill-failure-streaks.json"
+STAMP="$HOME/.local/state/update-skills/last-success"
+
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"flaky": "core"},
+  "hermesProfiles": {"flaky": []},
+  "hermesRegistry": {},
+  "npxTracked": {"flaky": {"repo": "fixture/flaky"}},
+  "clawhubTracked": {},
+  "forks": {}
+}
+EOF
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+ALERTER_LOG="$tmp/alerter.log"
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+mode=""
+skill=""
+prev=""
+for a in "\$@"; do
+  case "\$a" in add) mode=add ;; update) mode=update ;; esac
+  [[ \$prev == "--skill" ]] && skill="\$a"
+  prev="\$a"
+done
+if [[ \$mode == "add" ]]; then
+  if [[ -e "$tmp/npx-add-fail" ]]; then echo "npx add boom" >&2; exit 1; fi
+  mkdir -p "\$HOME/.agents/skills/\$skill"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "\$skill" >"\$HOME/.agents/skills/\$skill/SKILL.md"
+fi
+echo stub
+EOF
+cat >"$stub/alerter" <<EOF
+#!/usr/bin/env bash
+printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
+EOF
+cat >"$stub/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%u) printf '%s\n' "${FAKE_DOW:-1}" ;;
+  +%G-%V) printf '%s\n' "${FAKE_WEEK:-2026-28}" ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+# run <fail?> <week>
+run() {
+  if [[ -n $1 ]]; then touch "$tmp/npx-add-fail"; else rm -f "$tmp/npx-add-fail"; fi
+  : >"$ALERTER_LOG"
+  rm -f "$STAMP" # FORCE bypasses the stamp anyway; keep worlds independent
+  OUT="$(FAKE_WEEK="$2" UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" ||
+    fail "run exited non-zero (streaks must never stop convergence): $OUT"
+}
+
+streak_of() { jq -r --arg n "$1" '.[$n].consecutive_failed_weeks // 0' "$STREAKS" 2>/dev/null || echo 0; }
+week_of() { jq -r --arg n "$1" '.[$n].last_failed_week // ""' "$STREAKS" 2>/dev/null || echo ""; }
+
+# 1) First failing week: streak = 1, no escalation.
+run 1 "2026-28"
+[[ "$(streak_of flaky)" == "1" ]] || fail "first failing week did not set the streak to 1: $(cat "$STREAKS" 2>/dev/null)"
+[[ "$(week_of flaky)" == "2026-28" ]] || fail "last_failed_week not recorded: $(cat "$STREAKS" 2>/dev/null)"
+if grep -qi 'multiple weeks' "$ALERTER_LOG"; then
+  fail "a single failing week fired the escalated alert wording: $(cat "$ALERTER_LOG")"
+fi
+
+# 2) A second failing SLOT in the SAME week: streak stays 1 (at most one
+#    increment per week, not per hourly slot).
+run 1 "2026-28"
+[[ "$(streak_of flaky)" == "1" ]] ||
+  fail "a second slot in the same week double-incremented the streak: $(cat "$STREAKS")"
+
+# 3) A failing run in the NEXT week: streak = 2, escalated alert wording fires.
+run 1 "2026-29"
+[[ "$(streak_of flaky)" == "2" ]] || fail "second failing week did not raise the streak to 2: $(cat "$STREAKS")"
+grep -qi 'multiple weeks' "$ALERTER_LOG" ||
+  fail "a 2-week streak did not fire the escalated alert wording: $(cat "$ALERTER_LOG" 2>/dev/null)"
+grep -q 'flaky' "$ALERTER_LOG" || fail "the escalated alert does not name the failing skill: $(cat "$ALERTER_LOG")"
+grep -qi 'STREAK' <<<"$OUT" || fail "the run log does not carry the streak line: $OUT"
+
+# 4) A verified success resets the streaks; a later failure starts over at 1.
+run "" "2026-30"
+[[ "$(streak_of flaky)" == "0" ]] ||
+  fail "a verified success did not reset the streak: $(cat "$STREAKS" 2>/dev/null)"
+run 1 "2026-31"
+[[ "$(streak_of flaky)" == "1" ]] ||
+  fail "the post-reset failure did not restart the streak at 1: $(cat "$STREAKS")"
+
+echo "update-skills-streaks: OK"

--- a/test/update-skills-symlink-safety.sh
+++ b/test/update-skills-symlink-safety.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# update-skills-symlink-safety.sh, profile discovery must NOT delete through a
+# foreign directory symlink (Wave 3a item 8). The audit found that -d follows a
+# symlinked profile (or its skills child), and ownership is decided from the
+# literal relative link text, so a profiles/<name> symlink pointing outside
+# ~/.hermes let convergence remove links in a foreign location THROUGH it. A
+# managed hermes dir reached through a directory symlink must be skipped, so
+# nothing is created or removed in the foreign target.
+#
+# The real script runs unmodified in a sandbox: a FULL run (offline stubs) so
+# destructive convergence would happen, FORCE to bypass the idle-gate.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+STORE="$HOME/.agents/skills"
+HERMES="$HOME/.hermes/skills"
+PROFILES="$HOME/.hermes/profiles"
+mkdir -p "$STORE" "$HOME/.claude/skills" "$HERMES" "$PROFILES"
+
+mkdir -p "$STORE/alpha"
+printf -- '---\nname: alpha\ndescription: fixture\n---\n' >"$STORE/alpha/SKILL.md"
+
+# A FOREIGN store, outside ~/.hermes, with an owned-SHAPED stale link inside a
+# skills dir. If convergence walks THROUGH a symlinked profile into here, it
+# would unlink this via its literal relative target.
+OUTSIDE="$tmp/outside"
+mkdir -p "$OUTSIDE/skills"
+ln -s "../../../../.agents/skills/gone" "$OUTSIDE/skills/victim" # owned-shaped, stale
+printf 'precious\n' >"$OUTSIDE/skills/keepme.txt"
+
+# profiles/spec is a SYMLINK pointing outside .hermes; its skills child resolves
+# to the foreign dir above.
+ln -s "$OUTSIDE" "$PROFILES/spec"
+
+# Also test the skills-CHILD-is-a-symlink shape: a real profile dir whose skills
+# child is a symlink into a second foreign store.
+OUTSIDE2="$tmp/outside2"
+mkdir -p "$OUTSIDE2/skills"
+ln -s "../../../../.agents/skills/gone2" "$OUTSIDE2/skills/victim2"
+mkdir -p "$PROFILES/spec2"
+ln -s "$OUTSIDE2/skills" "$PROFILES/spec2/skills"
+
+# Lock maps alpha to the default profile only; spec/spec2 are unmapped. Their
+# skills dirs still EXIST on disk (through the symlinks), so the profile-universe
+# walk would reach them, but the symlink guard must skip them.
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{
+  "version": 2,
+  "tiers": {"alpha": "core"},
+  "hermesProfiles": {"alpha": ["default"]},
+  "hermesRegistry": {},
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "superpowersRouting": {},
+  "forks": {}
+}
+EOF
+
+stub="$tmp/stub"
+mkdir -p "$stub"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub/npx"
+printf '#!/usr/bin/env bash\necho stub\n' >"$stub/hermes"
+chmod +x "$stub"/*
+export PATH="$stub:$PATH"
+
+out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1)" || fail "full run exited non-zero: $out"
+
+# The foreign links reached through the symlinked profile dirs must survive.
+[[ -L "$OUTSIDE/skills/victim" ]] ||
+  fail "an owned-shaped link was deleted THROUGH a symlinked profile dir (profiles/spec): $out"
+[[ -f "$OUTSIDE/skills/keepme.txt" ]] ||
+  fail "a foreign file was removed through a symlinked profile dir"
+[[ -L "$OUTSIDE2/skills/victim2" ]] ||
+  fail "an owned-shaped link was deleted THROUGH a symlinked skills child (profiles/spec2/skills): $out"
+
+# The symlinked profile dirs must be reported as skipped.
+grep -qi 'symlink' <<<"$out" ||
+  fail "the run did not warn about skipping a symlinked profile/skills dir: $out"
+
+# Sanity: the legitimate default-profile link is still created.
+[[ -L "$HERMES/alpha" && "$(readlink "$HERMES/alpha")" == "../../.agents/skills/alpha" ]] ||
+  fail "the legitimate default-profile link was not created"
+
+echo "update-skills-symlink-safety: OK"

--- a/test/update-skills-validation-failure.sh
+++ b/test/update-skills-validation-failure.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# update-skills-validation-failure.sh — proves the whole-candidate discard rule
+# (Wave 3a fix4 brief step 4): ANY lane failure or validation failure discards
+# the WHOLE candidate (no partial promotion, ever). The live generation stays
+# byte-identical, a required failure is recorded, nothing is published, and the
+# staging is cleaned.
+#   Case A: a build lane exits non-zero (npx add fails).
+#   Case B: the lanes succeed but a roster skill is missing its SKILL.md.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+live_hash() { find "$SKILLS_CURRENT" -type f -exec shasum {} \; | sed "s#$SKILLS_CURRENT##" | sort; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
+{"tiers":{"alpha":"core"},"npxTracked":{"alpha":{"repo":"x/a"}},"clawhubTracked":{}}
+EOF
+
+# npx stub whose behavior is switched by a marker file: normally installs, but
+# when $tmp/npx-fail exists it exits non-zero (a failing lane).
+stub="$tmp/stub"
+mkdir -p "$stub"
+cat >"$stub/npx" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -f "$tmp/npx-fail" ]]; then
+  echo "stub npx: forced failure" >&2
+  exit 1
+fi
+mode=""; prev=""; skills=()
+for a in "\$@"; do
+  case "\$a" in add) mode=add ;; esac
+  [[ \$prev == --skill ]] && skills+=("\$a")
+  prev="\$a"
+done
+if [[ \$mode == add ]]; then
+  for s in "\${skills[@]}"; do
+    mkdir -p "\$HOME/.agents/skills/\$s"
+    printf -- '---\nname: %s\n---\n' "\$s" >"\$HOME/.agents/skills/\$s/SKILL.md"
+  done
+fi
+STUB
+chmod +x "$stub/npx"
+export PATH="$stub:$PATH"
+export UPDATE_SKILLS_GMV="$GMV_BIN"
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# Seed a published live generation.
+mkdir -p "$SKILLS_CURRENT/skills/alpha"
+printf -- '---\nname: alpha\n---\n# LIVE\n' >"$SKILLS_CURRENT/skills/alpha/SKILL.md"
+printf '{}' >"$SKILLS_CURRENT/.skill-lock.json"
+__gen_write_meta "$SKILLS_CURRENT" "live-1-1"
+__gen_plant_store_link alpha
+__gen_plant_lock_link
+before="$(live_hash)"
+
+# The orchestration a full run performs on a candidate, with the discard rule.
+attempt() {
+  local id
+  __gen_recover
+  id="$(__gen_new_id)"
+  __gen_build_candidate "$id" || return 1
+  if ! __gen_run_lanes "$GEN_CANDIDATE_HOME" "$id" >/dev/null 2>&1; then
+    record_required_failure "lanes failed"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  if ! __gen_validate_candidate "$GEN_CANDIDATE_AGENTS"; then
+    record_required_failure "validation failed"
+    __gen_garbage_destroy "$GENERATIONS/$id"
+    return 1
+  fi
+  __gen_publish "$GEN_CANDIDATE_AGENTS"
+}
+
+# --- Case A: failing lane.
+touch "$tmp/npx-fail"
+REQUIRED_FAILURES=0
+attempt && fail "case A: attempt should have failed on the lane error"
+[[ $REQUIRED_FAILURES -ge 1 ]] || fail "case A: no required failure was recorded"
+[[ "$(live_hash)" == "$before" ]] || fail "case A: the live generation was modified by a failed attempt"
+[[ "$(__gen_meta_field "$SKILLS_CURRENT" id)" == "live-1-1" ]] ||
+  fail "case A: the live generation was replaced despite the lane failure"
+shopt -s nullglob
+leftovers=("$GENERATIONS"/*/home)
+shopt -u nullglob
+[[ ${#leftovers[@]} -eq 0 ]] || fail "case A: staging was not cleaned: ${leftovers[*]}"
+
+# --- Case B: lanes succeed but a roster skill loses its SKILL.md. Model this
+#     with an npx stub variant that omits the SKILL.md.
+rm -f "$tmp/npx-fail"
+cat >"$stub/npx" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+mode=""; prev=""; skills=()
+for a in "$@"; do
+  case "$a" in add) mode=add ;; esac
+  [[ $prev == --skill ]] && skills+=("$a")
+  prev="$a"
+done
+if [[ $mode == add ]]; then
+  for s in "${skills[@]}"; do
+    mkdir -p "$HOME/.agents/skills/$s" # dir but NO SKILL.md (a broken install)
+    rm -f "$HOME/.agents/skills/$s/SKILL.md"
+  done
+fi
+STUB
+chmod +x "$stub/npx"
+REQUIRED_FAILURES=0
+attempt && fail "case B: attempt should have failed validation (missing SKILL.md)"
+[[ $REQUIRED_FAILURES -ge 1 ]] || fail "case B: no required failure recorded on validation failure"
+[[ "$(live_hash)" == "$before" ]] || fail "case B: the live generation was modified by a failed validation"
+[[ "$(__gen_meta_field "$SKILLS_CURRENT" id)" == "live-1-1" ]] ||
+  fail "case B: the live generation was replaced despite validation failure"
+shopt -s nullglob
+leftovers=("$GENERATIONS"/*/home)
+shopt -u nullglob
+[[ ${#leftovers[@]} -eq 0 ]] || fail "case B: staging was not cleaned: ${leftovers[*]}"
+
+echo "update-skills-validation-failure: OK"

--- a/test/update-skills-validation-failure.sh
+++ b/test/update-skills-validation-failure.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-skills-validation-failure.sh — proves the whole-candidate discard rule
+# update-skills-validation-failure.sh proves the whole-candidate discard rule
 # (Wave 3a fix4 brief step 4): ANY lane failure or validation failure discards
 # the WHOLE candidate (no partial promotion, ever). The live generation stays
 # byte-identical, a required failure is recorded, nothing is published, and the

--- a/test/update-skills-validation-failure.sh
+++ b/test/update-skills-validation-failure.sh
@@ -12,12 +12,18 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
-GMV_BIN="${UPDATE_SKILLS_GMV:-/opt/homebrew/bin/gmv}"
-
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+# Resolve the generation-exchange tool the way the updater does at run time
+# (gmv on a Homebrew host, plain mv in the Nix devshell), never a hardcoded
+# host path.
+# shellcheck source=test/fixtures/exchange-tool.lib.sh
+source "$REPO_ROOT/test/fixtures/exchange-tool.lib.sh"
+GMV_BIN="$(resolve_exchange_tool)" ||
+  fail "no GNU coreutils mv with a working --exchange on PATH (need gmv or mv)"
 
 live_hash() { find "$SKILLS_CURRENT" -type f -exec shasum {} \; | sed "s#$SKILLS_CURRENT##" | sort; }
 

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -228,6 +228,7 @@ in
       ".chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl"
       ".chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl"
       ".chezmoiscripts/run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl"
+      ".chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl"
       ".chezmoiscripts/run_onchange_after_66-tailscaled-status.sh.tmpl"
     ];
   };


### PR DESCRIPTION
## Context

This dotfiles repository is being modernized: `main` is rebuilt slice by slice while the live
machine keeps applying from the `integration/modernization` branch until a final cutover. A
weekly LaunchAgent runs the cross-harness skills updater, and a 2026-07-10 audit found it could
swap skill files under live agent sessions, delete files it did not own, and report failed runs
as successes.

This PR rebuilds that updater around two independently reviewed designs: an activity-based idle
gate, and generation-exchange publishing that makes every update atomic. It runs fully
unattended; no manual steps remain.

## Summary

- Updates are now atomic: a session sees the complete old skills or the complete new ones, never a mix.
- The weekly run works unattended; it defers only while a harness shows recent activity.
- A failed or crashed run leaves the old skills fully intact and self-heals next run.
- Failed weeks retry automatically forever; two stuck weeks for one skill escalates a phone alert.
- Outside writers (HyperFrames self-updates) are absorbed back into clean state weekly.
- The run lock, dry-run, and success stamp are now race-free, write-free, and honest respectively.
- Key files:
  - `dot_local/bin/executable_update-skills.sh` (the updater)
  - `Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl` (24 hourly Monday slots)
  - `.chezmoiscripts/run_onchange_after_64-update-skills-first-install.sh.tmpl` (apply-time bootstrap)
  - 15 `test/update-skills-*.sh` suites (8 new hostile groups)

## How it works

- All npx- and ClawHub-tracked skills live in one generation directory
  (`~/.agents/.skills-current/`), so their sibling references stay intact; store names are
  stable links into it.
- Each run builds a complete candidate generation in an isolated staging HOME (`env -i`, every
  XDG and cache path pinned inside), validates it wholesale, then publishes with a single
  atomic `gmv --exchange`.
- The npx lock file lives inside the generation and swaps with it, so content and bookkeeping
  can never disagree after a crash.
- A recovery step maps every crash window (staged, published, pruned, disk-full) to a
  self-healing action; the previous generation is retained for stragglers.
- Idleness is judged by harness activity evidence (transcript and log mtimes), not process
  existence, with fail-closed behavior on probe errors.
- The success stamp includes the roster and updater hashes, so a roster change after a Monday
  success re-arms the week.
- Vendored skills and the app-owned `cua-driver` link are untouched by all of this.

## How it was reviewed

- Two adversarial code-review rounds per provider (fresh-context Claude and Codex gpt-5.6-sol
  at ultra effort) on the audit fixes: discriminator, lock protocol, false-success accounting,
  deletion safety.
- A dedicated dual design review of the update mechanism. Both providers returned
  DESIGN-FLAWED on the first draft; the shipped architecture is sol's generation exchange with
  the Claude review's verified primitives (BSD `mv` proven wrong, `gmv --exchange` proven
  right, `$HOME`-only isolation proven leaky).
- Hostile tests are load-bearing: a reader loop across 100 publish cycles, decoy-home isolation
  checks, a fabricated crash-state table, and competing-writer drift, all red-first.
- The conductor re-ran the hostile suites and the full gate independently before merge.

## Effect of merging

`main` gains the rebuilt updater; nothing changes on any live machine until the D1 cutover
(this machine applies from the integration branch). After cutover, the first idle Monday slot
migrates the flat store to the generation layout, per-entry atomically; progress is logged to
`~/.local/log/skills/`. `gmv` (coreutils, already declared) becomes a hard runtime dependency
of publishing; its absence fails loudly and changes nothing. The honest guarantee is stated in
the script header: per-lookup completeness and per-generation coherence for our runs, with
upstream self-updates absorbed on the following weekly run.
