### PR TITLE
feat: S10 macOS defaults tooling + SSH hardening + R8 endpoint casks

### DIFF
--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -32,6 +32,9 @@ macos:
     - description: "SSH: write the public-key-only sshd drop-in (script self-escalates; reload is a separate operator step)"
       command: '"$HOME/.local/bin/ssh-hardening.sh"'
       sudo: false
+    - description: "Firewall: enable stealth mode (drop unsolicited probes silently)"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
+      sudo: true
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -32,6 +32,9 @@ macos:
     - description: "SSH: write the public-key-only sshd drop-in (script self-escalates; reload is a separate operator step)"
       command: '"$HOME/.local/bin/ssh-hardening.sh"'
       sudo: false
+    - description: "Firewall: enable the application firewall (required for stealth mode to be active protection)"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
+      sudo: true
     - description: "Firewall: enable stealth mode (drop unsolicited probes silently)"
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
       sudo: true

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -29,6 +29,9 @@ macos:
     - description: "Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
       command: '"$HOME/.local/bin/install-nix-repair-hook.sh"'
       sudo: true
+    - description: "SSH: write the public-key-only sshd drop-in (script self-escalates; reload is a separate operator step)"
+      command: '"$HOME/.local/bin/ssh-hardening.sh"'
+      sudo: false
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -181,6 +181,7 @@ packages:
         - google-chrome
         - karabiner-elements
         - keepassxc
+        - lulu
         - lunar
         - mediosz/tap/swipeaerospace
         - microsoft-auto-update
@@ -191,6 +192,7 @@ packages:
         - obsidian
         - openemu
         - osquery
+        - oversight
         - proton-drive
         - proton-mail
         - proton-mail-bridge

--- a/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
+++ b/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
@@ -76,7 +76,7 @@ check_posture() {
 check_posture "FileVault" "$fdesetup" "status" "FileVault is On" "FileVault is Off" \
   "enabling FileVault is disruptive; turn it on yourself in System Settings > Privacy & Security."
 check_posture "Gatekeeper" "$spctl" "--status" "assessments enabled" "assessments disabled" \
-  "re-enable with: sudo spctl --master-enable."
+  "re-enable in System Settings > Privacy & Security (spctl can no longer enable Gatekeeper from the CLI on macOS 15+; it only offers --global-disable)."
 check_posture "SIP" "$csrutil" "status" "status: enabled" "status: disabled" \
   "re-enable from Recovery (csrutil enable); this is a deliberate operator step."
 

--- a/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
+++ b/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
@@ -1,0 +1,70 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+set -euo pipefail
+
+# macOS security-posture reminder (sudo-free, ASSERT-ONLY). Reports FileVault,
+# Gatekeeper, and System Integrity Protection (SIP) state so a regression surfaces
+# on every apply; it NEVER changes any of them. SIP and FileVault are assert-only
+# by policy (enabling SIP needs Recovery; enabling FileVault is disruptive), and
+# Gatekeeper is likewise only reported. A disabled or indeterminate posture is a
+# loud stderr warning, never a fix attempt. Every path exits 0: a reminder must
+# never abort `chezmoi apply`. This is a run_after (not run_onchange) so posture
+# drift surfaces on EVERY apply, not only when the script body changes. Mirrors the
+# tailscaled-status reminder shape; the *_BIN overrides are the test seam.
+
+fdesetup="${FDESETUP_BIN:-fdesetup}"
+spctl="${SPCTL_BIN:-spctl}"
+csrutil="${CSRUTIL_BIN:-csrutil}"
+
+# classify_contains <output> <enabled-needle> <disabled-needle> -> enabled|disabled|unknown
+classify_contains() {
+  local out="$1" on="$2" off="$3"
+  if [[ $out == *"$on"* ]]; then
+    printf 'enabled'
+  elif [[ $out == *"$off"* ]]; then
+    printf 'disabled'
+  else
+    printf 'unknown'
+  fi
+}
+
+# report_posture <label> <state> <detail> <remedy>. enabled -> a one-line OK on
+# stdout; disabled -> a loud warning on stderr with the operator remedy; unknown ->
+# a could-not-determine note on stderr. Never runs a mutating command.
+report_posture() {
+  local label="$1" state="$2" detail="$3" remedy="$4"
+  case "$state" in
+    enabled)
+      printf '[posture] %s: enabled\n' "$label"
+      ;;
+    disabled)
+      printf '[posture] WARNING: %s is DISABLED. %s\n' "$label" "$remedy" >&2
+      ;;
+    *)
+      printf '[posture] %s: could not determine state (raw: %s)\n' "$label" "$detail" >&2
+      ;;
+  esac
+}
+
+# check_posture <label> <bin> <query> <on-needle> <off-needle> <remedy>. Tolerates
+# an absent or failing tool (empty output -> unknown); never aborts the run.
+check_posture() {
+  local label="$1" bin="$2" query="$3" on="$4" off="$5" remedy="$6" out
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    printf '[posture] %s: %s not found; skipping\n' "$label" "$bin" >&2
+    return 0
+  fi
+  out="$("$bin" "$query" 2>/dev/null || true)"
+  report_posture "$label" "$(classify_contains "$out" "$on" "$off")" "$out" "$remedy"
+}
+
+check_posture "FileVault" "$fdesetup" "status" "FileVault is On" "FileVault is Off" \
+  "enabling FileVault is disruptive; turn it on yourself in System Settings > Privacy & Security."
+check_posture "Gatekeeper" "$spctl" "--status" "assessments enabled" "assessments disabled" \
+  "re-enable with: sudo spctl --master-enable."
+check_posture "SIP" "$csrutil" "status" "status: enabled" "status: disabled" \
+  "re-enable from Recovery (csrutil enable); this is a deliberate operator step."
+
+exit 0
+{{ end -}}

--- a/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
+++ b/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl
@@ -48,15 +48,29 @@ report_posture() {
 }
 
 # check_posture <label> <bin> <query> <on-needle> <off-needle> <remedy>. Tolerates
-# an absent or failing tool (empty output -> unknown); never aborts the run.
+# an absent or failing tool; never aborts the run. Captures the query's stdout,
+# stderr, and exit status SEPARATELY: a NONZERO query is INDETERMINATE regardless
+# of what it printed (a failed probe's stdout is untrustworthy -- it may print
+# enabled-looking text yet have failed), so it is reported "could not determine",
+# never "enabled". Only a zero-exit query is classified from its stdout.
 check_posture() {
-  local label="$1" bin="$2" query="$3" on="$4" off="$5" remedy="$6" out
+  local label="$1" bin="$2" query="$3" on="$4" off="$5" remedy="$6"
   if ! command -v "$bin" >/dev/null 2>&1; then
     printf '[posture] %s: %s not found; skipping\n' "$label" "$bin" >&2
     return 0
   fi
-  out="$("$bin" "$query" 2>/dev/null || true)"
-  report_posture "$label" "$(classify_contains "$out" "$on" "$off")" "$out" "$remedy"
+  local out err rc=0 errfile state
+  errfile="$(mktemp)"
+  out="$("$bin" "$query" 2>"$errfile")" || rc=$?
+  err="$(cat "$errfile")"
+  rm -f "$errfile"
+  if [[ $rc -ne 0 ]]; then
+    state="unknown"
+    report_posture "$label" "$state" "query failed rc=$rc; stdout: ${out:-<none>}; stderr: ${err:-<none>}" "$remedy"
+  else
+    state="$(classify_contains "$out" "$on" "$off")"
+    report_posture "$label" "$state" "$out" "$remedy"
+  fi
 }
 
 check_posture "FileVault" "$fdesetup" "status" "FileVault is On" "FileVault is Off" \

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -18,9 +18,13 @@ exit 0
 # none during the loop — it covers the generated tailnet-pin commands too.
 sudo -v
 
+{{/* `index . "sudo"`, not `.sudo`: Go's text/template throws
+     `map has no entry for key "sudo"` on the .field form when a record omits the
+     key; `index` returns the empty value (falsy in `if`) — the same absent-key
+     gotcha the pins guard above documents. */ -}}
 {{ range .macos.system_setup -}}
 echo "→ {{ .description }}"
-{{ if .sudo }}sudo {{ end }}{{ .command }}
+{{ if index . "sudo" }}sudo {{ end }}{{ .command }}
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).
      Guard-then-append keeps each idempotent across runner re-runs. The sh -c

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -20,7 +20,7 @@ sudo -v
 
 {{/* `index . "sudo"`, not `.sudo`: Go's text/template throws
      `map has no entry for key "sudo"` on the .field form when a record omits the
-     key; `index` returns the empty value (falsy in `if`) — the same absent-key
+     key; `index` returns the empty value (falsy in `if`), the same absent-key
      gotcha the pins guard above documents. */ -}}
 {{ range .macos.system_setup -}}
 echo "→ {{ .description }}"

--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -9,18 +9,21 @@ set -euo pipefail
 # Note: no `shopt -s lastpipe` here — the while loops below don't mutate
 # outer-scope state (no counter to preserve, unlike drift.sh).
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
+DATA_FILE="$(macos_defaults_data_file)" || {
+  printf 'error: cannot resolve the chezmoi source dir for macos_defaults.yaml\n' >&2
   exit 2
-fi
+}
+
+require_readable_data_file "$DATA_FILE"
 
 # Pre-flight: close System Settings if open (same reason as runner).
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
 # Main loop: one `defaults write` per record.
-yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$DATA_FILE" |
+defaults_records_tsv "$DATA_FILE" |
   while IFS=$'\t' read -r domain key type value host; do
     [[ -z $domain ]] && continue
     if [[ -n $host ]]; then

--- a/dot_local/bin/executable_macos-defaults-capture.sh
+++ b/dot_local/bin/executable_macos-defaults-capture.sh
@@ -18,7 +18,13 @@
 
 set -euo pipefail
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
+
+DATA_FILE="$(macos_defaults_data_file)" || {
+  printf 'error: cannot resolve the chezmoi source dir for macos_defaults.yaml\n' >&2
+  exit 2
+}
 
 usage() {
   printf 'usage: macos-defaults-capture <domain> <key> [--host current]\n' >&2
@@ -65,10 +71,7 @@ done
   exit 3
 }
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
-  exit 2
-fi
+require_readable_data_file "$DATA_FILE"
 
 # Read live type. `defaults read-type` outputs e.g. "Type is boolean".
 host_flag=()

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -13,12 +13,15 @@
 set -euo pipefail
 shopt -s lastpipe
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
+DATA_FILE="$(macos_defaults_data_file)" || {
+  printf 'error: cannot resolve the chezmoi source dir for macos_defaults.yaml\n' >&2
   exit 2
-fi
+}
+
+require_readable_data_file "$DATA_FILE"
 
 # Normalize a value for comparison. macOS stores bools as 0/1; YAML ships them
 # as true/false. Strings/ints/floats compare directly.
@@ -45,10 +48,10 @@ print_header() {
   fi
 }
 
-# yq -r outputs each record as a single TSV line: domain<TAB>key<TAB>type<TAB>value<TAB>host
+# Each record arrives as one TSV line: domain<TAB>key<TAB>type<TAB>value<TAB>host.
 # Note: yq emits a single newline for an empty array; the inline guard below
 # skips that empty row so the script exits 0 cleanly when nothing is tracked.
-yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$DATA_FILE" |
+defaults_records_tsv "$DATA_FILE" |
   while IFS=$'\t' read -r domain key type value host; do
     [[ -z $domain ]] && continue
     expected="$(normalize "$type" "$value")"

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -41,7 +41,9 @@ DROPIN="$SSHD_CONFIG_D/000-ssh-hardening.conf"
 # away on install.
 LEGACY_DROPIN="$SSHD_CONFIG_D/50-no-password-auth.conf"
 
-SSHD_BIN="${SSHD_BIN:-sshd}"
+# Absolute path (macOS default) so a stripped PATH cannot silently fail to resolve the
+# verifier and let a security check no-op. Tests override this seam with a stub.
+SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-launchctl}"
 # ssh-keyscan is the post-reload readiness prover: it completes an SSH banner
 # exchange, so a host-key line on stdout proves sshd is actually accepting (not merely
@@ -225,9 +227,17 @@ verify_effective_specs() {
 # separately -- no blanket "all in force" claim unless every view passes.
 verify_effective() {
   if ! command -v "$SSHD_BIN" >/dev/null 2>&1; then
-    printf '[ssh-hardening] NOTE: %s not found; cannot verify the effective config here. On macOS verify with: sudo sshd -G -T -C user=root,addr=203.0.113.1,host=localhost | grep -iE "passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin"\n' \
+    # A verifier that cannot run must NEVER report success in a production path. The
+    # tool-absence SKIP is allowed ONLY via an explicit test env seam; the default
+    # (production) is FAIL CLOSED.
+    if [[ ${SSH_HARDENING_SKIP_IF_NO_SSHD:-0} == 1 ]]; then
+      printf '[ssh-hardening] NOTE: %s not found; skipping effective-config verification (SSH_HARDENING_SKIP_IF_NO_SSHD set -- test seam only).\n' \
+        "$SSHD_BIN" >&2
+      return 0
+    fi
+    printf '[ssh-hardening] ERROR: %s not found; refusing to verify -- FAILING CLOSED. A security check that cannot run must not report success. On macOS the verifier is /usr/sbin/sshd; verify by hand with: sudo /usr/sbin/sshd -G -T -C user=root,addr=203.0.113.1,host=localhost | grep -iE "passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin"\n' \
       "$SSHD_BIN" >&2
-    return 0
+    return 1
   fi
   local rc=0 global_eff
   # 1. Global (pre-Match) effective config.

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -19,10 +19,13 @@
 #   --print-config    print the drop-in content to stdout and exit. No sudo, no
 #                     writes, no sshd: the pure inspection and test seam.
 #   --print-path      print the managed drop-in's absolute path and exit.
-#   --verify          parse the FULL effective sshd config (main config + every
-#                     drop-in) with `sshd -G` and assert all five hardening values
-#                     are in force. Read-only: no reload, no writes. Nonzero if the
-#                     hardening is shadowed by a sibling drop-in.
+#   --verify          assert the hardening holds three ways, all read-only and
+#                     host-key-free: the global (pre-Match) config via `sshd -G`, a
+#                     raw scan of every included file for a Match block that re-enables
+#                     a protected directive, and a per-connection resolution via
+#                     `sshd -G -T -C` for a root and a normal-user spec. No reload, no
+#                     writes. Nonzero if any view is not fully hardened (a sibling
+#                     shadowing it, or a Match block re-opening a closed path).
 #   --reload          reload sshd so a running daemon picks up the drop-in. This
 #                     is the disruptive, operator-controlled step: it validates the
 #                     complete config first and fails closed, but a reload can drop

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1,26 +1,82 @@
 #!/bin/bash
-# Disable SSH password authentication via drop-in config and reload sshd.
-# Manually invoked (no launchd schedule). Run after enabling Remote Login
-# on a fresh Mac to lock the SSH server to public-key auth only.
+# ssh-hardening.sh -- lock sshd to public-key authentication via a drop-in,
+# closing the PAM password channel and denying root login.
 #
-# The drop-in file IS the lock — leave it in place permanently. Without it,
-# sshd reverts to its default of allowing password auth.
+# The drop-in file IS the lock: leave it in place permanently. Without it, sshd
+# reverts to its default of allowing password auth.
+#
+# Modes:
+#   (default)         write the drop-in if missing or stale (idempotent; needs
+#                     sudo). Does NOT reload sshd (see --reload).
+#   --print-config    print the drop-in content to stdout and exit. No sudo, no
+#                     writes, no sshd: the pure inspection and test seam.
+#   --reload          reload sshd so a running daemon picks up the drop-in. This
+#                     is the disruptive, operator-controlled step: a reload can
+#                     drop the current SSH session, so run it deliberately from a
+#                     local console (or with a second session open) and prove
+#                     key auth works in a NEW session before closing the old one.
+#
+# On a fresh Mac the drop-in applies the moment Remote Login is first enabled
+# (sshd starts and reads it), so no reload is needed there.
 set -euo pipefail
 
 DROPIN="/etc/ssh/sshd_config.d/50-no-password-auth.conf"
 
-if [[ ! -f $DROPIN ]] || ! sudo grep -q "PasswordAuthentication no" "$DROPIN" 2>/dev/null; then
-  echo "PasswordAuthentication no" | sudo tee "$DROPIN" >/dev/null
-  echo "[ssh-hardening] Wrote $DROPIN"
-fi
+# render_dropin -- print the desired drop-in content. Pure: no sudo, no writes.
+# PasswordAuthentication no + KbdInteractiveAuthentication no together close BOTH
+# interactive-password channels. UsePAM yes is required on macOS for account and
+# session management, and is safe here precisely because neither password channel
+# is open, so PAM has no password path to authenticate.
+render_dropin() {
+  cat <<'EOF'
+# Managed by ssh-hardening.sh: lock sshd to public-key authentication only.
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+UsePAM yes
+PubkeyAuthentication yes
+PermitRootLogin no
+EOF
+}
 
-# Reload sshd via the modern kickstart -k idiom (kill + restart in one call,
-# replaces the deprecated launchctl unload/load pair). Skip silently if sshd
-# isn't currently loaded — the drop-in stays in place and will apply
-# whenever Remote Login is next enabled.
-if sudo launchctl print system/com.openssh.sshd &>/dev/null; then
-  sudo launchctl kickstart -k system/com.openssh.sshd
-  echo "[ssh-hardening] sshd reloaded"
-else
-  echo "[ssh-hardening] sshd not currently running — config will apply when Remote Login is enabled"
-fi
+# install_dropin -- write the drop-in when missing or stale (idempotent).
+install_dropin() {
+  local desired current
+  desired="$(render_dropin)"
+  current=""
+  [[ -f $DROPIN ]] && current="$(sudo cat "$DROPIN" 2>/dev/null || true)"
+  if [[ $current != "$desired" ]]; then
+    render_dropin | sudo tee "$DROPIN" >/dev/null
+    printf '[ssh-hardening] wrote %s\n' "$DROPIN"
+  else
+    printf '[ssh-hardening] %s already current\n' "$DROPIN"
+  fi
+  printf '[ssh-hardening] drop-in in place; run ssh-hardening.sh --reload (or re-enable Remote Login) to activate it on a running sshd\n'
+}
+
+# do_reload -- reload a running sshd via the modern kickstart -k idiom (kill +
+# restart in one call). Skips silently when sshd is not loaded: the drop-in stays
+# in place and applies whenever Remote Login is next enabled.
+do_reload() {
+  if sudo launchctl print system/com.openssh.sshd &>/dev/null; then
+    sudo launchctl kickstart -k system/com.openssh.sshd
+    printf '[ssh-hardening] sshd reloaded\n'
+  else
+    printf '[ssh-hardening] sshd not currently running; the drop-in applies when Remote Login is next enabled\n'
+  fi
+}
+
+case "${1:-}" in
+  --print-config)
+    render_dropin
+    ;;
+  --reload)
+    do_reload
+    ;;
+  "")
+    install_dropin
+    ;;
+  *)
+    printf 'usage: ssh-hardening.sh [--print-config | --reload]\n' >&2
+    exit 2
+    ;;
+esac

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -43,6 +43,10 @@ LEGACY_DROPIN="$SSHD_CONFIG_D/50-no-password-auth.conf"
 
 SSHD_BIN="${SSHD_BIN:-sshd}"
 LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-launchctl}"
+# ssh-keyscan is the post-reload readiness prover: it completes an SSH banner
+# exchange, so a host-key line on stdout proves sshd is actually accepting (not merely
+# a loaded launchd job). Overridable for tests.
+KEYSCAN_BIN="${KEYSCAN_BIN:-ssh-keyscan}"
 SSHD_MAIN_CONFIG="${SSHD_MAIN_CONFIG:-/etc/ssh/sshd_config}"
 # Privilege prefix for live-system reads/writes/reloads. Default sudo; tests set
 # SSH_HARDENING_SUDO="" to operate unprivileged against a sandbox tree.
@@ -293,11 +297,46 @@ prime_sudo() {
   "$SUDO" -v
 }
 
+# effective_port -- the port sshd listens on, from the effective config (first `port`
+# line; default 22). Used to aim the readiness probe. Read-only, host-key-free.
+effective_port() {
+  local eff port
+  eff="$(priv "$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>/dev/null || true)"
+  port="$(grep -iE '^port ' <<<"$eff" | head -n1 | awk '{print $2}')"
+  [[ $port =~ ^[0-9]+$ ]] || port=22
+  printf '%s' "$port"
+}
+
+# ssh_ready_probe <port> -- bounded probe that sshd is ACTUALLY accepting SSH on the
+# loopback listener, not merely a loaded launchd job. `ssh-keyscan` completes an SSH
+# banner exchange, so a host-key line on stdout is the ready signal (its exit code is
+# unreliable across versions, so the presence of a non-comment stdout line is used).
+# Retries a few times with a short pause (both overridable for tests) to tolerate the
+# brief window while the kickstarted daemon rebinds. Returns 0 as soon as sshd
+# answers, nonzero if it never does.
+ssh_ready_probe() {
+  local port="$1" attempts="${SSH_READY_ATTEMPTS:-10}" pause="${SSH_READY_SLEEP_SECONDS:-1}" i banner
+  if ! command -v "$KEYSCAN_BIN" >/dev/null 2>&1; then
+    printf '[ssh-hardening] WARNING: readiness prover (%s) not found; cannot confirm sshd is accepting connections.\n' \
+      "$KEYSCAN_BIN" >&2
+    return 1
+  fi
+  for ((i = 1; i <= attempts; i++)); do
+    banner="$("$KEYSCAN_BIN" -T 2 -p "$port" 127.0.0.1 2>/dev/null || true)"
+    if grep -qvE '^[[:space:]]*(#|$)' <<<"$banner"; then
+      return 0
+    fi
+    [[ $i -lt $attempts ]] && sleep "$pause"
+  done
+  return 1
+}
+
 # do_reload -- reload a running sshd via the modern kickstart -k idiom (kill +
 # restart in one call). This TERMINATES the current listener, so it fails CLOSED:
 # it validates the complete config first, distinguishes a confirmed-absent service
 # from an errored probe, returns nonzero on any failure, and confirms sshd came
