### PR TITLE
feat: S6 Homebrew weekly-upgrade slice with hardened cleanup and teardown

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -5,7 +5,6 @@ packages:
         - antoniorodr/memo
         - buo/cask-upgrade
         - cirruslabs/cli
-        - domt4/autoupdate # Automatic Upgrades.
         - eugene1g/safehouse
         - felixkratz/formulae
         - mediosz/tap
@@ -28,7 +27,6 @@ packages:
         - antoniorodr/memo
         - buo/cask-upgrade
         - cirruslabs/cli
-        - domt4/autoupdate
         - eugene1g/safehouse
         - felixkratz/formulae
         - mediosz/tap

--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -54,6 +54,15 @@ if ! reason="$(herdr_health_check)"; then
   exit 0
 fi
 
+{{ if eq (env "SKIP_SYSTEM_PACKAGES") "1" -}}
+# SKIP_SYSTEM_PACKAGES=1: herdr is verified, but skip the deferred tmux/sesh
+# cleanup so an apply from a secondary worktree (whose declared package set
+# differs) cannot uninstall packages this worktree does not list -- the same
+# secondary-worktree safety before_10 honors. Only the literal "1" skips; a
+# normal apply completes the migration.
+printf 'SKIP_SYSTEM_PACKAGES=1: herdr verified but skipping the deferred tmux/sesh cleanup (secondary-worktree safety); a normal apply completes the migration.\n' >&2
+exit 0
+{{ end -}}
 # Verified: perform the deferred cleanup. Regenerate the Brewfile from the SAME
 # package data before_10 uses, then `brew bundle cleanup --force` removes every
 # installed formula/cask/tap absent from it (tmux/sesh among them) -- the exact

--- a/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
+++ b/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl
@@ -43,6 +43,8 @@ fi
 
 {{ includeTemplate "herdr-health-check.sh.tmpl" }}
 
+{{ includeTemplate "brew-bundle-cleanup-guard.sh.tmpl" }}
+
 # A legacy multiplexer is still installed: verify the CURRENT herdr before
 # removing it. On any failure, defer with a warning that names the interactive
 # activation step, and exit 0 so the next apply retries.
@@ -76,8 +78,12 @@ cask {{ . | quote }}
 mas {{ .name | quote }}, id: {{ .id }}
 {{ end -}}
 EOF
-if "$brew_bin" bundle cleanup --force --file="$brewfile"; then
-  printf 'herdr verified as a multiplexer; removed tmux/sesh via brew bundle cleanup (migration complete).\n'
+if brew_bundle_cleanup_guarded "$brewfile"; then
+  if [[ $BREW_CLEANUP_OUTCOME == refused ]]; then
+    printf 'WARNING: herdr verified but the forced cleanup was refused by the bulk-removal guard (the rendered manifest would remove more than the safety threshold); tmux/sesh may still be installed. Re-run with HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1 once the manifest is complete.\n' >&2
+  else
+    printf 'herdr verified as a multiplexer; removed tmux/sesh via brew bundle cleanup (migration complete).\n'
+  fi
 else
   printf 'WARNING: herdr verified but brew bundle cleanup failed; tmux/sesh may still be installed. Re-run chezmoi apply to retry.\n' >&2
 fi

--- a/.chezmoiscripts/run_onchange_after_65-load-homebrew-weekly-upgrade-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_65-load-homebrew-weekly-upgrade-launchagent.sh.tmpl
@@ -1,0 +1,26 @@
+#!/bin/bash
+# run_onchange_after_65-load-homebrew-weekly-upgrade-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist.tmpl" | sha256sum }}
+
+{{- if eq .chezmoi.os "darwin" }}
+set -euo pipefail
+
+mkdir -p "$HOME/.local/log/homebrew"
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist"
+TARGET="gui/$(id -u)/com.webdavis.homebrew-weekly-upgrade"
+
+# Re-bootstrap so a changed plist takes effect. launchd may return EIO when
+# bootstrap fires right after bootout; retry silently up to 3 times before
+# surfacing the real error on the final attempt.
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -93,8 +93,12 @@ mas {{ .name | quote }}, id: {{ .id }}
 {{ end -}}
 EOF
 "$brew_bin" bundle --file="$brewfile"
+{{ includeTemplate "brew-bundle-cleanup-guard.sh.tmpl" }}
 if [[ $multiplexer_present == false ]]; then
-  "$brew_bin" bundle cleanup --force --file="$brewfile"
+  # Guarded: refuses a bulk cleanup against a partial/empty Brewfile (returns 0
+  # on refuse or clean, non-zero only on a real cleanup failure -- so set -e
+  # still aborts the apply on a genuine failure, as before).
+  brew_bundle_cleanup_guarded "$brewfile"
 fi
 
 # Install uv tools (runs after Homebrew so uv is available). Guarded on uv being

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -3,6 +3,14 @@
 
 set -euo pipefail
 
+{{ if eq (env "SKIP_SYSTEM_PACKAGES") "1" -}}
+# SKIP_SYSTEM_PACKAGES=1 set: skipping the brew bundle sync entirely, so a
+# `chezmoi apply` from a secondary worktree (whose declared package set differs)
+# cannot uninstall packages this worktree does not list. Only the literal "1"
+# skips -- 0/false/anything-else still run the sync. A later normal apply re-runs
+# this and re-syncs.
+exit 0
+{{ end -}}
 # Resolve the Homebrew prefix once (honoring HOMEBREW_PREFIX, as the autoupdate
 # block below already does) so every brew/uv/volta call goes through one place.
 brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -39,7 +39,6 @@ brew_bin="$brew_prefix/bin/brew"
 #
 # ROLLBACK: while herdr is unverified, tmux/sesh stay installed and usable; no
 # teardown happens. Keep using tmux until after_58 completes the migration.
-bundle_args=(--cleanup --file=/dev/stdin)
 multiplexer_present=false
 for multiplexer in tmux sesh; do
   if "$brew_bin" list "$multiplexer" &>/dev/null; then
@@ -48,13 +47,20 @@ for multiplexer in tmux sesh; do
   fi
 done
 if [[ $multiplexer_present == true ]]; then
-  bundle_args=(--file=/dev/stdin)
-  printf 'Legacy multiplexer (tmux/sesh) still installed: running brew bundle WITHOUT --cleanup so it is not removed before herdr is verified.\n' >&2
+  printf 'Legacy multiplexer (tmux/sesh) still installed: running brew bundle WITHOUT cleanup so it is not removed before herdr is verified.\n' >&2
   printf 'run_after_58 owns the teardown and completes the migration once herdr is healthy: open an interactive terminal (bashrc auto-attaches and starts the herdr server), then run chezmoi apply again so after_58 verifies herdr and removes tmux/sesh.\n' >&2
 fi
 
-# Use `brew bundle ...` to install all taps, formulae, casks, and macOS App Store apps.
-"$brew_bin" bundle "${bundle_args[@]}" <<EOF
+# Install all taps, formulae, casks, and macOS App Store apps, then uninstall
+# anything not declared. Homebrew 6.x removed the old `brew bundle --cleanup`
+# behavior: the flag now only PRINTS what it would remove and exits 1 whenever
+# that list is non-empty, which aborts the whole apply under set -e. Removal is
+# now its own command, `brew bundle cleanup --force`. So write the Brewfile to a
+# temp file once, install from it, then (unless the legacy multiplexer is still
+# installed, per the withhold rationale above) run the cleanup command.
+brewfile=$(mktemp)
+trap 'rm -f "$brewfile"' EXIT
+cat >"$brewfile" <<EOF
 {{ range .packages.macos.homebrew.taps -}}
 tap {{ . | quote }}
 {{ end -}}
@@ -68,6 +74,10 @@ cask {{ . | quote }}
 mas {{ .name | quote }}, id: {{ .id }}
 {{ end -}}
 EOF
+"$brew_bin" bundle --file="$brewfile"
+if [[ $multiplexer_present == false ]]; then
+  "$brew_bin" bundle cleanup --force --file="$brewfile"
+fi
 
 # Configure Homebrew autoupdate (idempotent — only restart if not already running).
 HOMEBREW_BIN="${HOMEBREW_PREFIX:-/opt/homebrew}/bin/brew"

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -99,24 +99,39 @@ else
   echo "Homebrew autoupdate already running — skipping restart."
 fi
 
-# Install uv tools (runs after Homebrew so uv is available).
-{{ range .packages.macos.uv -}}
-"$brew_prefix/bin/uv" tool install {{ . | quote }}
+# Install uv tools (runs after Homebrew so uv is available). Guarded on uv being
+# on PATH so a fresh machine (or an apply whose PATH has not yet picked up a
+# just-installed uv) skips cleanly instead of aborting under set -e.
+{{ if .packages.macos.uv -}}
+if command -v uv >/dev/null 2>&1; then
+{{- range .packages.macos.uv }}
+  "$brew_prefix/bin/uv" tool install {{ . | quote }}
+{{- end }}
+fi
 {{ end -}}
 
-# Install npm global packages (runs after Homebrew so node is available).
-{{ range .packages.macos.npm -}}
-npm install -g {{ . | quote }}
+# Install npm global packages (runs after Homebrew so node is available). Same
+# command -v guard so a missing npm skips cleanly rather than aborting the apply.
+{{ if .packages.macos.npm -}}
+if command -v npm >/dev/null 2>&1; then
+{{- range .packages.macos.npm }}
+  npm install -g {{ . | quote }}
+{{- end }}
+fi
 {{ end -}}
 
 # Install Volta-pinned CLI tools. `volta install node@X` ensures the runtime is
-# present (and resets Volta's default to X — harmless because Homebrew's `node`
+# present (and resets Volta's default to X, harmless because Homebrew's `node`
 # wins in PATH). `volta run --node X npm install -g <pkg>` pins the resulting
 # shim in ~/.volta/bin/<bin> to Node X so the tool keeps working when Homebrew
-# bumps node majors.
-{{ range .packages.macos.volta -}}
-"$brew_prefix/bin/volta" install {{ printf "node@%s" .node | quote }}
-"$brew_prefix/bin/volta" run --node {{ .node | quote }} npm install -g {{ .package | quote }}
+# bumps node majors. Guarded on volta being on PATH so it skips cleanly if absent.
+{{ if .packages.macos.volta -}}
+if command -v volta >/dev/null 2>&1; then
+{{- range .packages.macos.volta }}
+  "$brew_prefix/bin/volta" install {{ printf "node@%s" .node | quote }}
+  "$brew_prefix/bin/volta" run --node {{ .node | quote }} npm install -g {{ .package | quote }}
+{{- end }}
+fi
 {{ end -}}
 
 {{ end -}}

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -16,6 +16,16 @@ exit 0
 brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
 brew_bin="$brew_prefix/bin/brew"
 