-# back. It never treats a sudo/launchctl error as proof the daemon is down.
+# back accepting connections. It never treats a sudo/launchctl error, nor a merely
+# loaded launchd job, as proof the daemon is up.
 do_reload() {
   # (a) Prime privilege escalation visibly. A sudo failure must NOT be mistaken for
   #     "sshd is down".
@@ -342,12 +381,24 @@ do_reload() {
     return 1
   fi
 
-  # (e) Verify the service came back after the kickstart.
+  # (e) First signal: the launchd job is loaded again. This is NOT readiness --
+  #     `launchctl print` returns 0 for a loaded-but-crashed service (active count 0,
+  #     "state = not running"), so treating it as "running" can green a remote lockout.
   if ! priv "$LAUNCHCTL_BIN" print system/com.openssh.sshd >/dev/null 2>&1; then
-    printf '[ssh-hardening] ERROR: sshd did NOT come back after kickstart. Investigate immediately: sudo launchctl print system/com.openssh.sshd\n' >&2
+    printf '[ssh-hardening] ERROR: the sshd job did NOT reload after kickstart. Investigate immediately: sudo launchctl print system/com.openssh.sshd\n' >&2
     return 1
   fi
-  printf '[ssh-hardening] sshd reloaded and confirmed running.\n'
+  # (f) Readiness: prove the listener actually ACCEPTS an SSH connection. A loaded job
+  #     that never completes a banner exchange means the new config crashed sshd -- a
+  #     possible remote lockout that must fail loud, not report green.
+  local ready_port
+  ready_port="$(effective_port)"
+  if ! ssh_ready_probe "$ready_port"; then
+    printf '[ssh-hardening] ERROR: sshd is loaded but did NOT become ready (its listener on port %s never completed an SSH banner exchange after the kickstart). This may be a remote lockout -- KEEP your current session open and investigate: sudo launchctl print system/com.openssh.sshd\n' \
+      "$ready_port" >&2
+    return 1
+  fi
+  printf '[ssh-hardening] sshd reloaded and confirmed accepting SSH connections on port %s.\n' "$ready_port"
 }
 
 case "${1:-}" in

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -58,6 +58,27 @@ ACCEPTED_EFFECTIVE=(
   'permitrootlogin no'
 )
 
+# The four auth directives that MAY appear inside a `Match` block, each with its
+# hardened value. A Match block that sets any of these to a different value re-enables
+# it for the matching connections (the criteria-based bypass `sshd -G` alone is blind
+# to). UsePAM is intentionally absent: it is not a Match-scoped keyword. Keys are
+# lowercased (sshd keywords are case-insensitive).
+declare -A PROTECTED_MATCH_HARDENED=(
+  [passwordauthentication]=no
+  [kbdinteractiveauthentication]=no
+  [pubkeyauthentication]=yes
+  [permitrootlogin]=no
+)
+
+# Representative connection specs for the authoritative per-connection resolution
+# (`sshd -G -T -C`). A privileged (root) login and an ordinary user, from a sample
+# address/host, cover the wildcard/address/root Match criteria; the raw file scan
+# below covers a Match keyed to a specific non-sampled user.
+VERIFY_SPECS=(
+  'user=root,addr=203.0.113.1,host=localhost'
+  'user=nobody,addr=203.0.113.1,host=localhost'
+)
+
 # priv <cmd...> -- run a command with the configured privilege prefix (sudo by
 # default; nothing when SSH_HARDENING_SUDO is empty, e.g. under test).
 priv() {
@@ -84,46 +105,154 @@ PermitRootLogin no
 EOF
 }
 
-# assert_effective_config <effective-config-text> -- return 0 iff ALL five accepted
-# values are present. On any mismatch, print a loud per-key WARNING to stderr and
+# assert_effective_config <effective-config-text> [context-label] -- return 0 iff ALL
+# five accepted values are present. On any mismatch, print a loud per-key WARNING to
+# stderr (tagged with the context label so the operator knows WHICH view failed) and
 # return 1. Pure: no sshd, no sudo, no writes -- the unit seam.
 assert_effective_config() {
-  local effective="$1" rc=0 pair key actual
+  local effective="$1" ctx="${2:-effective sshd config}" rc=0 pair key actual
   for pair in "${ACCEPTED_EFFECTIVE[@]}"; do
     if ! grep -qxiF "$pair" <<<"$effective"; then
       key="${pair%% *}"
       actual="$(grep -iE "^${key} " <<<"$effective" | head -n1 || true)"
-      printf '[ssh-hardening] WARNING: effective sshd config has "%s" but hardening requires "%s"\n' \
-        "${actual:-(no ${key} line)}" "$pair" >&2
+      printf '[ssh-hardening] WARNING: %s has "%s" but hardening requires "%s"\n' \
+        "$ctx" "${actual:-(no ${key} line)}" "$pair" >&2
       rc=1
     fi
   done
   return "$rc"
 }
 
-# verify_effective -- assert the FULL effective sshd config (main config + every
-# drop-in, in sshd's own Include precedence) resolves to the five accepted values.
-# Uses `sshd -G` (read-only, host-key-free: never reloads, never binds). Root is
-# needed to read the mode-0600 managed drop-in, so it runs under the privilege
-# prefix. When sshd is absent it cannot verify: it says so and returns 0 (macOS
-# always ships sshd, so that path is only hit off-target, e.g. Linux CI).
+# enumerate_config_files <main-config> -- print the main config path, then every file
+# it Includes, expanded in sshd's own lexical order. Handles absolute and
+# base-relative Include globs (one level -- the drop-in dir; the authoritative
+# `sshd -G -T -C` check below is the catch-all for any deeper structure). Reads under
+# the privilege prefix so a root-only main config is still enumerable.
+enumerate_config_files() {
+  local main="$1"
+  printf '%s\n' "$main"
+  local base
+  base="$(dirname "$main")"
+  local line first rest pat abspat match
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z $line || ${line:0:1} == '#' ]] && continue
+    read -r first rest <<<"$line"
+    [[ "$(printf '%s' "$first" | tr '[:upper:]' '[:lower:]')" == include ]] || continue
+    local -a pats=()
+    read -r -a pats <<<"$rest"
+    for pat in "${pats[@]}"; do
+      [[ $pat == /* ]] && abspat="$pat" || abspat="$base/$pat"
+      while IFS= read -r match; do
+        printf '%s\n' "$match"
+      done < <(compgen -G "$abspat" 2>/dev/null | LC_ALL=C sort)
+    done
+  done < <(priv cat "$main" 2>/dev/null || true)
+}
+
+# scan_one_file_match <file> -- scan a single sshd config file for a `Match` block
+# that sets a protected directive to a non-hardened value. Return 1 (with a loud
+# per-hit WARNING naming the file and the Match line) if any is found. Pure text scan:
+# host-key-free, catches even a Match keyed to a specific user the -C sampling misses.
+scan_one_file_match() {
+  local file="$1" rc=0 in_match=0 match_ctx="" raw line kw val lc_kw lc_val hardened
+  while IFS= read -r raw; do
+    line="${raw#"${raw%%[![:space:]]*}"}"
+    [[ -z $line || ${line:0:1} == '#' ]] && continue
+    read -r kw val _rest <<<"$line"
+    lc_kw="$(printf '%s' "$kw" | tr '[:upper:]' '[:lower:]')"
+    if [[ $lc_kw == match ]]; then
+      in_match=1
+      match_ctx="$line"
+      continue
+    fi
+    [[ $in_match -eq 1 ]] || continue
+    hardened="${PROTECTED_MATCH_HARDENED[$lc_kw]:-}"
+    [[ -n $hardened ]] || continue
+    lc_val="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
+    if [[ $lc_val != "$hardened" ]]; then
+      printf '[ssh-hardening] WARNING: %s re-enables a protected directive inside "%s": sets "%s %s" but hardening requires "%s %s" for ALL connections.\n' \
+        "$file" "$match_ctx" "$kw" "$val" "$kw" "$hardened" >&2
+      rc=1
+    fi
+  done < <(priv cat "$file" 2>/dev/null || true)
+  return "$rc"
+}
+
+# scan_match_reenables -- scan the whole include tree (main + every included file) for
+# a Match block that weakens a protected directive. Return 1 if any file does.
+scan_match_reenables() {
+  local rc=0 file
+  while IFS= read -r file; do
+    scan_one_file_match "$file" || rc=1
+  done < <(enumerate_config_files "$SSHD_MAIN_CONFIG")
+  return "$rc"
+}
+
+# verify_effective_specs -- authoritative per-connection resolution. For each
+# representative spec, `sshd -G -T -C <spec>` resolves ALL Match blocks (host-key-free,
+# root-free) and prints the effective config for that connection; assert the five
+# values hold. Return 1 if any spec diverges or cannot be resolved.
+verify_effective_specs() {
+  local rc=0 spec eff
+  for spec in "${VERIFY_SPECS[@]}"; do
+    if ! eff="$(priv "$SSHD_BIN" -G -T -C "$spec" -f "$SSHD_MAIN_CONFIG" 2>/dev/null)"; then
+      printf '[ssh-hardening] WARNING: could not resolve the effective config for connection spec %s (%s -G -T -C failed); NOT claiming hardened.\n' \
+        "$spec" "$SSHD_BIN" >&2
+      rc=1
+      continue
+    fi
+    assert_effective_config "$eff" "connection spec [$spec]" || rc=1
+  done
+  return "$rc"
+}
+
+# verify_effective -- assert the hardening holds THREE independent ways, all
+# read-only and host-key-free (never reload, never bind):
+#   1. the global (pre-Match) effective config via `sshd -G`;
+#   2. a raw scan of every included file for a Match block that re-enables a protected
+#      directive (the criteria-based bypass `sshd -G` alone is blind to -- it dumps
+#      only the pre-Match config);
+#   3. an authoritative per-connection resolution via `sshd -G -T -C` for a root spec
+#      and a normal-user spec (this DOES resolve Match blocks, without host keys).
+# The parse runs under the privilege prefix because a sibling drop-in in the include
+# tree may be root-only; running privileged lets the parse read the COMPLETE tree so a
+# hostile root-only sibling cannot hide from the check. Each view is reported
+# separately -- no blanket "all in force" claim unless every view passes.
 verify_effective() {
   if ! command -v "$SSHD_BIN" >/dev/null 2>&1; then
-    printf '[ssh-hardening] NOTE: %s not found; cannot verify the effective config here. On macOS verify with: sudo sshd -T | grep -iE "passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin"\n' \
+    printf '[ssh-hardening] NOTE: %s not found; cannot verify the effective config here. On macOS verify with: sudo sshd -G -T -C user=root,addr=203.0.113.1,host=localhost | grep -iE "passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin"\n' \
       "$SSHD_BIN" >&2
     return 0
   fi
-  local effective
-  if ! effective="$(priv "$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>/dev/null)"; then
-    printf '[ssh-hardening] WARNING: could not parse the effective sshd config (%s -G -f %s failed); NOT claiming this host is hardened.\n' \
+  local rc=0 global_eff
+  # 1. Global (pre-Match) effective config.
+  if ! global_eff="$(priv "$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>/dev/null)"; then
+    printf '[ssh-hardening] WARNING: could not parse the global effective sshd config (%s -G -f %s failed); NOT claiming this host is hardened.\n' \
       "$SSHD_BIN" "$SSHD_MAIN_CONFIG" >&2
     return 1
   fi
-  if assert_effective_config "$effective"; then
-    printf '[ssh-hardening] verified: all five hardening values are in force in the effective config\n'
-    return 0
+  if assert_effective_config "$global_eff" "global effective config (pre-Match)"; then
+    printf '[ssh-hardening] global effective config verified (sshd -G, pre-Match): all five values accepted\n'
+  else
+    rc=1
   fi
-  return 1
+  # 2. Raw Match-block scan (catches criteria-based re-enables; names the file).
+  if scan_match_reenables; then
+    printf '[ssh-hardening] Match-block scan: no sibling Match re-enables a protected directive\n'
+  else
+    rc=1
+  fi
+  # 3. Authoritative per-connection resolution (sshd -G -T -C; resolves Match blocks).
+  if verify_effective_specs; then
+    printf '[ssh-hardening] per-connection check (sshd -G -T -C): hardening holds for root and a normal user\n'
+  else
+    rc=1
+  fi
+  if [[ $rc -eq 0 ]]; then
+    printf '[ssh-hardening] verified: hardening holds globally, under the Match-block scan, and per connection spec\n'
+  fi
+  return "$rc"
 }
 
 # install_dropin -- write the drop-in when missing or stale (idempotent), migrate

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -42,6 +42,7 @@ DROPIN="$SSHD_CONFIG_D/000-ssh-hardening.conf"
 LEGACY_DROPIN="$SSHD_CONFIG_D/50-no-password-auth.conf"
 
 SSHD_BIN="${SSHD_BIN:-sshd}"
+LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-launchctl}"
 SSHD_MAIN_CONFIG="${SSHD_MAIN_CONFIG:-/etc/ssh/sshd_config}"
 # Privilege prefix for live-system reads/writes/reloads. Default sudo; tests set
 # SSH_HARDENING_SUDO="" to operate unprivileged against a sandbox tree.
@@ -156,16 +157,68 @@ install_dropin() {
   printf '[ssh-hardening] drop-in in place; run ssh-hardening.sh --reload (or re-enable Remote Login) to activate it on a running sshd\n'
 }
 
+# prime_sudo -- refresh the sudo timestamp visibly, failing closed if privilege
+# escalation is unavailable. No-op when the sudo prefix is empty (test mode).
+prime_sudo() {
+  [[ -n $SUDO ]] || return 0
+  "$SUDO" -v
+}
+
 # do_reload -- reload a running sshd via the modern kickstart -k idiom (kill +
-# restart in one call). Skips silently when sshd is not loaded: the drop-in stays
-# in place and applies whenever Remote Login is next enabled.
+# restart in one call). This TERMINATES the current listener, so it fails CLOSED:
+# it validates the complete config first, distinguishes a confirmed-absent service
+# from an errored probe, returns nonzero on any failure, and confirms sshd came
+# back. It never treats a sudo/launchctl error as proof the daemon is down.
 do_reload() {
-  if sudo launchctl print system/com.openssh.sshd &>/dev/null; then
-    sudo launchctl kickstart -k system/com.openssh.sshd
-    printf '[ssh-hardening] sshd reloaded\n'
-  else
-    printf '[ssh-hardening] sshd not currently running; the drop-in applies when Remote Login is next enabled\n'
+  # (a) Prime privilege escalation visibly. A sudo failure must NOT be mistaken for
+  #     "sshd is down".
+  if ! prime_sudo; then
+    printf '[ssh-hardening] ERROR: could not acquire sudo; refusing to reload sshd.\n' >&2
+    return 1
   fi
+
+  # (b) Validate the COMPLETE live config BEFORE the disruptive kickstart. A
+  #     kickstart -k terminates the listener, so never restart onto a config that
+  #     fails syntax or has lost the hardening (a broken sibling drop-in must not be
+  #     allowed to drop the daemon). Syntax first, then the five effective values.
+  if ! priv "$SSHD_BIN" -t; then
+    printf '[ssh-hardening] ERROR: sshd config failed syntax validation (sshd -t); refusing to reload.\n' >&2
+    return 1
+  fi
+  if ! verify_effective; then
+    printf '[ssh-hardening] ERROR: the live effective config is not fully hardened; refusing to reload.\n' >&2
+    return 1
+  fi
+
+  # (c)/(d) Probe the service, distinguishing CONFIRMED-absent from a probe ERROR.
+  #     `launchctl print` exits 0 when the service is loaded and 113 ("Could not
+  #     find service") when it is genuinely absent; ANY other nonzero is an errored
+  #     probe (e.g. a sudo/launchctl failure) and is NOT proof the daemon is down --
+  #     propagate it, never proceed as if stopped.
+  local probe_rc=0
+  priv "$LAUNCHCTL_BIN" print system/com.openssh.sshd >/dev/null 2>&1 || probe_rc=$?
+  if [[ $probe_rc -eq 0 ]]; then
+    : # loaded; fall through to the kickstart
+  elif [[ $probe_rc -eq 113 ]]; then
+    printf '[ssh-hardening] sshd is not loaded (Remote Login off); the drop-in applies when it is next enabled.\n'
+    return 0
+  else
+    printf '[ssh-hardening] ERROR: could not determine sshd state (launchctl print failed rc=%d); NOT proceeding as if it were stopped.\n' "$probe_rc" >&2
+    return 1
+  fi
+
+  # Disruptive step: kill + restart in one call.
+  if ! priv "$LAUNCHCTL_BIN" kickstart -k system/com.openssh.sshd; then
+    printf '[ssh-hardening] ERROR: launchctl kickstart failed; sshd may not have restarted. Check: sudo launchctl print system/com.openssh.sshd\n' >&2
+    return 1
+  fi
+
+  # (e) Verify the service came back after the kickstart.
+  if ! priv "$LAUNCHCTL_BIN" print system/com.openssh.sshd >/dev/null 2>&1; then
+    printf '[ssh-hardening] ERROR: sshd did NOT come back after kickstart. Investigate immediately: sudo launchctl print system/com.openssh.sshd\n' >&2
+    return 1
+  fi
+  printf '[ssh-hardening] sshd reloaded and confirmed running.\n'
 }
 
 case "${1:-}" in

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -283,6 +283,12 @@ install_dropin() {
     printf '[ssh-hardening] %s already current\n' "$DROPIN"
   fi
 
+  # Pin a deterministic, non-secret 0644 (world-readable, like Apple's 100-macos.conf).
+  # The drop-in holds NO credential and sshd needs it readable; `tee` alone leaves the
+  # mode to root's umask (022 -> 0644, but a stricter umask -> 0600), so set it
+  # explicitly rather than depend on the ambient umask or make a false "0600" claim.
+  priv chmod 0644 "$DROPIN"
+
   # Migrate the superseded 50- drop-in: it sorted AFTER 100-macos.conf and so was
   # shadowed. Remove it in the same privileged step so no orphan/duplicate lingers.
   if [[ -e $LEGACY_DROPIN ]]; then

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -5,22 +5,67 @@
 # The drop-in file IS the lock: leave it in place permanently. Without it, sshd
 # reverts to its default of allowing password auth.
 #
+# The drop-in is named 000-ssh-hardening.conf so it sorts FIRST under sshd's
+# `Include /etc/ssh/sshd_config.d/*`. That Include is lexical and FIRST-VALUE-WINS,
+# so a file that sorts before ours (e.g. Apple's 100-macos.conf, or any future
+# sibling) would SHADOW the hardening. Sorting first (000- before any 0*/1* file)
+# guarantees our values win. The old name (50-no-password-auth.conf) sorted AFTER
+# 100-macos.conf and was defeated; install migrates it away.
+#
 # Modes:
 #   (default)         write the drop-in if missing or stale (idempotent; needs
-#                     sudo). Does NOT reload sshd (see --reload).
+#                     sudo), migrate the old 50- name, then VERIFY the full
+#                     effective config is hardened. Does NOT reload sshd (--reload).
 #   --print-config    print the drop-in content to stdout and exit. No sudo, no
 #                     writes, no sshd: the pure inspection and test seam.
+#   --print-path      print the managed drop-in's absolute path and exit.
+#   --verify          parse the FULL effective sshd config (main config + every
+#                     drop-in) with `sshd -G` and assert all five hardening values
+#                     are in force. Read-only: no reload, no writes. Nonzero if the
+#                     hardening is shadowed by a sibling drop-in.
 #   --reload          reload sshd so a running daemon picks up the drop-in. This
-#                     is the disruptive, operator-controlled step: a reload can
-#                     drop the current SSH session, so run it deliberately from a
-#                     local console (or with a second session open) and prove
-#                     key auth works in a NEW session before closing the old one.
+#                     is the disruptive, operator-controlled step: it validates the
+#                     complete config first and fails closed, but a reload can drop
+#                     the current SSH session, so run it deliberately from a local
+#                     console (or with a second session open) and prove key auth
+#                     works in a NEW session before closing the old one.
 #
 # On a fresh Mac the drop-in applies the moment Remote Login is first enabled
 # (sshd starts and reads it), so no reload is needed there.
 set -euo pipefail
 
-DROPIN="/etc/ssh/sshd_config.d/50-no-password-auth.conf"
+# Overridable for tests, which target a sandbox tree and drop the sudo prefix.
+SSHD_CONFIG_D="${SSHD_CONFIG_D:-/etc/ssh/sshd_config.d}"
+DROPIN="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+# The superseded name (sorted AFTER 100-macos.conf, so it was shadowed). Migrated
+# away on install.
+LEGACY_DROPIN="$SSHD_CONFIG_D/50-no-password-auth.conf"
+
+SSHD_BIN="${SSHD_BIN:-sshd}"
+SSHD_MAIN_CONFIG="${SSHD_MAIN_CONFIG:-/etc/ssh/sshd_config}"
+# Privilege prefix for live-system reads/writes/reloads. Default sudo; tests set
+# SSH_HARDENING_SUDO="" to operate unprivileged against a sandbox tree.
+SUDO="${SSH_HARDENING_SUDO-sudo}"
+
+# The accepted effective values (the hardening ruling), exactly as `sshd -G` /
+# `sshd -T` print them (lowercased key, single space).
+ACCEPTED_EFFECTIVE=(
+  'passwordauthentication no'
+  'kbdinteractiveauthentication no'
+  'usepam yes'
+  'pubkeyauthentication yes'
+  'permitrootlogin no'
+)
+
+# priv <cmd...> -- run a command with the configured privilege prefix (sudo by
+# default; nothing when SSH_HARDENING_SUDO is empty, e.g. under test).
+priv() {
+  if [[ -n $SUDO ]]; then
+    "$SUDO" "$@"
+  else
+    "$@"
+  fi
+}
 
 # render_dropin -- print the desired drop-in content. Pure: no sudo, no writes.
 # PasswordAuthentication no + KbdInteractiveAuthentication no together close BOTH
@@ -38,18 +83,76 @@ PermitRootLogin no
 EOF
 }
 