+# Tear down the old domt4/autoupdate daily auto-upgrader (replaced by the
+# com.webdavis.homebrew-weekly-upgrade Monday-noon LaunchAgent). MUST run BEFORE
+# the `brew bundle cleanup` below untaps domt4/autoupdate -- otherwise the
+# `brew autoupdate` subcommand is gone when we call it. Guarded on the tap being
+# present so it is a clean no-op once removed / on fresh machines.
+if "$brew_bin" tap | grep -q '^domt4/autoupdate$'; then
+  "$brew_bin" autoupdate stop 2>/dev/null || true
+  "$brew_bin" autoupdate delete 2>/dev/null || true
+fi
+
 # Pre-trust taps that require it. `brew tap` first (no-op if already tapped) so
 # `brew trust` has a target to operate on, then trust. Both idempotent and safe
 # to re-run. Required because `brew bundle` will refuse to install formulae from
@@ -85,18 +95,6 @@ EOF
 "$brew_bin" bundle --file="$brewfile"
 if [[ $multiplexer_present == false ]]; then
   "$brew_bin" bundle cleanup --force --file="$brewfile"
-fi
-
-# Configure Homebrew autoupdate (idempotent — only restart if not already running).
-HOMEBREW_BIN="${HOMEBREW_PREFIX:-/opt/homebrew}/bin/brew"
-
-if ! "$HOMEBREW_BIN" autoupdate status 2>/dev/null | grep -q "running"; then
-  echo "Starting domt4/autoupdate [stop → delete → start]..."
-  "$HOMEBREW_BIN" autoupdate stop 2>/dev/null || true
-  "$HOMEBREW_BIN" autoupdate delete 2>/dev/null || true
-  "$HOMEBREW_BIN" autoupdate start 86400 --upgrade --cleanup --immediate --sudo
-else
-  echo "Homebrew autoupdate already running — skipping restart."
 fi
 
 # Install uv tools (runs after Homebrew so uv is available). Guarded on uv being

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -101,13 +101,21 @@ if [[ $multiplexer_present == false ]]; then
   brew_bundle_cleanup_guarded "$brewfile"
 fi
 
+# The ecosystem tools (uv, node/npm, volta) were just installed by the bundle at
+# $brew_prefix/bin, which the apply shell's PATH may not yet include (a fresh
+# machine, or `bash -lc` reaching an unsourced shell). Prepend it once so the
+# `command -v` guards and the invocations below see the SAME binaries -- without
+# this a guard could skip a tool the bundle just installed at an absolute path,
+# and run_onchange would not retry until the data file changes.
+export PATH="$brew_prefix/bin:$PATH"
+
 # Install uv tools (runs after Homebrew so uv is available). Guarded on uv being
-# on PATH so a fresh machine (or an apply whose PATH has not yet picked up a
-# just-installed uv) skips cleanly instead of aborting under set -e.
+# on PATH so a fresh machine (whose PATH now includes the brew prefix above)
+# skips cleanly instead of aborting under set -e when uv is genuinely absent.
 {{ if .packages.macos.uv -}}
 if command -v uv >/dev/null 2>&1; then
 {{- range .packages.macos.uv }}
-  "$brew_prefix/bin/uv" tool install {{ . | quote }}
+  uv tool install {{ . | quote }}
 {{- end }}
 fi
 {{ end -}}
@@ -130,8 +138,8 @@ fi
 {{ if .packages.macos.volta -}}
 if command -v volta >/dev/null 2>&1; then
 {{- range .packages.macos.volta }}
-  "$brew_prefix/bin/volta" install {{ printf "node@%s" .node | quote }}
-  "$brew_prefix/bin/volta" run --node {{ .node | quote }} npm install -g {{ .package | quote }}
+  volta install {{ printf "node@%s" .node | quote }}
+  volta run --node {{ .node | quote }} npm install -g {{ .package | quote }}
 {{- end }}
 fi
 {{ end -}}

--- a/.chezmoitemplates/brew-bundle-cleanup-guard.sh.tmpl
+++ b/.chezmoitemplates/brew-bundle-cleanup-guard.sh.tmpl
@@ -1,0 +1,51 @@
+{{- /*
+Shared bulk-cleanup guard, consumed via includeTemplate by
+.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl and
+.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl -- the two owners of
+a `brew bundle cleanup --force` against a rendered Brewfile. Under the two-world
+model main's manifest is legitimately partial until later slices land, so an
+unguarded forced cleanup would mass-uninstall at D1. One definition, two call
+sites, so the safety check cannot drift between them.
+*/ -}}
+# --- shared bulk-cleanup guard: .chezmoitemplates/brew-bundle-cleanup-guard.sh.tmpl ---
+#
+# brew_bundle_cleanup_guarded <brewfile>: run the forced `brew bundle cleanup`
+# only after the non-forced preview confirms the number of would-be removals is
+# at or below the safety threshold (default 5, override HOMEBREW_BUNDLE_CLEANUP_THRESHOLD).
+# Over the threshold it REFUSES (loud warning naming the would-be removals; the
+# preceding install results stand) unless HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1
+# authorizes it -- so a partial or empty rendered Brewfile cannot silently
+# uninstall a pile of packages. Requires $brew_bin to be set by the caller.
+#
+# Sets BREW_CLEANUP_OUTCOME to cleaned|refused|failed. Returns 0 for cleaned or
+# refused (both non-fatal, so a caller under `set -e` is not aborted by a
+# refusal), non-zero ONLY when the forced cleanup itself failed.
+# shellcheck disable=SC2034  # BREW_CLEANUP_OUTCOME is read by the after_58 caller; the before_10 caller ignores it
+brew_bundle_cleanup_guarded() {
+  local brewfile="$1"
+  local threshold="${HOMEBREW_BUNDLE_CLEANUP_THRESHOLD:-5}"
+  local preview removals
+  BREW_CLEANUP_OUTCOME=refused
+
+  # Homebrew 6.x's non-forced `brew bundle cleanup` PRINTS what it would remove
+  # ("Would uninstall ...:" / "Would untap:" headers, columnar names, a "Run ..."
+  # footer) and exits 1 when anything would be removed -- expected here, hence
+  # `|| true`. Count the item tokens on the non-header, non-footer lines.
+  preview="$("$brew_bin" bundle cleanup --file="$brewfile" 2>/dev/null || true)"
+  removals="$(printf '%s\n' "$preview" | { grep -vE '^(Would |Run )' || true; } | wc -w | tr -d '[:space:]')"
+  [[ -n $removals ]] || removals=0
+
+  if [[ ${HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP:-} != 1 && $removals -gt $threshold ]]; then
+    printf 'WARNING: brew bundle cleanup would remove %d item(s), over the safety threshold of %d; REFUSING the forced cleanup so a partial Brewfile cannot mass-uninstall. Install results stand. Set HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1 to authorize.\n' "$removals" "$threshold" >&2
+    printf 'Would-be removals:\n%s\n' "$preview" >&2
+    BREW_CLEANUP_OUTCOME=refused
+    return 0
+  fi
+
+  if "$brew_bin" bundle cleanup --force --file="$brewfile"; then
+    BREW_CLEANUP_OUTCOME=cleaned
+    return 0
+  fi
+  BREW_CLEANUP_OUTCOME=failed
+  return 1
+}

--- a/Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist.tmpl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.homebrew-weekly-upgrade</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>{{ .chezmoi.homeDir }}/.local/bin/homebrew-weekly-upgrade.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>{{ .chezmoi.homeDir }}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>1</integer>
+    <key>Hour</key>
+    <integer>12</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/homebrew/weekly-upgrade.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/homebrew/weekly-upgrade.log</string>
+</dict>
+</plist>

--- a/dot_local/bin/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/bin/executable_homebrew-weekly-upgrade.sh
@@ -15,10 +15,32 @@ set -uo pipefail
 BREW="${HOMEBREW_WEEKLY_BREW:-/opt/homebrew/bin/brew}"
 MAS="${HOMEBREW_WEEKLY_MAS:-/opt/homebrew/bin/mas}"
 TS="${HOMEBREW_WEEKLY_TAILSCALED:-/opt/homebrew/opt/tailscale/bin/tailscaled}"