-# install_dropin -- write the drop-in when missing or stale (idempotent).
+# assert_effective_config <effective-config-text> -- return 0 iff ALL five accepted
+# values are present. On any mismatch, print a loud per-key WARNING to stderr and
+# return 1. Pure: no sshd, no sudo, no writes -- the unit seam.
+assert_effective_config() {
+  local effective="$1" rc=0 pair key actual
+  for pair in "${ACCEPTED_EFFECTIVE[@]}"; do
+    if ! grep -qxiF "$pair" <<<"$effective"; then
+      key="${pair%% *}"
+      actual="$(grep -iE "^${key} " <<<"$effective" | head -n1 || true)"
+      printf '[ssh-hardening] WARNING: effective sshd config has "%s" but hardening requires "%s"\n' \
+        "${actual:-(no ${key} line)}" "$pair" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
+# verify_effective -- assert the FULL effective sshd config (main config + every
+# drop-in, in sshd's own Include precedence) resolves to the five accepted values.
+# Uses `sshd -G` (read-only, host-key-free: never reloads, never binds). Root is
+# needed to read the mode-0600 managed drop-in, so it runs under the privilege
+# prefix. When sshd is absent it cannot verify: it says so and returns 0 (macOS
+# always ships sshd, so that path is only hit off-target, e.g. Linux CI).
+verify_effective() {
+  if ! command -v "$SSHD_BIN" >/dev/null 2>&1; then
+    printf '[ssh-hardening] NOTE: %s not found; cannot verify the effective config here. On macOS verify with: sudo sshd -T | grep -iE "passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin"\n' \
+      "$SSHD_BIN" >&2
+    return 0
+  fi
+  local effective
+  if ! effective="$(priv "$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>/dev/null)"; then
+    printf '[ssh-hardening] WARNING: could not parse the effective sshd config (%s -G -f %s failed); NOT claiming this host is hardened.\n' \
+      "$SSHD_BIN" "$SSHD_MAIN_CONFIG" >&2
+    return 1
+  fi
+  if assert_effective_config "$effective"; then
+    printf '[ssh-hardening] verified: all five hardening values are in force in the effective config\n'
+    return 0
+  fi
+  return 1
+}
+
+# install_dropin -- write the drop-in when missing or stale (idempotent), migrate
+# the superseded 50- name, then verify the full effective config is hardened.
 install_dropin() {
   local desired current
   desired="$(render_dropin)"
   current=""
-  [[ -f $DROPIN ]] && current="$(sudo cat "$DROPIN" 2>/dev/null || true)"
+  [[ -f $DROPIN ]] && current="$(priv cat "$DROPIN" 2>/dev/null || true)"
   if [[ $current != "$desired" ]]; then
-    render_dropin | sudo tee "$DROPIN" >/dev/null
+    render_dropin | priv tee "$DROPIN" >/dev/null
     printf '[ssh-hardening] wrote %s\n' "$DROPIN"
   else
     printf '[ssh-hardening] %s already current\n' "$DROPIN"
   fi
+
+  # Migrate the superseded 50- drop-in: it sorted AFTER 100-macos.conf and so was
+  # shadowed. Remove it in the same privileged step so no orphan/duplicate lingers.
+  if [[ -e $LEGACY_DROPIN ]]; then
+    priv rm -f "$LEGACY_DROPIN"
+    printf '[ssh-hardening] removed superseded drop-in %s\n' "$LEGACY_DROPIN"
+  fi
+
+  # Defense in depth: the drop-in must WIN over every sibling (e.g. a future hostile
+  # 100-macos.conf). Refuse to claim success if any of the five is not accepted.
+  if ! verify_effective; then
+    printf '[ssh-hardening] ERROR: the drop-in is in place but the effective sshd config is NOT fully hardened -- a sibling drop-in is overriding it. Resolve before relying on this host.\n' >&2
+    return 1
+  fi
+
   printf '[ssh-hardening] drop-in in place; run ssh-hardening.sh --reload (or re-enable Remote Login) to activate it on a running sshd\n'
 }
 
@@ -69,6 +172,12 @@ case "${1:-}" in
   --print-config)
     render_dropin
     ;;
+  --print-path)
+    printf '%s\n' "$DROPIN"
+    ;;
+  --verify)
+    verify_effective
+    ;;
   --reload)
     do_reload
     ;;
@@ -76,7 +185,7 @@ case "${1:-}" in
     install_dropin
     ;;
   *)
-    printf 'usage: ssh-hardening.sh [--print-config | --reload]\n' >&2
+    printf 'usage: ssh-hardening.sh [--print-config | --print-path | --verify | --reload]\n' >&2
     exit 2
     ;;
 esac

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -67,17 +67,20 @@ ACCEPTED_EFFECTIVE=(
   'permitrootlogin no'
 )
 
-# The four auth directives that MAY appear inside a `Match` block, each with its
-# hardened value. A Match block that sets any of these to a different value re-enables
-# it for the matching connections (the criteria-based bypass `sshd -G` alone is blind
-# to). UsePAM is intentionally absent: it is not a Match-scoped keyword. Keys are
-# lowercased (sshd keywords are case-insensitive).
-declare -A PROTECTED_MATCH_HARDENED=(
-  [passwordauthentication]=no
-  [kbdinteractiveauthentication]=no
-  [pubkeyauthentication]=yes
-  [permitrootlogin]=no
-)
+# hardened_value_for <lowercased-keyword> -- echo the hardened value for a protected
+# Match-scoped auth directive, or nothing if the keyword is not one. A Match block that
+# sets one of these to a different value re-enables it for the matching connections
+# (the criteria-based bypass `sshd -G` alone is blind to). UsePAM is intentionally
+# absent: it is not a Match-scoped keyword. A `case` (not an associative array)
+# because macOS's stock /bin/bash is 3.2, which lacks `declare -A` -- and the script's
+# shebang selects that interpreter.
+hardened_value_for() {
+  case "$1" in
+    passwordauthentication | kbdinteractiveauthentication | permitrootlogin) printf 'no' ;;
+    pubkeyauthentication) printf 'yes' ;;
+    *) : ;;
+  esac
+}
 
 # Representative connection specs for the authoritative per-connection resolution
 # (`sshd -G -T -C`). A privileged (root) login and an ordinary user, from a sample
@@ -132,6 +135,19 @@ assert_effective_config() {
   return "$rc"
 }
 
+# expand_include_glob <glob-pattern> -- print the regular files matching an sshd
+# Include glob, honoring its basename pattern, in lexical (sshd) order. Uses `find`
+# (a stock binary) rather than `compgen -G` (not a builtin in every bash build -- it
+# is absent under nix bash --norc) or an unquoted variable glob. Empty when nothing
+# matches or the directory is absent.
+expand_include_glob() {
+  local pattern="$1" dir base
+  dir="$(dirname "$pattern")"
+  base="$(basename "$pattern")"
+  [[ -d $dir ]] || return 0
+  find "$dir" -maxdepth 1 -type f -name "$base" 2>/dev/null | LC_ALL=C sort
+}
+
 # enumerate_config_files <main-config> -- print the main config path, then every file
 # it Includes, expanded in sshd's own lexical order. Handles absolute and
 # base-relative Include globs (one level -- the drop-in dir; the authoritative
@@ -154,7 +170,7 @@ enumerate_config_files() {
       [[ $pat == /* ]] && abspat="$pat" || abspat="$base/$pat"
       while IFS= read -r match; do
         printf '%s\n' "$match"
-      done < <(compgen -G "$abspat" 2>/dev/null | LC_ALL=C sort)
+      done < <(expand_include_glob "$abspat")
     done
   done < <(priv cat "$main" 2>/dev/null || true)
 }
@@ -176,7 +192,7 @@ scan_one_file_match() {
       continue
     fi
     [[ $in_match -eq 1 ]] || continue
-    hardened="${PROTECTED_MATCH_HARDENED[$lc_kw]:-}"
+    hardened="$(hardened_value_for "$lc_kw")"
     [[ -n $hardened ]] || continue
     lc_val="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
     if [[ $lc_val != "$hardened" ]]; then

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# macos-defaults-lib.sh -- shared helpers for the macos-defaults-{apply,capture,
+# drift} tools. Sourced, never executed. Deployed to ~/.local/bin alongside the
+# tools; each sources it via
+#   source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
+# which resolves in BOTH the chezmoi source tree (dot_local/bin/) and the applied
+# ~/.local/bin layout, because this lib carries no executable_/dot_ rename, so its
+# basename is identical in both.
+
+# resolve_source_dir -- print the chezmoi source directory for the CURRENT context.
+#
+# Fixes the worktree-writes-primary bug: the tools used to hardcode the primary
+# checkout ("${HOME}/workspaces/Ivy/webdavis/dotfiles"), so a `just defaults-*` run
+# from a SECONDARY git worktree wrote (or read) the PRIMARY tree's YAML instead of
+# the worktree the operator is standing in. Resolution order:
+#   1. $MACOS_DEFAULTS_SOURCE_DIR, when set: an explicit override.
+#   2. The current git worktree's top-level, when it carries this repo's
+#      .chezmoidata/macos_defaults.yaml -- so a run from a secondary worktree
+#      targets THAT worktree. It is routed through `chezmoi --source=<top>
+#      source-path` so chezmoi normalizes and validates the path.
+#   3. Otherwise chezmoi's configured source dir (`chezmoi source-path`).
+resolve_source_dir() {
+  if [[ -n ${MACOS_DEFAULTS_SOURCE_DIR:-} ]]; then
+    printf '%s\n' "$MACOS_DEFAULTS_SOURCE_DIR"
+    return 0
+  fi
+  local top
+  if top="$(git rev-parse --show-toplevel 2>/dev/null)" &&
+    [[ -f "$top/.chezmoidata/macos_defaults.yaml" ]]; then
+    chezmoi --source="$top" source-path
+    return 0
+  fi
+  chezmoi source-path
+}
+
+# macos_defaults_data_file -- print the resolved path to macos_defaults.yaml.
+macos_defaults_data_file() {
+  local src
+  src="$(resolve_source_dir)" || return 1
+  printf '%s/.chezmoidata/macos_defaults.yaml\n' "$src"
+}
+
+# require_readable_data_file <path> -- exit 2 with a message if the file is not
+# readable (the shared "data file missing or unreadable" guard).
+require_readable_data_file() {
+  local file="$1"
+  if [[ ! -r $file ]]; then
+    printf 'error: cannot read %s\n' "$file" >&2
+    exit 2
+  fi
+}
+
+# defaults_records_tsv <path> -- emit each tracked record as one TSV line:
+#   domain<TAB>key<TAB>type<TAB>value<TAB>host   (host empty when global).
+# yq emits a single blank line for an empty array; callers skip the empty row.
+defaults_records_tsv() {
+  local file="$1"
+  yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$file"
+}

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -24,10 +24,14 @@ resolve_source_dir() {
     printf '%s\n' "$MACOS_DEFAULTS_SOURCE_DIR"
     return 0
   fi
-  local top
+  local top resolved
   if top="$(git rev-parse --show-toplevel 2>/dev/null)" &&
     [[ -f "$top/.chezmoidata/macos_defaults.yaml" ]]; then
-    chezmoi --source="$top" source-path
+    if ! resolved="$(chezmoi --source="$top" source-path)"; then
+      printf 'error: chezmoi --source=%s source-path failed\n' "$top" >&2
+      return 1
+    fi
+    printf '%s\n' "$resolved"
     return 0
   fi
   chezmoi source-path

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1123,7 +1123,7 @@
       "label": "usage()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L23",
+      "source_location": "L29",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1165,7 +1165,7 @@
       "label": "normalize()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L25",
+      "source_location": "L28",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1179,7 +1179,7 @@
       "label": "print_header()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L41",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1958,6 +1958,48 @@
       "id": "dot_local_bin_executable_ssh_hardening_sh__entry",
       "community": 263,
       "norm_label": "executable_ssh-hardening.sh script"
+    },
+    {
+      "label": "render_dropin()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L30",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_render_dropin",
+      "community": 263,
+      "norm_label": "render_dropin()"
+    },
+    {
+      "label": "install_dropin()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L42",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "community": 263,
+      "norm_label": "install_dropin()"
+    },
+    {
+      "label": "do_reload()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L59",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "community": 263,
+      "norm_label": "do_reload()"
     },
     {
       "label": "executable_update-skills.sh",
@@ -3120,6 +3162,90 @@
       "id": "dot_local_bin_executable_update_skills_check_fork_drift",
       "community": 0,
       "norm_label": "check_fork_drift()"
+    },
+    {
+      "label": "macos-defaults-lib.sh",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib",
+      "community": 304,
+      "norm_label": "macos-defaults-lib.sh"
+    },
+    {
+      "label": "macos-defaults-lib.sh script",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_sh__entry",
+      "community": 304,
+      "norm_label": "macos-defaults-lib.sh script"
+    },
+    {
+      "label": "resolve_source_dir()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L22",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_resolve_source_dir",
+      "community": 304,
+      "norm_label": "resolve_source_dir()"
+    },
+    {
+      "label": "macos_defaults_data_file()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_macos_defaults_data_file",
+      "community": 304,
+      "norm_label": "macos_defaults_data_file()"
+    },
+    {
+      "label": "require_readable_data_file()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L45",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_require_readable_data_file",
+      "community": 304,
+      "norm_label": "require_readable_data_file()"
+    },
+    {
+      "label": "defaults_records_tsv()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L56",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_tsv",
+      "community": 304,
+      "norm_label": "defaults_records_tsv()"
     },
     {
       "label": "main.rs",
@@ -5188,10 +5314,24 @@
       "norm_label": "teardown_harness()"
     },
     {
+      "label": "wait_for_log_match()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-alerter-lib.bash",
+      "source_location": "L90",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_alerter_lib_wait_for_log_match",
+      "community": 290,
+      "norm_label": "wait_for_log_match()"
+    },
+    {
       "label": "setup_poller_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L87",
+      "source_location": "L102",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5205,7 +5345,7 @@
       "label": "run_poller()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L101",
+      "source_location": "L116",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5219,7 +5359,7 @@
       "label": "run_poller_firstrun()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L112",
+      "source_location": "L127",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5233,7 +5373,7 @@
       "label": "run_poller_badperms()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L123",
+      "source_location": "L138",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5247,7 +5387,7 @@
       "label": "setup_watchdog_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L139",
+      "source_location": "L154",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5261,7 +5401,7 @@
       "label": "run_watchdog()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L166",
+      "source_location": "L184",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5275,7 +5415,7 @@
       "label": "seed_spool_file()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L177",
+      "source_location": "L195",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5289,7 +5429,7 @@
       "label": "setup_redaction_h2_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L193",
+      "source_location": "L211",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5303,7 +5443,7 @@
       "label": "run_redaction_h2()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L206",
+      "source_location": "L224",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5317,7 +5457,7 @@
       "label": "run_alerter_hardfail_spool()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L228",
+      "source_location": "L246",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5331,7 +5471,7 @@
       "label": "run_h2_drain()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L249",
+      "source_location": "L267",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5345,7 +5485,7 @@
       "label": "setup_heartbeat_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L263",
+      "source_location": "L281",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5359,7 +5499,7 @@
       "label": "seed_canary()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L271",
+      "source_location": "L289",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5373,7 +5513,7 @@
       "label": "run_heartbeat()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L280",
+      "source_location": "L298",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5387,7 +5527,7 @@
       "label": "setup_allowlist_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L290",
+      "source_location": "L308",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5401,7 +5541,7 @@
       "label": "teardown_allowlist_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L301",
+      "source_location": "L319",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5415,7 +5555,7 @@
       "label": "run_allowlist()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L304",
+      "source_location": "L322",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5429,7 +5569,7 @@
       "label": "assert_allowlisted()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L310",
+      "source_location": "L328",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5443,7 +5583,7 @@
       "label": "assert_not_allowlisted()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L316",
+      "source_location": "L334",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5457,7 +5597,7 @@
       "label": "assert_allowlist_label_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L323",
+      "source_location": "L341",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5471,7 +5611,7 @@
       "label": "digest_record()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L334",
+      "source_location": "L352",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5485,7 +5625,7 @@
       "label": "setup_tailscale_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L341",
+      "source_location": "L359",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5499,7 +5639,7 @@
       "label": "_seed_ts_state()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L354",
+      "source_location": "L372",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5513,7 +5653,7 @@
       "label": "run_tailscale_monitor()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L367",
+      "source_location": "L385",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5527,7 +5667,7 @@
       "label": "run_tailscale_monitor_missing_bin()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L378",
+      "source_location": "L396",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5541,7 +5681,7 @@
       "label": "run_tailscale_monitor_path_resolved()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L388",
+      "source_location": "L406",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5555,7 +5695,7 @@
       "label": "tailscale_state_funnel()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L398",
+      "source_location": "L416",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5569,7 +5709,7 @@
       "label": "seed_digest()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L401",
+      "source_location": "L419",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5583,7 +5723,7 @@
       "label": "run_digest()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L407",
+      "source_location": "L425",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5597,7 +5737,7 @@
       "label": "run_alerter()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L412",
+      "source_location": "L430",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5611,7 +5751,7 @@
       "label": "run_alerter_cursor()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L430",
+      "source_location": "L448",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5625,7 +5765,7 @@
       "label": "cursor_offset()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L452",
+      "source_location": "L470",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5639,7 +5779,7 @@
       "label": "assert_no_page()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L463",
+      "source_location": "L481",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5653,7 +5793,7 @@
       "label": "assert_page_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L470",
+      "source_location": "L488",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5667,7 +5807,7 @@
       "label": "assert_warn_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L477",
+      "source_location": "L495",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5681,7 +5821,7 @@
       "label": "assert_page_lacks()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L486",
+      "source_location": "L504",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5695,7 +5835,7 @@
       "label": "setup_dispatch_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L496",
+      "source_location": "L514",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5709,7 +5849,7 @@
       "label": "set_curl_codes()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L533",
+      "source_location": "L551",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5723,7 +5863,7 @@
       "label": "wait_for_alerter()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L537",
+      "source_location": "L555",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5737,7 +5877,7 @@
       "label": "run_drain()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L548",
+      "source_location": "L566",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5751,7 +5891,7 @@
       "label": "assert_spool_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L551",
+      "source_location": "L569",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5765,7 +5905,7 @@
       "label": "assert_mode()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L561",
+      "source_location": "L579",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5779,7 +5919,7 @@
       "label": "assert_post_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L571",
+      "source_location": "L589",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5793,7 +5933,7 @@
       "label": "assert_posted_to()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L581",
+      "source_location": "L599",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5807,7 +5947,7 @@
       "label": "assert_no_post()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L589",
+      "source_location": "L607",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5821,7 +5961,7 @@
       "label": "assert_no_dispatch()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L597",
+      "source_location": "L615",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5835,7 +5975,7 @@
       "label": "assert_digest_sent()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L605",
+      "source_location": "L623",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5849,7 +5989,7 @@
       "label": "assert_digest_silent()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L619",
+      "source_location": "L637",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5863,7 +6003,7 @@
       "label": "assert_digest_body_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L629",
+      "source_location": "L647",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5877,7 +6017,7 @@
       "label": "assert_store_rotated()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L637",
+      "source_location": "L655",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -5891,7 +6031,7 @@
       "label": "assert_digest_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L649",
+      "source_location": "L667",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6924,6 +7064,90 @@
       "norm_label": "make_brew()"
     },
     {
+      "label": "macos-defaults-source-path.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path",
+      "community": 305,
+      "norm_label": "macos-defaults-source-path.sh"
+    },
+    {
+      "label": "macos-defaults-source-path.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_sh__entry",
+      "community": 305,
+      "norm_label": "macos-defaults-source-path.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L27",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_fail",
+      "community": 305,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "macos-system-setup-sudo-guard.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard",
+      "community": 12,
+      "norm_label": "macos-system-setup-sudo-guard.sh"
+    },
+    {
+      "label": "macos-system-setup-sudo-guard.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "community": 12,
+      "norm_label": "macos-system-setup-sudo-guard.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L18",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_fail",
+      "community": 12,
+      "norm_label": "fail()"
+    },
+    {
       "label": "openclaw-services-retirement.sh",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
@@ -7916,6 +8140,62 @@
       "id": "test_integration_run_camp_runner_run_camp",
       "community": 187,
       "norm_label": "run_camp()"
+    },
+    {
+      "label": "ssh-hardening-sshd-validate.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate",
+      "community": 307,
+      "norm_label": "ssh-hardening-sshd-validate.sh"
+    },
+    {
+      "label": "ssh-hardening-sshd-validate.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "community": 307,
+      "norm_label": "ssh-hardening-sshd-validate.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L22",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_fail",
+      "community": 307,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "want",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L50",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_want",
+      "community": 307,
+      "norm_label": "want"
     },
     {
       "label": "tailnet-pins.sh",
@@ -11880,6 +12160,160 @@
       "norm_label": "assert_kv()"
     },
     {
+      "label": "macos-security-posture.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture",
+      "community": 308,
+      "norm_label": "macos-security-posture.sh"
+    },
+    {
+      "label": "macos-security-posture.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_sh__entry",
+      "community": 308,
+      "norm_label": "macos-security-posture.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L20",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_fail",
+      "community": 308,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "make_stub()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L49",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_make_stub",
+      "community": 308,
+      "norm_label": "make_stub()"
+    },
+    {
+      "label": "run_case()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_run_case",
+      "community": 308,
+      "norm_label": "run_case()"
+    },
+    {
+      "label": "report()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L79",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_report",
+      "community": 308,
+      "norm_label": "report()"
+    },
+    {
+      "label": "a0()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L85",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_a0",
+      "community": 308,
+      "norm_label": "a0()"
+    },
+    {
+      "label": "anomut()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L87",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_anomut",
+      "community": 308,
+      "norm_label": "anomut()"
+    },
+    {
+      "label": "outhas()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L88",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_outhas",
+      "community": 308,
+      "norm_label": "outhas()"
+    },
+    {
+      "label": "errhas()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L89",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_errhas",
+      "community": 308,
+      "norm_label": "errhas()"
+    },
+    {
+      "label": "errno()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L90",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_errno",
+      "community": 308,
+      "norm_label": "errno()"
+    },
+    {
       "label": "relay-codex-hooks.sh",
       "file_type": "code",
       "source_file": "test/unit/relay-codex-hooks.sh",
@@ -12132,6 +12566,76 @@
       "norm_label": "hermes_declaration_dirs()"
     },
     {
+      "label": "ssh-hardening-dropin.sh",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin",
+      "community": 270,
+      "norm_label": "ssh-hardening-dropin.sh"
+    },
+    {
+      "label": "ssh-hardening-dropin.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_sh__entry",
+      "community": 270,
+      "norm_label": "ssh-hardening-dropin.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L24",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_fail",
+      "community": 270,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "want",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L35",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_want",
+      "community": 270,
+      "norm_label": "want"
+    },
+    {
+      "label": "forbid",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L49",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_forbid",
+      "community": 270,
+      "norm_label": "forbid"
+    },
+    {
       "label": "tailscaled-status.sh",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
@@ -12342,333 +12846,333 @@
       "norm_label": "update_skills_lib_only"
     },
     {
-      "label": "CLAUDE.md",
+      "label": "AGENTS.md",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L1",
       "_origin": "ast",
-      "id": "claude",
-      "community": 12,
-      "norm_label": "claude.md"
+      "id": "agents",
+      "community": 303,
+      "norm_label": "agents.md"
     },
     {
       "label": "CLAUDE.md",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L7",
       "_origin": "ast",
-      "id": "claude_claude_md",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "community": 303,
       "norm_label": "claude.md"
     },
     {
       "label": "What This Is",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L11",
       "_origin": "ast",
-      "id": "claude_what_this_is",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_what_this_is",
+      "community": 303,
       "norm_label": "what this is"
     },
     {
       "label": "Key Commands",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L18",
       "_origin": "ast",
-      "id": "claude_key_commands",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "community": 303,
       "norm_label": "key commands"
     },
     {
       "label": "Linting & Formatting",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L20",
       "_origin": "ast",
-      "id": "claude_linting_formatting",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_linting_formatting",
+      "community": 303,
       "norm_label": "linting & formatting"
     },
     {
       "label": "Testing",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L46",
       "_origin": "ast",
-      "id": "claude_testing",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_testing",
+      "community": 303,
       "norm_label": "testing"
     },
     {
       "label": "Chezmoi Operations",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L74",
       "_origin": "ast",
-      "id": "claude_chezmoi_operations",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_chezmoi_operations",
+      "community": 303,
       "norm_label": "chezmoi operations"
     },
     {
       "label": "Claude Code Settings",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L102",
       "_origin": "ast",
-      "id": "claude_claude_code_settings",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_code_settings",
+      "community": 303,
       "norm_label": "claude code settings"
     },
     {
       "label": "Git Hooks",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L135",
       "_origin": "ast",
-      "id": "claude_git_hooks",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_hooks",
+      "community": 303,
       "norm_label": "git hooks"
     },
     {
       "label": "Architecture",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L178",
       "_origin": "ast",
-      "id": "claude_architecture",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "community": 303,
       "norm_label": "architecture"
     },
     {
       "label": "Source-Only Files",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L180",
       "_origin": "ast",
-      "id": "claude_source_only_files",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_source_only_files",
+      "community": 303,
       "norm_label": "source-only files"
     },
     {
       "label": "Minimum Chezmoi Version",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L188",
       "_origin": "ast",
-      "id": "claude_minimum_chezmoi_version",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_minimum_chezmoi_version",
+      "community": 303,
       "norm_label": "minimum chezmoi version"
     },
     {
       "label": "Secrets Management",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L192",
       "_origin": "ast",
-      "id": "claude_secrets_management",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_secrets_management",
+      "community": 303,
       "norm_label": "secrets management"
     },
     {
       "label": "System Package Management",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L199",
       "_origin": "ast",
-      "id": "claude_system_package_management",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_system_package_management",
+      "community": 303,
       "norm_label": "system package management"
     },
     {
       "label": "macOS Defaults Management",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L224",
       "_origin": "ast",
-      "id": "claude_macos_defaults_management",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_macos_defaults_management",
+      "community": 303,
       "norm_label": "macos defaults management"
     },
     {
       "label": "Template Files",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L269",
       "_origin": "ast",
-      "id": "claude_template_files",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_template_files",
+      "community": 303,
       "norm_label": "template files"
     },
     {
       "label": "Template Shellcheck Workaround",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L275",
       "_origin": "ast",
-      "id": "claude_template_shellcheck_workaround",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_template_shellcheck_workaround",
+      "community": 303,
       "norm_label": "template shellcheck workaround"
     },
     {
       "label": "OS Targeting",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L296",
       "_origin": "ast",
-      "id": "claude_os_targeting",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_os_targeting",
+      "community": 303,
       "norm_label": "os targeting"
     },
     {
       "label": "Dev Environment (Nix Flake)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L301",
       "_origin": "ast",
-      "id": "claude_dev_environment_nix_flake",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_dev_environment_nix_flake",
+      "community": 303,
       "norm_label": "dev environment (nix flake)"
     },
     {
       "label": "CI",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L312",
       "_origin": "ast",
-      "id": "claude_ci",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_ci",
+      "community": 303,
       "norm_label": "ci"
     },
     {
       "label": "Agent Skills (cross-harness store)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L322",
       "_origin": "ast",
-      "id": "claude_agent_skills_cross_harness_store",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_agent_skills_cross_harness_store",
+      "community": 303,
       "norm_label": "agent skills (cross-harness store)"
     },
     {
       "label": "Herdr Workspace Management",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L492",
       "_origin": "ast",
-      "id": "claude_herdr_workspace_management",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_herdr_workspace_management",
+      "community": 303,
       "norm_label": "herdr workspace management"
     },
     {
       "label": "Git Worktrees (Worktrunk)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L512",
       "_origin": "ast",
-      "id": "claude_git_worktrees_worktrunk",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_worktrees_worktrunk",
+      "community": 303,
       "norm_label": "git worktrees (worktrunk)"
     },
     {
       "label": "Bashrc Init Ordering",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L519",
       "_origin": "ast",
-      "id": "claude_bashrc_init_ordering",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_bashrc_init_ordering",
+      "community": 303,
       "norm_label": "bashrc init ordering"
     },
     {
       "label": "Shell History (Atuin)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L528",
       "_origin": "ast",
-      "id": "claude_shell_history_atuin",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_shell_history_atuin",
+      "community": 303,
       "norm_label": "shell history (atuin)"
     },
     {
       "label": "Happy Daemon (Remote Agent Control)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L557",
       "_origin": "ast",
-      "id": "claude_happy_daemon_remote_agent_control",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_happy_daemon_remote_agent_control",
+      "community": 303,
       "norm_label": "happy daemon (remote agent control)"
     },
     {
       "label": "Tailscale (headless daemon)",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L584",
       "_origin": "ast",
-      "id": "claude_tailscale_headless_daemon",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_tailscale_headless_daemon",
+      "community": 303,
       "norm_label": "tailscale (headless daemon)"
     },
     {
       "label": "AI Commit Messages",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L621",
       "_origin": "ast",
-      "id": "claude_ai_commit_messages",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_ai_commit_messages",
+      "community": 303,
       "norm_label": "ai commit messages"
     },
     {
       "label": "Long-running Command Notifier",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L634",
       "_origin": "ast",
-      "id": "claude_long_running_command_notifier",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_long_running_command_notifier",
+      "community": 303,
       "norm_label": "long-running command notifier"
     },
     {
       "label": "Herdr Native Status",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L640",
       "_origin": "ast",
-      "id": "claude_herdr_native_status",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_herdr_native_status",
+      "community": 303,
       "norm_label": "herdr native status"
     },
     {
       "label": "Code Style",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L646",
       "_origin": "ast",
-      "id": "claude_code_style",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_code_style",
+      "community": 303,
       "norm_label": "code style"
     },
     {
       "label": "Git Commits",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L672",
       "_origin": "ast",
-      "id": "claude_git_commits",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_commits",
+      "community": 303,
       "norm_label": "git commits"
     },
     {
       "label": "Security",
       "file_type": "document",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L679",
       "_origin": "ast",
-      "id": "claude_security",
-      "community": 12,
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_security",
+      "community": 303,
       "norm_label": "security"
     },
     {
@@ -18728,7 +19232,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "docs_research_2026_04_26_macos_defaults_management_introduction",
-      "community": 270,
+      "community": 306,
       "norm_label": "introduction"
     },
     {
@@ -18738,7 +19242,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "docs_research_2026_04_26_macos_defaults_management_scope",
-      "community": 270,
+      "community": 306,
       "norm_label": "scope"
     },
     {
@@ -18748,7 +19252,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "docs_research_2026_04_26_macos_defaults_management_methodology",
-      "community": 270,
+      "community": 306,
       "norm_label": "methodology"
     },
     {
@@ -18758,7 +19262,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "docs_research_2026_04_26_macos_defaults_management_key_assumptions",
-      "community": 270,
+      "community": 306,
       "norm_label": "key assumptions"
     },
     {
@@ -32099,7 +32603,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L23",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_capture",
       "target": "dot_local_bin_executable_macos_defaults_capture_usage",
@@ -32109,7 +32613,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L28",
+      "source_location": "L34",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_macos_defaults_capture_sh__entry",
@@ -32120,7 +32624,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L25",
+      "source_location": "L28",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_drift",
       "target": "dot_local_bin_executable_macos_defaults_drift_normalize",
@@ -32130,7 +32634,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L41",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_drift",
       "target": "dot_local_bin_executable_macos_defaults_drift_print_header",
@@ -32150,7 +32654,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L61",
+      "source_location": "L64",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_macos_defaults_drift_sh__entry",
@@ -32741,7 +33245,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_osquery-tailscale-monitor.sh",
-      "source_location": "L86",
+      "source_location": "L89",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_osquery_tailscale_monitor_sh__entry",
@@ -32821,6 +33325,36 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_render_dropin",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
@@ -32828,6 +33362,50 @@
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L73",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "target": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L76",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L70",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "target": "dot_local_bin_executable_ssh_hardening_render_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L48",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_render_dropin",
       "confidence_score": 1.0
     },
     {
@@ -35367,6 +35945,56 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_tsv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_macos_defaults_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_require_readable_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_resolve_source_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/share/herdr/plugins/herdr-last-workspace/src/main.rs",
@@ -37685,7 +38313,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L323",
+      "source_location": "L341",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_allowlist_label_count",
@@ -37695,7 +38323,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L310",
+      "source_location": "L328",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_allowlisted",
@@ -37705,7 +38333,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L629",
+      "source_location": "L647",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_digest_body_has",
@@ -37715,7 +38343,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L649",
+      "source_location": "L667",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_digest_count",
@@ -37725,7 +38353,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L605",
+      "source_location": "L623",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_digest_sent",
@@ -37735,7 +38363,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L619",
+      "source_location": "L637",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_digest_silent",
@@ -37745,7 +38373,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L561",
+      "source_location": "L579",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_mode",
@@ -37755,7 +38383,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L597",
+      "source_location": "L615",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_no_dispatch",
@@ -37765,7 +38393,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L463",
+      "source_location": "L481",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_no_page",
@@ -37775,7 +38403,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L589",
+      "source_location": "L607",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_no_post",
@@ -37785,7 +38413,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L316",
+      "source_location": "L334",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_not_allowlisted",
@@ -37795,7 +38423,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L470",
+      "source_location": "L488",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_page_has",
@@ -37805,7 +38433,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L486",
+      "source_location": "L504",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_page_lacks",
@@ -37815,7 +38443,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L571",
+      "source_location": "L589",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_post_count",
@@ -37825,7 +38453,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L581",
+      "source_location": "L599",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_posted_to",
@@ -37835,7 +38463,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L551",
+      "source_location": "L569",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_spool_count",
@@ -37845,7 +38473,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L637",
+      "source_location": "L655",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_store_rotated",
@@ -37855,7 +38483,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L477",
+      "source_location": "L495",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_assert_warn_has",
@@ -37875,7 +38503,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L452",
+      "source_location": "L470",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_cursor_offset",
@@ -37885,7 +38513,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L334",
+      "source_location": "L352",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_digest_record",
@@ -37925,7 +38553,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L412",
+      "source_location": "L430",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_alerter",
@@ -37935,7 +38563,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L430",
+      "source_location": "L448",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_alerter_cursor",
@@ -37945,7 +38573,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L228",
+      "source_location": "L246",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_alerter_hardfail_spool",
@@ -37955,7 +38583,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L304",
+      "source_location": "L322",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_allowlist",
@@ -37965,7 +38593,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L407",
+      "source_location": "L425",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_digest",
@@ -37975,7 +38603,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L548",
+      "source_location": "L566",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_drain",
@@ -37985,7 +38613,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L249",
+      "source_location": "L267",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_h2_drain",
@@ -37995,7 +38623,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L280",
+      "source_location": "L298",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_heartbeat",
@@ -38005,7 +38633,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L101",
+      "source_location": "L116",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_poller",
@@ -38015,7 +38643,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L123",
+      "source_location": "L138",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_poller_badperms",
@@ -38025,7 +38653,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L112",
+      "source_location": "L127",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_poller_firstrun",
@@ -38035,7 +38663,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L206",
+      "source_location": "L224",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_redaction_h2",
@@ -38045,7 +38673,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L367",
+      "source_location": "L385",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor",
@@ -38055,7 +38683,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L378",
+      "source_location": "L396",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor_missing_bin",
@@ -38065,7 +38693,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L388",
+      "source_location": "L406",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor_path_resolved",
@@ -38075,7 +38703,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L166",
+      "source_location": "L184",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_run_watchdog",
@@ -38095,7 +38723,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L271",
+      "source_location": "L289",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_seed_canary",
@@ -38105,7 +38733,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L401",
+      "source_location": "L419",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_seed_digest",
@@ -38125,7 +38753,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L177",
+      "source_location": "L195",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_seed_spool_file",
@@ -38135,7 +38763,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L354",
+      "source_location": "L372",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_seed_ts_state",
@@ -38145,7 +38773,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L533",
+      "source_location": "L551",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_set_curl_codes",
@@ -38155,7 +38783,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L290",
+      "source_location": "L308",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_allowlist_harness",
@@ -38165,7 +38793,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L496",
+      "source_location": "L514",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_dispatch_harness",
@@ -38185,7 +38813,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L263",
+      "source_location": "L281",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_heartbeat_harness",
@@ -38195,7 +38823,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L87",
+      "source_location": "L102",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_poller_harness",
@@ -38205,7 +38833,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L193",
+      "source_location": "L211",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_redaction_h2_harness",
@@ -38215,7 +38843,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L341",
+      "source_location": "L359",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_tailscale_harness",
@@ -38225,7 +38853,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L139",
+      "source_location": "L154",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_setup_watchdog_harness",
@@ -38235,7 +38863,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L398",
+      "source_location": "L416",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_tailscale_state_funnel",
@@ -38245,7 +38873,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L301",
+      "source_location": "L319",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_teardown_allowlist_harness",
@@ -38265,17 +38893,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L537",
+      "source_location": "L555",
       "weight": 1.0,
       "source": "test_fixtures_osquery_alerter_lib",
       "target": "test_fixtures_osquery_alerter_lib_wait_for_alerter",
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-alerter-lib.bash",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_alerter_lib",
+      "target": "test_fixtures_osquery_alerter_lib_wait_for_log_match",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L264",
+      "source_location": "L282",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_setup_heartbeat_harness",
@@ -38286,7 +38924,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L88",
+      "source_location": "L103",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_setup_poller_harness",
@@ -38297,7 +38935,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L194",
+      "source_location": "L212",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_setup_redaction_h2_harness",
@@ -38308,7 +38946,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L342",
+      "source_location": "L360",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_setup_tailscale_harness",
@@ -38319,7 +38957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L140",
+      "source_location": "L155",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_setup_watchdog_harness",
@@ -38330,7 +38968,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L368",
+      "source_location": "L386",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor",
@@ -38341,7 +38979,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L379",
+      "source_location": "L397",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor_missing_bin",
@@ -38352,7 +38990,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-alerter-lib.bash",
-      "source_location": "L389",
+      "source_location": "L407",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_alerter_lib_run_tailscale_monitor_path_resolved",
@@ -39480,6 +40118,68 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L40",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
       "source_location": "L264",
       "weight": 1.0,
@@ -40600,6 +41300,47 @@
       "context": "call",
       "source": "test_integration_run_camp_runner_sh__entry",
       "target": "test_integration_run_camp_runner_run_camp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_want",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "target": "test_integration_ssh_hardening_sshd_validate_fail",
       "confidence_score": 1.0
     },
     {
@@ -44022,6 +44763,249 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_a0",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L87",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_anomut",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L89",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_errhas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_errno",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_make_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L88",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_outhas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_a0",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L97",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_anomut",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L107",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_errhas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L101",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_errno",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L98",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_outhas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L95",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L68",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_run_case",
+      "target": "test_unit_macos_security_posture_make_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_a0",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L87",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_anomut",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L89",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_errhas",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L90",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_errno",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L88",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_outhas",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/relay-codex-hooks.sh",
@@ -44236,6 +45220,57 @@
       "context": "call",
       "source": "test_unit_skills_roster_fanout_roster",
       "target": "test_unit_skills_roster_fanout_vendored_dirs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_forbid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_want",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_dropin_sh__entry",
+      "target": "test_unit_ssh_hardening_dropin_fail",
       "confidence_score": 1.0
     },
     {
@@ -44503,321 +45538,321 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L7",
       "weight": 1.0,
-      "source": "claude",
-      "target": "claude_claude_md",
+      "source": "agents",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L178",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_architecture",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L646",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_code_style",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_code_style",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L672",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_git_commits",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_commits",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L18",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_key_commands",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L679",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_security",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_security",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L11",
       "weight": 1.0,
-      "source": "claude_claude_md",
-      "target": "claude_what_this_is",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_what_this_is",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L74",
       "weight": 1.0,
-      "source": "claude_key_commands",
-      "target": "claude_chezmoi_operations",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_chezmoi_operations",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L102",
       "weight": 1.0,
-      "source": "claude_key_commands",
-      "target": "claude_claude_code_settings",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_claude_code_settings",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L135",
       "weight": 1.0,
-      "source": "claude_key_commands",
-      "target": "claude_git_hooks",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_hooks",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L20",
       "weight": 1.0,
-      "source": "claude_key_commands",
-      "target": "claude_linting_formatting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_linting_formatting",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L46",
       "weight": 1.0,
-      "source": "claude_key_commands",
-      "target": "claude_testing",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_testing",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L322",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_agent_skills_cross_harness_store",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_agent_skills_cross_harness_store",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L621",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_ai_commit_messages",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_ai_commit_messages",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L519",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_bashrc_init_ordering",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_bashrc_init_ordering",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L312",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_ci",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_ci",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L301",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_dev_environment_nix_flake",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_dev_environment_nix_flake",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L512",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_git_worktrees_worktrunk",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_git_worktrees_worktrunk",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L557",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_happy_daemon_remote_agent_control",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_happy_daemon_remote_agent_control",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L640",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_herdr_native_status",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_herdr_native_status",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L492",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_herdr_workspace_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_herdr_workspace_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L634",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_long_running_command_notifier",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_long_running_command_notifier",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L224",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_macos_defaults_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_macos_defaults_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L188",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_minimum_chezmoi_version",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_minimum_chezmoi_version",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L296",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_os_targeting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_os_targeting",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L192",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_secrets_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_secrets_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L528",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_shell_history_atuin",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_shell_history_atuin",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L180",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_source_only_files",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_source_only_files",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L199",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_system_package_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_system_package_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L584",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_tailscale_headless_daemon",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_tailscale_headless_daemon",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L269",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_template_files",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_template_files",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
+      "source_file": "AGENTS.md",
       "source_location": "L275",
       "weight": 1.0,
-      "source": "claude_architecture",
-      "target": "claude_template_shellcheck_workaround",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_s10_macos_agents_template_shellcheck_workaround",
       "confidence_score": 1.0
     },
     {
@@ -62442,5 +63477,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "e40a5af65ed55c6bbee33cb720c32decaec5a347"
+  "built_at_commit": "e0c1e02622d60658b90e57c57bf6237bc6311429"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1960,10 +1960,24 @@
       "norm_label": "executable_ssh-hardening.sh script"
     },
     {
+      "label": "priv()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L63",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_priv",
+      "community": 263,
+      "norm_label": "priv()"
+    },
+    {
       "label": "render_dropin()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L30",
+      "source_location": "L76",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1974,10 +1988,38 @@
       "norm_label": "render_dropin()"
     },
     {
+      "label": "assert_effective_config()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L90",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_assert_effective_config",
+      "community": 263,
+      "norm_label": "assert_effective_config()"
+    },
+    {
+      "label": "verify_effective()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L110",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "community": 263,
+      "norm_label": "verify_effective()"
+    },
+    {
       "label": "install_dropin()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L42",
+      "source_location": "L131",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1988,10 +2030,24 @@
       "norm_label": "install_dropin()"
     },
     {
+      "label": "prime_sudo()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L162",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_prime_sudo",
+      "community": 263,
+      "norm_label": "prime_sudo()"
+    },
+    {
       "label": "do_reload()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L59",
+      "source_location": "L172",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3209,7 +3265,7 @@
       "label": "macos_defaults_data_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L37",
+      "source_location": "L41",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3223,7 +3279,7 @@
       "label": "require_readable_data_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L45",
+      "source_location": "L49",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3237,7 +3293,7 @@
       "label": "defaults_records_tsv()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L56",
+      "source_location": "L60",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7106,6 +7162,48 @@
       "norm_label": "fail()"
     },
     {
+      "label": "macos-firewall-globalstate-order.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order",
+      "community": 311,
+      "norm_label": "macos-firewall-globalstate-order.sh"
+    },
+    {
+      "label": "macos-firewall-globalstate-order.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "community": 311,
+      "norm_label": "macos-firewall-globalstate-order.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L18",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order_fail",
+      "community": 311,
+      "norm_label": "fail()"
+    },
+    {
       "label": "macos-system-setup-sudo-guard.sh",
       "file_type": "code",
       "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
@@ -8140,6 +8238,230 @@
       "id": "test_integration_run_camp_runner_run_camp",
       "community": 187,
       "norm_label": "run_camp()"
+    },
+    {
+      "label": "ssh-hardening-include-precedence.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence",
+      "community": 309,
+      "norm_label": "ssh-hardening-include-precedence.sh"
+    },
+    {
+      "label": "ssh-hardening-include-precedence.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "community": 309,
+      "norm_label": "ssh-hardening-include-precedence.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L31",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence_fail",
+      "community": 309,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "want",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L103",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence_want",
+      "community": 309,
+      "norm_label": "want"
+    },
+    {
+      "label": "ssh-hardening-reload-failclosed.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed",
+      "community": 310,
+      "norm_label": "ssh-hardening-reload-failclosed.sh"
+    },
+    {
+      "label": "ssh-hardening-reload-failclosed.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "community": 310,
+      "norm_label": "ssh-hardening-reload-failclosed.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L28",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_fail",
+      "community": 310,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "reload_case()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L116",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_reload_case",
+      "community": 310,
+      "norm_label": "reload_case()"
+    },
+    {
+      "label": "report()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L135",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_report",
+      "community": 310,
+      "norm_label": "report()"
+    },
+    {
+      "label": "rc_nonzero()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L141",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_rc_nonzero",
+      "community": 310,
+      "norm_label": "rc_nonzero()"
+    },
+    {
+      "label": "rc_zero()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L142",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_rc_zero",
+      "community": 310,
+      "norm_label": "rc_zero()"
+    },
+    {
+      "label": "no_kick()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L143",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_no_kick",
+      "community": 310,
+      "norm_label": "no_kick()"
+    },
+    {
+      "label": "did_kick()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L144",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_did_kick",
+      "community": 310,
+      "norm_label": "did_kick()"
+    },
+    {
+      "label": "err_has()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L145",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_err_has",
+      "community": 310,
+      "norm_label": "err_has()"
+    },
+    {
+      "label": "err_no()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L146",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_err_no",
+      "community": 310,
+      "norm_label": "err_no()"
+    },
+    {
+      "label": "out_has()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L147",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_out_has",
+      "community": 310,
+      "norm_label": "out_has()"
     },
     {
       "label": "ssh-hardening-sshd-validate.sh",
@@ -12160,6 +12482,48 @@
       "norm_label": "assert_kv()"
     },
     {
+      "label": "macos-defaults-source-path-propagation.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation",
+      "community": 312,
+      "norm_label": "macos-defaults-source-path-propagation.sh"
+    },
+    {
+      "label": "macos-defaults-source-path-propagation.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "community": 312,
+      "norm_label": "macos-defaults-source-path-propagation.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L19",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_fail",
+      "community": 312,
+      "norm_label": "fail()"
+    },
+    {
       "label": "macos-security-posture.sh",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
@@ -12205,7 +12569,7 @@
       "label": "make_stub()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L49",
+      "source_location": "L50",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12219,7 +12583,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L62",
+      "source_location": "L64",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12233,7 +12597,7 @@
       "label": "report()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L79",
+      "source_location": "L82",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12247,7 +12611,7 @@
       "label": "a0()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L85",
+      "source_location": "L88",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12261,7 +12625,7 @@
       "label": "anomut()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L87",
+      "source_location": "L90",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12275,7 +12639,7 @@
       "label": "outhas()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L88",
+      "source_location": "L91",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12286,10 +12650,24 @@
       "norm_label": "outhas()"
     },
     {
+      "label": "outno()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L92",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_security_posture_outno",
+      "community": 308,
+      "norm_label": "outno()"
+    },
+    {
       "label": "errhas()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L89",
+      "source_location": "L93",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -12303,7 +12681,7 @@
       "label": "errno()",
       "file_type": "code",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L90",
+      "source_location": "L94",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -33328,7 +33706,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L59",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_assert_effective_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L172",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_do_reload",
@@ -33338,7 +33726,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L42",
+      "source_location": "L131",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -33348,7 +33736,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L30",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_prime_sudo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_priv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L76",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_render_dropin",
@@ -33365,10 +33773,20 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L73",
+      "source_location": "L235",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
@@ -33379,7 +33797,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L76",
+      "source_location": "L238",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
@@ -33390,7 +33808,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L70",
+      "source_location": "L226",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
@@ -33401,11 +33819,88 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L48",
+      "source_location": "L232",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L184",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "target": "dot_local_bin_executable_ssh_hardening_priv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L137",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_priv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L137",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
       "target": "dot_local_bin_executable_ssh_hardening_render_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L122",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "target": "dot_local_bin_executable_ssh_hardening_assert_effective_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L188",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L152",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_effective",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L175",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_do_reload",
+      "target": "dot_local_bin_executable_ssh_hardening_prime_sudo",
       "confidence_score": 1.0
     },
     {
@@ -35948,7 +36443,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L56",
+      "source_location": "L60",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_defaults_records_tsv",
@@ -35958,7 +36453,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L37",
+      "source_location": "L41",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_macos_defaults_data_file",
@@ -35968,7 +36463,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L45",
+      "source_location": "L49",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_require_readable_data_file",
@@ -40149,6 +40644,37 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "test_integration_macos_firewall_globalstate_order",
+      "target": "test_integration_macos_firewall_globalstate_order_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_firewall_globalstate_order",
+      "target": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "target": "test_integration_macos_firewall_globalstate_order_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
       "source_location": "L18",
       "weight": 1.0,
@@ -41300,6 +41826,333 @@
       "context": "call",
       "source": "test_integration_run_camp_runner_sh__entry",
       "target": "test_integration_run_camp_runner_run_camp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_precedence",
+      "target": "test_integration_ssh_hardening_include_precedence_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_precedence",
+      "target": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_precedence",
+      "target": "test_integration_ssh_hardening_include_precedence_want",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L36",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "target": "test_integration_ssh_hardening_include_precedence_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_did_kick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L145",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_err_has",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_err_no",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_no_kick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_out_has",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_rc_nonzero",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_rc_zero",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_reload_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L135",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L187",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_did_kick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L157",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_err_has",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L155",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_err_no",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L154",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_no_kick",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L175",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_out_has",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L153",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_rc_nonzero",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L173",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_rc_zero",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L152",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "target": "test_integration_ssh_hardening_reload_failclosed_reload_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L144",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_did_kick",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L145",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_err_has",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_err_no",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L143",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_no_kick",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L147",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_out_has",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_rc_nonzero",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_reload_failclosed_rc_zero",
+      "target": "test_integration_ssh_hardening_reload_failclosed_report",
       "confidence_score": 1.0
     },
     {
@@ -44765,8 +45618,39 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L23",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "target": "test_unit_macos_defaults_source_path_propagation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L85",
+      "source_location": "L88",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_a0",
@@ -44776,7 +45660,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L87",
+      "source_location": "L90",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_anomut",
@@ -44786,7 +45670,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L89",
+      "source_location": "L93",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_errhas",
@@ -44796,7 +45680,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L90",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_errno",
@@ -44816,7 +45700,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L49",
+      "source_location": "L50",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_make_stub",
@@ -44826,7 +45710,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L88",
+      "source_location": "L91",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_outhas",
@@ -44836,7 +45720,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L79",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "test_unit_macos_security_posture",
+      "target": "test_unit_macos_security_posture_outno",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L82",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_report",
@@ -44846,7 +45740,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L62",
+      "source_location": "L64",
       "weight": 1.0,
       "source": "test_unit_macos_security_posture",
       "target": "test_unit_macos_security_posture_run_case",
@@ -44866,7 +45760,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L96",
+      "source_location": "L100",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44877,7 +45771,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L97",
+      "source_location": "L101",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44888,7 +45782,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L107",
+      "source_location": "L111",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44899,7 +45793,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L101",
+      "source_location": "L105",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44921,7 +45815,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L98",
+      "source_location": "L102",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44932,7 +45826,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L95",
+      "source_location": "L131",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_sh__entry",
+      "target": "test_unit_macos_security_posture_outno",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L99",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_sh__entry",
@@ -44943,7 +45848,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L68",
+      "source_location": "L71",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_run_case",
@@ -44954,7 +45859,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L85",
+      "source_location": "L88",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_a0",
@@ -44965,7 +45870,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L87",
+      "source_location": "L90",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_anomut",
@@ -44976,7 +45881,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L89",
+      "source_location": "L93",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_errhas",
@@ -44987,7 +45892,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L90",
+      "source_location": "L94",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_errno",
@@ -44998,10 +45903,21 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-security-posture.sh",
-      "source_location": "L88",
+      "source_location": "L91",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_macos_security_posture_outhas",
+      "target": "test_unit_macos_security_posture_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-security-posture.sh",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_security_posture_outno",
       "target": "test_unit_macos_security_posture_report",
       "confidence_score": 1.0
     },
@@ -63477,5 +64393,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "e0c1e02622d60658b90e57c57bf6237bc6311429"
+  "built_at_commit": "e97035004c93b223807a257415923441a8da3c3e"
 }

--- a/test/integration/macos-defaults-source-path.sh
+++ b/test/integration/macos-defaults-source-path.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# macos-defaults-source-path.sh -- the macos-defaults-{apply,capture,drift} tools
+# must resolve their .chezmoidata/macos_defaults.yaml for the CURRENT context, NOT
+# a hardcoded primary-checkout path. The old tools hardcoded
+# "${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml", so a
+# capture/apply/drift run from a SECONDARY git worktree wrote (or read) the PRIMARY
+# tree instead of the worktree the operator is standing in: the
+# worktree-writes-primary bug. The shared lib now resolves the source dir from the
+# current git worktree (falling back to `chezmoi source-path`), so a run from a
+# worktree targets THAT worktree.
+#
+# Everything below lives under one sandbox temp dir. HOME is pointed there and a
+# throwaway chezmoi config sets sourceDir to a sandbox "primary", so NEITHER the
+# real primary checkout NOR the buggy hardcoded ${HOME}/workspaces/... path can be
+# touched by this test -- the red run (buggy code) writes only the sandbox.
+#
+# capture is the write path (the strongest proof): a capture from the worktree must
+# land in the WORKTREE yaml and leave BOTH sandbox "primaries" untouched. drift is
+# the read path: pointed at an unreadable worktree yaml it must exit 2 naming the
+# WORKTREE file, proving it read the worktree and not a primary.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CAPTURE="$REPO_ROOT/dot_local/bin/executable_macos-defaults-capture.sh"
+DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Host-tool guards: plain test/*.sh scripts run with host tools, outside the Nix
+# shell. The de-homebrewed CI-faithful run has no chezmoi/yq on PATH -> SKIP.
+for tool in chezmoi yq git; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'SKIP: %s not on PATH; cannot exercise source-dir resolution\n' "$tool"
+    exit 0
+  fi
+done
+[[ -f $CAPTURE ]] || fail "missing script: $CAPTURE"
+[[ -f $DRIFT ]] || fail "missing script: $DRIFT"
+
+# Canonicalize away macOS's /var -> /private/var symlink so paths match what
+# `git rev-parse --show-toplevel` (used by the resolver under test) returns.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'chmod -R u+rwX "$sandbox" 2>/dev/null; rm -rf "$sandbox"' EXIT
+
+# A throwaway chezmoi config so the lib's `chezmoi source-path` fallback resolves
+# to a SANDBOX primary, never the operator's real checkout.
+mkdir -p "$sandbox/.config/chezmoi" "$sandbox/primary-src/.chezmoidata"
+printf 'sourceDir = "%s/primary-src"\n' "$sandbox" >"$sandbox/.config/chezmoi/chezmoi.toml"
+printf 'macos:\n  defaults: []\n  killall: []\n' >"$sandbox/primary-src/.chezmoidata/macos_defaults.yaml"
+
+# The buggy hardcoded path is ${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/
+# macos_defaults.yaml; with HOME=sandbox it lands here. Seed it so the red run has a
+# readable target and mutates ONLY the sandbox.
+hardcoded_dir="$sandbox/workspaces/Ivy/webdavis/dotfiles/.chezmoidata"
+mkdir -p "$hardcoded_dir"
+printf 'macos:\n  defaults: []\n  killall: []\n' >"$hardcoded_dir/macos_defaults.yaml"
+
+# The secondary worktree the operator is standing in: a real git repo carrying its
+# own macos_defaults.yaml.
+wt="$sandbox/wt"
+mkdir -p "$wt/.chezmoidata"
+printf 'macos:\n  defaults: []\n  killall: []\n' >"$wt/.chezmoidata/macos_defaults.yaml"
+git -C "$wt" init -q
+# Pre-flight: the worktree branch of resolution only fires when git sees this dir as
+# its own top-level. Assert that so a green-looking pass cannot hide a silent
+# fallback to a primary.
+[[ "$(git -C "$wt" rev-parse --show-toplevel)" == "$wt" ]] ||
+  fail "test setup: $wt is not its own git top-level"
+
+# Stub `defaults` so capture appends a deterministic record without reading live
+# system state. read-type -> boolean, read -> 1 (normalizes to true).
+stub_bin="$sandbox/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/defaults" <<'STUB'
+#!/bin/bash
+case "$1" in
+  read-type) echo "Type is boolean"; exit 0 ;;
+  read) echo "1"; exit 0 ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$stub_bin/defaults"
+
+DOMAIN="com.example.s10test"
+KEY="s10flag"
+
+# ---- capture (write path): must land in the WORKTREE, not a primary ----------
+(
+  cd "$wt" || exit 1
+  HOME="$sandbox" PATH="$stub_bin:$PATH" bash "$CAPTURE" "$DOMAIN" "$KEY"
+) || fail "capture exited non-zero from the worktree"
+
+grep -qF "$DOMAIN" "$wt/.chezmoidata/macos_defaults.yaml" ||
+  fail "capture did NOT write the worktree yaml (worktree-writes-primary bug: the record went to a primary)"
+if grep -qF "$DOMAIN" "$hardcoded_dir/macos_defaults.yaml"; then
+  fail "capture wrote the HARDCODED ~/workspaces/... primary instead of the worktree"
+fi
+if grep -qF "$DOMAIN" "$sandbox/primary-src/.chezmoidata/macos_defaults.yaml"; then
+  fail "capture wrote the chezmoi-configured primary instead of the worktree"
+fi
+
+# ---- drift (read path): unreadable worktree yaml -> exit 2 naming the worktree -
+chmod 000 "$wt/.chezmoidata/macos_defaults.yaml"
+drift_err="$sandbox/drift.err"
+drift_rc=0
+(
+  cd "$wt" || exit 1
+  HOME="$sandbox" PATH="$stub_bin:$PATH" bash "$DRIFT"
+) 2>"$drift_err" || drift_rc=$?
+chmod u+rw "$wt/.chezmoidata/macos_defaults.yaml"
+
+[[ $drift_rc -eq 2 ]] ||
+  fail "drift from the worktree with an unreadable yaml must exit 2 (got rc=$drift_rc); it read a primary, not the worktree"
+grep -qF "$wt/.chezmoidata/macos_defaults.yaml" "$drift_err" ||
+  fail "drift's exit-2 message must name the WORKTREE yaml, proving it resolved the worktree (stderr: $(cat "$drift_err"))"
+
+printf 'macos-defaults-source-path: OK (capture writes the worktree; drift reads the worktree; both primaries untouched)\n'

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# macos-firewall-globalstate-order.sh -- the Application Firewall must be globally
+# ENABLED before stealth mode is set (R1-3). `socketfilterfw --setstealthmode on`
+# only yields active protection when the firewall's global state is on; on a fresh
+# or drifted machine with the firewall off, a lone stealth record writes a
+# preference over an INACTIVE firewall. So macos_system_setup.yaml must declare
+# `--setglobalstate on` BEFORE `--setstealthmode on`, and the Tier-2 runner must
+# emit them in that order (both under sudo, both idempotent "set to on" commands).
+#
+# Renders the REAL after_41 runner against the REAL .chezmoidata and asserts both
+# firewall commands are emitted, each with a sudo prefix, with globalstate strictly
+# before stealth. SKIPs cleanly on a non-darwin host (the template renders empty).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render after_41\n'
+  exit 0
+}
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+rendered="$work/rendered.sh"
+render_home="$work/home"
+mkdir -p "$render_home"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$TEMPLATE" >"$rendered" || fail "chezmoi failed to render $TEMPLATE"
+
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+gs_cmd='sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on'
+sm_cmd='sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on'
+
+grep -qxF "$gs_cmd" "$rendered" ||
+  fail "runner must emit the firewall global-state enable ('$gs_cmd'); stealth is inert without it (rendered: $(cat "$rendered"))"
+grep -qxF "$sm_cmd" "$rendered" ||
+  fail "runner must emit the stealth-mode enable ('$sm_cmd')"
+
+gs_line="$(grep -nF "$gs_cmd" "$rendered" | head -n1 | cut -d: -f1)"
+sm_line="$(grep -nF "$sm_cmd" "$rendered" | head -n1 | cut -d: -f1)"
+[[ $gs_line -lt $sm_line ]] ||
+  fail "global-state enable (line $gs_line) must come BEFORE stealth (line $sm_line): enable the firewall, then set stealth"
+
+printf 'macos-firewall-globalstate-order: OK (globalstate-on precedes stealth-on; both sudo, both idempotent set-on)\n'

--- a/test/integration/macos-system-setup-sudo-guard.sh
+++ b/test/integration/macos-system-setup-sudo-guard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# macos-system-setup-sudo-guard.sh -- the Tier-2 runner template
+# (run_onchange_after_41-macos-system-setup) must guard its per-record sudo prefix
+# with `{{ if index . "sudo" }}`, NOT `{{ if .sudo }}`. Go's text/template throws
+# "map has no entry for key \"sudo\"" on the `.field` form when a system_setup
+# record omits the sudo key; the `index` form returns the empty value (falsy) and
+# renders no prefix. This is the documented Tier-1/Tier-2 runner gotcha.
+#
+# Renders the REAL template against fixture chezmoidata carrying a record WITHOUT a
+# sudo key alongside one WITH sudo: true, and asserts: the render succeeds, the
+# keyless record's command is emitted with NO sudo prefix, and the sudo: true
+# record still gets its prefix.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render after_41\n'
+  exit 0
+}
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+src="$work/src"
+mkdir -p "$src/.chezmoiscripts" "$src/.chezmoidata"
+cp "$TEMPLATE" "$src/.chezmoiscripts/"
+# A record with NO sudo key (the throwing case for `.sudo`) plus one WITH sudo:true.
+# No tailnet_pins key: also exercises the absent-key `index` gotcha for the pins.
+cat >"$src/.chezmoidata/macos_system_setup.yaml" <<'EOF'
+macos:
+  system_setup:
+    - description: "keyless record (no sudo field)"
+      command: "echo nosudo-marker"
+    - description: "privileged record"
+      command: "echo withsudo-marker"
+      sudo: true
+EOF
+
+rendered="$work/rendered.sh"
+render_home="$work/home"
+mkdir -p "$render_home"
+# A render FAILURE here is the red state: `.sudo` throws on the keyless record.
+HOME="$render_home" CI=1 chezmoi --source "$src" execute-template --no-tty \
+  <"$src/.chezmoiscripts/$(basename "$TEMPLATE")" >"$rendered" ||
+  fail 'render failed -- the runner throws on a record with no sudo key (use {{ index . "sudo" }}, not {{ .sudo }})'
+
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# The keyless record must be emitted with NO sudo prefix.
+grep -qxF 'echo nosudo-marker' "$rendered" ||
+  fail "keyless record must render its command with no sudo prefix (rendered: $(cat "$rendered"))"
+if grep -qxF 'sudo echo nosudo-marker' "$rendered"; then
+  fail "keyless record wrongly got a sudo prefix"
+fi
+# The sudo:true record must keep its prefix (guard must not drop sudo wholesale).
+grep -qxF 'sudo echo withsudo-marker' "$rendered" ||
+  fail "sudo:true record lost its sudo prefix (rendered: $(cat "$rendered"))"
+
+printf 'macos-system-setup-sudo-guard: OK (keyless record renders sans sudo; sudo:true keeps its prefix)\n'

--- a/test/integration/ssh-hardening-dropin-mode.sh
+++ b/test/integration/ssh-hardening-dropin-mode.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# ssh-hardening-dropin-mode.sh -- install must pin the managed drop-in to a
+# deterministic, non-secret 0644 (R2-5), not leave its mode to root's umask. The audit
+# found a comment claiming a "mode-0600 managed drop-in" while install never chmod'd,
+# so under root's umask 022 the file was actually 0644. The drop-in holds NO secret and
+# sshd needs it readable (like Apple's 100-macos.conf), so the correct, honest state is
+# an explicit 0644 -- independent of the ambient umask.
+#
+# Under a restrictive umask 0077, `tee` alone would create the file 0600; the explicit
+# chmod makes it 0644 regardless. This runs install against a SANDBOX drop-in dir (the
+# SSHD_CONFIG_D + SSH_HARDENING_SUDO="" seams -- NEVER touches live /etc/ssh, NEVER
+# reloads sshd) with umask 0077 and asserts the resulting mode is exactly 644.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+
+# GNU-first, BSD-fallback file mode (octal). GNU coreutils uses -c '%a'; BSD uses
+# -f '%Lp'. GNU MUST come first: on Linux `stat -f` means "filesystem status" and
+# would succeed with the wrong output.
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+confd="$work/sshd_config.d"
+mkdir -p "$confd"
+main="$work/sshd_config"
+printf 'Include %s/*\n' "$confd" >"$main"
+
+# Install under a restrictive umask so a missing chmod would yield 0600 (the RED).
+# SSH_HARDENING_SKIP_IF_NO_SSHD=1 lets the tail verify step skip cleanly where sshd is
+# absent (the file is written+chmod'd before verify either way); where sshd is present,
+# verify runs against this sandbox tree (hardened) and passes.
+rc=0
+(
+  umask 0077
+  SSH_HARDENING_SUDO="" SSHD_CONFIG_D="$confd" SSHD_MAIN_CONFIG="$main" \
+    SSH_HARDENING_SKIP_IF_NO_SSHD=1 bash "$SCRIPT" >"$work/out" 2>"$work/err"
+) || rc=$?
+
+dropin="$confd/000-ssh-hardening.conf"
+[[ -f $dropin ]] || fail "install did not write the drop-in (rc=$rc; err: $(cat "$work/err"))"
+
+mode="$(mode_of "$dropin")"
+[[ $mode == 644 ]] ||
+  fail "managed drop-in must be a deterministic non-secret 0644, got $mode (an explicit chmod must override root's umask; rc=$rc)"
+
+printf 'ssh-hardening-dropin-mode: OK (drop-in is 0644 even under umask 0077)\n'

--- a/test/integration/ssh-hardening-dropin-mode.sh
+++ b/test/integration/ssh-hardening-dropin-mode.sh
@@ -15,6 +15,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -42,7 +50,7 @@ rc=0
 (
   umask 0077
   SSH_HARDENING_SUDO="" SSHD_CONFIG_D="$confd" SSHD_MAIN_CONFIG="$main" \
-    SSH_HARDENING_SKIP_IF_NO_SSHD=1 bash "$SCRIPT" >"$work/out" 2>"$work/err"
+    SSH_HARDENING_SKIP_IF_NO_SSHD=1 "$BASH_BIN" "$SCRIPT" >"$work/out" 2>"$work/err"
 ) || rc=$?
 
 dropin="$confd/000-ssh-hardening.conf"

--- a/test/integration/ssh-hardening-include-precedence.sh
+++ b/test/integration/ssh-hardening-include-precedence.sh
@@ -28,6 +28,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -85,7 +93,7 @@ out="$work/out"
 err="$work/err"
 rc=0
 SSH_HARDENING_SUDO="" SSHD_CONFIG_D="$confd" SSHD_MAIN_CONFIG="$main" \
-  PATH="$stub:$PATH" bash "$SCRIPT" >"$out" 2>"$err" || rc=$?
+  PATH="$stub:$PATH" "$BASH_BIN" "$SCRIPT" >"$out" 2>"$err" || rc=$?
 
 [[ $rc -eq 0 ]] ||
   fail "installer must exit 0 on a tree where the drop-in wins (got rc=$rc; err: $(cat "$err"))"
@@ -115,14 +123,14 @@ done
 # ---- 3a. regression guard: the OLD 50- name is DEFEATED by the hostile 100- ------
 # (documents WHY the rename is required: hostile 100- sorts before 50-.)
 rm -f "$confd/000-ssh-hardening.conf"
-bash "$SCRIPT" --print-config >"$confd/50-no-password-auth.conf"
+"$BASH_BIN" "$SCRIPT" --print-config >"$confd/50-no-password-auth.conf"
 eff_legacy="$(sshd -G -f "$main" 2>/dev/null)" || fail "sshd -G failed on the legacy-name tree"
 grep -qxiF 'passwordauthentication yes' <<<"$eff_legacy" ||
   fail "regression guard: the 50- name should be DEFEATED (hostile 100- wins passwordauthentication) -- this is the shadowing the rename closes"
 
 # ---- 3b. --verify FAILS loudly on the shadowed tree -----------------------------
 vrc=0
-SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" bash "$SCRIPT" --verify \
+SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" "$BASH_BIN" "$SCRIPT" --verify \
   >"$work/vout" 2>"$work/verr" || vrc=$?
 [[ $vrc -ne 0 ]] ||
   fail "--verify must FAIL (nonzero) when the hardening is shadowed (defense in depth)"
@@ -130,9 +138,9 @@ grep -qi 'WARNING' "$work/verr" ||
   fail "--verify must warn loudly on a shadowed tree (stderr: $(cat "$work/verr"))"
 
 # ---- 3c. --verify PASSES once the winning 000- drop-in is restored ---------------
-bash "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
+"$BASH_BIN" "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
 vrc=0
-SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" bash "$SCRIPT" --verify \
+SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" "$BASH_BIN" "$SCRIPT" --verify \
   >"$work/vout2" 2>"$work/verr2" || vrc=$?
 [[ $vrc -eq 0 ]] ||
   fail "--verify must PASS when 000- wins (got rc=$vrc; err: $(cat "$work/verr2"))"

--- a/test/integration/ssh-hardening-include-precedence.sh
+++ b/test/integration/ssh-hardening-include-precedence.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# ssh-hardening-include-precedence.sh -- prove the managed sshd drop-in WINS sshd's
+# first-value-wins Include precedence, and that install migrates the superseded
+# name away (R1-1). The audit found the old drop-in was `50-no-password-auth.conf`,
+# which sorts lexically AFTER Apple's `100-macos.conf` under `Include
+# sshd_config.d/*` ("1" < "5"), so a hostile or updated 100- file would SHADOW the
+# hardening (password auth back on, root login back on). The fix renames it to
+# `000-ssh-hardening.conf` (sorts before any Apple 0*/1* file) and, on install,
+# removes a pre-existing 50- file.
+#
+# This reconstructs an Include tree in a SANDBOX (it NEVER touches live /etc/ssh and
+# NEVER reloads sshd) with a deliberately HOSTILE 100-macos.conf that reopens every
+# hole, then:
+#   1. runs the installer against the sandbox (the SSHD_CONFIG_D + SSH_HARDENING_SUDO
+#      seams) and asserts it writes 000-, REMOVES the seeded 50-, and reports the
+#      effective config fully hardened (exit 0);
+#   2. independently confirms via `sshd -G` that the 000- name wins all five values
+#      while the 50- name is DEFEATED -- the regression the rename closes;
+#   3. asserts `--verify` FAILS loudly on a tree where the hardening is shadowed --
+#      the defense-in-depth assertion actually catches a bad config, and PASSES once
+#      the winning 000- drop-in is restored.
+#
+# A failing `sudo` stub on PATH guarantees the UNFIXED script (bare `sudo tee
+# /etc/ssh/...`) cannot touch live /etc/ssh: it fails the write instead (a clean
+# RED). SKIPs cleanly where sshd is absent (de-homebrewed / Linux CI).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+command -v sshd >/dev/null 2>&1 || {
+  printf 'SKIP: sshd not on PATH; cannot exercise Include precedence with the real parser\n'
+  exit 0
+}
+if ! sshd -G -f /dev/null >/dev/null 2>&1; then
+  printf 'SKIP: sshd -G is not usable in this environment (older OpenSSH or sandbox)\n'
+  exit 0
+fi
+
+# Canonicalize the /var -> /private/var symlink so absolute Include paths match.
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+confd="$work/sshd_config.d"
+mkdir -p "$confd"
+main="$work/sshd_config"
+printf 'Include %s/*\n' "$confd" >"$main"
+
+# HOSTILE Apple file: reopens every closed path. Sorts as 100- (before 50-, after
+# 000-). If the hardening does not sort FIRST, these values win.
+cat >"$confd/100-macos.conf" <<'EOF'
+PasswordAuthentication yes
+KbdInteractiveAuthentication yes
+UsePAM yes
+PubkeyAuthentication no
+PermitRootLogin yes
+EOF
+
+# A pre-existing LEGACY 50- drop-in the migration must remove.
+cat >"$confd/50-no-password-auth.conf" <<'EOF'
+# Superseded managed drop-in (must be migrated away).
+PasswordAuthentication no
+EOF
+
+# A failing `sudo` stub: blocks the UNFIXED script from ever touching live /etc/ssh
+# (its bare `sudo tee /etc/ssh/...` fails here) and is never called by the fixed
+# script (SSH_HARDENING_SUDO="" drops the prefix entirely).
+stub="$work/bin"
+mkdir -p "$stub"
+cat >"$stub/sudo" <<'EOF'
+#!/bin/bash
+printf 'STUB sudo invoked (blocked to protect live /etc/ssh): %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$stub/sudo"
+
+# ---- 1. install against the sandbox: write 000-, migrate 50-, verify hardened ---
+out="$work/out"
+err="$work/err"
+rc=0
+SSH_HARDENING_SUDO="" SSHD_CONFIG_D="$confd" SSHD_MAIN_CONFIG="$main" \
+  PATH="$stub:$PATH" bash "$SCRIPT" >"$out" 2>"$err" || rc=$?
+
+[[ $rc -eq 0 ]] ||
+  fail "installer must exit 0 on a tree where the drop-in wins (got rc=$rc; err: $(cat "$err"))"
+[[ -f "$confd/000-ssh-hardening.conf" ]] ||
+  fail "installer did not write the 000- managed drop-in"
+grep -qxF 'PasswordAuthentication no' "$confd/000-ssh-hardening.conf" ||
+  fail "000- drop-in is missing the hardening content"
+[[ ! -e "$confd/50-no-password-auth.conf" ]] ||
+  fail "installer did NOT migrate away the superseded 50- drop-in (R1-1 migration)"
+grep -qi 'verified' "$out" ||
+  fail "installer must report the effective config verified when the drop-in wins (out: $(cat "$out"))"
+
+# ---- 2. independent proof: 000- wins all five effective values ------------------
+eff="$(sshd -G -f "$main" 2>/dev/null)" || fail "sshd -G failed on the reconstructed tree"
+declare -a want=(
+  'passwordauthentication no'
+  'kbdinteractiveauthentication no'
+  'usepam yes'
+  'pubkeyauthentication yes'
+  'permitrootlogin no'
+)
+for pair in "${want[@]}"; do
+  grep -qxiF "$pair" <<<"$eff" ||
+    fail "000- did not win '$pair' (effective: $(grep -iE '^(passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin) ' <<<"$eff" | tr '\n' ';'))"
+done
+
+# ---- 3a. regression guard: the OLD 50- name is DEFEATED by the hostile 100- ------
+# (documents WHY the rename is required: hostile 100- sorts before 50-.)
+rm -f "$confd/000-ssh-hardening.conf"
+bash "$SCRIPT" --print-config >"$confd/50-no-password-auth.conf"
+eff_legacy="$(sshd -G -f "$main" 2>/dev/null)" || fail "sshd -G failed on the legacy-name tree"
+grep -qxiF 'passwordauthentication yes' <<<"$eff_legacy" ||
+  fail "regression guard: the 50- name should be DEFEATED (hostile 100- wins passwordauthentication) -- this is the shadowing the rename closes"
+
+# ---- 3b. --verify FAILS loudly on the shadowed tree -----------------------------
+vrc=0
+SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" bash "$SCRIPT" --verify \
+  >"$work/vout" 2>"$work/verr" || vrc=$?
+[[ $vrc -ne 0 ]] ||
+  fail "--verify must FAIL (nonzero) when the hardening is shadowed (defense in depth)"
+grep -qi 'WARNING' "$work/verr" ||
+  fail "--verify must warn loudly on a shadowed tree (stderr: $(cat "$work/verr"))"
+
+# ---- 3c. --verify PASSES once the winning 000- drop-in is restored ---------------
+bash "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
+vrc=0
+SSH_HARDENING_SUDO="" SSHD_MAIN_CONFIG="$main" bash "$SCRIPT" --verify \
+  >"$work/vout2" 2>"$work/verr2" || vrc=$?
+[[ $vrc -eq 0 ]] ||
+  fail "--verify must PASS when 000- wins (got rc=$vrc; err: $(cat "$work/verr2"))"
+
+printf 'ssh-hardening-include-precedence: OK (000- wins; 50- migrated + defeated; --verify catches shadowing)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -46,6 +46,14 @@ if ! "$SSHD" -G -T -C user=root,addr=1.2.3.4,host=h -f /dev/null >/dev/null 2>&1
   exit 0
 fi
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator's Tier-2 runner invokes the script by its `#!/bin/bash` shebang -- so a
+# 3.2-only regression in the Match scan must fail HERE, not in production. Falls back
+# to the ambient bash only where /bin/bash is absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 work="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$work"' EXIT
 
@@ -55,7 +63,7 @@ main="$work/sshd_config"
 printf 'Include %s/*\n' "$confd" >"$main"
 
 # The winning managed drop-in (globally hardened; sorts first).
-bash "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
+"$BASH_BIN" "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
 
 failures=0
 report() {
@@ -69,7 +77,7 @@ report() {
 verify_run() {
   RC=0
   SSH_HARDENING_SUDO="" SSHD_BIN="$SSHD" SSHD_MAIN_CONFIG="$main" \
-    bash "$SCRIPT" --verify >"$work/vout" 2>"$work/verr" || RC=$?
+    "$BASH_BIN" "$SCRIPT" --verify >"$work/vout" 2>"$work/verr" || RC=$?
   ERR="$(cat "$work/verr")"
 }
 

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# ssh-hardening-match-reenable.sh -- `--verify` must catch a criteria-based Match
+# block that re-enables a protected directive (R2-1). The audit found the old
+# `--verify` parsed only `sshd -G` (WITHOUT -C), which dumps the global/pre-Match
+# config, so a hostile sibling drop-in with `Match Address 0.0.0.0/0` (or `Match
+# User *`, `Match all`, or a specific `Match User <name>`) re-enabling
+# PasswordAuthentication or PermitRootLogin PASSED --verify ("all five in force")
+# while `sshd -G -T -C user=root,...` showed password auth + root login back ON --
+# the most idiomatic sshd bypass.
+#
+# The fix makes --verify assert three ways, all read-only and host-key-free:
+#   1. the global (pre-Match) effective config via `sshd -G`;
+#   2. a RAW scan of every included file for a Match block that weakens a protected
+#      directive (PasswordAuthentication / KbdInteractiveAuthentication /
+#      PubkeyAuthentication / PermitRootLogin) -- this names the offending file and
+#      catches even a specific-user Match the connection-spec sampling would miss;
+#   3. an authoritative per-connection resolution via `sshd -G -T -C` for a root
+#      spec and a normal-user spec.
+#
+# This reconstructs an Include tree in a SANDBOX (NEVER touches live /etc/ssh, NEVER
+# reloads sshd), drops a hostile sibling per case, and asserts --verify FAILS loudly
+# (rc=1, a warning naming the file) on every re-enable while a clean tree PASSES.
+# SKIPs cleanly where sshd (or the `sshd -G -T -C` seam) is absent.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+SSHD="$(command -v sshd 2>/dev/null || true)"
+[[ -n $SSHD ]] || {
+  printf 'SKIP: sshd not on PATH; cannot exercise Match resolution with the real parser\n'
+  exit 0
+}
+if ! "$SSHD" -G -f /dev/null >/dev/null 2>&1; then
+  printf 'SKIP: sshd -G is not usable in this environment (older OpenSSH or sandbox)\n'
+  exit 0
+fi
+if ! "$SSHD" -G -T -C user=root,addr=1.2.3.4,host=h -f /dev/null >/dev/null 2>&1; then
+  printf 'SKIP: sshd -G -T -C (host-key-free Match resolution) is unavailable here\n'
+  exit 0
+fi
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+confd="$work/sshd_config.d"
+mkdir -p "$confd"
+main="$work/sshd_config"
+printf 'Include %s/*\n' "$confd" >"$main"
+
+# The winning managed drop-in (globally hardened; sorts first).
+bash "$SCRIPT" --print-config >"$confd/000-ssh-hardening.conf"
+
+failures=0
+report() {
+  if [[ $1 == ok ]]; then printf '  ok   %s\n' "$2"; else
+    printf '  FAIL %s\n' "$2"
+    failures=$((failures + 1))
+  fi
+}
+
+# verify_run -> populates RC, ERR by running --verify against the sandbox tree.
+verify_run() {
+  RC=0
+  SSH_HARDENING_SUDO="" SSHD_BIN="$SSHD" SSHD_MAIN_CONFIG="$main" \
+    bash "$SCRIPT" --verify >"$work/vout" 2>"$work/verr" || RC=$?
+  ERR="$(cat "$work/verr")"
+}
+
+# hostile_case <name> <sibling-basename> <sibling-content> [name_file] -- drop a
+# hostile sibling, assert --verify FAILS (rc!=0) and warns, then remove it. When
+# name_file is "yes" (the default), also assert the warning names the sibling file
+# (the Match-scan does this); a GLOBAL re-enable is caught by the pre-Match `sshd -G`
+# check, which fails+warns but does not attribute a file, so name_file="no" there.
+hostile_case() {
+  local name="$1" fname="$2" content="$3" name_file="${4:-yes}"
+  printf '%s' "$content" >"$confd/$fname"
+  verify_run
+  if [[ $RC -ne 0 ]]; then report ok "$name: --verify FAILS (rc=$RC)"; else
+    report bad "$name: --verify must FAIL on the re-enable (got rc=0; err: $ERR)"
+  fi
+  if grep -qi 'WARNING' <<<"$ERR"; then report ok "$name: warns loudly"; else
+    report bad "$name: must warn on stderr (err: $ERR)"
+  fi
+  if [[ $name_file == yes ]]; then
+    if grep -qF "$fname" <<<"$ERR"; then report ok "$name: names the offending file"; else
+      report bad "$name: warning must name '$fname' (err: $ERR)"
+    fi
+  fi
+  rm -f "$confd/$fname"
+}
+
+printf 'ssh-hardening --verify Match-re-enable cases:\n'
+
+# 1. clean tree (only the winning 000-) -> --verify PASSES.
+verify_run
+if [[ $RC -eq 0 ]]; then report ok "clean: --verify PASSES (rc=0)"; else
+  report bad "clean: --verify must PASS on a hardened tree (rc=$RC; err: $ERR)"
+fi
+if grep -qi 'verified' "$work/vout"; then report ok "clean: reports verified"; else
+  report bad "clean: must report verified (out: $(cat "$work/vout"))"
+fi
+
+# 2. Match Address 0.0.0.0/0 re-enabling password auth (the idiomatic bypass).
+hostile_case match-address 900-hostile-addr.conf \
+  $'Match Address 0.0.0.0/0\n    PasswordAuthentication yes\n'
+
+# 3. Match User * re-enabling root login.
+hostile_case match-user-star 900-hostile-userstar.conf \
+  $'Match User *\n    PermitRootLogin yes\n'
+
+# 4. Match all re-enabling keyboard-interactive (PAM password) auth.
+hostile_case match-all 900-hostile-all.conf \
+  $'Match all\n    KbdInteractiveAuthentication yes\n'
+
+# 5. A SPECIFIC-user Match the connection-spec sampling (root + a normal user) does
+#    NOT cover -- only the raw file scan catches it. Proves the scan is not merely a
+#    duplicate of the -C sampling.
+hostile_case match-specific-user 900-hostile-backdoor.conf \
+  $'Match User zzbackdoor\n    PasswordAuthentication yes\n    PubkeyAuthentication no\n'
+
+# 6. Regression: a GLOBAL (top-level) re-enable in a sibling that sorts BEFORE 000-
+#    still fails via the pre-Match global check (first-value-wins shadowing, R1-1).
+#    The global check attributes no file, so do not assert file-naming here.
+hostile_case global-shadow 000-aaa-hostile.conf \
+  $'PasswordAuthentication yes\nPermitRootLogin yes\n' no
+
+# 7. After all hostiles are removed, the clean tree PASSES again (no leakage).
+verify_run
+if [[ $RC -eq 0 ]]; then report ok "clean-again: --verify PASSES after cleanup"; else
+  report bad "clean-again: --verify must PASS once hostiles are removed (rc=$RC; err: $ERR)"
+fi
+
+if [[ $failures -gt 0 ]]; then
+  printf 'ssh-hardening-match-reenable: %d assertion(s) FAILED\n' "$failures" >&2
+  exit 1
+fi
+printf 'ssh-hardening-match-reenable: OK (Match re-enables caught + named; global shadow caught; clean passes)\n'

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -29,6 +29,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -144,7 +152,7 @@ reload_case() {
     SSHD_MAIN_CONFIG="$work/main" STUB_SSHD_EFFECTIVE="$work/eff-hardened" \
     STUB_LAUNCHCTL_KICKLOG="$kicklog" STUB_LAUNCHCTL_PRINT_COUNT="$pcount" \
     PATH="$stub:$PATH" "$@" \
-    bash "$SCRIPT" --reload 2>"$work/$name.err")" || RC=$?
+    "$BASH_BIN" "$SCRIPT" --reload 2>"$work/$name.err")" || RC=$?
   ERR="$(cat "$work/$name.err")"
   KICKED="$(cat "$kicklog")"
 }

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# ssh-hardening-reload-failclosed.sh -- the operator-facing `--reload` must FAIL
+# CLOSED (R1-2). The audit found: with sudo stubbed rc!=0, `--reload` returned 0 and
+# mis-reported "sshd not running" (every sudo/launchctl probe error fell into the
+# benign not-running branch); and it ran `launchctl kickstart -k` (which TERMINATES
+# the listener) with NO syntax/effective-value validation first, so a broken sibling
+# drop-in could drop the daemon. `--reload` is the command the operator runs during
+# the physically-present hardening step, so it must:
+#   (a) prime sudo and fail closed if it is unavailable;
+#   (b) validate the COMPLETE config BEFORE the disruptive kickstart -- `sshd -t`
+#       for syntax AND all five effective values -- and abort loudly if either
+#       fails (never restart onto a config that would drop or unharden the daemon);
+#   (c) distinguish "service CONFIRMED absent" (launchctl print rc 113) from a probe
+#       ERROR (any other nonzero): a sudo/launchctl error is NOT proof the daemon is
+#       down, so propagate it, never proceed as if stopped;
+#   (d) return NONZERO on any failure;
+#   (e) verify the service came back after the kickstart.
+#
+# Drives `--reload` through fully-controlled sudo/sshd/launchctl stubs (the
+# SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN seams, mirrored on PATH so the
+# UNFIXED script's bare-name calls hit the same stubs). NEVER touches the live
+# daemon or /etc/ssh. SKIPs never needed (no real tool required).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+stub="$work/bin"
+mkdir -p "$stub"
+: >"$work/main"
+
+# sudo stub: total failure when STUB_SUDO_FAIL=1 (models "operator cannot
+# escalate"); otherwise `-v` primes and anything else passes through.
+cat >"$stub/sudo" <<'EOF'
+#!/bin/bash
+[[ ${STUB_SUDO_FAIL:-0} == 1 ]] && {
+  printf 'stub sudo: a password is required\n' >&2
+  exit 77
+}
+[[ $1 == -v ]] && exit 0
+exec "$@"
+EOF
+
+# sshd stub: -t is syntax (fails when STUB_SSHD_T_FAIL=1); -G/-T dump a fixture
+# effective config.
+cat >"$stub/sshd" <<'EOF'
+#!/bin/bash
+case "$1" in
+  -t)
+    [[ ${STUB_SSHD_T_FAIL:-0} == 1 ]] && {
+      printf 'stub sshd: bad configuration\n' >&2
+      exit 1
+    }
+    exit 0
+    ;;
+  -G | -T) cat "${STUB_SSHD_EFFECTIVE:?}" ;;
+  *)
+    printf 'stub sshd: unexpected %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+
+# launchctl stub: `print` returns the n-th rc from a colon list (so pre- and
+# post-kickstart probes can differ); `kickstart` logs the call and returns a
+# controllable rc.
+cat >"$stub/launchctl" <<'EOF'
+#!/bin/bash
+case "$1" in
+  print)
+    n=1
+    [[ -f ${STUB_LAUNCHCTL_PRINT_COUNT:-} ]] && n=$(($(cat "$STUB_LAUNCHCTL_PRINT_COUNT") + 1))
+    printf '%s' "$n" >"${STUB_LAUNCHCTL_PRINT_COUNT:?}"
+    rc="$(printf '%s' "${STUB_LAUNCHCTL_PRINT_RCS:-0}" | cut -d: -f"$n")"
+    [[ -z $rc ]] && rc=0
+    exit "$rc"
+    ;;
+  kickstart)
+    printf 'kickstart %s\n' "$*" >>"${STUB_LAUNCHCTL_KICKLOG:?}"
+    exit "${STUB_LAUNCHCTL_KICKSTART_RC:-0}"
+    ;;
+  *)
+    printf 'stub launchctl: unexpected %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$stub/sudo" "$stub/sshd" "$stub/launchctl"
+
+cat >"$work/eff-hardened" <<'EOF'
+passwordauthentication no
+kbdinteractiveauthentication no
+usepam yes
+pubkeyauthentication yes
+permitrootlogin no
+EOF
+# One value lost (passwordauthentication back on) -> verify must abort the reload.
+cat >"$work/eff-lost" <<'EOF'
+passwordauthentication yes
+kbdinteractiveauthentication no
+usepam yes
+pubkeyauthentication yes
+permitrootlogin no
+EOF
+
+# reload_case <name> <env=val...> -> populates RC, OUT, ERR, KICKED.
+reload_case() {
+  local name="$1"
+  shift
+  local kicklog="$work/$name.kick"
+  : >"$kicklog"
+  local pcount="$work/$name.pcount"
+  rm -f "$pcount"
+  RC=0
+  OUT="$(env \
+    SSH_HARDENING_SUDO="$stub/sudo" SSHD_BIN="$stub/sshd" LAUNCHCTL_BIN="$stub/launchctl" \
+    SSHD_MAIN_CONFIG="$work/main" STUB_SSHD_EFFECTIVE="$work/eff-hardened" \
+    STUB_LAUNCHCTL_KICKLOG="$kicklog" STUB_LAUNCHCTL_PRINT_COUNT="$pcount" \
+    PATH="$stub:$PATH" "$@" \
+    bash "$SCRIPT" --reload 2>"$work/$name.err")" || RC=$?
+  ERR="$(cat "$work/$name.err")"
+  KICKED="$(cat "$kicklog")"
+}
+
+failures=0
+report() {
+  if [[ $1 == ok ]]; then printf '  ok   %s\n' "$2"; else
+    printf '  FAIL %s\n' "$2"
+    failures=$((failures + 1))
+  fi
+}
+rc_nonzero() { if [[ $RC -ne 0 ]]; then report ok "$1: exits nonzero"; else report bad "$1: must exit nonzero (got rc=0; out: $OUT; err: $ERR)"; fi; }
+rc_zero() { if [[ $RC -eq 0 ]]; then report ok "$1: exits 0"; else report bad "$1: must exit 0 (got rc=$RC; err: $ERR)"; fi; }
+no_kick() { if [[ -z $KICKED ]]; then report ok "$1: did NOT kickstart"; else report bad "$1: must NOT kickstart before validation ($KICKED)"; fi; }
+did_kick() { if [[ -n $KICKED ]]; then report ok "$1: kickstarted"; else report bad "$1: expected a kickstart, none logged"; fi; }
+err_has() { if grep -qi -- "$2" <<<"$ERR"; then report ok "$1: stderr has '$2'"; else report bad "$1: stderr must mention '$2' (err: $ERR)"; fi; }
+err_no() { if grep -qi -- "$2" <<<"$ERR"; then report bad "$1: stderr must NOT mention '$2' (err: $ERR)"; else report ok "$1: no '$2' in stderr"; fi; }
+out_has() { if grep -qi -- "$2" <<<"$OUT"; then report ok "$1: stdout has '$2'"; else report bad "$1: stdout must mention '$2' (out: $OUT)"; fi; }
+
+printf 'ssh-hardening --reload fail-closed cases:\n'
+
+# 1. sudo failure: propagate nonzero, do NOT misreport "not running", do NOT kick.
+reload_case sudo-fail STUB_SUDO_FAIL=1
+rc_nonzero sudo-fail
+no_kick sudo-fail
+err_no sudo-fail "not loaded"
+err_no sudo-fail "not currently running"
+err_has sudo-fail "sudo"
+
+# 2. malformed config: sshd -t fails -> abort BEFORE the kickstart.
+reload_case malformed STUB_SSHD_T_FAIL=1
+rc_nonzero malformed
+no_kick malformed
+err_has malformed "syntax"
+
+# 3. lost hardening: effective config missing a value -> abort BEFORE the kickstart.
+reload_case lost STUB_SSHD_EFFECTIVE="$work/eff-lost"
+rc_nonzero lost
+no_kick lost
+err_has lost "not fully hardened"
+
+# 4. service CONFIRMED absent (launchctl print rc 113): benign, exit 0, no kick.
+reload_case absent STUB_LAUNCHCTL_PRINT_RCS=113
+rc_zero absent
+no_kick absent
+out_has absent "not loaded"
+
+# 5. probe ERROR (nonzero but NOT 113): fail closed, do NOT treat as stopped, no kick.
+reload_case probe-error STUB_LAUNCHCTL_PRINT_RCS=1
+rc_nonzero probe-error
+no_kick probe-error
+err_has probe-error "could not determine"
+err_no probe-error "not loaded"
+
+# 6. kickstart failure: nonzero + loud, kickstart WAS attempted.
+reload_case kick-fail STUB_LAUNCHCTL_PRINT_RCS=0:0 STUB_LAUNCHCTL_KICKSTART_RC=1
+rc_nonzero kick-fail
+did_kick kick-fail
+err_has kick-fail "kickstart"
+
+# 7. service did not come back after kickstart: nonzero + loud.
+reload_case no-return STUB_LAUNCHCTL_PRINT_RCS=0:3
+rc_nonzero no-return
+did_kick no-return
+err_has no-return "come back"
+
+# 8. happy path: validated, kicked, confirmed back up.
+reload_case happy STUB_LAUNCHCTL_PRINT_RCS=0:0
+rc_zero happy
+did_kick happy
+out_has happy "confirmed running"
+
+if [[ $failures -gt 0 ]]; then
+  printf 'ssh-hardening-reload-failclosed: %d assertion(s) FAILED\n' "$failures" >&2
+  exit 1
+fi
+printf 'ssh-hardening-reload-failclosed: OK (validates before kickstart; distinguishes absent from errored; fails closed)\n'

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -14,12 +14,16 @@
 #       ERROR (any other nonzero): a sudo/launchctl error is NOT proof the daemon is
 #       down, so propagate it, never proceed as if stopped;
 #   (d) return NONZERO on any failure;