+LOCKFILE="${HOMEBREW_WEEKLY_LOCKFILE:-$HOME/.local/state/homebrew-weekly-upgrade.lock}"
+
+# Serialize: one weekly upgrade at a time, via the KERNEL. The Monday-noon
+# LaunchAgent and an ad-hoc `just brew-upgrade` must never run concurrent
+# brew/mas/cleanup/tailscaled operations. macOS ships /usr/bin/lockf
+# (flock(2)-backed): open $LOCKFILE on fd 9 and test-acquire with `lockf -s -t 0`
+# (non-blocking; exit 75 = EX_TEMPFAIL when another process already holds it).
+# The kernel releases the lock automatically when the fd closes (normal exit or
+# crash), so there is no stale-lock class. Non-darwin hosts (no /usr/bin/lockf)
+# proceed unlocked: the contending scheduled runs are darwin-only. Absolute path
+# because a stripped PATH would not carry /usr/bin. (House precedent: the same
+# kernel-lock shape guards ~/.local/bin/update-skills.sh.)
+acquire_lock() {
+  [[ -x /usr/bin/lockf ]] || return 0
+  mkdir -p "$(dirname "$LOCKFILE")" 2>/dev/null || return 1
+  exec 9>>"$LOCKFILE" || return 1
+  /usr/bin/lockf -s -t 0 9
+}
+
+# Aggregate exit status: a failing step is logged and the run continues, but the
+# helper exits non-zero when any step failed (an all-failed run must not exit 0).
+weekly_upgrade_failures=0
 
 run() {
   # run "<label>" cmd args... -- print a section header, run, log the outcome,
-  # and continue regardless of exit status.
+  # count a failure, and continue regardless of exit status.
   local label="$1"
   shift
   printf '== %s ==\n' "$label"
@@ -26,6 +48,7 @@ run() {
     printf '   ok: %s\n' "$label"
   else
     printf '   FAILED (exit %d): %s\n' "$?" "$label" >&2
+    weekly_upgrade_failures=$((weekly_upgrade_failures + 1))
   fi
 }
 
@@ -40,6 +63,11 @@ refresh_tailscaled() {
   sudo -n "$TS" install-system-daemon
 }
 
+if ! acquire_lock; then
+  printf 'homebrew-weekly-upgrade: another run holds the lock; deferring (exit 75).\n' >&2
+  exit 75
+fi
+
 printf '=== homebrew-weekly-upgrade %s ===\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 run "brew update" "$BREW" update
@@ -51,3 +79,8 @@ run "mas upgrade" "$MAS" upgrade
 run "brew cleanup" "$BREW" cleanup
 
 printf '=== done %s ===\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ $weekly_upgrade_failures -gt 0 ]]; then
+  printf '=== %d step(s) failed; see FAILED lines above ===\n' "$weekly_upgrade_failures" >&2
+  exit 1
+fi

--- a/dot_local/bin/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/bin/executable_homebrew-weekly-upgrade.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# homebrew-weekly-upgrade.sh -- run by the com.webdavis.homebrew-weekly-upgrade
+# LaunchAgent every Monday at 12:00 (when the operator is present). Upgrades
+# Homebrew formulae + casks + Mac App Store apps, then cleans up. Prints a
+# sectioned, timestamped report to stdout; the LaunchAgent routes that to
+# ~/.local/log/homebrew/weekly-upgrade.log. Resilient: a failing step is logged
+# but never aborts the rest, and cleanup always runs. No Gatekeeper/quarantine
+# stripping -- present-time "Open?" prompts are acceptable (operator is here).
+#
+# brew/mas are overridable (HOMEBREW_WEEKLY_BREW / HOMEBREW_WEEKLY_MAS) so the
+# test harness can inject mocks; default to absolute Homebrew paths.
+set -uo pipefail
+
+BREW="${HOMEBREW_WEEKLY_BREW:-/opt/homebrew/bin/brew}"
+MAS="${HOMEBREW_WEEKLY_MAS:-/opt/homebrew/bin/mas}"
+TS="${HOMEBREW_WEEKLY_TAILSCALED:-/opt/homebrew/opt/tailscale/bin/tailscaled}"
+
+run() {
+  # run "<label>" cmd args... -- print a section header, run, log the outcome,
+  # and continue regardless of exit status.
+  local label="$1"
+  shift
+  printf '== %s ==\n' "$label"
+  if "$@"; then
+    printf '   ok: %s\n' "$label"
+  else
+    printf '   FAILED (exit %d): %s\n' "$?" "$label" >&2
+  fi
+}
+
+# Re-copy the tailscaled binary into the system daemon if brew just upgraded it (the
+# daemon runs a root-owned copy in /usr/local/bin that `brew upgrade` does not touch).
+# Guarded so it only fires when the binary actually changed -- no needless weekly VPN
+# restart -- and only when tailscale is installed. sudo is passwordless here via the
+# user's sudo config; if that ever changes the step just logs and continues.
+refresh_tailscaled() {
+  [[ -x $TS ]] || return 0
+  cmp -s "$TS" /usr/local/bin/tailscaled 2>/dev/null && return 0
+  sudo -n "$TS" install-system-daemon
+}
+
+printf '=== homebrew-weekly-upgrade %s ===\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+run "brew update" "$BREW" update
+run "brew outdated" "$BREW" outdated
+run "mas outdated" "$MAS" outdated
+run "brew upgrade" "$BREW" upgrade
+run "tailscaled refresh (if upgraded)" refresh_tailscaled
+run "mas upgrade" "$MAS" upgrade
+run "brew cleanup" "$BREW" cleanup
+
+printf '=== done %s ===\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/justfile
+++ b/justfile
@@ -125,6 +125,14 @@ test: test-unit test-integration test-e2e
     fi
   fi
 
+# Run the weekly Homebrew upgrade by hand (formulae + casks + Mac App Store +
+# cleanup). Same job the Monday-noon com.webdavis.homebrew-weekly-upgrade
+# LaunchAgent runs; use it for the first upgrade or any ad-hoc one. Runs the
+# DEPLOYED helper (what launchd runs), not the repo source copy, and uses the
+# host brew outside the Nix shell.
+brew-upgrade:
+  ~/.local/bin/homebrew-weekly-upgrade.sh
+
 # macOS Defaults: drift, apply, capture
 
 defaults-drift:

--- a/test/e2e/homebrew-weekly-lock.sh
+++ b/test/e2e/homebrew-weekly-lock.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# homebrew-weekly-lock.sh (Fix 2): the weekly-upgrade helper serializes itself
+# with a KERNEL lock via macOS /usr/bin/lockf, so the Monday-noon LaunchAgent and
+# an ad-hoc `just brew-upgrade` can never run concurrent brew/mas/cleanup/
+# tailscaled operations. While one run holds the lock a second run must exit
+# quickly and loudly (retryable exit 75, EX_TEMPFAIL) rather than proceed.
+#
+# e2e: two REAL concurrent processes drive the actual lockf acquisition (the
+# first parks mid-run holding the lock via a blocking brew stub); timing-bound,
+# so it lives in the e2e camp. Darwin-only (the LaunchAgent that creates
+# contention is darwin-only, and /usr/bin/lockf is the darwin lock primitive).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+helper="$REPO_ROOT/dot_local/bin/executable_homebrew-weekly-upgrade.sh"
+
+fail() {
+  printf 'homebrew-weekly-lock: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ "$(uname -s)" != "Darwin" || ! -x /usr/bin/lockf ]]; then
+  echo "homebrew-weekly-lock: SKIP (no /usr/bin/lockf on this host)"
+  exit 0
+fi
+[[ -x $helper ]] || fail "helper not found/executable: $helper"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+lockfile="$tmp/weekly.lock"
+parked="$tmp/parked"
+go="$tmp/go"
+
+# Blocking brew stub: on `update` it signals it has parked (holding the lock,
+# which the helper acquires before any step) and then blocks until $go appears.
+cat >"$tmp/brew" <<MOCK
+#!/usr/bin/env bash
+if [[ \${1:-} == update ]]; then
+  : >"$parked"
+  while [[ ! -e "$go" ]]; do sleep 0.02; done
+fi
+exit 0
+MOCK
+printf '#!/usr/bin/env bash\nexit 0\n' >"$tmp/mas"
+chmod +x "$tmp/brew" "$tmp/mas"
+
+# --- run 1: parks mid-run holding the lock ------------------------------------
+o1="$tmp/o1.log"
+HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$lockfile" \
+  bash "$helper" >"$o1" 2>&1 &
+run1_pid=$!
+for _ in $(seq 1 300); do
+  [[ -e $parked ]] && break
+  sleep 0.02
+done
+[[ -e $parked ]] || {
+  : >"$go"
+  fail "run 1 never parked (setup): $(cat "$o1" 2>/dev/null)"
+}
+
+# --- run 2: contends for the held lock -> must defer with exit 75 -------------
+set +e
+out2="$(HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$lockfile" \
+  bash "$helper" 2>&1)"
+rc2=$?
+set -e
+[[ $rc2 -eq 75 ]] || {
+  : >"$go"
+  fail "a concurrent run did not defer with the retryable exit 75 (got $rc2): $out2"
+}
+grep -qiE 'another run holds the lock|deferring' <<<"$out2" || {
+  : >"$go"
+  fail "a concurrent run did not announce the deferral: $out2"
+}
+
+# --- release: run 1 completes -------------------------------------------------
+: >"$go"
+wait "$run1_pid" 2>/dev/null || true
+grep -qF "=== done" "$o1" || fail "the parked run 1 did not finish: $(cat "$o1")"
+
+printf 'homebrew-weekly-lock: OK (second concurrent run defers with exit 75 while the first holds the lock)\n'

--- a/test/integration/herdr-migration-ordering.sh
+++ b/test/integration/herdr-migration-ordering.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 # herdr-migration-ordering.sh: run_onchange_before_10-system-packages must NEVER
-# remove the old multiplexer (tmux/sesh) itself. `brew bundle --cleanup`
+# remove the old multiplexer (tmux/sesh) itself. `brew bundle cleanup`
 # uninstalls anything installed but absent from the desired set, so once
-# tmux/sesh leave the manifest a --cleanup here would strip the only multiplexer.
+# tmux/sesh leave the manifest a cleanup here would strip the only multiplexer.
 # Chezmoi runs ALL before_ scripts, THEN updates target files, THEN runs after_
-# scripts, so a --cleanup in this before_ script would validate/tear down against
+# scripts, so a cleanup in this before_ script would validate/tear down against
 # the PREVIOUS revision and a broken new revision would only surface after the
 # fallback was gone. The teardown therefore lives in run_after_58
-# (post-target-update); before_10's only job is to WITHHOLD --cleanup while a
+# (post-target-update); before_10's only job is to WITHHOLD cleanup while a
 # legacy multiplexer is installed.
 #
 # Invariant: while tmux OR sesh is installed, before_10 runs `brew bundle`
-# WITHOUT --cleanup and prints a deferral note that names the interactive
+# WITHOUT cleanup and prints a deferral note that names the interactive
 # activation step (open a terminal so the herdr server starts, then re-apply so
 # after_58 verifies and cleans). When neither is installed (already migrated),
-# --cleanup proceeds normally. before_10 makes NO herdr contact and consults no
+# cleanup proceeds normally. before_10 makes NO herdr contact and consults no
 # stamp -- all migration verification moved to after_58.
 #
 # This renders the REAL before_10 and runs it with a stub Homebrew prefix
@@ -95,20 +95,24 @@ run_case() {
   RC=0
   HOME="$case_home" HOMEBREW_PREFIX="$prefix" \
     PATH="$path_bin:$PATH" INSTALLED_PKGS="$installed" BUNDLE_RECORD="$BUNDLE_RECORD" \
-    bash "$rendered" >/dev/null 2>"$ERR_FILE" || RC=$?
+    bash "$rendered" </dev/null >/dev/null 2>"$ERR_FILE" || RC=$?
 }
 
-cleanup_used() { grep -qw -- '--cleanup' "$BUNDLE_RECORD"; }
+# Homebrew 6.x moved removal out of `brew bundle --cleanup` (now a dry run) into
+# the separate `brew bundle cleanup --force` command; before_10 runs that command
+# only when no legacy multiplexer remains. "cleanup used" == that command was
+# recorded (the plain install `bundle --file=...` line never contains "cleanup").
+cleanup_used() { grep -q 'bundle cleanup --force' "$BUNDLE_RECORD"; }
 
 # tmux still installed -> defer cleanup, and SAY so, naming the interactive
 # activation step (the deferral note is part of the contract: silently
-# withholding --cleanup would leave the operator with no clue why tmux/sesh
+# withholding cleanup would leave the operator with no clue why tmux/sesh
 # survive or how to finish the migration).
 run_case tmux-present "tmux"
 [[ $RC -eq 0 ]] || fail "tmux-present: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
 [[ -s $BUNDLE_RECORD ]] || fail "tmux-present: brew bundle was never invoked"
-cleanup_used && fail "tmux-present: --cleanup passed though tmux is installed (before_10 must never tear down the multiplexer)"
-grep -q 'WITHOUT --cleanup' "$ERR_FILE" ||
+cleanup_used && fail "tmux-present: cleanup passed though tmux is installed (before_10 must never tear down the multiplexer)"
+grep -q 'WITHOUT cleanup' "$ERR_FILE" ||
   fail "tmux-present: the deferral note was not printed (stderr: $(cat "$ERR_FILE"))"
 grep -qi 'interactive terminal' "$ERR_FILE" ||
   fail "tmux-present: the deferral note does not name the interactive activation step (stderr: $(cat "$ERR_FILE"))"
@@ -118,11 +122,11 @@ grep -q 'after_58' "$ERR_FILE" ||
 # sesh still installed -> defer cleanup too.
 run_case sesh-present "sesh"
 [[ $RC -eq 0 ]] || fail "sesh-present: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-cleanup_used && fail "sesh-present: --cleanup passed though sesh is installed"
+cleanup_used && fail "sesh-present: cleanup passed though sesh is installed"
 
-# Neither installed (already migrated) -> --cleanup proceeds normally.
+# Neither installed (already migrated) -> cleanup proceeds normally.
 run_case none "wget"
 [[ $RC -eq 0 ]] || fail "none: script errored (rc=$RC; stderr: $(cat "$ERR_FILE"))"
-cleanup_used || fail "none: --cleanup withheld though no multiplexer is installed (migrated machines must still get cleanup)"
+cleanup_used || fail "none: cleanup withheld though no multiplexer is installed (migrated machines must still get cleanup)"
 
-printf 'PASS: before_10 withholds --cleanup while tmux/sesh is installed (deferral note names the interactive activation step and after_58 as the teardown owner), makes no herdr contact, and lets --cleanup proceed once no multiplexer remains\n'
+printf 'PASS: before_10 withholds cleanup while tmux/sesh is installed (deferral note names the interactive activation step and after_58 as the teardown owner), makes no herdr contact, and lets cleanup proceed once no multiplexer remains\n'

--- a/test/integration/herdr-migration-verify.sh
+++ b/test/integration/herdr-migration-verify.sh
@@ -159,6 +159,12 @@ case "$1" in
     exit 1 ;;
   bundle)
     printf '%s\n' "$*" >>"$BUNDLE_RECORD"