-#   (e) verify the service came back after the kickstart.
+#   (e) verify the launchd job reloaded after the kickstart (first signal only); and
+#   (f) prove sshd is actually READY -- accepting an SSH connection -- not merely a
+#       loaded launchd job (R2-2). `launchctl print` returns 0 for a loaded-but-
+#       crashed service, so a readiness probe (ssh-keyscan on the listener) must gate
+#       the green result; a loaded-but-not-accepting sshd fails loud (remote lockout).
 #
-# Drives `--reload` through fully-controlled sudo/sshd/launchctl stubs (the
-# SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN seams, mirrored on PATH so the
-# UNFIXED script's bare-name calls hit the same stubs). NEVER touches the live
-# daemon or /etc/ssh. SKIPs never needed (no real tool required).
+# Drives `--reload` through fully-controlled sudo/sshd/launchctl/ssh-keyscan stubs
+# (the SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN seams, mirrored on
+# PATH so the UNFIXED script's bare-name calls hit the same stubs). NEVER touches the
+# live daemon or /etc/ssh. SKIPs never needed (no real tool required).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -94,9 +98,21 @@ case "$1" in
     ;;
 esac
 EOF
-chmod +x "$stub/sudo" "$stub/sshd" "$stub/launchctl"
 
+# ssh-keyscan stub: models the readiness probe. STUB_KEYSCAN_READY=1 -> emit a fake
+# host-key line (sshd answered the SSH banner exchange); otherwise emit nothing (the
+# listener is not accepting -- a loaded-but-crashed sshd).
+cat >"$stub/ssh-keyscan" <<'EOF'
+#!/bin/bash
+[[ ${STUB_KEYSCAN_READY:-0} == 1 ]] && printf '[127.0.0.1]:22 ssh-ed25519 AAAAFAKEKEYMATERIAL\n'
+exit 0
+EOF
+chmod +x "$stub/sudo" "$stub/sshd" "$stub/launchctl" "$stub/ssh-keyscan"
+
+# The effective config the sshd stub reports. Includes a `port` line so effective_port
+# aims the readiness probe (and exercises the extraction).
 cat >"$work/eff-hardened" <<'EOF'
+port 22
 passwordauthentication no
 kbdinteractiveauthentication no
 usepam yes
@@ -105,6 +121,7 @@ permitrootlogin no
 EOF
 # One value lost (passwordauthentication back on) -> verify must abort the reload.
 cat >"$work/eff-lost" <<'EOF'
+port 22
 passwordauthentication yes
 kbdinteractiveauthentication no
 usepam yes
@@ -123,6 +140,7 @@ reload_case() {
   RC=0
   OUT="$(env \
     SSH_HARDENING_SUDO="$stub/sudo" SSHD_BIN="$stub/sshd" LAUNCHCTL_BIN="$stub/launchctl" \
+    KEYSCAN_BIN="$stub/ssh-keyscan" SSH_READY_ATTEMPTS=2 SSH_READY_SLEEP_SECONDS=0 \
     SSHD_MAIN_CONFIG="$work/main" STUB_SSHD_EFFECTIVE="$work/eff-hardened" \
     STUB_LAUNCHCTL_KICKLOG="$kicklog" STUB_LAUNCHCTL_PRINT_COUNT="$pcount" \
     PATH="$stub:$PATH" "$@" \
@@ -187,17 +205,27 @@ rc_nonzero kick-fail
 did_kick kick-fail
 err_has kick-fail "kickstart"
 
-# 7. service did not come back after kickstart: nonzero + loud.
+# 7. launchd job did not reload after kickstart: nonzero + loud.
 reload_case no-return STUB_LAUNCHCTL_PRINT_RCS=0:3
 rc_nonzero no-return
 did_kick no-return
-err_has no-return "come back"
+err_has no-return "did not reload"
 
-# 8. happy path: validated, kicked, confirmed back up.
-reload_case happy STUB_LAUNCHCTL_PRINT_RCS=0:0
+# 8. loaded but NOT READY (R2-2): launchctl reports the job loaded (rc 0 both probes)
+#    and the kickstart succeeds, but the readiness probe never sees sshd accept a
+#    connection -> fail closed, loud, NOT green.
+reload_case not-ready STUB_LAUNCHCTL_PRINT_RCS=0:0 STUB_KEYSCAN_READY=0
+rc_nonzero not-ready
+did_kick not-ready
+err_has not-ready "did NOT become ready"
+err_has not-ready "lockout"
+
+# 9. happy path: validated, kicked, launchd job reloaded AND the readiness probe saw
+#    sshd accept a connection.
+reload_case happy STUB_LAUNCHCTL_PRINT_RCS=0:0 STUB_KEYSCAN_READY=1
 rc_zero happy
 did_kick happy
-out_has happy "confirmed running"
+out_has happy "accepting SSH connections"
 
 if [[ $failures -gt 0 ]]; then
   printf 'ssh-hardening-reload-failclosed: %d assertion(s) FAILED\n' "$failures" >&2

--- a/test/integration/ssh-hardening-sshd-validate.sh
+++ b/test/integration/ssh-hardening-sshd-validate.sh
@@ -19,6 +19,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -39,7 +47,7 @@ work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
 dropin="$work/50-ssh-hardening.conf"
-bash "$SCRIPT" --print-config >"$dropin" || fail "--print-config exited non-zero"
+"$BASH_BIN" "$SCRIPT" --print-config >"$dropin" || fail "--print-config exited non-zero"
 
 # sshd -G rejects bad syntax; a non-zero exit here means the drop-in is malformed.
 effective="$work/effective"

--- a/test/integration/ssh-hardening-sshd-validate.sh
+++ b/test/integration/ssh-hardening-sshd-validate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ssh-hardening-sshd-validate.sh -- validate ssh-hardening.sh's drop-in through the
+# REAL sshd parser, from its effective-config output. The brief named `sshd -t` /
+# `sshd -T`, but both require host keys and root and fail as an unprivileged CI/test
+# user ("no hostkeys available"). `sshd -G` parses the config and dumps the
+# effective settings WITHOUT host keys or root -- the correct host-key-free seam. It
+# also rejects bad syntax (exit != 0), so it doubles as the syntax gate the brief
+# asked for.
+#
+# This test NEVER touches the live /etc/ssh config and NEVER reloads sshd: it feeds
+# a temp file (the --print-config output) to `sshd -G` and diffs the effective
+# values against the accepted set. Whether the drop-in wins against the live main
+# config on the real host is the operator's apply-time `sshd -T` check.
+#
+# SKIPs cleanly where sshd is absent (the de-homebrewed CI-faithful PATH has no
+# /usr/sbin) or where `sshd -G` is unusable in the sandbox.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+command -v sshd >/dev/null 2>&1 || {
+  printf 'SKIP: sshd not on PATH; cannot validate the drop-in with the real parser\n'
+  exit 0
+}
+# Probe: is `sshd -G` usable unprivileged here? An empty config must parse+dump.
+if ! sshd -G -f /dev/null >/dev/null 2>&1; then
+  printf 'SKIP: sshd -G is not usable in this environment (older OpenSSH or sandbox)\n'
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+dropin="$work/50-ssh-hardening.conf"
+bash "$SCRIPT" --print-config >"$dropin" || fail "--print-config exited non-zero"
+
+# sshd -G rejects bad syntax; a non-zero exit here means the drop-in is malformed.
+effective="$work/effective"
+sshd -G -f "$dropin" >"$effective" 2>"$work/err" ||
+  fail "sshd -G rejected the drop-in (syntax/value error): $(cat "$work/err")"
+
+# sshd -G lowercases keys and prints "key value". Assert each accepted pair.
+declare -a want=(
+  'passwordauthentication no'
+  'kbdinteractiveauthentication no'
+  'usepam yes'
+  'pubkeyauthentication yes'
+  'permitrootlogin no'
+)
+for pair in "${want[@]}"; do
+  grep -qxF "$pair" "$effective" ||
+    fail "sshd effective config missing '$pair' (got: $(grep -iE '^(passwordauthentication|kbdinteractiveauthentication|usepam|pubkeyauthentication|permitrootlogin) ' "$effective" | tr '\n' ';'))"
+done
+
+printf 'ssh-hardening-sshd-validate: OK (sshd -G accepts the drop-in; all five effective values match the ruling)\n'