+    # Non-forced `bundle cleanup` is the bulk-guard preview: emit $BREW_PREVIEW
+    # (a would-remove block) on stdout so the guard can count removals. Forced
+    # cleanup and plain install print nothing extra.
+    if [[ ${2:-} == cleanup && "$*" != *--force* && -n "${BREW_PREVIEW:-}" ]]; then
+      printf '%s\n' "$BREW_PREVIEW"
+    fi
     exit "${BREW_BUNDLE_RC:-0}" ;;
 esac
 exit 0
@@ -185,6 +191,7 @@ run_case() {
   HOME="$CASE_HOME" HOMEBREW_PREFIX="$prefix" PATH="$path_bin:$PATH" \
     INSTALLED_PKGS="$installed" HERDR_RECORD="$HERDR_RECORD" \
     BUNDLE_RECORD="$BUNDLE_RECORD" BREW_BUNDLE_RC="$bundle_rc" \
+    BREW_PREVIEW="${BREW_PREVIEW:-}" \
     bash "$rendered" >"$OUT_FILE" 2>"$ERR_FILE" || RC=$?
 }
 
@@ -254,4 +261,21 @@ run_case cleanup-fails healthy "tmux" config 5
 cleanup_ran || fail "cleanup-fails: brew bundle cleanup was expected to be attempted"
 [[ -s $ERR_FILE ]] || fail "cleanup-fails: no warning printed about the failed cleanup"
 
-printf 'PASS: after_58 short-circuits with no herdr contact when no multiplexer is installed, verifies the current herdr (binary, running session, validated config, both plugins enabled+warning-free by exact id) before running brew bundle cleanup --force, defers with an activation-step warning on any unhealthy state or a serverless host, and never aborts the apply even when the cleanup fails\n'
+# --- bulk-cleanup guard: herdr verified but the manifest would remove too much -
+# after_58 is the second owner of the forced cleanup, so it shares the same
+# bulk-removal guard. herdr is fully healthy and tmux is installed, but the
+# non-forced preview reports 8 would-be removals (> threshold 5): the forced
+# cleanup must be REFUSED (tmux/sesh survive), and after_58 must NOT claim the
+# migration complete.
+BREW_PREVIEW="$(printf 'Would uninstall formulae:\ncodex codex-app lulu oversight paseo foo bar\nWould untap:\nrjyo/moshi\nRun cleanup to make these changes.\n')" \
+  run_case migrate-bulk-refused healthy "tmux" config
+[[ $RC -eq 0 ]] || fail "migrate-bulk-refused: expected exit 0, got $RC ($(cat "$ERR_FILE"))"
+grep -q 'bundle cleanup --force' "$BUNDLE_RECORD" &&
+  fail "migrate-bulk-refused: forced cleanup ran though 8 removals exceed the threshold (unguarded)"
+grep -q 'migration complete' "$OUT_FILE" &&
+  fail "migrate-bulk-refused: claimed migration complete though the cleanup was refused"
+grep -qiE 'refus' "$ERR_FILE" ||
+  fail "migrate-bulk-refused: no refusal warning printed ($(cat "$ERR_FILE"))"
+unset BREW_PREVIEW
+
+printf 'PASS: after_58 short-circuits with no herdr contact when no multiplexer is installed, verifies the current herdr (binary, running session, validated config, both plugins enabled+warning-free by exact id) before running the guarded brew bundle cleanup --force (which refuses a bulk removal against a partial manifest), defers with an activation-step warning on any unhealthy state or a serverless host, and never aborts the apply even when the cleanup fails\n'

--- a/test/integration/homebrew-after58-skip-cleanup.sh
+++ b/test/integration/homebrew-after58-skip-cleanup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Fix 4 (SKIP_SYSTEM_PACKAGES must cover every cleanup owner): the literal-1 skip
+# guard existed only in before_10, but after_58 independently regenerates the
+# worktree's Brewfile and can run `brew bundle cleanup --force` -- the exact
+# secondary-worktree scenario SKIP_SYSTEM_PACKAGES exists for. The same
+# `{{ if eq (env "SKIP_SYSTEM_PACKAGES") "1" }}` guard must gate after_58's
+# cleanup path (the cleanup, NOT the herdr verification the script also does).
+#
+# Integration test: render after_58 twice (SKIP=1 and unset), run each against a
+# healthy herdr stub with tmux installed, and assert the forced cleanup argv is
+# absent under SKIP=1 and present when unset. herdr is verified in BOTH renders.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_58-herdr-migration-verify.sh.tmpl"
+
+fail() {
+  printf 'homebrew-after58-skip-cleanup: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot render/run after_58\n' "$tool"
+    exit 0
+  }
+done
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Healthy herdr stub: version ok, one running session, reload applied with empty
+# diagnostics, both required plugins enabled+warning-free by exact id.
+make_healthy_herdr() {
+  local dir="$1"
+  cat >"$dir/herdr" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HERDR_RECORD"
+[[ $1 == --version ]] && { echo "herdr 0.7.0-test"; exit 0; }
+case "$1 $2" in
+  "session list") printf '{"sessions":[{"default":true,"name":"default","running":true}]}\n'; exit 0 ;;
+  "server reload-config") printf '{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}\n'; exit 0 ;;
+  "plugin list") printf '{"id":"cli:plugin","result":{"plugins":[{"plugin_id":"%s","enabled":true}],"type":"plugin_list"}}\n' "$4"; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/herdr"
+}
+
+# Brew stub: `list <pkg>` installed only for names in $INSTALLED_PKGS; `bundle`
+# records its argv (non-forced preview prints nothing -> 0 removals -> the guard
+# proceeds when the cleanup path runs at all).
+make_brew() {
+  local dir="$1"
+  cat >"$dir/brew" <<'STUB'
+#!/bin/bash
+case "$1" in
+  list)
+    read -ra pkgs <<<"$INSTALLED_PKGS"
+    for p in "${pkgs[@]}"; do [[ $2 == "$p" ]] && exit 0; done
+    exit 1 ;;
+  bundle) printf '%s\n' "$*" >>"$BUNDLE_RECORD"; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/brew"
+}
+
+# run_render <name> <skip-value|__unset__>: render after_58 with the given
+# SKIP_SYSTEM_PACKAGES, run it healthy+tmux, and set BUNDLE_RECORD/ERR/RC.
+run_render() {
+  local name="$1" skip="$2"
+  local dir="$work/$name"
+  local prefix="$dir/prefix" path_bin="$dir/path-bin" case_home="$dir/home"
+  local rendered="$dir/rendered.sh"
+  BUNDLE_RECORD="$dir/bundle-argv"
+  HERDR_RECORD="$dir/herdr-argv"
+  ERR="$dir/stderr"
+  mkdir -p "$prefix/bin" "$path_bin" "$case_home/.config/herdr"
+  make_brew "$prefix/bin"
+  make_healthy_herdr "$path_bin"
+  printf 'x = 1\n' >"$case_home/.config/herdr/config.toml"
+  : >"$BUNDLE_RECORD"
+  : >"$HERDR_RECORD"
+
+  local render_home="$dir/render-home"
+  mkdir -p "$render_home"
+  if [[ $skip == __unset__ ]]; then
+    HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+      <"$SCRIPT" >"$rendered" || fail "$name: render failed"
+  else
+    HOME="$render_home" CI=1 SKIP_SYSTEM_PACKAGES="$skip" chezmoi --source "$REPO_ROOT" \
+      execute-template --no-tty <"$SCRIPT" >"$rendered" || fail "$name: render failed"
+  fi
+  if [[ ! -s $rendered ]]; then
+    printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+    exit 0
+  fi
+  RC=0
+  HOME="$case_home" HOMEBREW_PREFIX="$prefix" PATH="$path_bin:$PATH" \
+    INSTALLED_PKGS="tmux" HERDR_RECORD="$HERDR_RECORD" BUNDLE_RECORD="$BUNDLE_RECORD" \
+    bash "$rendered" >"$dir/stdout" 2>"$ERR" || RC=$?
+}
+
+herdr_contacted() { [[ -s $HERDR_RECORD ]]; }
+cleanup_ran() { grep -q 'bundle cleanup --force' "$BUNDLE_RECORD"; }
+
+# --- SKIP=1: herdr still verified, but the forced cleanup must NOT run ---------
+run_render skip-on 1
+[[ $RC -eq 0 ]] || fail "skip-on: expected exit 0, got $RC ($(cat "$ERR"))"
+herdr_contacted || fail "skip-on: herdr was not verified (the SKIP guard must gate the cleanup, not the verification)"
+cleanup_ran && fail "skip-on: brew bundle cleanup --force ran under SKIP_SYSTEM_PACKAGES=1"
+
+# --- unset: the forced cleanup runs normally ----------------------------------
+run_render skip-off __unset__
+[[ $RC -eq 0 ]] || fail "skip-off: expected exit 0, got $RC ($(cat "$ERR"))"
+cleanup_ran || fail "skip-off: brew bundle cleanup --force did not run with SKIP unset"
+
+printf 'homebrew-after58-skip-cleanup: OK (SKIP=1 gates the cleanup, herdr still verified; unset runs the cleanup)\n'

--- a/test/integration/homebrew-before10-autoupdate-teardown.sh
+++ b/test/integration/homebrew-before10-autoupdate-teardown.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Fix 1 (atomic domt4/autoupdate replacement): run_onchange_before_10 must NOT
+# start the old domt4/autoupdate daily upgrader anymore (the Monday-noon weekly
+# LaunchAgent supersedes it). Instead it must TEAR DOWN autoupdate, and that
+# teardown must run BEFORE any `brew bundle cleanup` could untap domt4/autoupdate
+# (once the tap leaves the manifest a cleanup removes it, and then the
+# `brew autoupdate` subcommand is gone). So:
+#   1. no rendered path may contain `autoupdate start`;
+#   2. the teardown argv (`autoupdate stop`/`delete`) must precede the cleanup
+#      argv in a stubbed run.
+#
+# Integration test: render the real chezmoiscript, run it with brew stubbed at
+# the boundary (the stub reports domt4/autoupdate as tapped so the guarded
+# teardown fires and logs its argv), and read back the captured brew argv.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'homebrew-before10-autoupdate-teardown: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# (1) The daily-upgrader STARTER must be gone from the rendered script entirely.
+if grep -qE 'autoupdate[[:space:]]+start' "$rendered"; then
+  printf 'rendered before_10:\n' >&2
+  grep -nE 'autoupdate' "$rendered" >&2
+  fail "before_10 still starts domt4/autoupdate (found 'autoupdate start')"
+fi
+
+# Stub brew: logs every call's argv (one line each). `brew tap` with no further
+# argument lists the live taps and reports domt4/autoupdate present so the
+# teardown guard fires; `brew tap <name>`/`brew trust ...` (trust loop) succeed;
+# `list` exits 1 so the multiplexer probe reports absent and the cleanup path is
+# reached; `bundle cleanup` (non-forced preview) prints nothing (0 removals) so
+# any bulk-cleanup guard proceeds; everything else exits 0.
+prefix="$work/prefix"
+mkdir -p "$prefix/bin"
+brew_log="$work/brew-argv.log"
+cat >"$prefix/bin/brew" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$brew_log"
+case "\${1:-}" in
+  tap)
+    if [[ -z \${2:-} ]]; then printf 'domt4/autoupdate\n'; fi
+    exit 0 ;;
+  list) exit 1 ;;
+esac
+exit 0
+MOCK
+for tool in uv npm volta mas; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$prefix/bin/$tool"
+done
+chmod +x "$prefix/bin/"*
+
+: >"$brew_log"
+HOMEBREW_PREFIX="$prefix" PATH="$prefix/bin:$PATH" bash "$rendered" >/dev/null 2>&1 ||
+  fail "rendered before_10 exited non-zero under stubs"
+
+[[ -s $brew_log ]] || fail "no brew invocations captured"
+
+# (2) The teardown must precede the cleanup. First autoupdate stop/delete line
+# number must be smaller than the first bundle-cleanup line number.
+teardown_ln="$(grep -nE '^autoupdate (stop|delete)' "$brew_log" | head -1 | cut -d: -f1)"
+cleanup_ln="$(grep -nE '^bundle cleanup' "$brew_log" | head -1 | cut -d: -f1)"
+[[ -n $teardown_ln ]] || {
+  printf 'captured brew argv:\n' >&2
+  cat "$brew_log" >&2
+  fail "no autoupdate teardown (stop/delete) captured; teardown did not run"
+}
+[[ -n $cleanup_ln ]] || {
+  printf 'captured brew argv:\n' >&2
+  cat "$brew_log" >&2
+  fail "no bundle cleanup captured; cannot assert ordering"
+}
+[[ $teardown_ln -lt $cleanup_ln ]] ||
+  fail "autoupdate teardown (line $teardown_ln) did not precede bundle cleanup (line $cleanup_ln)"
+
+printf 'homebrew-before10-autoupdate-teardown: OK (no autoupdate start; teardown precedes cleanup)\n'

--- a/test/integration/homebrew-before10-bundle-split.sh
+++ b/test/integration/homebrew-before10-bundle-split.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Fix 1 (Homebrew 6.x bundle split): run_onchange_before_10 must install and
+# clean up in TWO separate brew invocations against one rendered Brewfile --
+# `brew bundle --file=<f>` then `brew bundle cleanup --force --file=<f>` -- not
+# the old single `brew bundle --cleanup` form. Homebrew 6.x made `--cleanup` on
+# `brew bundle` a dry-run that exits 1 whenever anything would be removed, which
+# aborts the apply under set -e; removal is now its own `brew bundle cleanup`.
+#
+# Integration test: render the real chezmoiscript, run it with brew (and the
+# ecosystem tools) stubbed at the boundary, and read back the captured brew
+# argv. HOMEBREW_PREFIX points every brew/uv/volta call at the stub dir.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'homebrew-before10-bundle-split: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Render the darwin-only script (scratch HOME, CI=1 -- same mechanics as the
+# treefmt rendered-template lint). Empty render == non-darwin host: skip.
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Stub dir: brew logs its full argv (one line per call) and exits 0, except
+# `list` exits non-zero so the multiplexer-present probe reports absent and the
+# cleanup runs. uv/npm/volta/mas stubs exit 0 so the whole script completes.
+prefix="$work/prefix"
+mkdir -p "$prefix/bin"
+brew_log="$work/brew-argv.log"
+cat >"$prefix/bin/brew" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$brew_log"
+[[ \${1:-} == list ]] && exit 1
+exit 0
+MOCK
+for tool in uv npm volta mas; do
+  cat >"$prefix/bin/$tool" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+done
+chmod +x "$prefix/bin/"*
+
+: >"$brew_log"
+HOMEBREW_PREFIX="$prefix" PATH="$prefix/bin:$PATH" bash "$rendered" >/dev/null 2>&1 ||
+  fail "rendered before_10 exited non-zero under stubs"
+
+[[ -s $brew_log ]] || fail "no brew invocations captured"
+
+# The old single-command form must be gone.
+if grep -qE '(^|[[:space:]])bundle[[:space:]]+--cleanup' "$brew_log"; then
+  printf 'captured brew argv:\n' >&2
+  cat "$brew_log" >&2
+  fail "old 'brew bundle --cleanup' form still present (6.x split not applied)"
+fi
+
+install_line="$(grep -E '^bundle --file=' "$brew_log" | head -1 || true)"
+cleanup_line="$(grep -E '^bundle cleanup --force --file=' "$brew_log" | head -1 || true)"
+[[ -n $install_line ]] || fail "no 'brew bundle --file=<f>' install call captured"
+[[ -n $cleanup_line ]] || fail "no 'brew bundle cleanup --force --file=<f>' call captured"
+
+install_file="${install_line#bundle --file=}"
+cleanup_file="${cleanup_line##*--file=}"
+[[ $install_file == "$cleanup_file" ]] ||
+  fail "install and cleanup ran against different Brewfiles ($install_file vs $cleanup_file)"
+
+printf 'homebrew-before10-bundle-split: OK (install then cleanup --force against one Brewfile)\n'

--- a/test/integration/homebrew-before10-ecosystem-guards.sh
+++ b/test/integration/homebrew-before10-ecosystem-guards.sh
@@ -90,4 +90,35 @@ for tool in uv npm volta; do
   [[ -s "$work/$tool.invoked" ]] || fail "$tool loop did not run when $tool was present (guard over-eager)"
 done
 
-printf 'homebrew-before10-ecosystem-guards: OK (absent tools skip cleanly; present tools run)\n'
+# --- Scenario 3 (Fix 5): tools exist at the brew prefix but the prefix is NOT on
+# PATH (the fresh-machine apply shell right after the bundle installed them at
+# absolute paths). The guards and invocations must see the SAME world, so each
+# loop must still run. The old code guarded on `command -v` (PATH) but invoked
+# `$brew_prefix/bin/<tool>`, so the guard skipped a tool the bundle just
+# installed. ---
+pathless="$work/pathless"
+make_brew "$pathless"
+for tool in uv npm volta; do
+  log="$work/pathless-$tool.invoked"
+  cat >"$pathless/bin/$tool" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$log"
+exit 0
+MOCK
+  chmod +x "$pathless/bin/$tool"
+done
+rc=0
+# PATH deliberately EXCLUDES $pathless/bin; HOMEBREW_PREFIX points at it.
+env -i HOME="$work" PATH="/usr/bin:/bin" HOMEBREW_PREFIX="$pathless" \
+  bash "$rendered" >"$work/pathless.out" 2>&1 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  printf 'rendered output (pathless):\n' >&2
+  cat "$work/pathless.out" >&2
+  fail "script aborted (rc=$rc) with the prefix absent from PATH"
+fi
+for tool in uv npm volta; do
+  [[ -s "$work/pathless-$tool.invoked" ]] ||
+    fail "$tool loop did not run when $tool exists at the prefix but the prefix is off PATH (guard/invocation see different worlds)"
+done
+
+printf 'homebrew-before10-ecosystem-guards: OK (absent tools skip cleanly; present tools run; prefix-off-PATH tools run)\n'