--- a/test/unit/macos-defaults-source-path-propagation.sh
+++ b/test/unit/macos-defaults-source-path-propagation.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# macos-defaults-source-path-propagation.sh -- resolve_source_dir (in
+# macos-defaults-lib.sh) must PROPAGATE a nonzero `chezmoi source-path` exit, not
+# mask it with an unconditional `return 0` (R1-6). The worktree branch ran `chezmoi
+# --source=<top> source-path` on its own line then `return 0` regardless of exit
+# status, so a chezmoi failure was swallowed; the tool only failed later, and less
+# precisely, via a downstream readability guard.
+#
+# Sources the lib with a git stub (so the worktree branch fires) and a chezmoi stub
+# that FAILS `source-path`, then calls resolve_source_dir in a shell WITHOUT `set
+# -e` (a caller without set -e is exactly where the `return 0` masks the failure;
+# under set -e the mask is incidentally hidden). Asserts nonzero return and a
+# precise message. Pure stubs, fast: a unit test.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+[[ -f $LIB ]] || fail "missing lib: $LIB"
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# A fake worktree top carrying the data file, so the worktree branch of
+# resolve_source_dir is the branch that runs.
+top="$work/top"
+mkdir -p "$top/.chezmoidata"
+: >"$top/.chezmoidata/macos_defaults.yaml"
+
+stub="$work/bin"
+mkdir -p "$stub"
+cat >"$stub/git" <<EOF
+#!/bin/bash
+if [[ "\$1 \$2" == "rev-parse --show-toplevel" ]]; then
+  printf '%s\n' "$top"
+  exit 0
+fi
+exit 0
+EOF
+cat >"$stub/chezmoi" <<'EOF'
+#!/bin/bash
+# Fail specifically on the source-path call (the masked one); succeed otherwise.
+for a in "$@"; do
+  [[ $a == source-path ]] && {
+    printf 'chezmoi: boom\n' >&2
+    exit 1
+  }
+done
+exit 0
+EOF
+chmod +x "$stub/git" "$stub/chezmoi"
+
+# Deliberately NO `set -e` in the inner shell: that is the caller context in which
+# the old `return 0` masks the chezmoi failure.
+rc=0
+out="$(PATH="$stub:$PATH" LIB="$LIB" MACOS_DEFAULTS_SOURCE_DIR="" bash -c '
+  unset MACOS_DEFAULTS_SOURCE_DIR
+  source "$LIB"
+  resolve_source_dir
+' 2>"$work/err")" || rc=$?
+
+[[ $rc -ne 0 ]] ||
+  fail "resolve_source_dir must PROPAGATE the chezmoi source-path failure (got rc=0, masked; stdout: '$out')"
+grep -qi 'source-path' "$work/err" ||
+  fail "expected a precise error mentioning source-path (stderr: $(cat "$work/err"))"
+
+printf 'macos-defaults-source-path-propagation: OK (chezmoi source-path failure propagates with a precise message, not masked)\n'

--- a/test/unit/macos-security-posture.sh
+++ b/test/unit/macos-security-posture.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# macos-security-posture.sh -- the security-posture reminder
+# (run_after_67-macos-security-posture) must REPORT FileVault, Gatekeeper, and SIP
+# (System Integrity Protection) state and NEVER change any of them. It renders the
+# REAL chezmoiscript and runs the rendered body against fake fdesetup/spctl/csrutil
+# binaries (FDESETUP_BIN/SPCTL_BIN/CSRUTIL_BIN) per posture. The fakes answer ONLY
+# their status query; ANY other invocation (an enable/--master-enable fix attempt)
+# is logged to a mutation file and fails, so a single fix attempt is caught.
+#
+# Asserts, for every case: exit 0 (a reminder must never abort `chezmoi apply`) and
+# an EMPTY mutation log (assert-only). Plus: enabled -> a stdout OK line and no
+# DISABLED warning; disabled -> a stderr DISABLED warning; unknown -> a
+# "could not determine" note. SIP and FileVault are assert-only by policy; a
+# disabled stub must produce a warning, never a fix.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the posture reminder\n'
+  exit 0
+}
+[[ -f $SCRIPT ]] || fail "missing template: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Render the darwin-only script once (scratch HOME, CI=1). Empty render ==
+# non-darwin host: skip.
+rendered="$work/rendered.sh"
+render_home="$(mktemp -d)"
+HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
+rm -rf "$render_home"
+if [[ ! -s $rendered ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# make_stub <path> <status_output> <mutation_log>: a fake fdesetup/spctl/csrutil.
+# It answers `status` / `--status` with the given text; ANY other argument is a
+# fix attempt -> record it and fail loudly.
+make_stub() {
+  local path="$1" out="$2" mlog="$3"
+  cat >"$path" <<STUB
+#!/bin/bash
+case "\$1" in
+  status|--status) printf '%s\n' "$out"; exit 0 ;;
+  *) printf '%s %s\n' "\$(basename "\$0")" "\$*" >>"$mlog"; exit 1 ;;
+esac
+STUB
+  chmod +x "$path"
+}
+
+# run_case <name> <fv_out> <gk_out> <sip_out> -> populates RC, OUT, ERR, MUT.
+run_case() {
+  local name="$1" fv="$2" gk="$3" sip="$4"
+  local dir="$work/$name"
+  mkdir -p "$dir"
+  local mlog="$dir/mutations"
+  : >"$mlog"
+  make_stub "$dir/fdesetup" "$fv" "$mlog"
+  make_stub "$dir/spctl" "$gk" "$mlog"
+  make_stub "$dir/csrutil" "$sip" "$mlog"
+  RC=0
+  OUT="$(FDESETUP_BIN="$dir/fdesetup" SPCTL_BIN="$dir/spctl" CSRUTIL_BIN="$dir/csrutil" \
+    bash "$rendered" 2>"$dir/err")" || RC=$?
+  ERR="$(cat "$dir/err")"
+  MUT="$(cat "$mlog")"
+}
+
+failures=0
+report() {
+  if [[ $1 == ok ]]; then printf '  ok   %s\n' "$2"; else
+    printf '  FAIL %s\n' "$2"
+    failures=$((failures + 1))
+  fi
+}
+a0() { if [[ $RC -eq 0 ]]; then report ok "$1: exits 0"; else report bad "$1: exits 0 (got rc=$RC; err: $ERR)"; fi; }
+# Assert-only: no fix command was ever invoked.
+anomut() { if [[ -z $MUT ]]; then report ok "$1: no mutation attempted"; else report bad "$1: attempted a fix: $MUT"; fi; }
+outhas() { if grep -qi -- "$2" <<<"$OUT"; then report ok "$1: stdout has '$2'"; else report bad "$1: stdout has '$2' (out: $OUT)"; fi; }
+errhas() { if grep -qi -- "$2" <<<"$ERR"; then report ok "$1: stderr warns '$2'"; else report bad "$1: stderr warns '$2' (err: $ERR)"; fi; }
+errno() { if grep -qi -- "$2" <<<"$ERR"; then report bad "$1: stderr must NOT contain '$2' (err: $ERR)"; else report ok "$1: no '$2' in stderr"; fi; }
+
+printf 'macos-security-posture cases:\n'
+
+# All enabled -> OK on stdout, no warnings, no mutation.
+run_case enabled "FileVault is On." "assessments enabled" "System Integrity Protection status: enabled."
+a0 enabled
+anomut enabled
+outhas enabled "FileVault: enabled"
+outhas enabled "Gatekeeper: enabled"
+outhas enabled "SIP: enabled"
+errno enabled "DISABLED"
+
+# All disabled -> a DISABLED warning per posture, exit 0, and NO fix attempt.
+run_case disabled "FileVault is Off." "assessments disabled" "System Integrity Protection status: disabled."
+a0 disabled
+anomut disabled
+errhas disabled "FileVault is DISABLED"
+errhas disabled "Gatekeeper is DISABLED"
+errhas disabled "SIP is DISABLED"
+
+# Unparseable -> a could-not-determine note, exit 0, no mutation.
+run_case unknown "gibberish" "gibberish" "unknown (Custom Configuration)"
+a0 unknown
+anomut unknown
+errhas unknown "could not determine"
+
+if [[ $failures -gt 0 ]]; then
+  printf 'macos-security-posture: %d assertion(s) FAILED\n' "$failures" >&2
+  exit 1
+fi
+printf 'macos-security-posture: OK (reports FileVault/Gatekeeper/SIP; warns on disabled; never mutates; always exits 0)\n'

--- a/test/unit/macos-security-posture.sh
+++ b/test/unit/macos-security-posture.sh
@@ -43,31 +43,34 @@ if [[ ! -s $rendered ]]; then
   exit 0
 fi
 