--- a/test/integration/homebrew-before10-ecosystem-guards.sh
+++ b/test/integration/homebrew-before10-ecosystem-guards.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Fix 4: the uv / npm / volta install loops in run_onchange_before_10 must be
+# skipped cleanly when their tool is absent (a `command -v` guard) instead of
+# aborting the whole `chezmoi apply` under set -e. A fresh machine, or an apply
+# whose PATH has not yet picked up a just-installed tool, must not fail here.
+#
+# Integration test, two scenarios, both rendering the real chezmoiscript and
+# running it with brew stubbed at the boundary:
+#   absent  -- no uv/npm/volta on PATH: the script must still exit 0 (clean skip)
+#   present -- stub uv/npm/volta on PATH: each loop must run (guard not over-eager)
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'homebrew-before10-ecosystem-guards: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Render the darwin-only script (SKIP_SYSTEM_PACKAGES unset so the full body
+# renders). Empty render == non-darwin host: skip.
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# A brew stub that exits 0 for everything except `list` (so the multiplexer
+# probe reports absent and the cleanup runs). $brew_prefix/bin/brew resolves
+# here via HOMEBREW_PREFIX.
+make_brew() {
+  local dir="$1"
+  mkdir -p "$dir/bin"
+  cat >"$dir/bin/brew" <<'MOCK'
+#!/usr/bin/env bash
+[[ ${1:-} == list ]] && exit 1
+exit 0
+MOCK
+  chmod +x "$dir/bin/brew"
+}
+
+# --- Scenario 1: tools ABSENT -> must exit 0 (clean skip) ---
+absent="$work/absent"
+make_brew "$absent"
+rc=0
+env -i HOME="$work" PATH="$absent/bin:/usr/bin:/bin" HOMEBREW_PREFIX="$absent" \
+  bash "$rendered" >"$work/absent.out" 2>&1 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  printf 'rendered output (absent):\n' >&2
+  cat "$work/absent.out" >&2
+  fail "script aborted (rc=$rc) with uv/npm/volta absent; loops are not guarded"
+fi
+
+# --- Scenario 2: tools PRESENT -> each loop must run (guard not over-eager) ---
+present="$work/present"
+make_brew "$present"
+for tool in uv npm volta; do
+  log="$work/$tool.invoked"
+  cat >"$present/bin/$tool" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$log"
+exit 0
+MOCK
+  chmod +x "$present/bin/$tool"
+done
+rc=0
+env -i HOME="$work" PATH="$present/bin:/usr/bin:/bin" HOMEBREW_PREFIX="$present" \
+  bash "$rendered" >"$work/present.out" 2>&1 || rc=$?
+if [[ $rc -ne 0 ]]; then
+  printf 'rendered output (present):\n' >&2
+  cat "$work/present.out" >&2
+  fail "script aborted (rc=$rc) with uv/npm/volta present"
+fi
+for tool in uv npm volta; do
+  [[ -s "$work/$tool.invoked" ]] || fail "$tool loop did not run when $tool was present (guard over-eager)"
+done
+
+printf 'homebrew-before10-ecosystem-guards: OK (absent tools skip cleanly; present tools run)\n'

--- a/test/integration/homebrew-cleanup-guard.sh
+++ b/test/integration/homebrew-cleanup-guard.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Fix 3 (forced cleanup must not trust an empty/partial Brewfile): before_10 runs
+# `brew bundle cleanup --force` against the rendered Brewfile. Under the two-world
+# model main's manifest is legitimately partial until later slices land, so an
+# unguarded forced cleanup would mass-uninstall at D1. The guard runs the
+# non-forced `brew bundle cleanup` preview FIRST, counts would-be removals, and
+# REFUSES the forced cleanup (loud warning naming the packages; install results
+# stand) when the count exceeds a threshold (default 5), unless
+# HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1 authorizes it.
+#
+# Integration test: render the real before_10 and run it with brew stubbed at the
+# boundary; the stub's non-forced `bundle cleanup` prints a controllable
+# would-remove block, and forced `bundle cleanup --force` is recorded so a test
+# can prove whether it ran.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'homebrew-cleanup-guard: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Preview blocks mimic Homebrew 6.x's non-forced `brew bundle cleanup` dry-run
+# output ("Would uninstall formulae:" / "Would untap:" + columnar names +
+# footer). BULK has 8 items (> threshold 5); SMALL has 3 (<= 5).
+bulk_preview="$work/bulk-preview.txt"
+cat >"$bulk_preview" <<'EOF'
+Would uninstall formulae:
+codex codex-app lulu oversight paseo foo bar
+Would untap:
+rjyo/moshi
+Run `brew bundle cleanup --force` to make these changes.
+EOF
+small_preview="$work/small-preview.txt"
+cat >"$small_preview" <<'EOF'
+Would uninstall formulae:
+codex paseo lulu
+Run `brew bundle cleanup --force` to make these changes.
+EOF
+
+# Build a stub prefix. The brew stub: `tap` (no arg) lists nothing (teardown
+# skips); `list` exits 1 (multiplexer absent -> cleanup path runs); `bundle
+# cleanup --force` is RECORDED in $FORCE_LOG; the non-forced `bundle cleanup`
+# preview prints $PREVIEW_FILE and exits 1 (removals present); plain `bundle`
+# install exits 0. uv/npm/volta/mas stubs exit 0.
+make_prefix() {
+  local prefix="$1"
+  mkdir -p "$prefix/bin"
+  cat >"$prefix/bin/brew" <<'MOCK'
+#!/usr/bin/env bash
+case "${1:-}" in
+  tap) exit 0 ;;
+  list) exit 1 ;;
+  autoupdate) exit 0 ;;
+  bundle)
+    if [[ ${2:-} == cleanup ]]; then
+      for a in "$@"; do
+        if [[ $a == --force ]]; then
+          printf '%s\n' "$*" >>"$FORCE_LOG"
+          exit 0
+        fi
+      done
+      [[ -n ${PREVIEW_FILE:-} && -f ${PREVIEW_FILE:-} ]] && cat "$PREVIEW_FILE"
+      exit 1
+    fi
+    exit 0 ;;
+esac
+exit 0
+MOCK
+  for tool in uv npm volta mas; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$prefix/bin/$tool"
+  done
+  chmod +x "$prefix/bin/"*
+}
+
+# run_case <name> <preview-file> <allow-bulk 0|1> -> sets FORCE_LOG, WARN
+run_case() {
+  local name="$1" preview="$2" allow="$3"
+  local prefix="$work/$name/prefix"
+  FORCE_LOG="$work/$name/force.log"
+  WARN="$work/$name/stderr"
+  local case_home="$work/$name/home"
+  mkdir -p "$prefix" "$case_home"
+  make_prefix "$prefix"
+  : >"$FORCE_LOG"
+  local -a env_extra=()
+  [[ $allow == 1 ]] && env_extra+=("HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1")
+  env -i HOME="$case_home" PATH="$prefix/bin:/usr/bin:/bin" HOMEBREW_PREFIX="$prefix" \
+    PREVIEW_FILE="$preview" FORCE_LOG="$FORCE_LOG" "${env_extra[@]}" \
+    bash "$rendered" >"$work/$name/stdout" 2>"$WARN" ||
+    fail "$name: rendered before_10 exited non-zero (stderr: $(cat "$WARN"))"
+}
+
+forced_ran() { [[ -s $FORCE_LOG ]]; }
+
+# --- partial manifest (8 > 5): forced cleanup REFUSED, warning names packages --
+run_case partial "$bulk_preview" 0
+forced_ran && {
+  printf 'stderr:\n' >&2
+  cat "$WARN" >&2
+  fail "partial: forced cleanup ran though 8 removals exceed the threshold"
+}
+grep -qiE 'refus' "$WARN" || fail "partial: no refusal warning printed (stderr: $(cat "$WARN"))"
+grep -qF 'codex' "$WARN" || fail "partial: the refusal warning does not name the would-be removals (stderr: $(cat "$WARN"))"
+
+# --- small delta (3 <= 5): forced cleanup PROCEEDS ----------------------------
+run_case small "$small_preview" 0
+forced_ran || fail "small: forced cleanup was withheld though only 3 removals (<= threshold)"
+
+# --- override: 8 removals but authorized -> forced cleanup PROCEEDS ------------
+run_case override "$bulk_preview" 1
+forced_ran || fail "override: forced cleanup was withheld though HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1"
+
+printf 'homebrew-cleanup-guard: OK (bulk refused + named; small proceeds; override proceeds)\n'

--- a/test/integration/homebrew-weekly-upgrade.sh
+++ b/test/integration/homebrew-weekly-upgrade.sh
@@ -1,59 +1,126 @@
 #!/usr/bin/env bash
 #
-# Verifies homebrew-weekly-upgrade.sh is resilient: a failing step is logged but
-# does NOT abort the run, and every later step (including cleanup) still runs.
-# Uses mock brew/mas (no real upgrade), so it is safe to run anywhere. This is
-# an integration test: it runs the whole helper script end to end with brew,
-# mas, and tailscaled stubbed at the boundary (no sleeps, no timing).
+# homebrew-weekly-upgrade.sh helper: resilience AND aggregate exit status.
+#
+#   - Resilient: a failing step is logged but does NOT abort the run; every
+#     later step (including cleanup) still runs.
+#   - Aggregate exit (Fix 2 / plan-mandated): the helper accumulates step
+#     failures and exits NON-zero when any step failed, so an all-steps-failed
+#     run cannot exit 0. A fully clean run exits 0.
+#
+# Integration test: runs the whole helper end to end with brew, mas, tailscaled,
+# and (for the refresh-failure case) sudo stubbed at the boundary. No sleeps, no
+# timing, no real upgrades -- safe anywhere.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 helper="$REPO_ROOT/dot_local/bin/executable_homebrew-weekly-upgrade.sh"
 
-if [[ ! -x $helper ]]; then
-  echo "homebrew-weekly-upgrade: FAIL -- helper not found/executable: $helper" >&2
+fail() {
+  printf 'homebrew-weekly-upgrade: FAIL -- %s\n' "$*" >&2
   exit 1
-fi
+}
+
+[[ -x $helper ]] || fail "helper not found/executable: $helper"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# Mock brew: succeed on everything EXCEPT `upgrade`, which fails (exit 1) -- to
-# prove the run continues past a failed step.
-cat >"$tmp/brew" <<'MOCK'
+# All seven section headers plus the done marker; every scenario must print them
+# (resilience: no failure short-circuits a later step).
+sections=(
+  "== brew update ==" "== brew outdated ==" "== mas outdated =="
+  "== brew upgrade ==" "== tailscaled refresh" "== mas upgrade =="
+  "== brew cleanup ==" "=== done"
+)
+
+assert_all_sections() {
+  local out="$1" name="$2" marker
+  for marker in "${sections[@]}"; do
+    grep -qF "$marker" <<<"$out" || {
+      printf '=== %s output ===\n%s\n' "$name" "$out" >&2
+      fail "$name: missing section: $marker"
+    }
+  done
+}
+
+# A brew stub that succeeds on everything except the subcommands named in
+# $BREW_FAIL (space separated); a mas stub that always succeeds.
+make_brew() {
+  cat >"$tmp/brew" <<'MOCK'
 #!/usr/bin/env bash
 echo "mock brew $*"
-[[ ${1:-} == upgrade ]] && exit 1
+for bad in $BREW_FAIL; do
+  [[ ${1:-} == "$bad" ]] && exit 1
+done
 exit 0
 MOCK
-# Mock mas: succeed on everything.
-cat >"$tmp/mas" <<'MOCK'
+  cat >"$tmp/mas" <<'MOCK'
 #!/usr/bin/env bash
 echo "mock mas $*"
 exit 0
 MOCK
-chmod +x "$tmp/brew" "$tmp/mas"
+  chmod +x "$tmp/brew" "$tmp/mas"
+}
+make_brew
 
-# HOMEBREW_WEEKLY_TAILSCALED points at a nonexistent path so the tailscaled-refresh
-# step skips (its `[[ -x $TS ]]` guard fails) -- the test never touches the real daemon.
-out="$(HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" bash "$helper" 2>&1)"
-
-fail=0
-for marker in "== brew update ==" "== brew outdated ==" "== mas outdated ==" \
-  "== brew upgrade ==" "== tailscaled refresh" "== mas upgrade ==" "== brew cleanup ==" "=== done"; do
-  if ! grep -qF "$marker" <<<"$out"; then
-    echo "homebrew-weekly-upgrade: FAIL -- missing section: $marker" >&2
-    fail=1
-  fi
-done
-grep -qF "FAILED" <<<"$out" || {
-  echo "homebrew-weekly-upgrade: FAIL -- failed step not reported" >&2
-  fail=1
+# --- Scenario 1: partial failure -> resilient AND non-zero aggregate exit -----
+# brew upgrade fails; every later step still runs and the helper exits non-zero.
+out="$(BREW_FAIL="upgrade" HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$tmp/lock1" \
+  bash "$helper" 2>&1)"
+rc=$?
+assert_all_sections "$out" "partial-failure"
+grep -qF "FAILED" <<<"$out" || fail "partial-failure: the failed step was not reported"
+[[ $rc -ne 0 ]] || {
+  printf '=== partial-failure output ===\n%s\n' "$out" >&2
+  fail "partial-failure: a failed step must make the helper exit non-zero (got rc=0)"
 }
 
-if [[ $fail -ne 0 ]]; then
-  echo "--- helper output ---" >&2
-  echo "$out" >&2
-  exit 1
-fi
-echo "homebrew-weekly-upgrade: OK -- resilient (continued past failure; all sections + cleanup ran)"
+# --- Scenario 2: fully clean run -> exit 0 ------------------------------------
+out="$(BREW_FAIL="" HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$tmp/lock2" \
+  bash "$helper" 2>&1)"
+rc=$?
+assert_all_sections "$out" "all-success"
+grep -qF "FAILED" <<<"$out" && fail "all-success: reported a FAILED step though none should fail"
+[[ $rc -eq 0 ]] || {
+  printf '=== all-success output ===\n%s\n' "$out" >&2
+  fail "all-success: a clean run must exit 0 (got rc=$rc)"
+}
+
+# --- Scenario 3: missing tool -> steps fail, run completes, non-zero exit -----
+# brew binary does not exist: every brew step fails (127) but the run continues
+# through mas and the done marker, and the aggregate exit is non-zero.
+out="$(HOMEBREW_WEEKLY_BREW="$tmp/does-not-exist-brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$tmp/lock3" \
+  bash "$helper" 2>&1)"
+rc=$?
+assert_all_sections "$out" "missing-tool"
+[[ $rc -ne 0 ]] || fail "missing-tool: a missing brew must make the helper exit non-zero (got rc=0)"
+
+# --- Scenario 4: Tailscale-refresh failure -> logged, later steps run, non-zero
+# TS is an executable stub and /usr/local/bin/tailscaled differs, so cmp fails
+# and the refresh proceeds to `sudo -n <TS> install-system-daemon`; a stub sudo
+# on PATH exits 1, so the refresh step FAILS. Later steps must still run and the
+# aggregate exit must be non-zero.
+stubdir="$tmp/stub-path"
+mkdir -p "$stubdir"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$stubdir/sudo"
+chmod +x "$stubdir/sudo"
+ts_stub="$tmp/tailscaled-stub"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$ts_stub"
+chmod +x "$ts_stub"
+out="$(BREW_FAIL="" PATH="$stubdir:/usr/bin:/bin" \
+  HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="$ts_stub" HOMEBREW_WEEKLY_LOCKFILE="$tmp/lock4" \
+  bash "$helper" 2>&1)"
+rc=$?
+assert_all_sections "$out" "tailscale-refresh-failure"
+grep -qF "FAILED" <<<"$out" || fail "tailscale-refresh-failure: the failed refresh was not reported"
+[[ $rc -ne 0 ]] || {
+  printf '=== tailscale-refresh-failure output ===\n%s\n' "$out" >&2
+  fail "tailscale-refresh-failure: a failed refresh must make the helper exit non-zero (got rc=0)"
+}
+
+printf 'homebrew-weekly-upgrade: OK (resilient; clean run exits 0; any failed step exits non-zero)\n'

--- a/test/integration/homebrew-weekly-upgrade.sh
+++ b/test/integration/homebrew-weekly-upgrade.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Verifies homebrew-weekly-upgrade.sh is resilient: a failing step is logged but
+# does NOT abort the run, and every later step (including cleanup) still runs.
+# Uses mock brew/mas (no real upgrade), so it is safe to run anywhere. This is
+# an integration test: it runs the whole helper script end to end with brew,
+# mas, and tailscaled stubbed at the boundary (no sleeps, no timing).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+helper="$REPO_ROOT/dot_local/bin/executable_homebrew-weekly-upgrade.sh"
+
+if [[ ! -x $helper ]]; then
+  echo "homebrew-weekly-upgrade: FAIL -- helper not found/executable: $helper" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Mock brew: succeed on everything EXCEPT `upgrade`, which fails (exit 1) -- to
+# prove the run continues past a failed step.
+cat >"$tmp/brew" <<'MOCK'
+#!/usr/bin/env bash
+echo "mock brew $*"
+[[ ${1:-} == upgrade ]] && exit 1
+exit 0
+MOCK
+# Mock mas: succeed on everything.
+cat >"$tmp/mas" <<'MOCK'
+#!/usr/bin/env bash
+echo "mock mas $*"
+exit 0
+MOCK
+chmod +x "$tmp/brew" "$tmp/mas"
+
+# HOMEBREW_WEEKLY_TAILSCALED points at a nonexistent path so the tailscaled-refresh
+# step skips (its `[[ -x $TS ]]` guard fails) -- the test never touches the real daemon.
+out="$(HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" bash "$helper" 2>&1)"
+
+fail=0
+for marker in "== brew update ==" "== brew outdated ==" "== mas outdated ==" \
+  "== brew upgrade ==" "== tailscaled refresh" "== mas upgrade ==" "== brew cleanup ==" "=== done"; do
+  if ! grep -qF "$marker" <<<"$out"; then
+    echo "homebrew-weekly-upgrade: FAIL -- missing section: $marker" >&2
+    fail=1
+  fi
+done
+grep -qF "FAILED" <<<"$out" || {
+  echo "homebrew-weekly-upgrade: FAIL -- failed step not reported" >&2
+  fail=1
+}
+
+if [[ $fail -ne 0 ]]; then
+  echo "--- helper output ---" >&2
+  echo "$out" >&2
+  exit 1
+fi
+echo "homebrew-weekly-upgrade: OK -- resilient (continued past failure; all sections + cleanup ran)"