-# make_stub <path> <status_output> <mutation_log>: a fake fdesetup/spctl/csrutil.
-# It answers `status` / `--status` with the given text; ANY other argument is a
-# fix attempt -> record it and fail loudly.
+# make_stub <path> <status_output> <mutation_log> [status_rc]: a fake fdesetup/
+# spctl/csrutil. It answers `status` / `--status` with the given text and exit code
+# (default 0); ANY other argument is a fix attempt -> record it and fail loudly. A
+# nonzero status_rc models a DEGRADED query (a probe that prints text yet fails).
 make_stub() {
-  local path="$1" out="$2" mlog="$3"
+  local path="$1" out="$2" mlog="$3" status_rc="${4:-0}"
   cat >"$path" <<STUB
 #!/bin/bash
 case "\$1" in
-  status|--status) printf '%s\n' "$out"; exit 0 ;;
+  status|--status) printf '%s\n' "$out"; exit $status_rc ;;
   *) printf '%s %s\n' "\$(basename "\$0")" "\$*" >>"$mlog"; exit 1 ;;
 esac
 STUB
   chmod +x "$path"
 }
 
-# run_case <name> <fv_out> <gk_out> <sip_out> -> populates RC, OUT, ERR, MUT.
+# run_case <name> <fv_out> <gk_out> <sip_out> [fv_rc] [gk_rc] [sip_rc] -> populates
+# RC, OUT, ERR, MUT. The trailing rc args default to 0 (successful query).
 run_case() {
   local name="$1" fv="$2" gk="$3" sip="$4"
+  local fv_rc="${5:-0}" gk_rc="${6:-0}" sip_rc="${7:-0}"
   local dir="$work/$name"
   mkdir -p "$dir"
   local mlog="$dir/mutations"
   : >"$mlog"
-  make_stub "$dir/fdesetup" "$fv" "$mlog"
-  make_stub "$dir/spctl" "$gk" "$mlog"
-  make_stub "$dir/csrutil" "$sip" "$mlog"
+  make_stub "$dir/fdesetup" "$fv" "$mlog" "$fv_rc"
+  make_stub "$dir/spctl" "$gk" "$mlog" "$gk_rc"
+  make_stub "$dir/csrutil" "$sip" "$mlog" "$sip_rc"
   RC=0
   OUT="$(FDESETUP_BIN="$dir/fdesetup" SPCTL_BIN="$dir/spctl" CSRUTIL_BIN="$dir/csrutil" \
     bash "$rendered" 2>"$dir/err")" || RC=$?
@@ -86,6 +89,7 @@ a0() { if [[ $RC -eq 0 ]]; then report ok "$1: exits 0"; else report bad "$1: ex
 # Assert-only: no fix command was ever invoked.
 anomut() { if [[ -z $MUT ]]; then report ok "$1: no mutation attempted"; else report bad "$1: attempted a fix: $MUT"; fi; }
 outhas() { if grep -qi -- "$2" <<<"$OUT"; then report ok "$1: stdout has '$2'"; else report bad "$1: stdout has '$2' (out: $OUT)"; fi; }
+outno() { if grep -qi -- "$2" <<<"$OUT"; then report bad "$1: stdout must NOT contain '$2' (out: $OUT)"; else report ok "$1: no '$2' in stdout"; fi; }
 errhas() { if grep -qi -- "$2" <<<"$ERR"; then report ok "$1: stderr warns '$2'"; else report bad "$1: stderr warns '$2' (err: $ERR)"; fi; }
 errno() { if grep -qi -- "$2" <<<"$ERR"; then report bad "$1: stderr must NOT contain '$2' (err: $ERR)"; else report ok "$1: no '$2' in stderr"; fi; }
 
@@ -113,6 +117,20 @@ run_case unknown "gibberish" "gibberish" "unknown (Custom Configuration)"
 a0 unknown
 anomut unknown
 errhas unknown "could not determine"
+
+# Degraded query (R1-4): a probe that prints ENABLED-looking text but EXITS
+# NONZERO must be reported INDETERMINATE, never enabled -- a failed query's stdout
+# is untrustworthy. Here fdesetup fails (rc 23) while printing "FileVault is On.";
+# Gatekeeper and SIP succeed and stay classifiable. FileVault must read
+# could-not-determine (never "FileVault: enabled"); the others still report enabled.
+run_case degraded "FileVault is On." "assessments enabled" \
+  "System Integrity Protection status: enabled." 23 0 0
+a0 degraded
+anomut degraded
+errhas degraded "FileVault: could not determine"
+outno degraded "FileVault: enabled"
+outhas degraded "Gatekeeper: enabled"
+outhas degraded "SIP: enabled"
 
 if [[ $failures -gt 0 ]]; then
   printf 'macos-security-posture: %d assertion(s) FAILED\n' "$failures" >&2

--- a/test/unit/macos-security-posture.sh
+++ b/test/unit/macos-security-posture.sh
@@ -4,8 +4,8 @@
 # (System Integrity Protection) state and NEVER change any of them. It renders the
 # REAL chezmoiscript and runs the rendered body against fake fdesetup/spctl/csrutil
 # binaries (FDESETUP_BIN/SPCTL_BIN/CSRUTIL_BIN) per posture. The fakes answer ONLY
-# their status query; ANY other invocation (an enable/--master-enable fix attempt)
-# is logged to a mutation file and fails, so a single fix attempt is caught.
+# their status query; ANY other invocation (an enable/mutation fix attempt) is logged
+# to a mutation file and fails, so a single fix attempt is caught.
 #
 # Asserts, for every case: exit 0 (a reminder must never abort `chezmoi apply`) and
 # an EMPTY mutation log (assert-only). Plus: enabled -> a stdout OK line and no
@@ -111,6 +111,12 @@ anomut disabled
 errhas disabled "FileVault is DISABLED"
 errhas disabled "Gatekeeper is DISABLED"
 errhas disabled "SIP is DISABLED"
+# R2-4: the Gatekeeper remedy must not name a removed flag. `spctl --master-enable`
+# was removed on macOS 15+ (this box's `spctl` offers only --global-disable /
+# --disable-status / --status -- no enable flag), so re-enabling is System-Settings-
+# gated. The remedy must point there, never to a nonexistent spctl flag.
+errno disabled "master-enable"
+errhas disabled "System Settings"
 
 # Unparseable -> a could-not-determine note, exit 0, no mutation.
 run_case unknown "gibberish" "gibberish" "unknown (Custom Configuration)"

--- a/test/unit/ssh-hardening-dropin.sh
+++ b/test/unit/ssh-hardening-dropin.sh
@@ -21,6 +21,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -29,7 +37,7 @@ fail() {
 [[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
 
 # --print-config must succeed with no sudo and no writes.
-config="$(bash "$SCRIPT" --print-config)" || fail "ssh-hardening.sh --print-config exited non-zero"
+config="$("$BASH_BIN" "$SCRIPT" --print-config)" || fail "ssh-hardening.sh --print-config exited non-zero"
 
 # Each accepted key=value must be present as its own exact line.
 declare -a want=(
@@ -61,7 +69,7 @@ done
 # --print-path must name a drop-in that sorts FIRST in sshd's lexical Include order,
 # AHEAD of Apple's 100-macos.conf. Under `Include sshd_config.d/*`, sshd is
 # first-value-wins, so a drop-in that sorts after 100- is silently shadowed (R1-1).
-dropin_path="$(bash "$SCRIPT" --print-path)" || fail "ssh-hardening.sh --print-path exited non-zero"
+dropin_path="$("$BASH_BIN" "$SCRIPT" --print-path)" || fail "ssh-hardening.sh --print-path exited non-zero"
 dropin_base="$(basename "$dropin_path")"
 [[ $dropin_base == "000-ssh-hardening.conf" ]] ||
   fail "managed drop-in must be 000-ssh-hardening.conf so it sorts first (got: $dropin_base)"

--- a/test/unit/ssh-hardening-dropin.sh
+++ b/test/unit/ssh-hardening-dropin.sh
@@ -58,4 +58,15 @@ for line in "${forbid[@]}"; do
   fi
 done
 
-printf 'ssh-hardening-dropin: OK (all five accepted keys present, no conflicting directive)\n'
+# --print-path must name a drop-in that sorts FIRST in sshd's lexical Include order,
+# AHEAD of Apple's 100-macos.conf. Under `Include sshd_config.d/*`, sshd is
+# first-value-wins, so a drop-in that sorts after 100- is silently shadowed (R1-1).
+dropin_path="$(bash "$SCRIPT" --print-path)" || fail "ssh-hardening.sh --print-path exited non-zero"
+dropin_base="$(basename "$dropin_path")"
+[[ $dropin_base == "000-ssh-hardening.conf" ]] ||
+  fail "managed drop-in must be 000-ssh-hardening.conf so it sorts first (got: $dropin_base)"
+first="$(printf '%s\n100-macos.conf\n' "$dropin_base" | LC_ALL=C sort | head -n1)"
+[[ $first == "$dropin_base" ]] ||
+  fail "managed drop-in must sort before 100-macos.conf (LC_ALL=C sort put '$first' first)"
+
+printf 'ssh-hardening-dropin: OK (all five accepted keys present, no conflicting directive; 000- sorts first)\n'

--- a/test/unit/ssh-hardening-dropin.sh
+++ b/test/unit/ssh-hardening-dropin.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ssh-hardening-dropin.sh -- ssh-hardening.sh must emit an sshd drop-in that closes
+# the PAM password hole. The audit found the old drop-in set only
+# `PasswordAuthentication no`; with `UsePAM yes` and the default
+# `KbdInteractiveAuthentication`, PAM keyboard-interactive password login stays
+# OPEN. The accepted effective config (the ruling) is exactly:
+#   passwordauthentication no
+#   kbdinteractiveauthentication no
+#   usepam yes            (macOS REQUIRES UsePAM yes for account/session mgmt;
+#                          safe because BOTH password paths above are no)
+#   pubkeyauthentication yes
+#   permitrootlogin no
+#
+# The script's `--print-config` mode prints the drop-in to stdout with NO side
+# effects (no sudo, no writes, no sshd) -- the pure inspection seam. This unit test
+# greps that output for each key at its accepted value and rejects any conflicting
+# line. sshd's own effective-config validation lives in the integration camp
+# (needs the sshd binary).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+
+# --print-config must succeed with no sudo and no writes.
+config="$(bash "$SCRIPT" --print-config)" || fail "ssh-hardening.sh --print-config exited non-zero"
+
+# Each accepted key=value must be present as its own exact line.
+declare -a want=(
+  'PasswordAuthentication no'
+  'KbdInteractiveAuthentication no'
+  'UsePAM yes'
+  'PubkeyAuthentication yes'
+  'PermitRootLogin no'
+)
+for line in "${want[@]}"; do
+  grep -qxF "$line" <<<"$config" ||
+    fail "drop-in is missing the accepted line: '$line' (got:
+$config)"
+done
+
+# No conflicting directive may reopen a closed path.
+declare -a forbid=(
+  'PasswordAuthentication yes'
+  'KbdInteractiveAuthentication yes'
+  'PermitRootLogin yes'
+  'PubkeyAuthentication no'
+)
+for line in "${forbid[@]}"; do
+  if grep -qxF "$line" <<<"$config"; then
+    fail "drop-in contains a conflicting directive: '$line'"
+  fi
+done
+
+printf 'ssh-hardening-dropin: OK (all five accepted keys present, no conflicting directive)\n'

--- a/test/unit/ssh-hardening-verify-failclosed.sh
+++ b/test/unit/ssh-hardening-verify-failclosed.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ssh-hardening-verify-failclosed.sh -- a verifier that CANNOT run must never report
+# success in a production path (R2-3). The audit found: with the sshd binary off PATH,
+# `--verify` printed "cannot verify" and returned 0; install_dropin calls --verify
+# after writing the drop-in, so an environment without sshd claimed success having
+# checked NOTHING. A security check that cannot run must FAIL CLOSED.
+#
+# The fix uses the absolute `/usr/sbin/sshd` (macOS default) and, when the verifier
+# cannot run, returns NONZERO and loud in production. The tool-absence SKIP is
+# permitted ONLY via an explicit test env seam (SSH_HARDENING_SKIP_IF_NO_SSHD), never
+# in the default production path.
+#
+# Pure/fast: drives `--verify` with SSHD_BIN pointed at a nonexistent path (no real
+# sshd, no config parse -- verify_effective returns at the binary-absence check). Unit
+# camp. No SKIP needed.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+[[ -f $SCRIPT ]] || fail "missing script: $SCRIPT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+missing="$work/no-such-sshd"
+
+failures=0
+report() {
+  if [[ $1 == ok ]]; then printf '  ok   %s\n' "$2"; else
+    printf '  FAIL %s\n' "$2"
+    failures=$((failures + 1))
+  fi
+}
+
+printf 'ssh-hardening --verify fail-closed cases:\n'
+
+# 1. PRODUCTION path (no skip seam), sshd binary absent -> FAIL CLOSED (nonzero, loud).
+rc=0
+err="$(SSH_HARDENING_SUDO="" SSHD_BIN="$missing" SSHD_MAIN_CONFIG=/dev/null \
+  bash "$SCRIPT" --verify 2>&1 >/dev/null)" || rc=$?
+if [[ $rc -ne 0 ]]; then report ok "production: --verify FAILS closed (rc=$rc)"; else
+  report bad "production: --verify must FAIL when the verifier cannot run (got rc=0; out/err: $err)"
+fi
+if grep -qi 'closed' <<<"$err"; then report ok "production: warns it is failing closed"; else
+  report bad "production: must warn it is failing closed (err: $err)"
+fi
+
+# 2. TEST seam set, sshd absent -> clean SKIP (rc 0, a skip note, never a bogus pass).
+rc=0
+out="$(SSH_HARDENING_SUDO="" SSHD_BIN="$missing" SSHD_MAIN_CONFIG=/dev/null \
+  SSH_HARDENING_SKIP_IF_NO_SSHD=1 bash "$SCRIPT" --verify 2>"$work/e2")" || rc=$?
+err2="$(cat "$work/e2")"
+if [[ $rc -eq 0 ]]; then report ok "test-seam: --verify skips cleanly (rc=0)"; else
+  report bad "test-seam: --verify must skip (rc=0) when the seam is set (rc=$rc; err: $err2)"
+fi
+if grep -qi 'skip' <<<"$err2$out"; then report ok "test-seam: notes the skip"; else
+  report bad "test-seam: must note the skip (out: $out; err: $err2)"
+fi
+# The skip must NOT masquerade as a verification pass.
+if grep -qi 'verified' <<<"$out"; then
+  report bad "test-seam: skip must not print a 'verified' claim (out: $out)"
+else report ok "test-seam: no false 'verified' claim"; fi
+
+# 3. The absolute default matters: with no SSHD_BIN override, the default must be the
+#    absolute /usr/sbin/sshd (macOS default), not a bare PATH name a stripped PATH
+#    could silently fail to resolve.
+if grep -qF 'SSHD_BIN:-/usr/sbin/sshd' "$SCRIPT"; then
+  report ok "default: SSHD_BIN defaults to absolute /usr/sbin/sshd"
+else
+  report bad "default: SSHD_BIN must default to the absolute /usr/sbin/sshd"
+fi
+
+if [[ $failures -gt 0 ]]; then
+  printf 'ssh-hardening-verify-failclosed: %d assertion(s) FAILED\n' "$failures" >&2
+  exit 1
+fi
+printf 'ssh-hardening-verify-failclosed: OK (production fails closed; test seam skips cleanly; absolute default)\n'

--- a/test/unit/ssh-hardening-verify-failclosed.sh
+++ b/test/unit/ssh-hardening-verify-failclosed.sh
@@ -18,6 +18,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/dot_local/bin/executable_ssh-hardening.sh"
 
+# Exercise the script through its PRODUCTION shebang interpreter (/bin/bash). macOS
+# ships /bin/bash 3.2, which lacks associative arrays and the compgen builtin, and the
+# operator invokes the script by its `#!/bin/bash` shebang -- so a 3.2-only regression
+# must fail HERE, not in production. Falls back to the ambient bash where /bin/bash is
+# absent (non-macOS).
+BASH_BIN=/bin/bash
+[[ -x $BASH_BIN ]] || BASH_BIN="bash"
+
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
@@ -41,7 +49,7 @@ printf 'ssh-hardening --verify fail-closed cases:\n'
 # 1. PRODUCTION path (no skip seam), sshd binary absent -> FAIL CLOSED (nonzero, loud).
 rc=0
 err="$(SSH_HARDENING_SUDO="" SSHD_BIN="$missing" SSHD_MAIN_CONFIG=/dev/null \
-  bash "$SCRIPT" --verify 2>&1 >/dev/null)" || rc=$?
+  "$BASH_BIN" "$SCRIPT" --verify 2>&1 >/dev/null)" || rc=$?
 if [[ $rc -ne 0 ]]; then report ok "production: --verify FAILS closed (rc=$rc)"; else
   report bad "production: --verify must FAIL when the verifier cannot run (got rc=0; out/err: $err)"
 fi
@@ -52,7 +60,7 @@ fi
 # 2. TEST seam set, sshd absent -> clean SKIP (rc 0, a skip note, never a bogus pass).
 rc=0
 out="$(SSH_HARDENING_SUDO="" SSHD_BIN="$missing" SSHD_MAIN_CONFIG=/dev/null \
-  SSH_HARDENING_SKIP_IF_NO_SSHD=1 bash "$SCRIPT" --verify 2>"$work/e2")" || rc=$?
+  SSH_HARDENING_SKIP_IF_NO_SSHD=1 "$BASH_BIN" "$SCRIPT" --verify 2>"$work/e2")" || rc=$?
 err2="$(cat "$work/e2")"
 if [[ $rc -eq 0 ]]; then report ok "test-seam: --verify skips cleanly (rc=0)"; else
   report bad "test-seam: --verify must skip (rc=0) when the seam is set (rc=$rc; err: $err2)"


### PR DESCRIPTION
## Context

Main is being rebuilt slice by slice while the live machine (dresden) applies from `integration/modernization` until the D1 cutover. S10 is the macOS defaults / system-setup slice: it fixes the defaults-management tooling, closes a real SSH password-login hole, carries the already-approved endpoint-hardening casks to main, and adds a check-only security-posture reminder.

You asked to review this PR yourself before merge, so it is open, not auto-merged. It touches SSH hardening on the machine you connect to, so it went through the full three-pass adversarial review (two dual rounds plus an isolated final pass), with the sshd component attacked hardest.

## Summary

- The macOS-defaults tools now resolve their source per-worktree, fixing a worktree-writes-primary bug.
- The SSH drop-in closes the PAM/keyboard-interactive password hole and is wired for fresh machines.
- The drop-in is renamed to win include-precedence, and its verifier now catches Match-block bypasses.
- LuLu + OverSight casks and firewall stealth mode reach main (the R8 endpoint hardening).
- A check-only FileVault/Gatekeeper/SIP posture reminder reports on every apply, never changes state.

Key files:
- `dot_local/bin/executable_ssh-hardening.sh`
- `dot_local/bin/macos-defaults-lib.sh` + the defaults trio
- `.chezmoiscripts/run_after_67-macos-security-posture.sh.tmpl`
- `.chezmoidata/macos_system_setup.yaml`, `.chezmoidata/system_packages_autoinstall.yaml`

## What changed

- Defaults tooling: the apply/capture/drift trio share a lib that resolves the chezmoi source via `chezmoi source-path`, so running a capture from a secondary worktree writes that worktree's YAML, not the primary checkout. The `after_41` sudo runner is guarded with `{{ if index . "sudo" }}` so a record without a sudo key no longer throws.
- SSH hardening: the drop-in sets `PasswordAuthentication no`, `KbdInteractiveAuthentication no`, `UsePAM yes`, `PubkeyAuthentication yes`, `PermitRootLogin no` (the audit's accepted effective config; the old drop-in set only the first, leaving the keyboard-interactive/PAM password path open). It is renamed `000-ssh-hardening.conf` so it wins first-value-wins over Apple's `100-macos.conf`, migrates the old `50-` file away, and is wired as a `macos_system_setup.yaml` record so a fresh machine actually locks sshd. The verifier checks three ways (global `sshd -G`, a raw scan of every included file for a `Match` block re-enabling a protected directive, and `sshd -G -T -C` for a root and a normal-user connection spec), and fails closed when it cannot run. The operator-only `--reload` validates the full config and probes real sshd readiness before trusting a restart.
- Endpoint hardening (R8, previously operator-approved): LuLu (outbound firewall) and OverSight (mic/camera alerts) casks, plus a firewall record that enables the Application Firewall and stealth mode.
- Posture reminder: reports FileVault / Gatekeeper / SIP on every apply; a failed query reads "could not determine" rather than a false "enabled"; it never enables anything.

## How it was reviewed

- Three sequential adversarial passes (two dual Opus+sol rounds, one isolated sol final gate), sol hardened each round. Round 1 caught the include-precedence hole and that the local de-homebrewed gate was itself invalid; round 2 caught that the verifier was blind to `Match`-block re-enables and that the post-reload check proved job-load not readiness; round 3 found nothing new.
- Conductor verification independently reproduced the `Match Group` bypass against the fixed verifier (correctly rejected, including case/tab variants) and ran the corrected de-homebrewed gate.
- 13 findings fixed red-first across the two rounds; the bats suite plus new SSH/posture/defaults tests all pass or skip cleanly.

## Operator steps (this slice needs you, physically present)

1. Apply from a LOCAL console (not over the SSH session being hardened), KeePassXC unlocked. The Tier-2 runner writes `000-ssh-hardening.conf`, removes the old `50-`, enables the firewall + stealth, and installs the casks. One sudo prompt.
2. Live sshd reload + proof (deliberately not automated): keep the current session open, run `~/.local/bin/ssh-hardening.sh --reload` (it validates and probes readiness), then prove a key-only login in a NEW session before closing the old one. Verify with connection specs (the plain `sudo sshd -T` shares a Match blind spot): `sudo /usr/sbin/sshd -G -T -C user=root,addr=203.0.113.1,host=localhost | grep -iE 'passwordauthentication|kbdinteractive|usepam|pubkey|permitrootlogin'` reads no/no/yes/yes/no, then repeat with your own user. Rollback = remove `000-ssh-hardening.conf` and reload.
3. Firewall: the apply enables the inbound Application Firewall (global state on) before stealth, this affects inbound connections on a fresh machine (dresden is already on). Flagged for your sign-off.
4. Casks: LuLu and OverSight install on apply and need manual first-run approval (LuLu is a network system extension; OverSight needs mic/camera permission).
5. SIP is disabled on dresden (the posture reminder surfaces it); re-enabling SIP is Recovery-only and is never automated.

## Effect of merging

Merging changes main only; dresden applies these at D1 (or when you apply interactively, since this slice needs a physically-present console). Nothing here reloads sshd or changes live posture on its own. `dresden`'s live drop-in is still the old one-key `50-` version (the password hole is live) until you apply; apply overwrites it in place and closes the hole.