--- a/test/integration/rendered-template-coverage.sh
+++ b/test/integration/rendered-template-coverage.sh
@@ -182,6 +182,7 @@ is_shell_template() { # <file>
 declare -A EXCLUDED=(
   [".chezmoitemplates/herdr-plugin-build.sh.tmpl"]='includeTemplate fragment: needs a (dict "id" ...) arg, so it never renders standalone; exercised through its includers run_onchange_after_55/57, which ARE covered'
   [".chezmoitemplates/herdr-health-check.sh.tmpl"]='includeTemplate fragment: defines a shell function with no standalone shebang entry point, so it never renders on its own; exercised through its covered includer run_after_58-herdr-migration-verify'
+  [".chezmoitemplates/brew-bundle-cleanup-guard.sh.tmpl"]='includeTemplate fragment: defines a shell function with no standalone shebang entry point, so it never renders on its own; exercised through its covered includers run_onchange_before_10-system-packages and run_after_58-herdr-migration-verify'
 )
 
 # Host-tool guards: plain test/*.sh scripts run with host tools.

--- a/test/unit/homebrew-before10-skip-truthiness.sh
+++ b/test/unit/homebrew-before10-skip-truthiness.sh
@@ -27,28 +27,36 @@ command -v chezmoi >/dev/null 2>&1 || {
 # was skipped for this render.
 SENTINEL='skipping the brew bundle sync'
 
-# render_has_skip <value|__unset__> -> prints "yes"/"no". Empty render (non-darwin
-# host) skips the whole test.
-render_has_skip() {
-  local value="$1"
-  local home rendered
+# render <value|__unset__> -> the rendered script on stdout. A render failure is
+# fatal at TOP level (set -e propagates the failed assignment out of render_has_skip,
+# so this never mis-classifies a broken render as a "no").
+render() {
+  local value="$1" home out
   home="$(mktemp -d)"
-  rendered="$(
-    if [[ $value == __unset__ ]]; then
-      HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT"
-    else
-      HOME="$home" CI=1 SKIP_SYSTEM_PACKAGES="$value" \
-        chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT"
-    fi
-  )" || {
-    rm -rf "$home"
-    fail "chezmoi failed to render with SKIP_SYSTEM_PACKAGES=$value"
-  }
-  rm -rf "$home"
-  if [[ -z ${rendered//[[:space:]]/} ]]; then
-    printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
-    exit 0
+  if [[ $value == __unset__ ]]; then
+    out="$(HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT")"
+  else
+    out="$(HOME="$home" CI=1 SKIP_SYSTEM_PACKAGES="$value" \
+      chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT")"
   fi
+  rm -rf "$home"
+  printf '%s' "$out"
+}
+
+# Detect the non-darwin host (empty render) ONCE, at top level, and skip the
+# whole test there -- so the empty-render exit is a real script exit, not a
+# subshell exit that leaves an assertion comparing SKIP text against "yes".
+probe="$(render __unset__)" || fail 'chezmoi failed to render before_10'
+if [[ -z ${probe//[[:space:]]/} ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# render_has_skip <value|__unset__> -> "yes"/"no". The probe above proved the
+# template renders, so this only classifies presence of the skip sentinel.
+render_has_skip() {
+  local rendered
+  rendered="$(render "$1")"
   if grep -qF "$SENTINEL" <<<"$rendered"; then printf 'yes'; else printf 'no'; fi
 }
 

--- a/test/unit/homebrew-before10-skip-truthiness.sh
+++ b/test/unit/homebrew-before10-skip-truthiness.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Fix 3: the SKIP_SYSTEM_PACKAGES guard in run_onchange_before_10 must skip the
+# brew bundle sync ONLY for the literal value "1". A bare-truthiness guard
+# (`{{ if env "SKIP_SYSTEM_PACKAGES" }}`) treats "0" and "false" as truthy and
+# wrongly skips, so the correct form is `{{ if eq (env "...") "1" }}`.
+#
+# Unit test: render the template under a range of SKIP_SYSTEM_PACKAGES values
+# and assert the skip block is present ONLY for "1".
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl"
+
+fail() {
+  printf 'homebrew-before10-skip-truthiness: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render before_10\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+# The skip block emits this sentinel comment; its presence == the bundle sync
+# was skipped for this render.
+SENTINEL='skipping the brew bundle sync'
+
+# render_has_skip <value|__unset__> -> prints "yes"/"no". Empty render (non-darwin
+# host) skips the whole test.
+render_has_skip() {
+  local value="$1"
+  local home rendered
+  home="$(mktemp -d)"
+  rendered="$(
+    if [[ $value == __unset__ ]]; then
+      HOME="$home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT"
+    else
+      HOME="$home" CI=1 SKIP_SYSTEM_PACKAGES="$value" \
+        chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$SCRIPT"
+    fi
+  )" || {
+    rm -rf "$home"
+    fail "chezmoi failed to render with SKIP_SYSTEM_PACKAGES=$value"
+  }
+  rm -rf "$home"
+  if [[ -z ${rendered//[[:space:]]/} ]]; then
+    printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+    exit 0
+  fi
+  if grep -qF "$SENTINEL" <<<"$rendered"; then printf 'yes'; else printf 'no'; fi
+}
+
+# Only "1" skips.
+[[ "$(render_has_skip 1)" == yes ]] || fail 'SKIP_SYSTEM_PACKAGES=1 must skip the bundle sync'
+# "0", "false", and unset must NOT skip (the bare-truthiness bug the fix closes).
+[[ "$(render_has_skip 0)" == no ]] || fail 'SKIP_SYSTEM_PACKAGES=0 must NOT skip (bare-truthiness bug)'
+[[ "$(render_has_skip false)" == no ]] || fail 'SKIP_SYSTEM_PACKAGES=false must NOT skip (bare-truthiness bug)'
+[[ "$(render_has_skip __unset__)" == no ]] || fail 'unset SKIP_SYSTEM_PACKAGES must NOT skip'
+
+printf 'homebrew-before10-skip-truthiness: OK (only the literal "1" skips; 0/false/unset run the sync)\n'

--- a/test/unit/homebrew-brew-upgrade-recipe.sh
+++ b/test/unit/homebrew-brew-upgrade-recipe.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Fix 2: `just brew-upgrade` must invoke the DEPLOYED helper
+# (~/.local/bin/homebrew-weekly-upgrade.sh) -- the exact artifact launchd runs
+# every Monday -- not the repo SOURCE copy (dot_local/bin/executable_...). An
+# ad-hoc upgrade has to exercise what the LaunchAgent exercises.
+#
+# Unit test: read the recipe body with `just --show` (parses the justfile, runs
+# nothing) and assert which path it names.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  printf 'homebrew-brew-upgrade-recipe: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v just >/dev/null 2>&1 || {
+  printf 'SKIP: just not on PATH; cannot inspect the brew-upgrade recipe\n'
+  exit 0
+}
+
+body="$(just --justfile "$REPO_ROOT/justfile" --show brew-upgrade 2>/dev/null)" ||
+  fail "no brew-upgrade recipe in the justfile"
+
+grep -qF '.local/bin/homebrew-weekly-upgrade.sh' <<<"$body" ||
+  fail "recipe does not invoke the deployed ~/.local/bin/homebrew-weekly-upgrade.sh"
+
+if grep -qF 'dot_local/bin/executable_homebrew-weekly-upgrade.sh' <<<"$body"; then
+  printf 'recipe body:\n%s\n' "$body" >&2
+  fail "recipe invokes the repo SOURCE copy instead of the deployed one"
+fi
+
+printf 'homebrew-brew-upgrade-recipe: OK (runs the deployed ~/.local/bin/homebrew-weekly-upgrade.sh)\n'

--- a/test/unit/homebrew-weekly-plist.sh
+++ b/test/unit/homebrew-weekly-plist.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Fix 5 (plist wiring): the com.webdavis.homebrew-weekly-upgrade LaunchAgent must
+# fire Monday at 12:00 (launchd Weekday 1 == Monday) and must NOT run at load
+# time (RunAtLoad false), so loading the agent never triggers an unattended
+# upgrade -- the whole point is that upgrades happen only when the operator is
+# present at Monday noon.
+#
+# Unit test: render the plist template with the host chezmoi and assert the
+# StartCalendarInterval fields and RunAtLoad. No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist.tmpl"
+
+fail() {
+  printf 'homebrew-weekly-plist: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the plist\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+rendered="$work/plist.xml"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$PLIST" >"$rendered" || fail "chezmoi failed to render the plist"
+rm -rf "$render_home"
+[[ -s $rendered ]] || fail "empty plist render"
+
+# assert_kv <key> <expected-value-line-fragment> -- the plist pairs a <key> with
+# the value element on the FOLLOWING line, so match the key then its next line.
+assert_kv() {
+  local key="$1" want="$2"
+  if ! grep -A1 -F "<key>$key</key>" "$rendered" | grep -qF "$want"; then
+    printf 'rendered plist:\n' >&2
+    cat "$rendered" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# Must actually be a calendar-scheduled agent, not an interval one.
+grep -qF '<key>StartCalendarInterval</key>' "$rendered" ||
+  fail "no StartCalendarInterval (not a calendar-scheduled agent)"
+
+assert_kv Weekday '<integer>1</integer>' # Monday
+assert_kv Hour '<integer>12</integer>'   # 12:00
+assert_kv Minute '<integer>0</integer>'
+assert_kv RunAtLoad '<false/>' # loading must never trigger an upgrade
+
+printf 'homebrew-weekly-plist: OK (Monday 12:00, Weekday 1; RunAtLoad false)\n'


### PR DESCRIPTION
## Context

Main is being rebuilt slice by slice while the live machine (dresden) applies from `integration/modernization` until the D1 cutover. S6 is the Homebrew weekly-upgrade slice: it ports the Monday-noon upgrade stack from integration to main and replaces the old domt4/autoupdate daily auto-upgrader that main still described.

The branch is 13 commits: a 6-commit implementation (the port plus five ledger fixes from the plan), then 7 commits fixing everything the slice's single adversarial review round (one Claude leg, one gpt-5.6-sol leg) found.

## Summary

- The weekly-upgrade helper, Monday-noon LaunchAgent, and loader are ported from integration.
- domt4/autoupdate is torn down and removed from the manifest, not restarted.
- The helper now takes a kernel lock and exits nonzero when any step failed.
- Forced `brew bundle cleanup` refuses bulk removals against a partial manifest.
- `SKIP_SYSTEM_PACKAGES=1` now covers both cleanup owners, and only the literal `1` skips.
- uv/npm/volta installs no longer skip when the apply shell's PATH lacks the brew prefix.

Key files:
- `dot_local/bin/executable_homebrew-weekly-upgrade.sh`
- `.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl`
- `.chezmoitemplates/brew-bundle-cleanup-guard.sh.tmpl`
- `Library/LaunchAgents/com.webdavis.homebrew-weekly-upgrade.plist.tmpl` + `run_onchange_after_65` loader

## What changed

- Port: helper, plist (Weekday=1, Hour=12, RunAtLoad=false), and after_65 loader (bootout + bootstrap retry, mirroring the atuin/happy loaders) come from integration; the integration-era test was re-camped into the unit/integration pyramid. `just brew-upgrade` runs the deployed `~/.local/bin` copy, the same artifact launchd runs.
- Ledger fixes from the plan: the Homebrew 6.x `brew bundle` install/cleanup split against one rendered temp Brewfile; `SKIP_SYSTEM_PACKAGES` skips only on the literal `1` (0/false/empty/unset all sync); the uv/npm/volta loops are guarded so a missing tool skips cleanly instead of aborting the apply.
- Review-round fixes: the domt4/autoupdate starter block became a guarded teardown (stop + delete, ordered before any cleanup could untap the command) and the tap left both manifest lists, so a D1 apply cannot resurrect the daily upgrader beside the weekly agent. The helper gained `/usr/bin/lockf` mutual exclusion (a second concurrent run defers with exit 75; the kernel releases the lock on any exit, so no stale-lock class) and an aggregate exit (individual steps still continue on failure, but an all-failed run no longer exits 0). Both `brew bundle cleanup --force` owners (before_10 and after_58) now share one guard partial: a non-forced preview counts would-be removals and refuses the forced cleanup above a threshold of 5 (override: `HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1`), naming what it would have removed. after_58's deferred tmux/sesh cleanup honors `SKIP_SYSTEM_PACKAGES=1` (the herdr verification itself still runs). before_10 prepends the brew prefix to PATH once so tool guards and invocations see the same binaries on a fresh machine.
- The helper deliberately diverges from integration's byte-identical copy (lock + aggregate exit): the plan's audit amendment mandating both post-dates the integration copy. Dresden picks the hardened helper up at D1.

## How it was reviewed

- One adversarial round, two independent legs, both verifying by execution: the Claude leg diffed the port byte-for-byte against integration and rendered the SKIP truthiness matrix; the sol leg ran a real non-forced cleanup preview against the branch's exact render (surfacing that a partial manifest would remove live packages such as `lulu` and `paseo` at D1) and proved the helper exited 0 with every step stubbed to fail.
- All six round findings were fixed red-first with failing runs captured before each fix.
- Gates: `just lint-check`, `just test` (all camps), and a CI-faithful run with Homebrew stripped from PATH, all green locally, plus the pre-push hook's full re-run. GitHub CI was quota-blocked at push time (Actions minutes exhausted); the required `lint` check runs before merge once minutes are restored.

## Effect of merging

Merging changes main only; dresden keeps applying from integration until D1. At D1, applying this main tears down domt4/autoupdate if present (a no-op on dresden, where it is already gone), loads the weekly agent, and the cleanup guard prevents the still-partial manifest from mass-uninstalling packages that later slices have not yet declared. The bulk-cleanup threshold means the deferred tmux/sesh removal may be refused until the manifest is reconciled at cutover; the D1 checklist covers lifting the guard once (`HOMEBREW_BUNDLE_ALLOW_BULK_CLEANUP=1`) if needed.
