### PR TITLE
Re-land the osquery dispatch library with save-first alert durability

### DIFF
--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
 #
 # alert-dispatch.sh, sourced helper, not run directly. Provides
-# send_alert(), which dispatches one finding to BOTH the local macOS notifier
-# (alerter) and a hermes Discord webhook, routing by severity (CRIT -> #priority,
-# else -> #osquery). Signing, dual-channel delivery, and durable handling of an
-# undelivered page all live here so the three producers (results-alerter.sh,
-# firewall-gatekeeper-monitor.sh, and uptime-watchdog.sh) share one
-# implementation.
+# send_alert(), which always fires the local macOS notifier (alerter) and, for a
+# CRIT severity ONLY, POSTs the page to the hermes #priority Discord webhook. v2
+# has NO #osquery channel: there is deliberately no non-priority route for a
+# producer to leak to. Signing and durable handling of an undelivered page live
+# here so the three producers (results-alerter.sh, firewall-gatekeeper-monitor.sh,
+# and uptime-watchdog.sh) share one implementation.
 #
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 #   send_alert CRIT "Firewall disabled" "alf global_state 1 -> 0" Sosumi
 
-# Two routes, same app (osquery), each signed with the one osquery key below.
-# CRIT findings go to the #priority channel (the one channel the user watches);
-# everything else goes to the quiet #osquery log channel. send_alert picks the
-# URL from its severity argument.
-OSQUERY_HERMES_URL="${OSQUERY_HERMES_URL:-http://127.0.0.1:8644/webhooks/osquery}"
+# One Discord route: the #priority channel (the one channel the user watches),
+# signed with the osquery HMAC key below. v2 has NO #osquery channel, only a
+# confirmed CRIT page is POSTed; any other severity does the local notification
+# only. There is deliberately no non-priority URL for a producer to leak to.
 OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
 # The notifier signs with its OWN copy of the HMAC key, read from its own secret
 # file, NOT from hermes's .env. HMAC is symmetric so the value must match the
@@ -138,10 +137,6 @@ retry_undelivered_alerts() {
 send_alert() {
   local severity="$1" title="$2" detail="$3" sound="${4-}" occurrence="${5-}"
 
-  # Route by severity: only CRIT reaches #priority.
-  local webhook_url="$OSQUERY_HERMES_URL"
-  [[ $severity == "CRIT" ]] && webhook_url="$OSQUERY_HERMES_PRIORITY_URL"
-
   # The local notifier renders plain text, so strip Discord markdown (**bold**,
   # `code`) for it; the webhook POST below keeps the markdown intact.
   local plain_title plain_detail
@@ -165,16 +160,28 @@ send_alert() {
     fi
   fi
 
-  # Build the webhook body and an occurrence-stable request id. The request id
-  # derives from OCCURRENCE IDENTITY (threaded from the caller) when present, so
-  # two distinct incidents that render the same body get distinct ids (both
-  # stored, both delivered) while a retry of the same occurrence reuses one id
-  # (the gateway dedups it, the stored filename is idempotent). No occurrence
-  # means a per-call unique seed. Built BEFORE reading the secret so a
+  # v2: only a CRIT page is delivered to Discord. Any other severity stops here,
+  # after the local notification, there is no #osquery channel to POST to.
+  [[ $severity == "CRIT" ]] || return 0
+  local url="$OSQUERY_HERMES_PRIORITY_URL"
+
+  # Build the webhook body and an occurrence-stable request id. tier: a page is
+  # loud (a sound was requested), a digest/heartbeat is muted (no sound). Both
+  # severities are CRIT and both POST; tier lets the Hermes adapter suppress the
+  # notification for muted traffic instead of pinging it like a page. host is
+  # INSIDE the signed body, the spec's body shape and the multi-host migration
+  # seam both require {event_type, host, tier, alert}.
+  #
+  # The request id derives from OCCURRENCE IDENTITY (threaded from the caller)
+  # when present, so two distinct incidents that render the same body get distinct
+  # ids (both stored, both delivered) while a retry of the same occurrence reuses
+  # one id (the gateway dedups it, the stored filename is idempotent). No
+  # occurrence means a per-call unique seed. Built BEFORE reading the secret so a
   # missing-secret page stores with the same id the drain later signs and sends.
-  local body request_id id_seed
-  body="$(jq -cn --arg t "$title" --arg d "$detail" \
-    '{event_type:"osquery.alert", alert:{title:$t, detail:$d}}')"
+  local body request_id id_seed tier
+  if [[ -n $sound ]]; then tier="page"; else tier="muted"; fi
+  body="$(jq -cn --arg h "$(hostname -s)" --arg t "$title" --arg d "$detail" --arg tier "$tier" \
+    '{event_type:"osquery.alert", host:$h, tier:$tier, alert:{title:$t, detail:$d}}')"
   if [[ -n $occurrence ]]; then
     id_seed="$occurrence"
   else
@@ -197,7 +204,7 @@ send_alert() {
     # LOUD local notice naming the broken channel. If storing ALSO fails, the
     # page is neither delivered nor stored, a hard failure that must be loud AND
     # return nonzero, never a bare success that drops the page.
-    if _store_undelivered_alert "$request_id" "$webhook_url" "$body"; then
+    if _store_undelivered_alert "$request_id" "$url" "$body"; then
       _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
       _loud_local "osquery Discord paging BROKEN" \
         "No webhook secret. This page was stored locally and delivers when the secret is restored."
@@ -214,7 +221,7 @@ send_alert() {
 
   for attempt in 1 2 3; do
     http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-      -X POST "$webhook_url" \
+      -X POST "$url" \
       -H 'Content-Type: application/json' \
       -H "X-Webhook-Signature: $signature" \
       -H "X-Request-ID: $request_id" \
@@ -230,7 +237,7 @@ send_alert() {
   # the drain replays it. If storage ALSO fails, the page is neither delivered
   # nor stored, a hard failure that returns nonzero and fires a loud local alert,
   # so the caller does NOT advance its cursor past a page that was actually lost.
-  if _store_undelivered_alert "$request_id" "$webhook_url" "$body"; then
+  if _store_undelivered_alert "$request_id" "$url" "$body"; then
     _osquery_log "STORED webhook delivery: request_id=$request_id http=$http_status"
     return 0
   fi

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -2,26 +2,25 @@
 #
 # alert-dispatch.sh, sourced helper, not run directly. Provides
 # send_alert(), which always fires the local macOS notifier (alerter) and, for a
-# CRIT severity ONLY, POSTs the page to the hermes #priority Discord webhook. v2
-# has NO #osquery channel: there is deliberately no non-priority route for a
-# producer to leak to. Signing and durable handling of an undelivered page live
-# here so the three producers (results-alerter.sh, firewall-gatekeeper-monitor.sh,
-# and uptime-watchdog.sh) share one implementation.
+# CRIT severity ONLY, POSTs the page to the hermes #priority Discord webhook.
+# Signing and durable handling of an undelivered page live here so the three
+# producers (results-alerter.sh, firewall-gatekeeper-monitor.sh, and
+# uptime-watchdog.sh) share one implementation.
 #
 # The undelivered-alerts store is WRITE-AHEAD: send_alert persists the page to
 # disk BEFORE the first network attempt and deletes it only after a confirmed 2xx.
 # A crash or kill anywhere between persist and success therefore leaves a
-# recoverable record for the next drain (a lost page is indistinguishable from
-# "all clear").
+# recoverable record for the next drain. Durability matters this much because a
+# page that vanishes leaves no trace: the operator sees a quiet system and has no
+# way to tell a lost alert apart from genuinely good news.
 #
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 #   send_alert CRIT "Firewall disabled" "alf global_state 1 -> 0" Sosumi
 
 # One Discord route: the #priority channel (the one channel the user watches),
-# signed with the osquery HMAC key below. v2 has NO #osquery channel, only a
-# confirmed CRIT page is POSTed; any other severity does the local notification
-# only. There is deliberately no non-priority URL for a producer to leak to.
+# signed with the osquery HMAC key below. Only a CRIT page is POSTed; any other
+# severity does the local notification only.
 OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
 # The notifier signs with its OWN copy of the HMAC key, read from its own secret
 # file, NOT from hermes's .env. HMAC is symmetric so the value must match the
@@ -30,16 +29,19 @@ OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:864
 OSQUERY_WEBHOOK_SECRET_FILE="${OSQUERY_WEBHOOK_SECRET_FILE:-$HOME/.config/osquery/webhook-secret}"
 OSQUERY_DELIVERY_LOG="${OSQUERY_DELIVERY_LOG:-$HOME/.local/log/osquery/webhook-delivery.log}"
 # Undelivered pages are stored here, one mode-600 file per page in a mode-700
-# dir, so a transient gateway outage never loses a page. retry_undelivered_alerts
-# replays them in occurrence-time order.
+# directory, so a transient gateway outage never loses a page.
+# retry_undelivered_alerts replays them in occurrence-time order.
 OSQUERY_UNDELIVERED_ALERTS_DIR="${OSQUERY_UNDELIVERED_ALERTS_DIR:-$HOME/.local/state/osquery-undelivered-alerts}"
 
 # A monotonic per-process sequence so the fallback request id (when no occurrence
 # identity is threaded) is unique across calls in one process.
 _OSQUERY_ALERT_SEQUENCE=0
 
-# Append a timestamped line to the delivery log (best-effort; never fails caller).
-# Only metadata is ever logged, never the body or the HMAC secret.
+# Append a timestamped line to the delivery log. If the log directory cannot be
+# created or the append fails, the line is dropped and the function still
+# returns 0: a logging problem must never break alert delivery, so the caller
+# carries on and only this log line is lost. Only metadata is ever logged, never
+# the body or the HMAC secret.
 _osquery_log() {
   mkdir -p "$(dirname "$OSQUERY_DELIVERY_LOG")" 2>/dev/null || true
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"$OSQUERY_DELIVERY_LOG" 2>/dev/null || true
@@ -85,13 +87,13 @@ _hmac_sha256_hex() {
 # the occurrence timestamp are computed and VALIDATED in checked assignments
 # BEFORE the record file is opened, so an encoder failure fails the store instead
 # of writing an empty body that a later drain would silently skip. Written through
-# a checked temp file, flushed, then atomically renamed, and it RETURNS NONZERO on
-# any persistence failure so the caller treats a failed store as a hard delivery
-# failure (never "stored" when the file does not exist).
-# Line: <occurrence_ts>\t<request_id>\t<url>\t<base64(body)>.
+# a checked temporary file, flushed, then atomically renamed, and it RETURNS
+# NONZERO on any persistence failure so the caller treats a failed store as a
+# hard delivery failure (never "stored" when the file does not exist).
+# Line: <occurrence_timestamp>\t<request_id>\t<url>\t<base64(body)>.
 _store_undelivered_alert() {
-  local occurrence_ts="$1" request_id="$2" url="$3" body="$4" stored_file temp_file encoded_body
-  [[ $occurrence_ts =~ ^[0-9]+$ ]] || return 1
+  local occurrence_timestamp="$1" request_id="$2" url="$3" body="$4" stored_file temporary_file encoded_body
+  [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || return 1
   [[ -n $request_id ]] || return 1
   # pipefail inside the subshell so a base64 failure is the assignment's status,
   # not masked by the trailing tr; then reject an empty result defensively.
@@ -105,47 +107,55 @@ _store_undelivered_alert() {
   mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || return 1
   chmod 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || true
   stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
-  temp_file="$stored_file.tmp.$$"
-  if ! printf '%s\t%s\t%s\t%s\n' "$occurrence_ts" "$request_id" "$url" "$encoded_body" >"$temp_file" 2>/dev/null; then
-    rm -f "$temp_file" 2>/dev/null || true
+  temporary_file="$stored_file.tmp.$$"
+  if ! printf '%s\t%s\t%s\t%s\n' "$occurrence_timestamp" "$request_id" "$url" "$encoded_body" >"$temporary_file" 2>/dev/null; then
+    rm -f "$temporary_file" 2>/dev/null || true
     return 1
   fi
-  chmod 600 "$temp_file" 2>/dev/null || true
+  chmod 600 "$temporary_file" 2>/dev/null || true
   # Flush the record's bytes before the rename so a crash right after the rename
-  # cannot leave a present-but-empty file. GNU `sync FILE` fsyncs just this file;
-  # BSD sync takes no argument and flushes all. Best-effort either way.
-  sync "$temp_file" 2>/dev/null || sync 2>/dev/null || true
-  if ! mv -f "$temp_file" "$stored_file" 2>/dev/null; then
-    rm -f "$temp_file" 2>/dev/null || true
+  # cannot leave a present-but-empty file. GNU `sync FILE` flushes just this
+  # file; BSD sync takes no argument and flushes everything. If both forms fail
+  # the write continues anyway: the rename below still lands a complete record
+  # in the common case, and refusing to store over a failed flush would trade a
+  # rare torn record for a certain lost page.
+  sync "$temporary_file" 2>/dev/null || sync 2>/dev/null || true
+  if ! mv -f "$temporary_file" "$stored_file" 2>/dev/null; then
+    rm -f "$temporary_file" 2>/dev/null || true
     return 1
   fi
   return 0
 }
 
-# Move any crashed *.tmp.* partial (a temp whose writer process is gone) OUT of
-# the store, into a sibling quarantine dir, so a torn write is never replayed and
-# never skipped forever. A temp whose writer pid is still alive is an in-flight
-# write and is left alone. Best-effort; never fails the caller.
+# Move any crashed *.tmp.* partial (a temporary file whose writer process is
+# gone) OUT of the store, into a sibling quarantine directory, so a torn write is
+# never replayed and never skipped forever. A temporary file whose writer process
+# is still alive is an in-flight write and is left alone. If the quarantine
+# directory cannot be created or a move fails, the file simply stays where it was
+# and this function still returns 0; the next drain retries the quarantine, and
+# the drain itself must never abort over housekeeping.
 _quarantine_stale_partials() {
   [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
-  local temp_file pid quarantine_dir
-  quarantine_dir="${OSQUERY_UNDELIVERED_ALERTS_DIR%/}.quarantine"
-  for temp_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*.tmp.*; do
-    [[ -f $temp_file ]] || continue
-    pid="${temp_file##*.tmp.}"
-    if [[ $pid =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
-      continue # a live writer still owns this temp
+  local temporary_file writer_process_id quarantine_directory
+  quarantine_directory="${OSQUERY_UNDELIVERED_ALERTS_DIR%/}.quarantine"
+  for temporary_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*.tmp.*; do
+    [[ -f $temporary_file ]] || continue
+    writer_process_id="${temporary_file##*.tmp.}"
+    if [[ $writer_process_id =~ ^[0-9]+$ ]] && kill -0 "$writer_process_id" 2>/dev/null; then
+      continue # a live writer still owns this temporary file
     fi
-    mkdir -p "$quarantine_dir" 2>/dev/null || continue
-    mv -f "$temp_file" "$quarantine_dir/${temp_file##*/}" 2>/dev/null || true
+    mkdir -p "$quarantine_directory" 2>/dev/null || continue
+    mv -f "$temporary_file" "$quarantine_directory/${temporary_file##*/}" 2>/dev/null || true
   done
   return 0
 }
 
 # Fire ONE loud, interruptive local notification. Used when a page can be neither
 # delivered NOR durably stored: the operator MUST learn that a CRITICAL alert was
-# lost, since a silently dropped page is indistinguishable from "all clear".
-# Best-effort, never fails caller.
+# lost, because a dropped page leaves no trace and would otherwise read as good
+# news. If no notifier is available or the notification itself fails, nothing
+# further happens and the function still returns 0: the dispatch flow continues,
+# already in its worst case, and must not break over a notifier problem.
 _loud_local() {
   local title="$1" message="$2"
   if command -v alerter >/dev/null 2>&1; then
@@ -161,8 +171,8 @@ _loud_local() {
 # verbatim so the gateway dedups), and delete the record only on a confirmed 2xx.
 # Fully set -e-safe: any malformed field returns 0 so the drain continues.
 _deliver_stored_record() {
-  local stored_file="$1" secret="$2" ts request_id url body signature http_status
-  IFS=$'\t' read -r ts request_id url body <"$stored_file" || return 0
+  local stored_file="$1" secret="$2" occurrence_timestamp request_id url body signature http_status
+  IFS=$'\t' read -r occurrence_timestamp request_id url body <"$stored_file" || return 0
   [[ -n $request_id && -n $url && -n $body ]] || return 0
   case "$url" in
     http://127.0.0.1:8644/*) ;;
@@ -187,9 +197,9 @@ _deliver_stored_record() {
 # Replay stored undelivered pages in OCCURRENCE-TIME order (earliest first, with
 # the file path as a deterministic tie-breaker), so a backlog delivers in the
 # order events happened, not in SHA-derived filename order. Crashed partials are
-# quarantined first. Localhost only. Fully set -e-safe: a malformed entry or empty
-# dir must NEVER abort the caller (a delivery feature must not cause a detection
-# outage).
+# quarantined first. Localhost only. Fully set -e-safe: a malformed entry or an
+# empty directory must NEVER abort the caller (a delivery feature must not cause
+# a detection outage).
 retry_undelivered_alerts() {
   [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
   _quarantine_stale_partials
@@ -201,17 +211,17 @@ retry_undelivered_alerts() {
   fi
   [[ -n $secret ]] || return 0
 
-  # Collect "<occurrence_ts>\t<file>" for every well-formed record, then sort by
-  # occurrence time (numeric) with the path as the tie-breaker.
-  local records="" stored_file ts
+  # Collect "<occurrence_timestamp>\t<file>" for every well-formed record, then
+  # sort by occurrence time (numeric) with the path as the tie-breaker.
+  local records="" stored_file occurrence_timestamp
   for stored_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*; do
     [[ -f $stored_file ]] || continue
     case "$stored_file" in
-      *.tmp.*) continue ;; # an in-flight temp; quarantine handles crashed ones
+      *.tmp.*) continue ;; # an in-flight write; quarantine handles crashed ones
     esac
-    IFS=$'\t' read -r ts _ <"$stored_file" || continue
-    [[ $ts =~ ^[0-9]+$ ]] || continue
-    records+="$ts	$stored_file"$'\n'
+    IFS=$'\t' read -r occurrence_timestamp _ <"$stored_file" || continue
+    [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || continue
+    records+="$occurrence_timestamp	$stored_file"$'\n'
   done
   [[ -n $records ]] || return 0
 
@@ -265,47 +275,48 @@ send_alert() {
     fi
   fi
 
-  # v2: only a CRIT page is delivered to Discord. Any other severity stops here,
-  # after the local notification, there is no #osquery channel to POST to.
+  # Only a CRIT page is delivered to Discord. Any other severity stops here,
+  # after the local notification.
   [[ $severity == "CRIT" ]] || return 0
   local url="$OSQUERY_HERMES_PRIORITY_URL"
 
   # Occurrence time: when this page was raised. It is the drain's ordering key AND
   # part of the signed body. A clock glitch never blocks a page (fall back to 0).
-  local occurrence_ts
-  occurrence_ts="$(date -u +%s)"
-  [[ $occurrence_ts =~ ^[0-9]+$ ]] || occurrence_ts=0
+  local occurrence_timestamp
+  occurrence_timestamp="$(date -u +%s)"
+  [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || occurrence_timestamp=0
 
   # Build the webhook body and an occurrence-stable request id. tier: a page is
   # loud (a sound was requested), a digest/heartbeat is muted (no sound). Both
   # severities are CRIT and both POST; tier lets the Hermes adapter suppress the
-  # notification for muted traffic instead of pinging it like a page. host and the
-  # occurrence ts live INSIDE the signed body, the spec's body shape and the
-  # multi-host migration seam both require {event_type, host, tier, ts, alert}.
+  # notification for muted traffic instead of pinging it like a page. The host and
+  # the occurrence timestamp live INSIDE the signed body, the spec's body shape
+  # and the multi-host migration seam both require {event_type, host, tier, ts,
+  # alert} (ts is the wire name of the occurrence timestamp).
   #
   # The request id derives from OCCURRENCE IDENTITY (threaded from the caller)
   # when present, so two distinct incidents that render the same body get distinct
   # ids (both stored, both delivered) while a retry of the same occurrence reuses
   # one id (the gateway dedups it, the stored filename is idempotent). No
   # occurrence means a per-call unique seed.
-  local body request_id id_seed tier
+  local body request_id request_id_seed tier
   if [[ -n $sound ]]; then tier="page"; else tier="muted"; fi
   body="$(jq -cn --arg h "$(hostname -s)" --arg t "$title" --arg d "$detail" \
-    --arg tier "$tier" --argjson ts "$occurrence_ts" \
+    --arg tier "$tier" --argjson ts "$occurrence_timestamp" \
     '{event_type:"osquery.alert", host:$h, tier:$tier, ts:$ts, alert:{title:$t, detail:$d}}')"
   if [[ -n $occurrence ]]; then
-    id_seed="$occurrence"
+    request_id_seed="$occurrence"
   else
     _OSQUERY_ALERT_SEQUENCE=$((_OSQUERY_ALERT_SEQUENCE + 1))
-    id_seed="fallback|$occurrence_ts|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
+    request_id_seed="fallback|$occurrence_timestamp|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
   fi
-  request_id="osquery-$(printf '%s' "$id_seed" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
+  request_id="osquery-$(printf '%s' "$request_id_seed" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
 
   # WRITE-AHEAD: persist the page BEFORE the first network attempt, so a crash or
   # kill before a confirmed success leaves a recoverable record. A persist failure
   # is a HARD failure (loud + nonzero): the page can be neither delivered nor
   # stored, and the caller must not advance its cursor past it.
-  if ! _store_undelivered_alert "$occurrence_ts" "$request_id" "$url" "$body"; then
+  if ! _store_undelivered_alert "$occurrence_timestamp" "$request_id" "$url" "$body"; then
     _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
     _loud_local "osquery paging FAILED, page LOST" \
       "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
@@ -313,9 +324,11 @@ send_alert() {
   fi
   local stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
 
-  # 2) Discord via the hermes webhook (best-effort, bounded retry). Read the HMAC
-  #    key from the notifier's own secret file (env override allowed for tests);
-  #    strip CR so a CRLF file can't corrupt the key.
+  # 2) Discord via the hermes webhook (bounded retry; the page is already safe on
+  #    disk, so a failed delivery here costs latency, not the page). Read the
+  #    HMAC key from the notifier's own secret file (an environment override is
+  #    allowed for tests); strip any carriage return so a CRLF file cannot
+  #    corrupt the key.
   local secret="${OSQUERY_WEBHOOK_SECRET:-}"
   if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
     IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
@@ -350,8 +363,9 @@ send_alert() {
       *) break ;; # 401/413/etc, retry won't help
     esac
   done
-  # Delivery failed after retries: the write-ahead record REMAINS for the next
-  # drain. Best-effort, a down gateway never fails the caller.
+  # Delivery failed after retries: the write-ahead record REMAINS on disk and the
+  # next drain retries it, so send_alert still returns 0. A down gateway delays
+  # the page; it never fails the caller and never loses the page.
   _osquery_log "STORED webhook delivery pending: request_id=$request_id http=$http_status (retained for retry)"
   return 0
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -8,6 +8,12 @@
 # here so the three producers (results-alerter.sh, firewall-gatekeeper-monitor.sh,
 # and uptime-watchdog.sh) share one implementation.
 #
+# The undelivered-alerts store is WRITE-AHEAD: send_alert persists the page to
+# disk BEFORE the first network attempt and deletes it only after a confirmed 2xx.
+# A crash or kill anywhere between persist and success therefore leaves a
+# recoverable record for the next drain (a lost page is indistinguishable from
+# "all clear").
+#
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 #   send_alert CRIT "Firewall disabled" "alf global_state 1 -> 0" Sosumi
@@ -24,8 +30,8 @@ OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:864
 OSQUERY_WEBHOOK_SECRET_FILE="${OSQUERY_WEBHOOK_SECRET_FILE:-$HOME/.config/osquery/webhook-secret}"
 OSQUERY_DELIVERY_LOG="${OSQUERY_DELIVERY_LOG:-$HOME/.local/log/osquery/webhook-delivery.log}"
 # Undelivered pages are stored here, one mode-600 file per page in a mode-700
-# dir, so a transient gateway outage never loses a page (a lost page is
-# indistinguishable from "all clear"). retry_undelivered_alerts replays them.
+# dir, so a transient gateway outage never loses a page. retry_undelivered_alerts
+# replays them in occurrence-time order.
 OSQUERY_UNDELIVERED_ALERTS_DIR="${OSQUERY_UNDELIVERED_ALERTS_DIR:-$HOME/.local/state/osquery-undelivered-alerts}"
 
 # A monotonic per-process sequence so the fallback request id (when no occurrence
@@ -41,28 +47,64 @@ _osquery_log() {
 
 # Store one undelivered page and REPORT persistence success. The file is named by
 # the occurrence-unique request_id, so re-storing the same occurrence is
-# idempotent while two DISTINCT occurrences never collide. Written through a
-# checked temp file then an atomic rename so a reader never sees a torn entry, and
-# it RETURNS NONZERO on any persistence failure so the caller treats a failed
-# store as a hard delivery failure (never "stored" when the file does not exist).
-# Line: <unix_ts>\t<request_id>\t<url>\t<base64(body)>.
+# idempotent while two DISTINCT occurrences never collide. The encoded body and
+# the occurrence timestamp are computed and VALIDATED in checked assignments
+# BEFORE the record file is opened, so an encoder failure fails the store instead
+# of writing an empty body that a later drain would silently skip. Written through
+# a checked temp file, flushed, then atomically renamed, and it RETURNS NONZERO on
+# any persistence failure so the caller treats a failed store as a hard delivery
+# failure (never "stored" when the file does not exist).
+# Line: <occurrence_ts>\t<request_id>\t<url>\t<base64(body)>.
 _store_undelivered_alert() {
-  local request_id="$1" url="$2" body="$3" stored_file temp_file
+  local occurrence_ts="$1" request_id="$2" url="$3" body="$4" stored_file temp_file encoded_body
+  [[ $occurrence_ts =~ ^[0-9]+$ ]] || return 1
+  [[ -n $request_id ]] || return 1
+  # pipefail inside the subshell so a base64 failure is the assignment's status,
+  # not masked by the trailing tr; then reject an empty result defensively.
+  if ! encoded_body="$(
+    set -o pipefail
+    printf '%s' "$body" | base64 | tr -d '\n'
+  )"; then
+    return 1
+  fi
+  [[ -n $encoded_body ]] || return 1
   mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || return 1
   chmod 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || true
   stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
   temp_file="$stored_file.tmp.$$"
-  if ! printf '%s\t%s\t%s\t%s\n' \
-    "$(date -u +%s)" "$request_id" "$url" "$(printf '%s' "$body" | base64 | tr -d '\n')" \
-    >"$temp_file" 2>/dev/null; then
+  if ! printf '%s\t%s\t%s\t%s\n' "$occurrence_ts" "$request_id" "$url" "$encoded_body" >"$temp_file" 2>/dev/null; then
     rm -f "$temp_file" 2>/dev/null || true
     return 1
   fi
   chmod 600 "$temp_file" 2>/dev/null || true
+  # Flush the record's bytes before the rename so a crash right after the rename
+  # cannot leave a present-but-empty file. GNU `sync FILE` fsyncs just this file;
+  # BSD sync takes no argument and flushes all. Best-effort either way.
+  sync "$temp_file" 2>/dev/null || sync 2>/dev/null || true
   if ! mv -f "$temp_file" "$stored_file" 2>/dev/null; then
     rm -f "$temp_file" 2>/dev/null || true
     return 1
   fi
+  return 0
+}
+
+# Move any crashed *.tmp.* partial (a temp whose writer process is gone) OUT of
+# the store, into a sibling quarantine dir, so a torn write is never replayed and
+# never skipped forever. A temp whose writer pid is still alive is an in-flight
+# write and is left alone. Best-effort; never fails the caller.
+_quarantine_stale_partials() {
+  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
+  local temp_file pid quarantine_dir
+  quarantine_dir="${OSQUERY_UNDELIVERED_ALERTS_DIR%/}.quarantine"
+  for temp_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*.tmp.*; do
+    [[ -f $temp_file ]] || continue
+    pid="${temp_file##*.tmp.}"
+    if [[ $pid =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      continue # a live writer still owns this temp
+    fi
+    mkdir -p "$quarantine_dir" 2>/dev/null || continue
+    mv -f "$temp_file" "$quarantine_dir/${temp_file##*/}" 2>/dev/null || true
+  done
   return 0
 }
 
@@ -80,60 +122,89 @@ _loud_local() {
   fi
 }
 
-# Replay stored undelivered pages: re-POST each (stored request_id verbatim so the
-# gateway dedups; signature recomputed from the stored body), remove on delivery,
-# leave on failure for the next run. Localhost only, a tampered or off-box url is
-# skipped, never sent. Fully set -e-safe: a malformed entry or empty dir must
-# NEVER abort the caller (a delivery feature must not cause a detection outage).
+# Deliver ONE stored record: read it, skip a non-localhost url (never send an
+# off-box page), decode and sign the stored body, POST it (stored request_id
+# verbatim so the gateway dedups), and delete the record only on a confirmed 2xx.
+# Fully set -e-safe: any malformed field returns 0 so the drain continues.
+_deliver_stored_record() {
+  local stored_file="$1" secret="$2" ts request_id url body signature http_status
+  IFS=$'\t' read -r ts request_id url body <"$stored_file" || return 0
+  [[ -n $request_id && -n $url && -n $body ]] || return 0
+  case "$url" in
+    http://127.0.0.1:8644/*) ;;
+    *) return 0 ;;
+  esac
+  body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || return 0
+  [[ -n $body ]] || return 0
+  signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
+  http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+    -X POST "$url" \
+    -H 'Content-Type: application/json' \
+    -H "X-Webhook-Signature: $signature" \
+    -H "X-Request-ID: $request_id" \
+    --data "$body")" || http_status=000
+  case "$http_status" in
+    2*) rm -f "$stored_file" ;;
+    *) : ;;
+  esac
+  return 0
+}
+
+# Replay stored undelivered pages in OCCURRENCE-TIME order (earliest first, with
+# the file path as a deterministic tie-breaker), so a backlog delivers in the
+# order events happened, not in SHA-derived filename order. Crashed partials are
+# quarantined first. Localhost only. Fully set -e-safe: a malformed entry or empty
+# dir must NEVER abort the caller (a delivery feature must not cause a detection
+# outage).
 retry_undelivered_alerts() {
   [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
-  local secret stored_file request_id url body signature http_status
+  _quarantine_stale_partials
+  local secret
   secret="${OSQUERY_WEBHOOK_SECRET:-}"
   if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
     IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
     secret="$(printf '%s' "$secret" | tr -d '\r')"
   fi
   [[ -n $secret ]] || return 0
+
+  # Collect "<occurrence_ts>\t<file>" for every well-formed record, then sort by
+  # occurrence time (numeric) with the path as the tie-breaker.
+  local records="" stored_file ts
   for stored_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*; do
     [[ -f $stored_file ]] || continue
     case "$stored_file" in
-      *.tmp.*) continue ;; # skip an in-flight temp from a crashed write
+      *.tmp.*) continue ;; # an in-flight temp; quarantine handles crashed ones
     esac
-    IFS=$'\t' read -r _ request_id url body <"$stored_file" || continue
-    if [[ -z $request_id || -z $url || -z $body ]]; then continue; fi
-    case "$url" in
-      http://127.0.0.1:8644/*) ;;
-      *) continue ;;
-    esac
-    body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || continue
-    [[ -n $body ]] || continue
-    signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
-    http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-      -X POST "$url" \
-      -H 'Content-Type: application/json' \
-      -H "X-Webhook-Signature: $signature" \
-      -H "X-Request-ID: $request_id" \
-      --data "$body")" || http_status=000
-    case "$http_status" in
-      2*) rm -f "$stored_file" ;;
-      *) : ;;
-    esac
+    IFS=$'\t' read -r ts _ <"$stored_file" || continue
+    [[ $ts =~ ^[0-9]+$ ]] || continue
+    records+="$ts	$stored_file"$'\n'
   done
+  [[ -n $records ]] || return 0
+
+  local sorted
+  sorted="$(printf '%s' "$records" | sort -t$'\t' -k1,1n -k2,2)" || return 0
+  while IFS=$'\t' read -r _ stored_file; do
+    [[ -n $stored_file ]] || continue
+    _deliver_stored_record "$stored_file" "$secret"
+  done <<<"$sorted"
   return 0
 }
 
 # send_alert <severity> <title> <detail> [sound] [occurrence_id]
-# severity is CRIT | NOTICE | INFO. CRIT routes the Discord POST to the #priority
-# channel; NOTICE/INFO route to the quiet #osquery channel. The local
+# severity is CRIT | NOTICE | INFO. Only CRIT is delivered to Discord (#priority);
+# any other severity does the local notification and returns. The local
 # notification always fires regardless. An empty sound argument means a silent
 # notification (used for the low INFO tier). occurrence_id (optional) identifies
 # THIS occurrence so its request_id and stored filename are occurrence-unique
 # (distinct incidents survive) yet stable across a retry of the same occurrence
 # (the gateway dedups it). Absent means a per-call unique id.
 #
-# Return contract: 0 when the page was DELIVERED or durably STORED; NONZERO only
-# on a HARD failure (neither delivered nor stored), after firing a loud local
-# alert, so the caller does not advance its cursor past a page that was lost.
+# Delivery is WRITE-AHEAD: the page is persisted BEFORE the first network attempt
+# and deleted only after a confirmed 2xx. Return contract: 0 when the page was
+# DELIVERED or durably STORED; NONZERO only on a HARD failure (the write-ahead
+# persist itself failed, so the page is neither delivered nor stored), after
+# firing a loud local alert, so the caller does not advance its cursor past a page
+# that was lost.
 send_alert() {
   local severity="$1" title="$2" detail="$3" sound="${4-}" occurrence="${5-}"
 
@@ -165,30 +236,48 @@ send_alert() {
   [[ $severity == "CRIT" ]] || return 0
   local url="$OSQUERY_HERMES_PRIORITY_URL"
 
+  # Occurrence time: when this page was raised. It is the drain's ordering key AND
+  # part of the signed body. A clock glitch never blocks a page (fall back to 0).
+  local occurrence_ts
+  occurrence_ts="$(date -u +%s)"
+  [[ $occurrence_ts =~ ^[0-9]+$ ]] || occurrence_ts=0
+
   # Build the webhook body and an occurrence-stable request id. tier: a page is
   # loud (a sound was requested), a digest/heartbeat is muted (no sound). Both
   # severities are CRIT and both POST; tier lets the Hermes adapter suppress the
-  # notification for muted traffic instead of pinging it like a page. host is
-  # INSIDE the signed body, the spec's body shape and the multi-host migration
-  # seam both require {event_type, host, tier, alert}.
+  # notification for muted traffic instead of pinging it like a page. host and the
+  # occurrence ts live INSIDE the signed body, the spec's body shape and the
+  # multi-host migration seam both require {event_type, host, tier, ts, alert}.
   #
   # The request id derives from OCCURRENCE IDENTITY (threaded from the caller)
   # when present, so two distinct incidents that render the same body get distinct
   # ids (both stored, both delivered) while a retry of the same occurrence reuses
   # one id (the gateway dedups it, the stored filename is idempotent). No
-  # occurrence means a per-call unique seed. Built BEFORE reading the secret so a
-  # missing-secret page stores with the same id the drain later signs and sends.
+  # occurrence means a per-call unique seed.
   local body request_id id_seed tier
   if [[ -n $sound ]]; then tier="page"; else tier="muted"; fi
-  body="$(jq -cn --arg h "$(hostname -s)" --arg t "$title" --arg d "$detail" --arg tier "$tier" \
-    '{event_type:"osquery.alert", host:$h, tier:$tier, alert:{title:$t, detail:$d}}')"
+  body="$(jq -cn --arg h "$(hostname -s)" --arg t "$title" --arg d "$detail" \
+    --arg tier "$tier" --argjson ts "$occurrence_ts" \
+    '{event_type:"osquery.alert", host:$h, tier:$tier, ts:$ts, alert:{title:$t, detail:$d}}')"
   if [[ -n $occurrence ]]; then
     id_seed="$occurrence"
   else
     _OSQUERY_ALERT_SEQUENCE=$((_OSQUERY_ALERT_SEQUENCE + 1))
-    id_seed="fallback|$(date -u +%s)|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
+    id_seed="fallback|$occurrence_ts|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
   fi
   request_id="osquery-$(printf '%s' "$id_seed" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
+
+  # WRITE-AHEAD: persist the page BEFORE the first network attempt, so a crash or
+  # kill before a confirmed success leaves a recoverable record. A persist failure
+  # is a HARD failure (loud + nonzero): the page can be neither delivered nor
+  # stored, and the caller must not advance its cursor past it.
+  if ! _store_undelivered_alert "$occurrence_ts" "$request_id" "$url" "$body"; then
+    _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
+    _loud_local "osquery paging FAILED, page LOST" \
+      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
+    return 1
+  fi
+  local stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
 
   # 2) Discord via the hermes webhook (best-effort, bounded retry). Read the HMAC
   #    key from the notifier's own secret file (env override allowed for tests);
@@ -199,21 +288,12 @@ send_alert() {
     secret="$(printf '%s' "$secret" | tr -d '\r')"
   fi
   if [[ -z $secret ]]; then
-    # A missing secret must NOT silently degrade a page to local-only. Store it
-    # durably (unsigned; the drain signs it once the secret returns) and fire a
-    # LOUD local notice naming the broken channel. If storing ALSO fails, the
-    # page is neither delivered nor stored, a hard failure that must be loud AND
-    # return nonzero, never a bare success that drops the page.
-    if _store_undelivered_alert "$request_id" "$url" "$body"; then
-      _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
-      _loud_local "osquery Discord paging BROKEN" \
-        "No webhook secret. This page was stored locally and delivers when the secret is restored."
-      return 0
-    fi
-    _osquery_log "STORE-FAILED-NOSECRET request_id=$request_id (no secret AND storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
-    _loud_local "osquery paging FAILED, page LOST" \
-      "No webhook secret AND the page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
-    return 1
+    # The page is already persisted (write-ahead); the drain signs and sends it
+    # once the secret returns. Name the broken channel loudly.
+    _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
+    _loud_local "osquery Discord paging BROKEN" \
+      "No webhook secret. This page was stored locally and delivers when the secret is restored."
+    return 0
   fi
 
   local signature http_status attempt
@@ -227,22 +307,17 @@ send_alert() {
       -H "X-Request-ID: $request_id" \
       --data "$body")" || http_status=000
     case "$http_status" in
-      2*) return 0 ;;  # delivered
+      2*)
+        rm -f "$stored_file" # delete ONLY after a confirmed 2xx
+        return 0
+        ;;
       429 | 5?? | 000) # transient, back off and retry (base overridable for tests)
         if [[ $attempt -lt 3 ]]; then sleep "$((attempt * ${OSQUERY_RETRY_BACKOFF_BASE:-1}))"; fi ;;
       *) break ;; # 401/413/etc, retry won't help
     esac
   done
-  # Delivery failed after retries: store the page so it is never silently lost;
-  # the drain replays it. If storage ALSO fails, the page is neither delivered
-  # nor stored, a hard failure that returns nonzero and fires a loud local alert,
-  # so the caller does NOT advance its cursor past a page that was actually lost.
-  if _store_undelivered_alert "$request_id" "$url" "$body"; then
-    _osquery_log "STORED webhook delivery: request_id=$request_id http=$http_status"
-    return 0
-  fi
-  _osquery_log "STORE-FAILED webhook delivery: request_id=$request_id http=$http_status (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
-  _loud_local "osquery paging FAILED, page LOST" \
-    "Discord POST failed (http=$http_status) AND the page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
-  return 1
+  # Delivery failed after retries: the write-ahead record REMAINS for the next
+  # drain. Best-effort, a down gateway never fails the caller.
+  _osquery_log "STORED webhook delivery pending: request_id=$request_id http=$http_status (retained for retry)"
+  return 0
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -239,7 +239,11 @@ _deliver_stored_record() {
   esac
   body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || return 0
   [[ -n $body ]] || return 0
-  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
+  # Same signing check as the send path: a failed or empty signature must never
+  # go on the wire. The record stays put and a later drain retries it.
+  if ! signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")" || [[ -z $signature ]]; then
+    return 0
+  fi
   http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
   case "$http_status" in
     2*) rm -f "$stored_file" ;;
@@ -312,7 +316,15 @@ _derive_request_id() { # <request_id_seed>
 # and the like) stops early, a retry cannot fix it.
 _attempt_alert_delivery() { # <url> <request_id> <secret> <body>
   local url="$1" request_id="$2" secret="$3" body="$4" signature http_status attempt
-  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
+  # This function runs inside an if condition, where errexit is suppressed, so
+  # a failing signature assignment must be checked explicitly: unchecked, the
+  # code would continue with an EMPTY signature, POST it, and a 2xx would
+  # delete the write-ahead record. A failed or empty signature stops the
+  # attempt BEFORE any POST; the record stays for a later drain.
+  if ! signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")" || [[ -z $signature ]]; then
+    printf 'signing-failed'
+    return 1
+  fi
   for attempt in 1 2 3; do
     http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
     case "$http_status" in

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -45,6 +45,40 @@ _osquery_log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"$OSQUERY_DELIVERY_LOG" 2>/dev/null || true
 }
 
+# HMAC-SHA256 of the message on STDIN under the key in $1, hex digest on stdout.
+# The key is a FUNCTION argument (it lives in this shell's memory, never a child
+# process argv), and it is never passed to openssl: openssl only ever hashes
+# bytes on stdin (`openssl dgst -sha256`), so the secret cannot appear in any
+# `ps` output. HMAC is built by hand from SHA-256 (the standard
+# H((K'^opad)||H((K'^ipad)||m)) construction); a unit test pins it byte-identical
+# to `openssl dgst -hmac`. openssl `dgst` is used (not the OpenSSL-3-only `mac`)
+# so it works with the host's LibreSSL too.
+_hmac_sha256_hex() {
+  local key="$1" block_size=64 key_hex byte_hex ipad_format="" opad_format="" inner_hex inner_format="" i
+  # Key to hex bytes; if longer than the block size, replace it with its digest.
+  key_hex="$(printf '%s' "$key" | od -v -A n -t x1 | tr -d ' \n')"
+  if ((${#key_hex} > block_size * 2)); then
+    key_hex="$(printf '%s' "$key" | openssl dgst -sha256 | awk '{print $NF}')"
+  fi
+  while ((${#key_hex} < block_size * 2)); do key_hex+="00"; done
+  # Build the padded-key-XOR-pad byte strings as printf \xHH format specifiers.
+  for ((i = 0; i < block_size; i++)); do
+    byte_hex="${key_hex:i*2:2}"
+    printf -v ipad_format '%s\\x%02x' "$ipad_format" "$((16#$byte_hex ^ 0x36))"
+    printf -v opad_format '%s\\x%02x' "$opad_format" "$((16#$byte_hex ^ 0x5c))"
+  done
+  # inner = SHA256( (K' xor ipad) || message ); the message streams from stdin.
+  # shellcheck disable=SC2059 # the format is a fixed \xHH byte string, no user data
+  inner_hex="$({
+    printf "$ipad_format"
+    cat
+  } | openssl dgst -sha256 | awk '{print $NF}')"
+  for ((i = 0; i < ${#inner_hex}; i += 2)); do inner_format+="\\x${inner_hex:i:2}"; done
+  # outer = SHA256( (K' xor opad) || inner ).
+  # shellcheck disable=SC2059 # the format is a fixed \xHH byte string, no user data
+  printf "$opad_format$inner_format" | openssl dgst -sha256 | awk '{print $NF}'
+}
+
 # Store one undelivered page and REPORT persistence success. The file is named by
 # the occurrence-unique request_id, so re-storing the same occurrence is
 # idempotent while two DISTINCT occurrences never collide. The encoded body and
@@ -136,7 +170,7 @@ _deliver_stored_record() {
   esac
   body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || return 0
   [[ -n $body ]] || return 0
-  signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
+  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
   http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
     -X POST "$url" \
     -H 'Content-Type: application/json' \
@@ -297,7 +331,7 @@ send_alert() {
   fi
 
   local signature http_status attempt
-  signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
+  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
 
   for attempt in 1 2 3; do
     http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -47,20 +47,27 @@ _osquery_log() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"$OSQUERY_DELIVERY_LOG" 2>/dev/null || true
 }
 
+# Security protocol boundary: every SHA-256 hash in this library flows through
+# here, and the bytes to hash arrive ONLY on stdin, never as a command-line
+# argument, so nothing that gets hashed (a key, a body, a request-id seed) can
+# ever appear in `ps` output. Prints the lowercase hex digest. openssl `dgst` is
+# used (not the OpenSSL-3-only `mac`) so it works with the host's LibreSSL too.
+_sha256_hex_of_stdin() {
+  openssl dgst -sha256 | awk '{print $NF}'
+}
+
 # HMAC-SHA256 of the message on STDIN under the key in $1, hex digest on stdout.
 # The key is a FUNCTION argument (it lives in this shell's memory, never a child
-# process argv), and it is never passed to openssl: openssl only ever hashes
-# bytes on stdin (`openssl dgst -sha256`), so the secret cannot appear in any
-# `ps` output. HMAC is built by hand from SHA-256 (the standard
-# H((K'^opad)||H((K'^ipad)||m)) construction); a unit test pins it byte-identical
-# to `openssl dgst -hmac`. openssl `dgst` is used (not the OpenSSL-3-only `mac`)
-# so it works with the host's LibreSSL too.
+# process argv), and every hash goes through _sha256_hex_of_stdin, so the secret
+# cannot appear in any `ps` output. HMAC is built by hand from SHA-256 (the
+# standard H((K'^opad)||H((K'^ipad)||m)) construction); a test pins it
+# byte-identical to `openssl dgst -hmac`.
 _hmac_sha256_hex() {
   local key="$1" block_size=64 key_hex byte_hex ipad_format="" opad_format="" inner_hex inner_format="" i
   # Key to hex bytes; if longer than the block size, replace it with its digest.
   key_hex="$(printf '%s' "$key" | od -v -A n -t x1 | tr -d ' \n')"
   if ((${#key_hex} > block_size * 2)); then
-    key_hex="$(printf '%s' "$key" | openssl dgst -sha256 | awk '{print $NF}')"
+    key_hex="$(printf '%s' "$key" | _sha256_hex_of_stdin)"
   fi
   while ((${#key_hex} < block_size * 2)); do key_hex+="00"; done
   # Build the padded-key-XOR-pad byte strings as printf \xHH format specifiers.
@@ -74,11 +81,11 @@ _hmac_sha256_hex() {
   inner_hex="$({
     printf "$ipad_format"
     cat
-  } | openssl dgst -sha256 | awk '{print $NF}')"
+  } | _sha256_hex_of_stdin)"
   for ((i = 0; i < ${#inner_hex}; i += 2)); do inner_format+="\\x${inner_hex:i:2}"; done
   # outer = SHA256( (K' xor opad) || inner ).
   # shellcheck disable=SC2059 # the format is a fixed \xHH byte string, no user data
-  printf "$opad_format$inner_format" | openssl dgst -sha256 | awk '{print $NF}'
+  printf "$opad_format$inner_format" | _sha256_hex_of_stdin
 }
 
 # Store one undelivered page and REPORT persistence success. The file is named by
@@ -166,6 +173,19 @@ _loud_local() {
   fi
 }
 
+# The one place a webhook POST is made. Prints the HTTP status code; a transport
+# failure (no connection, timeout) makes curl exit nonzero, which this function
+# passes through for the caller to map to status 000. Every delivery path goes
+# through here so the request shape (method, headers, timeout) lives in one spot.
+_post_alert_to_webhook() { # <url> <request_id> <signature> <body>
+  curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+    -X POST "$1" \
+    -H 'Content-Type: application/json' \
+    -H "X-Webhook-Signature: $3" \
+    -H "X-Request-ID: $2" \
+    --data "$4"
+}
+
 # Deliver ONE stored record: read it, skip a non-localhost url (never send an
 # off-box page), decode and sign the stored body, POST it (stored request_id
 # verbatim so the gateway dedups), and delete the record only on a confirmed 2xx.
@@ -181,12 +201,7 @@ _deliver_stored_record() {
   body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || return 0
   [[ -n $body ]] || return 0
   signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
-  http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-    -X POST "$url" \
-    -H 'Content-Type: application/json' \
-    -H "X-Webhook-Signature: $signature" \
-    -H "X-Request-ID: $request_id" \
-    --data "$body")" || http_status=000
+  http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
   case "$http_status" in
     2*) rm -f "$stored_file" ;;
     *) : ;;
@@ -310,7 +325,7 @@ send_alert() {
     _OSQUERY_ALERT_SEQUENCE=$((_OSQUERY_ALERT_SEQUENCE + 1))
     request_id_seed="fallback|$occurrence_timestamp|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
   fi
-  request_id="osquery-$(printf '%s' "$request_id_seed" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
+  request_id="osquery-$(printf '%s' "$request_id_seed" | _sha256_hex_of_stdin | cut -c1-32)"
 
   # WRITE-AHEAD: persist the page BEFORE the first network attempt, so a crash or
   # kill before a confirmed success leaves a recoverable record. A persist failure
@@ -347,12 +362,7 @@ send_alert() {
   signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
 
   for attempt in 1 2 3; do
-    http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
-      -X POST "$url" \
-      -H 'Content-Type: application/json' \
-      -H "X-Webhook-Signature: $signature" \
-      -H "X-Request-ID: $request_id" \
-      --data "$body")" || http_status=000
+    http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
     case "$http_status" in
       2*)
         rm -f "$stored_file" # delete ONLY after a confirmed 2xx

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -3,9 +3,10 @@
 # alert-dispatch.sh, sourced helper, not run directly. Provides
 # send_alert(), which dispatches one finding to BOTH the local macOS notifier
 # (alerter) and a hermes Discord webhook, routing by severity (CRIT -> #priority,
-# else -> #osquery). Signing and dual-channel delivery live here so the three
-# producers (results-alerter.sh, firewall-gatekeeper-monitor.sh,
-# and uptime-watchdog.sh) share one implementation.
+# else -> #osquery). Signing, dual-channel delivery, and durable handling of an
+# undelivered page all live here so the three producers (results-alerter.sh,
+# firewall-gatekeeper-monitor.sh, and uptime-watchdog.sh) share one
+# implementation.
 #
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -23,21 +24,119 @@ OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:864
 # each side owns its own copy. Single-value file, mode 600, runtime (not tracked).
 OSQUERY_WEBHOOK_SECRET_FILE="${OSQUERY_WEBHOOK_SECRET_FILE:-$HOME/.config/osquery/webhook-secret}"
 OSQUERY_DELIVERY_LOG="${OSQUERY_DELIVERY_LOG:-$HOME/.local/log/osquery/webhook-delivery.log}"
+# Undelivered pages are stored here, one mode-600 file per page in a mode-700
+# dir, so a transient gateway outage never loses a page (a lost page is
+# indistinguishable from "all clear"). retry_undelivered_alerts replays them.
+OSQUERY_UNDELIVERED_ALERTS_DIR="${OSQUERY_UNDELIVERED_ALERTS_DIR:-$HOME/.local/state/osquery-undelivered-alerts}"
+
+# A monotonic per-process sequence so the fallback request id (when no occurrence
+# identity is threaded) is unique across calls in one process.
+_OSQUERY_ALERT_SEQUENCE=0
 
 # Append a timestamped line to the delivery log (best-effort; never fails caller).
+# Only metadata is ever logged, never the body or the HMAC secret.
 _osquery_log() {
   mkdir -p "$(dirname "$OSQUERY_DELIVERY_LOG")" 2>/dev/null || true
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"$OSQUERY_DELIVERY_LOG" 2>/dev/null || true
 }
 
-# send_alert <severity> <title> <detail> [sound]
-# severity is CRIT | NOTICE | INFO. CRIT routes the Discord POST to the
-# #priority channel; NOTICE/INFO route to the quiet #osquery channel. The local
-# notification always fires regardless. The Discord POST is best-effort and
-# never fails the caller (so a down gateway can't break the local alert). An
-# empty sound argument means a silent notification (used for the low INFO tier).
+# Store one undelivered page and REPORT persistence success. The file is named by
+# the occurrence-unique request_id, so re-storing the same occurrence is
+# idempotent while two DISTINCT occurrences never collide. Written through a
+# checked temp file then an atomic rename so a reader never sees a torn entry, and
+# it RETURNS NONZERO on any persistence failure so the caller treats a failed
+# store as a hard delivery failure (never "stored" when the file does not exist).
+# Line: <unix_ts>\t<request_id>\t<url>\t<base64(body)>.
+_store_undelivered_alert() {
+  local request_id="$1" url="$2" body="$3" stored_file temp_file
+  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || return 1
+  chmod 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || true
+  stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
+  temp_file="$stored_file.tmp.$$"
+  if ! printf '%s\t%s\t%s\t%s\n' \
+    "$(date -u +%s)" "$request_id" "$url" "$(printf '%s' "$body" | base64 | tr -d '\n')" \
+    >"$temp_file" 2>/dev/null; then
+    rm -f "$temp_file" 2>/dev/null || true
+    return 1
+  fi
+  chmod 600 "$temp_file" 2>/dev/null || true
+  if ! mv -f "$temp_file" "$stored_file" 2>/dev/null; then
+    rm -f "$temp_file" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}
+
+# Fire ONE loud, interruptive local notification. Used when a page can be neither
+# delivered NOR durably stored: the operator MUST learn that a CRITICAL alert was
+# lost, since a silently dropped page is indistinguishable from "all clear".
+# Best-effort, never fails caller.
+_loud_local() {
+  local title="$1" message="$2"
+  if command -v alerter >/dev/null 2>&1; then
+    alerter --timeout 60 --title "$title" --message "$message" --sound Funk >/dev/null 2>&1 &
+  else
+    local escaped=${message//\"/\\\"}
+    osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1 || true
+  fi
+}
+
+# Replay stored undelivered pages: re-POST each (stored request_id verbatim so the
+# gateway dedups; signature recomputed from the stored body), remove on delivery,
+# leave on failure for the next run. Localhost only, a tampered or off-box url is
+# skipped, never sent. Fully set -e-safe: a malformed entry or empty dir must
+# NEVER abort the caller (a delivery feature must not cause a detection outage).
+retry_undelivered_alerts() {
+  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
+  local secret stored_file request_id url body signature http_status
+  secret="${OSQUERY_WEBHOOK_SECRET:-}"
+  if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
+    IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
+    secret="$(printf '%s' "$secret" | tr -d '\r')"
+  fi
+  [[ -n $secret ]] || return 0
+  for stored_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*; do
+    [[ -f $stored_file ]] || continue
+    case "$stored_file" in
+      *.tmp.*) continue ;; # skip an in-flight temp from a crashed write
+    esac
+    IFS=$'\t' read -r _ request_id url body <"$stored_file" || continue
+    if [[ -z $request_id || -z $url || -z $body ]]; then continue; fi
+    case "$url" in
+      http://127.0.0.1:8644/*) ;;
+      *) continue ;;
+    esac
+    body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || continue
+    [[ -n $body ]] || continue
+    signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
+    http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+      -X POST "$url" \
+      -H 'Content-Type: application/json' \
+      -H "X-Webhook-Signature: $signature" \
+      -H "X-Request-ID: $request_id" \
+      --data "$body")" || http_status=000
+    case "$http_status" in
+      2*) rm -f "$stored_file" ;;
+      *) : ;;
+    esac
+  done
+  return 0
+}
+
+# send_alert <severity> <title> <detail> [sound] [occurrence_id]
+# severity is CRIT | NOTICE | INFO. CRIT routes the Discord POST to the #priority
+# channel; NOTICE/INFO route to the quiet #osquery channel. The local
+# notification always fires regardless. An empty sound argument means a silent
+# notification (used for the low INFO tier). occurrence_id (optional) identifies
+# THIS occurrence so its request_id and stored filename are occurrence-unique
+# (distinct incidents survive) yet stable across a retry of the same occurrence
+# (the gateway dedups it). Absent means a per-call unique id.
+#
+# Return contract: 0 when the page was DELIVERED or durably STORED; NONZERO only
+# on a HARD failure (neither delivered nor stored), after firing a loud local
+# alert, so the caller does not advance its cursor past a page that was lost.
 send_alert() {
-  local severity="$1" title="$2" detail="$3" sound="${4-}"
+  local severity="$1" title="$2" detail="$3" sound="${4-}" occurrence="${5-}"
 
   # Route by severity: only CRIT reaches #priority.
   local webhook_url="$OSQUERY_HERMES_URL"
@@ -66,27 +165,52 @@ send_alert() {
     fi
   fi
 
+  # Build the webhook body and an occurrence-stable request id. The request id
+  # derives from OCCURRENCE IDENTITY (threaded from the caller) when present, so
+  # two distinct incidents that render the same body get distinct ids (both
+  # stored, both delivered) while a retry of the same occurrence reuses one id
+  # (the gateway dedups it, the stored filename is idempotent). No occurrence
+  # means a per-call unique seed. Built BEFORE reading the secret so a
+  # missing-secret page stores with the same id the drain later signs and sends.
+  local body request_id id_seed
+  body="$(jq -cn --arg t "$title" --arg d "$detail" \
+    '{event_type:"osquery.alert", alert:{title:$t, detail:$d}}')"
+  if [[ -n $occurrence ]]; then
+    id_seed="$occurrence"
+  else
+    _OSQUERY_ALERT_SEQUENCE=$((_OSQUERY_ALERT_SEQUENCE + 1))
+    id_seed="fallback|$(date -u +%s)|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
+  fi
+  request_id="osquery-$(printf '%s' "$id_seed" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
+
   # 2) Discord via the hermes webhook (best-effort, bounded retry). Read the HMAC
   #    key from the notifier's own secret file (env override allowed for tests);
-  #    strip CR so a CRLF file can't corrupt the key. A missing/empty secret is
-  #    handled gracefully (local alert already fired) rather than aborting.
+  #    strip CR so a CRLF file can't corrupt the key.
   local secret="${OSQUERY_WEBHOOK_SECRET:-}"
   if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
     IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
     secret="$(printf '%s' "$secret" | tr -d '\r')"
   fi
   if [[ -z $secret ]]; then
-    _osquery_log "WARN no webhook secret in $OSQUERY_WEBHOOK_SECRET_FILE, Discord delivery skipped"
-    return 0
+    # A missing secret must NOT silently degrade a page to local-only. Store it
+    # durably (unsigned; the drain signs it once the secret returns) and fire a
+    # LOUD local notice naming the broken channel. If storing ALSO fails, the
+    # page is neither delivered nor stored, a hard failure that must be loud AND
+    # return nonzero, never a bare success that drops the page.
+    if _store_undelivered_alert "$request_id" "$webhook_url" "$body"; then
+      _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
+      _loud_local "osquery Discord paging BROKEN" \
+        "No webhook secret. This page was stored locally and delivers when the secret is restored."
+      return 0
+    fi
+    _osquery_log "STORE-FAILED-NOSECRET request_id=$request_id (no secret AND storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
+    _loud_local "osquery paging FAILED, page LOST" \
+      "No webhook secret AND the page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
+    return 1
   fi
 
-  local body signature request_id http_status attempt
-  body="$(jq -cn --arg t "$title" --arg d "$detail" \
-    '{event_type:"osquery.alert", alert:{title:$t, detail:$d}}')"
+  local signature http_status attempt
   signature="$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$secret" | awk '{print $NF}')"
-  # Content-stable request id: a retry or double-fire of the SAME alert dedups
-  # at the gateway (it honours X-Request-ID for 1h) instead of double-posting.
-  request_id="osquery-$(printf '%s' "$body" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-32)"
 
   for attempt in 1 2 3; do
     http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
@@ -97,11 +221,21 @@ send_alert() {
       --data "$body")" || http_status=000
     case "$http_status" in
       2*) return 0 ;;  # delivered
-      429 | 5?? | 000) # transient → back off and retry
-        if [[ $attempt -lt 3 ]]; then sleep "$attempt"; fi ;;
+      429 | 5?? | 000) # transient, back off and retry (base overridable for tests)
+        if [[ $attempt -lt 3 ]]; then sleep "$((attempt * ${OSQUERY_RETRY_BACKOFF_BASE:-1}))"; fi ;;
       *) break ;; # 401/413/etc, retry won't help
     esac
   done
-  _osquery_log "ERROR webhook delivery failed: http=$http_status url=$webhook_url"
-  return 0
+  # Delivery failed after retries: store the page so it is never silently lost;
+  # the drain replays it. If storage ALSO fails, the page is neither delivered
+  # nor stored, a hard failure that returns nonzero and fires a loud local alert,
+  # so the caller does NOT advance its cursor past a page that was actually lost.
+  if _store_undelivered_alert "$request_id" "$webhook_url" "$body"; then
+    _osquery_log "STORED webhook delivery: request_id=$request_id http=$http_status"
+    return 0
+  fi
+  _osquery_log "STORE-FAILED webhook delivery: request_id=$request_id http=$http_status (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
+  _loud_local "osquery paging FAILED, page LOST" \
+    "Discord POST failed (http=$http_status) AND the page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
+  return 1
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -157,6 +157,32 @@ _quarantine_stale_partials() {
   return 0
 }
 
+# Fire the ordinary local macOS notification for one alert (alerter, with an
+# AppleScript fallback). The local notifier renders plain text, so Discord
+# markdown (**bold**, `code`) is stripped first; the webhook body elsewhere
+# keeps the markdown intact. --sound is passed only when a sound is given, so a
+# silent tier stays visible but quiet. The notifier is backgrounded or its
+# failure ignored: a broken notifier must never stall or fail dispatch.
+_notify_locally() {
+  local title="$1" detail="$2" sound="$3" plain_title plain_detail
+  plain_title="$(printf '%s' "$title" | sed -e 's/\*\*//g' -e 's/`//g')"
+  plain_detail="$(printf '%s' "$detail" | sed -e 's/\*\*//g' -e 's/`//g')"
+  if command -v alerter >/dev/null 2>&1; then
+    if [[ -n $sound ]]; then
+      alerter --timeout 60 --title "$plain_title" --message "$plain_detail" --sound "$sound" >/dev/null 2>&1 &
+    else
+      alerter --timeout 60 --title "$plain_title" --message "$plain_detail" >/dev/null 2>&1 &
+    fi
+  else
+    local escaped_detail=${plain_detail//\"/\\\"}
+    if [[ -n $sound ]]; then
+      osascript -e "display notification \"$escaped_detail\" with title \"$plain_title\" sound name \"$sound\"" >/dev/null 2>&1 || true
+    else
+      osascript -e "display notification \"$escaped_detail\" with title \"$plain_title\"" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
 # Fire ONE loud, interruptive local notification. Used when a page can be neither
 # delivered NOR durably stored: the operator MUST learn that a CRITICAL alert was
 # lost, because a dropped page leaves no trace and would otherwise read as good
@@ -171,6 +197,19 @@ _loud_local() {
     local escaped=${message//\"/\\\"}
     osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1 || true
   fi
+}
+
+# Print the webhook signing key: the environment override when set, otherwise
+# the first line of the notifier's own secret file with any carriage return
+# stripped (so a CRLF file cannot corrupt the key). Prints nothing when no key
+# is available; the caller decides what an absent key means for its path.
+_read_webhook_secret() {
+  local secret="${OSQUERY_WEBHOOK_SECRET:-}"
+  if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
+    IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
+    secret="$(printf '%s' "$secret" | tr -d '\r')"
+  fi
+  printf '%s' "$secret"
 }
 
 # The one place a webhook POST is made. Prints the HTTP status code; a transport
@@ -219,11 +258,7 @@ retry_undelivered_alerts() {
   [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
   _quarantine_stale_partials
   local secret
-  secret="${OSQUERY_WEBHOOK_SECRET:-}"
-  if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
-    IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
-    secret="$(printf '%s' "$secret" | tr -d '\r')"
-  fi
+  secret="$(_read_webhook_secret)"
   [[ -n $secret ]] || return 0
 
   # Collect "<occurrence_timestamp>\t<file>" for every well-formed record, then
@@ -249,6 +284,51 @@ retry_undelivered_alerts() {
   return 0
 }
 
+# Build the signed webhook body for one CRIT page and print it. tier: a page is
+# loud (a sound was requested), a digest/heartbeat is muted (no sound). Both
+# POST; tier lets the Hermes adapter suppress the notification for muted traffic
+# instead of pinging it like a page. The host and the occurrence timestamp live
+# INSIDE the signed body, the spec's body shape and the multi-host migration
+# seam both require {event_type, host, tier, ts, alert} (ts is the wire name of
+# the occurrence timestamp).
+_build_webhook_body() { # <title> <detail> <tier> <occurrence_timestamp>
+  jq -cn --arg h "$(hostname -s)" --arg t "$1" --arg d "$2" \
+    --arg tier "$3" --argjson ts "$4" \
+    '{event_type:"osquery.alert", host:$h, tier:$tier, ts:$ts, alert:{title:$t, detail:$d}}'
+}
+
+# Derive and print the occurrence-stable request id from the seed. Two distinct
+# incidents that render the same body get distinct ids (both stored, both
+# delivered) while a retry of the same occurrence reuses one id (the gateway
+# dedups it, and the stored filename is idempotent).
+_derive_request_id() { # <request_id_seed>
+  printf 'osquery-%s' "$(printf '%s' "$1" | _sha256_hex_of_stdin | cut -c1-32)"
+}
+
+# Sign the body and POST it, retrying a transient failure (429, 5xx, or a
+# transport error) up to three times with growing backoff. Prints the final HTTP
+# status and returns 0 exactly when a 2xx confirmed delivery; any other outcome
+# returns 1 with the failing status printed. A non-transient status (401, 413,
+# and the like) stops early, a retry cannot fix it.
+_attempt_alert_delivery() { # <url> <request_id> <secret> <body>
+  local url="$1" request_id="$2" secret="$3" body="$4" signature http_status attempt
+  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
+  for attempt in 1 2 3; do
+    http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
+    case "$http_status" in
+      2*)
+        printf '%s' "$http_status"
+        return 0
+        ;;
+      429 | 5?? | 000) # transient, back off and retry (base overridable for tests)
+        if [[ $attempt -lt 3 ]]; then sleep "$((attempt * ${OSQUERY_RETRY_BACKOFF_BASE:-1}))"; fi ;;
+      *) break ;; # 401/413/etc, retry won't help
+    esac
+  done
+  printf '%s' "$http_status"
+  return 1
+}
+
 # send_alert <severity> <title> <detail> [sound] [occurrence_id]
 # severity is CRIT | NOTICE | INFO. Only CRIT is delivered to Discord (#priority);
 # any other severity does the local notification and returns. The local
@@ -267,28 +347,7 @@ retry_undelivered_alerts() {
 send_alert() {
   local severity="$1" title="$2" detail="$3" sound="${4-}" occurrence="${5-}"
 
-  # The local notifier renders plain text, so strip Discord markdown (**bold**,
-  # `code`) for it; the webhook POST below keeps the markdown intact.
-  local plain_title plain_detail
-  plain_title="$(printf '%s' "$title" | sed -e 's/\*\*//g' -e 's/`//g')"
-  plain_detail="$(printf '%s' "$detail" | sed -e 's/\*\*//g' -e 's/`//g')"
-
-  # 1) Local macOS notification (alerter, AppleScript fallback). Pass --sound
-  #    only when one is given so INFO-tier alerts are visible but silent.
-  if command -v alerter >/dev/null 2>&1; then
-    if [[ -n $sound ]]; then
-      alerter --timeout 60 --title "$plain_title" --message "$plain_detail" --sound "$sound" >/dev/null 2>&1 &
-    else
-      alerter --timeout 60 --title "$plain_title" --message "$plain_detail" >/dev/null 2>&1 &
-    fi
-  else
-    local escaped_detail=${plain_detail//\"/\\\"}
-    if [[ -n $sound ]]; then
-      osascript -e "display notification \"$escaped_detail\" with title \"$plain_title\" sound name \"$sound\"" >/dev/null 2>&1 || true
-    else
-      osascript -e "display notification \"$escaped_detail\" with title \"$plain_title\"" >/dev/null 2>&1 || true
-    fi
-  fi
+  _notify_locally "$title" "$detail" "$sound"
 
   # Only a CRIT page is delivered to Discord. Any other severity stops here,
   # after the local notification.
@@ -301,31 +360,20 @@ send_alert() {
   occurrence_timestamp="$(date -u +%s)"
   [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || occurrence_timestamp=0
 
-  # Build the webhook body and an occurrence-stable request id. tier: a page is
-  # loud (a sound was requested), a digest/heartbeat is muted (no sound). Both
-  # severities are CRIT and both POST; tier lets the Hermes adapter suppress the
-  # notification for muted traffic instead of pinging it like a page. The host and
-  # the occurrence timestamp live INSIDE the signed body, the spec's body shape
-  # and the multi-host migration seam both require {event_type, host, tier, ts,
-  # alert} (ts is the wire name of the occurrence timestamp).
-  #
-  # The request id derives from OCCURRENCE IDENTITY (threaded from the caller)
-  # when present, so two distinct incidents that render the same body get distinct
-  # ids (both stored, both delivered) while a retry of the same occurrence reuses
-  # one id (the gateway dedups it, the stored filename is idempotent). No
-  # occurrence means a per-call unique seed.
-  local body request_id request_id_seed tier
+  # The body, and the request id from OCCURRENCE IDENTITY (threaded from the
+  # caller) when present, a per-call unique seed otherwise. The sequence
+  # increment happens here, not inside a command substitution, so it survives
+  # the call and keeps fallback ids unique across calls in one process.
+  local tier body request_id request_id_seed
   if [[ -n $sound ]]; then tier="page"; else tier="muted"; fi
-  body="$(jq -cn --arg h "$(hostname -s)" --arg t "$title" --arg d "$detail" \
-    --arg tier "$tier" --argjson ts "$occurrence_timestamp" \
-    '{event_type:"osquery.alert", host:$h, tier:$tier, ts:$ts, alert:{title:$t, detail:$d}}')"
+  body="$(_build_webhook_body "$title" "$detail" "$tier" "$occurrence_timestamp")"
   if [[ -n $occurrence ]]; then
     request_id_seed="$occurrence"
   else
     _OSQUERY_ALERT_SEQUENCE=$((_OSQUERY_ALERT_SEQUENCE + 1))
     request_id_seed="fallback|$occurrence_timestamp|$$|${_OSQUERY_ALERT_SEQUENCE}|${RANDOM}|$body"
   fi
-  request_id="osquery-$(printf '%s' "$request_id_seed" | _sha256_hex_of_stdin | cut -c1-32)"
+  request_id="$(_derive_request_id "$request_id_seed")"
 
   # WRITE-AHEAD: persist the page BEFORE the first network attempt, so a crash or
   # kill before a confirmed success leaves a recoverable record. A persist failure
@@ -339,40 +387,23 @@ send_alert() {
   fi
   local stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
 
-  # 2) Discord via the hermes webhook (bounded retry; the page is already safe on
-  #    disk, so a failed delivery here costs latency, not the page). Read the
-  #    HMAC key from the notifier's own secret file (an environment override is
-  #    allowed for tests); strip any carriage return so a CRLF file cannot
-  #    corrupt the key.
-  local secret="${OSQUERY_WEBHOOK_SECRET:-}"
-  if [[ -z $secret && -r $OSQUERY_WEBHOOK_SECRET_FILE ]]; then
-    IFS= read -r secret <"$OSQUERY_WEBHOOK_SECRET_FILE" || true
-    secret="$(printf '%s' "$secret" | tr -d '\r')"
-  fi
+  # Deliver via the hermes webhook (the page is already safe on disk, so a
+  # failed delivery here costs latency, not the page). No key means no send: the
+  # drain signs and sends the stored page once the secret returns.
+  local secret
+  secret="$(_read_webhook_secret)"
   if [[ -z $secret ]]; then
-    # The page is already persisted (write-ahead); the drain signs and sends it
-    # once the secret returns. Name the broken channel loudly.
     _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
     _loud_local "osquery Discord paging BROKEN" \
       "No webhook secret. This page was stored locally and delivers when the secret is restored."
     return 0
   fi
 
-  local signature http_status attempt
-  signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")"
-
-  for attempt in 1 2 3; do
-    http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
-    case "$http_status" in
-      2*)
-        rm -f "$stored_file" # delete ONLY after a confirmed 2xx
-        return 0
-        ;;
-      429 | 5?? | 000) # transient, back off and retry (base overridable for tests)
-        if [[ $attempt -lt 3 ]]; then sleep "$((attempt * ${OSQUERY_RETRY_BACKOFF_BASE:-1}))"; fi ;;
-      *) break ;; # 401/413/etc, retry won't help
-    esac
-  done
+  local http_status
+  if http_status="$(_attempt_alert_delivery "$url" "$request_id" "$secret" "$body")"; then
+    rm -f "$stored_file" # delete ONLY after a confirmed 2xx
+    return 0
+  fi
   # Delivery failed after retries: the write-ahead record REMAINS on disk and the
   # next drain retries it, so send_alert still returns 0. A down gateway delays
   # the page; it never fails the caller and never loses the page.

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Delivery durability: a CRIT page that cannot be delivered must be STORED as an
+# undelivered alert, never silently dropped (a lost page looks exactly like
+# all-clear). The retry drain replays a stored alert idempotently, to localhost
+# only, and never aborts its caller.
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  # shellcheck source=test/helpers/run-dispatch-and-drain.sh
+  source "$helpers/run-dispatch-and-drain.sh"
+  build_dispatch_harness
+}
+teardown() { teardown_dispatch_harness; }
+
+@test "T-SEC-undelivered-retry: a page failing all retries is stored (600/700), then drained" {
+  set_curl_codes 503 503 503
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
+  [[ $send_status -eq 0 ]] # a down gateway never fails the caller
+  assert_undelivered_alert_count 1 # stored, not lost
+  assert_mode 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR"
+  assert_mode 600 "$(first_undelivered_alert_file)"
+  grep -q STORED "$OSQUERY_DELIVERY_LOG"
+  # gateway recovers: the drain delivers and clears the stored alert
+  run_retry_undelivered_alerts drain_output drain_status
+  assert_undelivered_alert_count 0
+}
+
+@test "T-SEC-undelivered-idem: re-storing the SAME occurrence stays one file; drain replays once (R2-4)" {
+  # Idempotency is keyed on OCCURRENCE IDENTITY, not body content (R2-4): the SAME
+  # occurrence re-stored stays one file and reuses one request_id, so the gateway
+  # dedups a retry. (Two DISTINCT occurrences that render the same body get two
+  # files, the collapse bug this design fixes.)
+  set_curl_codes 503 503 503 503 503 503
+  send_alert CRIT "🔴 title" "same detail" "Sosumi" "occ:disk3:900:1000"
+  send_alert CRIT "🔴 title" "same detail" "Sosumi" "occ:disk3:900:1000" # same occurrence, same request_id
+  assert_undelivered_alert_count 1
+  local stored_request_id
+  stored_request_id=$(cut -f2 "$(first_undelivered_alert_file)")
+  : >"$CURL_LOG"
+  retry_undelivered_alerts
+  assert_post_count 1
+  grep -qF "X-Request-ID: $stored_request_id" "$CURL_LOG" # the stored request_id is reused verbatim
+  assert_undelivered_alert_count 0                        # so the gateway dedups instead of double-posting
+  : >"$CURL_LOG"
+  retry_undelivered_alerts # nothing left
+  assert_post_count 0
+}
+
+@test "T-SEC-localhost: send and drain POST only to 127.0.0.1; a tampered url is not sent" {
+  set_curl_codes 503 503 503
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  assert_post_count 3 # positive anchor: the three retries actually POSTed
+  assert_posted_to '127.0.0.1:8644'
+  run grep -v '127.0.0.1:8644' "$CURL_LOG"
+  [[ -z $output ]] # ...and every send POST was to loopback, nothing else
+  local stored_file
+  stored_file=$(first_undelivered_alert_file)
+  awk 'BEGIN{FS=OFS="\t"} {$3="http://10.0.0.5:8644/webhooks/osquery-priority"; print}' \
+    "$stored_file" >"$stored_file.t" && mv "$stored_file.t" "$stored_file"
+  : >"$CURL_LOG"
+  retry_undelivered_alerts
+  ! grep -q '10.0.0.5' "$CURL_LOG"     # never sent off-box
+  assert_undelivered_alert_count 1 # the off-box entry is RETAINED (skipped), not silently dropped
+}
+
+@test "T-SEC-drain-setE: drain is set -e-safe on empty or malformed input" {
+  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
+  printf 'garbage-no-tabs\n' >"$OSQUERY_UNDELIVERED_ALERTS_DIR/bad"
+  printf '%s\t%s\n' 123 incomplete >"$OSQUERY_UNDELIVERED_ALERTS_DIR/short"
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]
+  [[ $output == *DONE* ]]
+}
+
+@test "T-SEC-no-secret-log: the webhook secret never appears in any log or stored file" {
+  export OSQUERY_WEBHOOK_SECRET="SUPERSECRET123"
+  set_curl_codes 503 503 503
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  retry_undelivered_alerts || true
+  ! grep -rqF "SUPERSECRET123" \
+    "$HARNESS_HOME/.local" "$OSQUERY_UNDELIVERED_ALERTS_DIR" "$CURL_LOG" "$OSQUERY_DELIVERY_LOG" 2>/dev/null
+}

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -74,6 +74,48 @@ teardown() { teardown_dispatch_harness; }
   [[ $output == *DONE* ]]
 }
 
+@test "T-SEC-write-ahead: the record is persisted BEFORE the first send attempt" {
+  # The curl stub records the stored-record count seen at each POST. Under the
+  # write-ahead store the FIRST POST must already see the record on disk (count
+  # >= 1); the old attempt-then-persist path showed 0 at the first POST, so a
+  # crash between the attempt and success would have lost the page.
+  set_curl_codes 503 503 503
+  send_alert CRIT "🔴 title" "detail body" "Sosumi" "occ:wa:1"
+  local first_witnessed_count
+  first_witnessed_count=$(head -1 "$CURL_PERSIST_WITNESS")
+  [[ $first_witnessed_count =~ ^[0-9]+$ ]]
+  [[ $first_witnessed_count -ge 1 ]]
+}
+
+@test "T-SEC-quarantine-partial: a crashed *.tmp.* partial is quarantined on the next drain, not skipped forever" {
+  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
+  # A leftover temp from a dead writer (a pid that is not running).
+  printf '%s\tosquery-crash\thttp://127.0.0.1:8644/x\tYm9keQ==\n' "$(date -u +%s)" \
+    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-crash.tmp.999999"
+  retry_undelivered_alerts
+  # No *.tmp.* remains in the store dir (it is not skipped and left forever)...
+  [[ -z "$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -maxdepth 1 -name '*.tmp.*' 2>/dev/null)" ]]
+  # ...it was moved into the quarantine sibling, not silently deleted.
+  [[ -n "$(find "${OSQUERY_UNDELIVERED_ALERTS_DIR}.quarantine" -type f 2>/dev/null)" ]]
+}
+
+@test "T-SEC-drain-order: the drain delivers in occurrence-time order, not filename order" {
+  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
+  # Two records: z-old has the EARLIER occurrence ts, a-new the later. By filename
+  # glob order a-new sorts first; by occurrence time z-old must deliver first.
+  local body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  printf '%s\t%s\t%s\t%s\n' 1000 osquery-z-old 'http://127.0.0.1:8644/webhooks/osquery-priority' "$body_b64" \
+    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-z-old"
+  printf '%s\t%s\t%s\t%s\n' 2000 osquery-a-new 'http://127.0.0.1:8644/webhooks/osquery-priority' "$body_b64" \
+    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-a-new"
+  set_curl_codes 200 200
+  retry_undelivered_alerts
+  local first_posted_request_id
+  first_posted_request_id=$(grep -oE 'X-Request-ID: osquery-[a-z-]+' "$CURL_LOG" | head -1)
+  [[ $first_posted_request_id == "X-Request-ID: osquery-z-old" ]]
+}
+
 @test "T-SEC-no-secret-log: the webhook secret never appears in any log or stored file" {
   export OSQUERY_WEBHOOK_SECRET="SUPERSECRET123"
   set_curl_codes 503 503 503

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -1,0 +1,124 @@
+# shellcheck shell=bash
+# build-dispatch-harness.sh -- stand up a throwaway HOME for exercising the REAL
+# osquery dispatch library (dot_local/libexec/osquery/executable_alert-dispatch.sh).
+# Sourced by the dispatch suites; no main.
+#
+# The harness records what the library does through two stubs on PATH: an alerter
+# stub that appends its argv to $ALERTER_LOG (so a test can read the local
+# notification's text) and a curl stub that appends its argv to $CURL_LOG and
+# returns the next HTTP code queued in $CURL_CODES_FILE (so a test can script
+# "503 503 503 then success"). It then exports the paths and secret the library
+# reads and sources the library into the test's shell, so send_alert and
+# retry_undelivered_alerts run for real.
+#
+# Being a fixture, this helper's whole contract is to EXPORT that environment;
+# unlike the pure helpers it owns the harness state. It sets nothing at source
+# time -- every export happens inside build_dispatch_harness, called from setup().
+
+# build_dispatch_harness -- create the temp HOME, install the recording stubs,
+# export the library's inputs, and source the library.
+build_dispatch_harness() {
+  HARNESS_HOME="$(mktemp -d)"
+  mkdir -p "$HARNESS_HOME/bin" "$HARNESS_HOME/.local/log/osquery"
+
+  export ALERTER_LOG="$HARNESS_HOME/alerter.log"
+  : >"$ALERTER_LOG"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"%s"\nexit 0\n' "$ALERTER_LOG" >"$HARNESS_HOME/bin/alerter"
+
+  # curl stub: record the invocation, then emit the next queued HTTP code (one
+  # per line in $CURL_CODES_FILE, popped per call), defaulting to 200 when the
+  # queue is empty.
+  cat >"$HARNESS_HOME/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_LOG"
+code=200
+if [[ -s "$CURL_CODES_FILE" ]]; then
+  code=$(head -1 "$CURL_CODES_FILE")
+  tail -n +2 "$CURL_CODES_FILE" >"$CURL_CODES_FILE.tmp" 2>/dev/null && mv "$CURL_CODES_FILE.tmp" "$CURL_CODES_FILE"
+fi
+printf '%s' "$code"
+STUB
+  chmod +x "$HARNESS_HOME/bin/alerter" "$HARNESS_HOME/bin/curl"
+
+  export CURL_LOG="$HARNESS_HOME/curl.log"
+  : >"$CURL_LOG"
+  export CURL_CODES_FILE="$HARNESS_HOME/curl_codes"
+  : >"$CURL_CODES_FILE"
+  export PATH="$HARNESS_HOME/bin:$PATH"
+  export HOME="$HARNESS_HOME"
+
+  export OSQUERY_WEBHOOK_SECRET="testsecret"
+  export OSQUERY_DELIVERY_LOG="$HARNESS_HOME/.local/log/osquery/webhook-delivery.log"
+  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/.local/state/osquery-undelivered-alerts"
+  export OSQUERY_RETRY_BACKOFF_BASE=0 # do not really sleep between retries in tests
+
+  DISPATCH="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_alert-dispatch.sh"
+  # shellcheck source=/dev/null
+  source "$DISPATCH"
+}
+
+# teardown_dispatch_harness -- remove the temp HOME (safe when setup never ran).
+teardown_dispatch_harness() {
+  [[ -n ${HARNESS_HOME:-} ]] && rm -rf "$HARNESS_HOME"
+}
+
+# set_curl_codes <code>... -- queue the HTTP codes the curl stub returns, one per
+# send/retry POST.
+set_curl_codes() {
+  printf '%s\n' "$@" >"$CURL_CODES_FILE"
+}
+
+# first_undelivered_alert_file -- print the path of one stored undelivered-alert
+# file, or nothing when none exist.
+first_undelivered_alert_file() {
+  find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -type f 2>/dev/null | head -1
+}
+
+# assert_undelivered_alert_count <n> -- exactly <n> undelivered-alert files exist.
+assert_undelivered_alert_count() {
+  local count=0
+  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] &&
+    count=$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s undelivered-alert file(s), got %s: %s\n' \
+      "$1" "$count" "$(ls -la "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null)" >&2
+    return 1
+  fi
+}
+
+# assert_mode <octal> <path> -- the path carries the expected permission bits.
+# GNU stat first (the nix shell), BSD stat as the fallback (the portable order).
+assert_mode() {
+  local mode
+  mode=$(stat -c '%a' "$2" 2>/dev/null || stat -f '%Lp' "$2" 2>/dev/null)
+  if [[ $mode != "$1" ]]; then
+    printf 'expected mode %s on %s, got %s\n' "$1" "$2" "$mode" >&2
+    return 1
+  fi
+}
+
+# assert_post_count <n> -- the curl stub recorded exactly <n> POSTs.
+assert_post_count() {
+  local count
+  count=$(grep -c 'POST' "$CURL_LOG" 2>/dev/null || echo 0)
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s POST(s), got %s: %s\n' "$1" "$count" "$(cat "$CURL_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_posted_to <substring> -- some POST targeted a URL containing <substring>.
+assert_posted_to() {
+  if ! grep -qF -- "$1" "$CURL_LOG"; then
+    printf 'expected a POST to a URL containing %s; curl log: %s\n' "$1" "$(cat "$CURL_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_no_post -- no webhook POST happened at all.
+assert_no_post() {
+  if [[ -s $CURL_LOG ]]; then
+    printf 'expected NO webhook POST, but curl was called: %s\n' "$(cat "$CURL_LOG")" >&2
+    return 1
+  fi
+}

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -25,12 +25,17 @@ build_dispatch_harness() {
   : >"$ALERTER_LOG"
   printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"%s"\nexit 0\n' "$ALERTER_LOG" >"$HARNESS_HOME/bin/alerter"
 
-  # curl stub: record the invocation, then emit the next queued HTTP code (one
+  # curl stub: record the invocation and the count of stored undelivered-alert
+  # files AT CALL TIME (so a test can prove the write-ahead record already existed
+  # when the first POST was attempted), then emit the next queued HTTP code (one
   # per line in $CURL_CODES_FILE, popped per call), defaulting to 200 when the
   # queue is empty.
   cat >"$HARNESS_HOME/bin/curl" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$CURL_LOG"
+if [[ -n "${CURL_PERSIST_WITNESS:-}" ]]; then
+  find "${OSQUERY_UNDELIVERED_ALERTS_DIR:-/nonexistent}" -type f 2>/dev/null | wc -l | tr -d ' ' >>"$CURL_PERSIST_WITNESS"
+fi
 code=200
 if [[ -s "$CURL_CODES_FILE" ]]; then
   code=$(head -1 "$CURL_CODES_FILE")
@@ -44,6 +49,11 @@ STUB
   : >"$CURL_LOG"
   export CURL_CODES_FILE="$HARNESS_HOME/curl_codes"
   : >"$CURL_CODES_FILE"
+  # The write-ahead witness: the curl stub appends the stored-record count seen at
+  # each POST here, one line per call. Empty until a test opts in by pointing it
+  # at a file.
+  export CURL_PERSIST_WITNESS="$HARNESS_HOME/curl_persist_witness"
+  : >"$CURL_PERSIST_WITNESS"
   export PATH="$HARNESS_HOME/bin:$PATH"
   export HOME="$HARNESS_HOME"
 

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -19,6 +19,9 @@
 # export the library's inputs, and source the library.
 build_dispatch_harness() {
   HARNESS_HOME="$(mktemp -d)"
+  # Record ownership ONLY after we created our own temp dir, so teardown removes
+  # this path and never a pre-set or inherited HARNESS_HOME.
+  _DISPATCH_HARNESS_OWNED_DIR="$HARNESS_HOME"
   mkdir -p "$HARNESS_HOME/bin" "$HARNESS_HOME/.local/log/osquery"
 
   export ALERTER_LOG="$HARNESS_HOME/alerter.log"
@@ -67,9 +70,13 @@ STUB
   source "$DISPATCH"
 }
 
-# teardown_dispatch_harness -- remove the temp HOME (safe when setup never ran).
+# teardown_dispatch_harness -- remove ONLY a temp dir this harness created. The
+# ownership marker is set by build_dispatch_harness after its own mktemp, so a
+# pre-set or inherited HARNESS_HOME (marker unset) is left untouched.
 teardown_dispatch_harness() {
-  [[ -n ${HARNESS_HOME:-} ]] && rm -rf "$HARNESS_HOME"
+  [[ -n ${_DISPATCH_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_DISPATCH_HARNESS_OWNED_DIR"
+  unset _DISPATCH_HARNESS_OWNED_DIR
 }
 
 # set_curl_codes <code>... -- queue the HTTP codes the curl stub returns, one per

--- a/test/helpers/run-dispatch-and-drain.sh
+++ b/test/helpers/run-dispatch-and-drain.sh
@@ -1,0 +1,55 @@
+# shellcheck shell=bash
+# run-dispatch-and-drain.sh -- drive the dispatch library's entry points from a
+# test and capture each run's combined output and exit code WITHOUT aborting the
+# caller on a nonzero exit. Sourced by the dispatch suites; no main.
+#
+# The two destinations are nameref output parameters, so the helper keeps no
+# global state: a caller declares two locals and passes their names. Following
+# test-system/helpers/capture-output.sh, two internal destination names are
+# RESERVED and rejected up front (passing one would make the nameref alias
+# itself), and the two destinations must be different names (the same name would
+# let the status write clobber the captured output). The caller's errexit setting
+# is saved and restored, so this works whether or not the caller runs under
+# `set -e`.
+
+# _capture_dispatch_run <output-variable-name> <status-variable-name> <command> [args...]
+_capture_dispatch_run() {
+  local _capture_dispatch_reserved
+  for _capture_dispatch_reserved in _capture_dispatch_output_destination _capture_dispatch_status_destination; do
+    if [[ $1 == "$_capture_dispatch_reserved" || $2 == "$_capture_dispatch_reserved" ]]; then
+      printf 'run-dispatch-and-drain: destination name %s is reserved by this helper; pick another variable name\n' "$_capture_dispatch_reserved" >&2
+      return 2
+    fi
+  done
+  if [[ $1 == "$2" ]]; then
+    printf 'run-dispatch-and-drain: the output and status destinations must be different variable names (both were %s)\n' "$1" >&2
+    return 2
+  fi
+  local -n _capture_dispatch_output_destination="$1"
+  local -n _capture_dispatch_status_destination="$2"
+  shift 2
+  local _capture_dispatch_errexit_was_on=0
+  [[ $- == *e* ]] && _capture_dispatch_errexit_was_on=1
+  set +e
+  # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
+  _capture_dispatch_output_destination="$("$@" 2>&1)"
+  # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
+  _capture_dispatch_status_destination=$?
+  [[ $_capture_dispatch_errexit_was_on -eq 1 ]] && set -e
+  return 0
+}
+
+# run_dispatch <output-variable-name> <status-variable-name> <send_alert-args...>
+# Run the library's send_alert with the given arguments, capturing its combined
+# output and exit code into the caller-named variables.
+run_dispatch() {
+  local output_variable_name="$1" status_variable_name="$2"
+  shift 2
+  _capture_dispatch_run "$output_variable_name" "$status_variable_name" send_alert "$@"
+}
+
+# run_retry_undelivered_alerts <output-variable-name> <status-variable-name>
+# Run the library's retry drain, capturing its combined output and exit code.
+run_retry_undelivered_alerts() {
+  _capture_dispatch_run "$1" "$2" retry_undelivered_alerts
+}

--- a/test/helpers/run-dispatch-and-drain.sh
+++ b/test/helpers/run-dispatch-and-drain.sh
@@ -4,20 +4,24 @@
 # caller on a nonzero exit. Sourced by the dispatch suites; no main.
 #
 # The two destinations are nameref output parameters, so the helper keeps no
-# global state: a caller declares two locals and passes their names. Following
-# test-system/helpers/capture-output.sh, two internal destination names are
-# RESERVED and rejected up front (passing one would make the nameref alias
-# itself), and the two destinations must be different names (the same name would
-# let the status write clobber the captured output). The caller's errexit setting
-# is saved and restored, so this works whether or not the caller runs under
-# `set -e`.
+# global state: a caller declares two locals and passes their names. Naming
+# system (shared with test-system/helpers/capture-output.sh): every internal
+# local is prefixed with the full function name (_capture_dispatch_run_*), and
+# the guard rejects any destination name matching that reserved internal prefix.
+# A destination sharing an internal's name would make the nameref alias the
+# helper's own local instead of the caller's variable, and the write would be
+# silently lost. Guarding the whole prefix covers every current and future
+# internal, unlike a hand-kept name list. The two destinations must be different
+# names (the same name would let the status write clobber the captured output).
+# The caller's errexit setting is saved and restored, so this works whether or
+# not the caller runs under `set -e`.
 
 # _capture_dispatch_run <output-variable-name> <status-variable-name> <command> [args...]
 _capture_dispatch_run() {
-  local _capture_dispatch_reserved
-  for _capture_dispatch_reserved in _capture_dispatch_output_destination _capture_dispatch_status_destination; do
-    if [[ $1 == "$_capture_dispatch_reserved" || $2 == "$_capture_dispatch_reserved" ]]; then
-      printf 'run-dispatch-and-drain: destination name %s is reserved by this helper; pick another variable name\n' "$_capture_dispatch_reserved" >&2
+  local _capture_dispatch_run_destination_name
+  for _capture_dispatch_run_destination_name in "$1" "$2"; do
+    if [[ $_capture_dispatch_run_destination_name == _capture_dispatch_run_* ]]; then
+      printf 'run-dispatch-and-drain: destination name %s matches the reserved internal prefix _capture_dispatch_run_; pick another variable name\n' "$_capture_dispatch_run_destination_name" >&2
       return 2
     fi
   done
@@ -25,27 +29,27 @@ _capture_dispatch_run() {
     printf 'run-dispatch-and-drain: the output and status destinations must be different variable names (both were %s)\n' "$1" >&2
     return 2
   fi
-  local -n _capture_dispatch_output_destination="$1"
-  local -n _capture_dispatch_status_destination="$2"
+  local -n _capture_dispatch_run_output_destination="$1"
+  local -n _capture_dispatch_run_status_destination="$2"
   shift 2
-  local _capture_dispatch_errexit_was_on=0
-  [[ $- == *e* ]] && _capture_dispatch_errexit_was_on=1
+  local _capture_dispatch_run_errexit_was_on=0
+  [[ $- == *e* ]] && _capture_dispatch_run_errexit_was_on=1
   set +e
   # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
-  _capture_dispatch_output_destination="$("$@" 2>&1)"
+  _capture_dispatch_run_output_destination="$("$@" 2>&1)"
   # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
-  _capture_dispatch_status_destination=$?
-  [[ $_capture_dispatch_errexit_was_on -eq 1 ]] && set -e
+  _capture_dispatch_run_status_destination=$?
+  [[ $_capture_dispatch_run_errexit_was_on -eq 1 ]] && set -e
   return 0
 }
 
 # run_dispatch <output-variable-name> <status-variable-name> <send_alert-args...>
 # Run the library's send_alert with the given arguments, capturing its combined
-# output and exit code into the caller-named variables.
+# output and exit code into the caller-named variables. Deliberately declares no
+# locals of its own: an intermediate local holding a destination name would be
+# one more name a caller could collide with.
 run_dispatch() {
-  local output_variable_name="$1" status_variable_name="$2"
-  shift 2
-  _capture_dispatch_run "$output_variable_name" "$status_variable_name" send_alert "$@"
+  _capture_dispatch_run "$1" "$2" send_alert "${@:3}"
 }
 
 # run_retry_undelivered_alerts <output-variable-name> <status-variable-name>

--- a/test/helpers/wait-for-log-line.sh
+++ b/test/helpers/wait-for-log-line.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+# wait-for-log-line.sh -- poll a log file for a line matching an extended regex,
+# with a bounded timeout. Sourced by the dispatch suites; no main.
+#
+# The dispatch library fires its loud local notification through a backgrounded
+# process (alerter ... &), so a single immediate grep races the write under a
+# loaded parallel CI host. This polls up to <tries> times at 50 ms each and
+# returns 0 as soon as the pattern lands, nonzero after the timeout, so a
+# genuinely absent line still fails the test. The match path returns on the first
+# iteration, so a passing assertion is not slowed.
+
+# wait_for_log_line <extended-regex> <file> [tries]
+wait_for_log_line() {
+  local pattern="$1" file="$2" tries="${3:-40}" attempt
+  for ((attempt = 0; attempt < tries; attempt++)); do
+    if grep -qiE "$pattern" "$file" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  printf 'wait_for_log_line: /%s/ did not appear in %s within %s tries; contents:\n' "$pattern" "$file" "$tries" >&2
+  cat "$file" >&2 2>/dev/null || true
+  return 1
+}

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -137,3 +137,11 @@ teardown() { teardown_dispatch_harness; }
   grep -qF '"tier":"muted"' "$CURL_LOG"
   ! grep -qF '"tier":"page"' "$CURL_LOG"
 }
+
+@test "T-DISP-body-ts: a CRIT body carries a numeric occurrence ts (the drain ordering key)" {
+  # The occurrence time is inside the signed body so a replayed page keeps its
+  # original ordering key and the field is tamper-evident.
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  run grep -oE '"ts":[0-9]+' "$CURL_LOG"
+  [[ $status -eq 0 ]]
+}

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -145,3 +145,33 @@ teardown() { teardown_dispatch_harness; }
   run grep -oE '"ts":[0-9]+' "$CURL_LOG"
   [[ $status -eq 0 ]]
 }
+
+@test "T-DISP-secret-not-in-argv: the signing key never reaches any openssl argv (F-B)" {
+  # Shim openssl to log its full argv, then delegate to the real one so signing
+  # still works. A CRIT send must never pass the secret as an openssl argument,
+  # any user's `ps` would otherwise see the key.
+  local real_openssl
+  real_openssl="$(command -v openssl)"
+  export OPENSSL_ARGV_LOG="$HARNESS_HOME/openssl_argv.log"
+  : >"$OPENSSL_ARGV_LOG"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "%%s\\n" "$*" >>"%s"\n' "$OPENSSL_ARGV_LOG"
+    printf 'exec %q "$@"\n' "$real_openssl"
+  } >"$HARNESS_HOME/bin/openssl"
+  chmod +x "$HARNESS_HOME/bin/openssl"
+  export OSQUERY_WEBHOOK_SECRET="SUPERSECRET-argv-probe"
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  [[ -s $OPENSSL_ARGV_LOG ]] # openssl WAS invoked (sanity)
+  ! grep -qF 'SUPERSECRET-argv-probe' "$OPENSSL_ARGV_LOG"
+}
+
+@test "T-DISP-sign-matches-openssl: the argv-free signer equals openssl's HMAC output (F-B)" {
+  # Correctness anchor: the manual HMAC must be byte-identical to openssl's -hmac,
+  # or a wrong-but-consistent signature would pass the curl-mocked tests yet be
+  # rejected by the gateway in production.
+  local message="the message" key="k3y" got want
+  got="$(printf '%s' "$message" | _hmac_sha256_hex "$key")"
+  want="$(printf '%s' "$message" | openssl dgst -sha256 -hmac "$key" | awk '{print $NF}')"
+  [[ $got == "$want" ]]
+}

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# Shared dispatch library (alert-dispatch.sh): v2 delivers ONLY a CRIT page to the
+# #priority webhook. Any other severity does the local notification and never
+# POSTs (there is no #osquery channel for a producer to leak to). A CRIT body
+# carries the host and a tier field, and an undelivered page is stored durably
+# rather than dropped.
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  # shellcheck source=test/helpers/run-dispatch-and-drain.sh
+  source "$helpers/run-dispatch-and-drain.sh"
+  # shellcheck source=test/helpers/wait-for-log-line.sh
+  source "$helpers/wait-for-log-line.sh"
+  build_dispatch_harness
+}
+teardown() { teardown_dispatch_harness; }
+
+@test "T-DISP-crit-priority: a CRIT page POSTs to the #priority webhook" {
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  assert_posted_to "/webhooks/osquery-priority"
+}
+
+@test "T-DISP-noncrit-silent: a non-CRIT severity never POSTs (no #osquery channel)" {
+  send_alert NOTICE "🟡 title" "detail" "Glass"
+  assert_no_post
+}
+
+@test "T-DISP-host-field: the signed webhook body carries a host field (multi-host seam)" {
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  # The curl stub records the full invocation including --data <body>; host must
+  # be inside the signed bytes, the master-spec body shape and the multi-host
+  # seam both require {event_type, host, alert:{...}}.
+  run grep -F '"host":"' "$CURL_LOG"
+  [[ $status -eq 0 ]]
+}
+
+@test "T-DISP-nosecret-store: a CRIT with no webhook secret stores the page and loudly names the broken channel" {
+  # The old code logged a WARN and returned SUCCESS without storing, so the
+  # critical silently degraded to local-only and was lost. With no secret the
+  # page must be stored durably (it delivers when the secret returns) and a LOUD
+  # local notice must name the broken channel; nothing may be signed or POSTed
+  # without a key.
+  unset OSQUERY_WEBHOOK_SECRET
+  : >"$ALERTER_LOG"
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
+  [[ $send_status -eq 0 ]]          # still fire-and-forget for its callers
+  assert_undelivered_alert_count 1  # durably stored, not dropped
+  assert_no_post                    # nothing signed/POSTed without a key
+  grep -qiE 'secret|degraded|broken' "$OSQUERY_DELIVERY_LOG"
+  # The loud local notice fires via a backgrounded alerter (& so it never blocks
+  # dispatch), so poll rather than grep once.
+  wait_for_log_line 'secret|Discord|broken|deliver' "$ALERTER_LOG"
+}
+
+# --- occurrence-identity request id + occurrence-unique stored filenames (R2-4) ---
+# request_id was sha256(body): two DISTINCT incidents with the same body collapsed
+# to one id, so the gateway deduped them AND the second overwrote the first in the
+# store (the filename is the id). The id must derive from OCCURRENCE IDENTITY, so
+# two same-body incidents survive as two stored files.
+
+@test "T-DISP-occurrence-distinct: two same-body incidents at different occurrences store as TWO files (R2-4)" {
+  set_curl_codes 503 503 503 503 503 503
+  send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
+  send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:200:300"
+  assert_undelivered_alert_count 2 # both incidents survive, a later same-body incident does not clobber the earlier
+}
+
+@test "T-DISP-occurrence-retry-stable: the SAME occurrence retried reuses one id (idempotent store) (R2-4)" {
+  set_curl_codes 503 503 503 503 503 503
+  send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
+  send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
+  assert_undelivered_alert_count 1
+}
+
+# --- a store failure is a HARD failure, not a silent success (R2-6) ---------------
+@test "T-DISP-store-hardfail: an unwritable store dir + no secret returns nonzero and loudly alerts (R2-6)" {
+  # Point the store at a path whose parent is a FILE, so mkdir cannot succeed for
+  # any uid (deterministic, not permission/uid-dependent). With no secret the page
+  # cannot be signed either, so it can be neither delivered NOR stored, which MUST
+  # be loud and nonzero.
+  unset OSQUERY_WEBHOOK_SECRET
+  : >"$ALERTER_LOG"
+  touch "$HARNESS_HOME/notadir"
+  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/notadir/store"
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
+  [[ $send_status -ne 0 ]]                          # hard delivery failure, NOT a silent success
+  assert_undelivered_alert_count 0                  # nothing was stored
+  assert_no_post                                    # nothing signed/POSTed without a key
+  grep -qiE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"  # synchronous: the hard failure is recorded
+  wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG" # the loud local alert fired
+}
+
+@test "T-DISP-store-hardfail-delivery: delivery failure + unwritable store returns nonzero and loudly alerts (R2-6)" {
+  : >"$ALERTER_LOG"
+  set_curl_codes 503 503 503
+  touch "$HARNESS_HOME/notadir2"
+  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/notadir2/store"
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
+  [[ $send_status -ne 0 ]]
+  assert_undelivered_alert_count 0
+  grep -qiE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"
+  wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
+}
+
+@test "T-DISP-store-atomic: a stored page is written atomically and drains on recovery (R2-6)" {
+  # A store file appears (delivery failed) and drains clean once curl recovers,
+  # proving the temp+rename path produces a well-formed, replayable entry (no torn
+  # temp left behind).
+  set_curl_codes 503 503 503
+  send_alert CRIT "🔴 title" "detail body" "Sosumi" "occ:1:2"
+  assert_undelivered_alert_count 1
+  [[ -z "$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -name '*.tmp.*' 2>/dev/null)" ]] # no torn temp file left
+  set_curl_codes 200
+  retry_undelivered_alerts
+  assert_undelivered_alert_count 0
+}
+
+# --- digest/heartbeat traffic DOES reach the remote POST; mark its tier (R2-11) ---
+# The dispatcher POSTs for severity==CRIT, and the digest and heartbeat both
+# dispatch at CRIT, so they DO reach the remote POST. The `sound` arg only muted
+# the LOCAL notifier; the POST carried no tier, so a silent digest looked
+# identical to a real page on the wire. Thread an explicit tier the Hermes adapter
+# can map to a suppressed notification: a page (non-empty sound) is tier=page, a
+# muted digest/heartbeat (empty sound) is tier=muted. Both still POST (both CRIT).
+
+@test "T-DISP-tier-page: a real page (non-empty sound) POSTs tier=page (R2-11)" {
+  send_alert CRIT "🔴 title" "detail" "Sosumi"
+  assert_post_count 1
+  grep -qF '"tier":"page"' "$CURL_LOG"
+}
+
+@test "T-DISP-tier-muted: a muted digest/heartbeat (empty sound) POSTs tier=muted, not page (R2-11)" {
+  send_alert CRIT "🗒️ daily digest" "detail" ""
+  assert_post_count 1 # it DOES reach the remote POST (not moot)
+  grep -qF '"tier":"muted"' "$CURL_LOG"
+  ! grep -qF '"tier":"page"' "$CURL_LOG"
+}

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -166,6 +166,19 @@ teardown() { teardown_dispatch_harness; }
   ! grep -qF 'SUPERSECRET-argv-probe' "$OPENSSL_ARGV_LOG"
 }
 
+@test "T-DISP-signing-failure: a failed signature makes NO POST and retains the write-ahead record" {
+  # The delivery attempt runs inside an if condition, where errexit is
+  # suppressed, so a failing signature assignment must be checked explicitly:
+  # otherwise execution continues with an EMPTY signature, POSTs it, and a 2xx
+  # deletes the write-ahead record. Force the signer to fail and assert the
+  # attempt stops before any POST, leaving the record for a later drain.
+  _hmac_sha256_hex() { return 17; }
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:signfail:1"
+  [[ $send_status -eq 0 ]] # the record is retained, so this is not a hard failure
+  assert_no_post
+  assert_undelivered_alert_count 1
+}
+
 @test "T-DISP-sign-matches-openssl: the argv-free signer equals openssl's HMAC output (F-B)" {
   # Correctness anchor: the manual HMAC must be byte-identical to openssl's -hmac,
   # or a wrong-but-consistent signature would pass the curl-mocked tests yet be

--- a/test/test-system/dispatch-harness-teardown.sh
+++ b/test/test-system/dispatch-harness-teardown.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# dispatch-harness-teardown.sh -- guard the shared dispatch harness's teardown
+# ownership contract: teardown_dispatch_harness must remove ONLY a temp dir the
+# harness itself created, never a pre-set or inherited HARNESS_HOME. Collect all
+# failures and report them at the end.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=test/test-system/helpers/report-test-failures.sh
+source "$REPO_ROOT/test/test-system/helpers/report-test-failures.sh"
+# shellcheck source=test/helpers/build-dispatch-harness.sh
+source "$REPO_ROOT/test/helpers/build-dispatch-harness.sh"
+
+# An inherited HARNESS_HOME the harness never created must survive teardown.
+assert_teardown_spares_inherited_home() {
+  local inherited
+  inherited="$(mktemp -d)"
+  HARNESS_HOME="$inherited"
+  unset _DISPATCH_HARNESS_OWNED_DIR 2>/dev/null || true
+  teardown_dispatch_harness
+  if [[ ! -d $inherited ]]; then
+    record_failure "teardown deleted an inherited HARNESS_HOME it did not create: $inherited"
+  fi
+  rm -rf "$inherited"
+}
+
+# A dir the harness DID create is removed by teardown.
+assert_teardown_removes_owned_dir() {
+  # build_dispatch_harness resolves the dispatch library from BATS_TEST_DIRNAME.
+  BATS_TEST_DIRNAME="$REPO_ROOT/test/e2e"
+  build_dispatch_harness
+  local owned="$HARNESS_HOME"
+  teardown_dispatch_harness
+  if [[ -d $owned ]]; then
+    record_failure "teardown did not remove the dir the harness created: $owned"
+  fi
+}
+
+main() {
+  assert_teardown_spares_inherited_home
+  assert_teardown_removes_owned_dir
+  report_failures dispatch-harness-teardown
+}
+
+main "$@"

--- a/test/test-system/helpers/capture-output.sh
+++ b/test/test-system/helpers/capture-output.sh
@@ -3,8 +3,10 @@
 # Run the command, writing its combined stdout+stderr into the first named
 # variable and its exit code into the second. The names are nameref output
 # parameters, so the helper keeps no global state: callers declare locals and
-# pass their names. Wraps the run in `set +e` / `set -e` so a nonzero exit
-# never aborts the caller. Sourced by the test-system suite; no main.
+# pass their names. Runs the command under `set +e` and then restores the
+# caller's ORIGINAL errexit state, so a nonzero exit never aborts the caller
+# and a deliberate set +e caller stays set +e afterward. Sourced by the
+# test-system suite; no main.
 #
 # Naming system: every internal local is prefixed with the full function name
 # (capture_output_*), and the guard below rejects any destination name matching
@@ -29,10 +31,13 @@ capture_output() {
   local -n capture_output_text_destination="$1"
   local -n capture_output_status_destination="$2"
   shift 2
+  local capture_output_errexit_was_on=0
+  [[ $- == *e* ]] && capture_output_errexit_was_on=1
   set +e
   # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
   capture_output_text_destination="$("$@" 2>&1)"
   # shellcheck disable=SC2034 # nameref: the assignment writes the caller's variable
   capture_output_status_destination=$?
-  set -e
+  [[ $capture_output_errexit_was_on -eq 1 ]] && set -e
+  return 0
 }

--- a/test/test-system/helpers/capture-output.sh
+++ b/test/test-system/helpers/capture-output.sh
@@ -6,18 +6,19 @@
 # pass their names. Wraps the run in `set +e` / `set -e` so a nonzero exit
 # never aborts the caller. Sourced by the test-system suite; no main.
 #
-# The internal nameref names are deliberately distinctive: a nameref that
-# shares its caller's variable name would alias itself instead of the caller's
-# variable. Two destination names are RESERVED and rejected up front,
-# `capture_output_text_destination` and `capture_output_status_destination`
-# (passing one would make the nameref circular), and the two destinations must
-# be different names (the same name would make the status write clobber the
-# output).
+# Naming system: every internal local is prefixed with the full function name
+# (capture_output_*), and the guard below rejects any destination name matching
+# that reserved internal prefix. A destination sharing an internal's name would
+# make the nameref alias the helper's own local instead of the caller's
+# variable, and the write would be silently lost. Guarding the whole prefix
+# covers every current and future internal, unlike a hand-kept name list. The
+# two destinations must also be different names (the same name would make the
+# status write clobber the output).
 capture_output() {
-  local capture_output_reserved_name
-  for capture_output_reserved_name in capture_output_text_destination capture_output_status_destination; do
-    if [[ $1 == "$capture_output_reserved_name" || $2 == "$capture_output_reserved_name" ]]; then
-      printf 'capture_output: destination name %s is reserved by this helper; pick another variable name\n' "$capture_output_reserved_name" >&2
+  local capture_output_destination_name
+  for capture_output_destination_name in "$1" "$2"; do
+    if [[ $capture_output_destination_name == capture_output_* ]]; then
+      printf 'capture_output: destination name %s matches the reserved internal prefix capture_output_; pick another variable name\n' "$capture_output_destination_name" >&2
       return 2
     fi
   done

--- a/test/test-system/nameref-guards.sh
+++ b/test/test-system/nameref-guards.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# nameref-guards.sh -- regression suite for the two nameref-output capture
+# helpers (test/test-system/helpers/capture-output.sh and
+# test/helpers/run-dispatch-and-drain.sh). Each helper writes results through
+# caller-named namerefs, so a destination name that matches one of the helper's
+# own internal locals would make the nameref alias the helper instead of the
+# caller: the call returns 0 and the caller's variable silently never receives
+# the write. The guard contract under test: every internal local is prefixed
+# with the full function name, any destination name matching that prefix is
+# rejected up front, and the two destination names must differ.
+# Collect-then-report: every failed assertion is recorded and reported at the end.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=test/test-system/helpers/report-test-failures.sh
+source "$REPO_ROOT/test/test-system/helpers/report-test-failures.sh"
+# shellcheck source=test/test-system/helpers/capture-output.sh
+source "$REPO_ROOT/test/test-system/helpers/capture-output.sh"
+# shellcheck source=test/helpers/run-dispatch-and-drain.sh
+source "$REPO_ROOT/test/helpers/run-dispatch-and-drain.sh"
+
+# The probe that exposed the reserve-list hole: the guard's own loop variable
+# was an internal local missing from the hand-kept reserve list, so the nameref
+# aliased it and the caller's variable silently never received the write.
+assert_capture_output_rejects_its_own_loop_variable_name() {
+  local rejection_output rejection_status
+  set +e
+  rejection_output="$(capture_output capture_output_reserved_name harmless_status_name true 2>&1)"
+  rejection_status=$?
+  set -e
+  [[ $rejection_status -ne 0 ]] ||
+    record_failure "capture_output accepted its own internal loop-variable name as a destination (rc 0; the write would be silently lost)"
+  [[ $rejection_output == *capture_output_* ]] ||
+    record_failure "the capture_output prefix rejection should name the offending prefix (got: $rejection_output)"
+}
+
+# The prefix guard must cover names no current internal uses yet, so a future
+# internal local can never reopen the hole.
+assert_capture_output_rejects_any_prefixed_name() {
+  local rejection_output rejection_status
+  set +e
+  rejection_output="$(capture_output harmless_output_name capture_output_probe_of_a_future_internal true 2>&1)"
+  rejection_status=$?
+  set -e
+  [[ $rejection_status -ne 0 ]] ||
+    record_failure "capture_output must reject ANY destination matching its internal prefix, including names no internal uses yet (rc 0)"
+}
+
+assert_capture_output_normal_names_still_work() {
+  local probe_output probe_status
+  capture_output probe_output probe_status printf 'captured-text'
+  [[ $probe_status -eq 0 ]] ||
+    record_failure "capture_output with ordinary names should report the command's exit 0 (got $probe_status)"
+  [[ $probe_output == "captured-text" ]] ||
+    record_failure "capture_output with ordinary names should deliver the output (got: $probe_output)"
+}
+
+# _capture_dispatch_run: same contract, prefixed with ITS full function name.
+assert_dispatch_capture_rejects_prefixed_output_name() {
+  local rejection_output rejection_status
+  set +e
+  rejection_output="$(_capture_dispatch_run _capture_dispatch_run_errexit_was_on harmless_status_name true 2>&1)"
+  rejection_status=$?
+  set -e
+  [[ $rejection_status -ne 0 ]] ||
+    record_failure "_capture_dispatch_run accepted a destination matching its internal prefix (rc 0; the write would be silently lost)"
+  [[ $rejection_output == *_capture_dispatch_run_* ]] ||
+    record_failure "the _capture_dispatch_run prefix rejection should name the offending prefix (got: $rejection_output)"
+}
+
+assert_dispatch_capture_rejects_prefixed_status_name() {
+  local rejection_output rejection_status
+  set +e
+  rejection_output="$(_capture_dispatch_run harmless_output_name _capture_dispatch_run_probe_of_a_future_internal true 2>&1)"
+  rejection_status=$?
+  set -e
+  [[ $rejection_status -ne 0 ]] ||
+    record_failure "_capture_dispatch_run must reject ANY status destination matching its internal prefix (rc 0)"
+}
+
+assert_dispatch_capture_rejects_identical_names() {
+  local rejection_output rejection_status
+  set +e
+  rejection_output="$(_capture_dispatch_run same_name same_name true 2>&1)"
+  rejection_status=$?
+  set -e
+  [[ $rejection_status -ne 0 ]] ||
+    record_failure "_capture_dispatch_run must reject identical output and status destinations (rc 0)"
+  [[ $rejection_output == *different* ]] ||
+    record_failure "the identical-names rejection should say the names must differ (got: $rejection_output)"
+}
+
+assert_dispatch_capture_normal_names_still_work() {
+  local probe_output probe_status
+  _capture_dispatch_run probe_output probe_status printf 'dispatch-captured'
+  [[ $probe_status -eq 0 ]] ||
+    record_failure "_capture_dispatch_run with ordinary names should report the command's exit 0 (got $probe_status)"
+  [[ $probe_output == "dispatch-captured" ]] ||
+    record_failure "_capture_dispatch_run with ordinary names should deliver the output (got: $probe_output)"
+}
+
+main() {
+  assert_capture_output_rejects_its_own_loop_variable_name
+  assert_capture_output_rejects_any_prefixed_name
+  assert_capture_output_normal_names_still_work
+  assert_dispatch_capture_rejects_prefixed_output_name
+  assert_dispatch_capture_rejects_prefixed_status_name
+  assert_dispatch_capture_rejects_identical_names
+  assert_dispatch_capture_normal_names_still_work
+
+  report_failures nameref-guards
+}
+
+main "$@"

--- a/test/test-system/nameref-guards.sh
+++ b/test/test-system/nameref-guards.sh
@@ -99,10 +99,54 @@ assert_dispatch_capture_normal_names_still_work() {
     record_failure "_capture_dispatch_run with ordinary names should deliver the output (got: $probe_output)"
 }
 
+# capture_output must restore the caller's ORIGINAL errexit state, not force
+# set -e: a caller that deliberately runs under set +e must stay set +e after a
+# capture, so its own later failing commands do not abort the script.
+assert_capture_output_preserves_errexit_off_caller() {
+  local probe_output probe_status
+  set +e
+  probe_output="$(bash -c '
+    source "$1"
+    set +e
+    captured="" status=""
+    capture_output captured status true
+    false
+    echo SURVIVED
+  ' _ "$REPO_ROOT/test/test-system/helpers/capture-output.sh" 2>&1)"
+  probe_status=$?
+  set -e
+  [[ $probe_status -eq 0 && $probe_output == *SURVIVED* ]] ||
+    record_failure "capture_output must not turn a set +e caller into set -e (rc=$probe_status, output: $probe_output)"
+}
+
+# The other direction: a set -e caller keeps errexit after the capture (the
+# capture of a failing command itself must not abort, but a later bare failing
+# command must still do so).
+assert_capture_output_restores_errexit_on_caller() {
+  local probe_output
+  set +e
+  probe_output="$(bash -c '
+    set -e
+    source "$1"
+    captured="" status=""
+    capture_output captured status false
+    echo AFTER
+    false
+    echo NOT_REACHED
+  ' _ "$REPO_ROOT/test/test-system/helpers/capture-output.sh" 2>&1)"
+  set -e
+  [[ $probe_output == *AFTER* ]] ||
+    record_failure "capturing a failing command must not abort a set -e caller (output: $probe_output)"
+  [[ $probe_output != *NOT_REACHED* ]] ||
+    record_failure "capture_output must restore errexit for a set -e caller (output: $probe_output)"
+}
+
 main() {
   assert_capture_output_rejects_its_own_loop_variable_name
   assert_capture_output_rejects_any_prefixed_name
   assert_capture_output_normal_names_still_work
+  assert_capture_output_preserves_errexit_off_caller
+  assert_capture_output_restores_errexit_on_caller
   assert_dispatch_capture_rejects_prefixed_output_name
   assert_dispatch_capture_rejects_prefixed_status_name
   assert_dispatch_capture_rejects_identical_names

--- a/test/test-system/placement.sh
+++ b/test/test-system/placement.sh
@@ -226,6 +226,39 @@ assert_nested_test_system_sh_fails() {
   [[ $guard_output == *"nested"* ]] || record_failure "expected a nested-placement message: $guard_output"
 }
 
+# The shared, cross-suite test/helpers/ dir sits at test/ root (not inside a
+# suite) and follows the same rule as a suite's helpers/: sourced, non-executable
+# *.sh only.
+
+assert_shared_helpers_non_executable_passes() {
+  local guard_output guard_status root
+  root="$(make_test_tree "$work" sharedhelpers unit helpers)"
+  write_probe_script "$root/unit/a.sh"
+  printf '# shellcheck shell=bash\ntrue\n' >"$root/helpers/build-x.sh" # sourced, not executable
+  run_guard guard_output guard_status "$root"
+  [[ $guard_status -eq 0 ]] || record_failure "a sourced file in the shared test/helpers/ should pass (rc=$guard_status): $guard_output"
+}
+
+assert_shared_helpers_executable_fails() {
+  local guard_output guard_status root
+  root="$(make_test_tree "$work" sharedhelpersexec helpers)"
+  write_probe_script "$root/helpers/forgotten-test.sh" 'exit 23'
+  run_guard guard_output guard_status "$root"
+  [[ $guard_status -ne 0 ]] || record_failure "an executable test/helpers/ *.sh must fail the guard: $guard_output"
+  [[ $guard_output == *"forgotten-test.sh"* ]] || record_failure "expected the executable helper named in the message: $guard_output"
+  [[ $guard_output == *"sourced, not executed"* ]] || record_failure "expected the helpers-are-sourced explanation: $guard_output"
+}
+
+assert_shared_helpers_bats_fails() {
+  local guard_output guard_status root
+  root="$(make_test_tree "$work" sharedhelpersbats helpers)"
+  printf '#!/usr/bin/env bats\n@test "x" { true; }\n' >"$root/helpers/suite.bats"
+  run_guard guard_output guard_status "$root"
+  [[ $guard_status -ne 0 ]] || record_failure "a *.bats inside test/helpers/ must fail the guard: $guard_output"
+  [[ $guard_output == *"suite.bats"* ]] || record_failure "expected the helper bats named in the message: $guard_output"
+  [[ $guard_output == *"only sourced"* ]] || record_failure "expected the only-sourced explanation: $guard_output"
+}
+
 main() {
   work="$(mktemp -d)"
   trap 'rm -rf "$work"' EXIT
@@ -248,6 +281,9 @@ main() {
   assert_helper_bats_fails
   assert_fixtures_bats_fails
   assert_nested_test_system_sh_fails
+  assert_shared_helpers_non_executable_passes
+  assert_shared_helpers_executable_fails
+  assert_shared_helpers_bats_fails
 
   report_failures placement
 }

--- a/test/validate-tests.sh
+++ b/test/validate-tests.sh
@@ -6,10 +6,10 @@
 #
 #   - a *.sh OR *.bats not sitting DIRECTLY in a recognized suite
 #     (test/unit, test/integration, test/e2e, test/test-system); a suite's
-#     helpers/ may hold only NON-executable *.sh (sourced libs; an executable
-#     file there is a misplaced test, and bats never belong there);
-#     test/fixtures/** is exempt; only validate-tests.sh and run-test-suite.sh
-#     may sit at test/ root;
+#     helpers/ AND the shared, cross-suite test/helpers/ may hold only
+#     NON-executable *.sh (sourced libs; an executable file there is a misplaced
+#     test, and bats never belong there); test/fixtures/** is exempt; only
+#     validate-tests.sh and run-test-suite.sh may sit at test/ root;
 #   - a suite *.sh that is not executable (invisible to the runner's -perm probe);
 #   - ANY symlink below test/. A physical `find -type f` skips symlinked files
 #     and symlinked suite dirs, so a tracked symlink would evade this guard and
@@ -70,6 +70,18 @@ check_placement() { # <root> <workdir>
         ;;
       "$root"/unit/helpers/* | "$root"/integration/helpers/* | "$root"/e2e/helpers/* | "$root"/test-system/helpers/*)
         bad+="$file (only sourced *.sh belong in a suite's helpers/)"$'\n'
+        ;;
+      # The shared, cross-suite test/helpers/ dir (sourced libs used by more than
+      # one suite) follows the same rule as a suite's helpers/: sourced,
+      # non-executable *.sh only. An executable file there is a misplaced test no
+      # runner discovers, and bats never belong there, so both fail the guard.
+      "$root"/helpers/*.sh)
+        if [[ -x $file ]]; then
+          bad+="$file (helpers are sourced, not executed; remove the executable bit, or move the test into a suite)"$'\n'
+        fi
+        ;;
+      "$root"/helpers/*)
+        bad+="$file (only sourced *.sh belong in test/helpers/)"$'\n'
         ;;
       # The control scripts allowed to sit at test/ root, run by just, never
       # discovered as tests.


### PR DESCRIPTION
## What this PR does

This PR re-lands the upgrade to the osquery alert dispatch library, the shared helper that
every osquery producer uses to raise an alert. It also adds the repository's first
cross-suite test helpers and the two behavior tests that exercise the library.

It is one piece of re-landing the previously reverted S9 work in small, reviewable steps.

## The reliability change

The headline is a durability fix for how a critical alert reaches its destination. Think of
mailing an important letter: the old approach dropped the letter straight into the slot and
only kept a copy if the post office refused it. If the mail carrier stumbled between the slot
and the truck, the letter was simply gone, and a lost alert looks exactly like "nothing is
wrong."

The dispatcher now writes a copy of every alert to disk BEFORE it attempts to send, and
deletes that copy only after the send is confirmed. A crash or a kill at any point during the
send can no longer lose the alert: the saved copy remains and is retried on the next run, in
the order the events actually happened. This is stronger than the original behavior, which
saved a copy only after a send had already failed.

## Summary

- Undelivered alerts are saved to disk before the send and deleted only on a confirmed success.
- A partially written record left by a crash is quarantined for inspection, never silently skipped.
- Retries deliver the oldest alert first, ordered by the time each event was recorded.
- Only CRIT pages route to the priority channel, and each page is marked with its tier.
- The webhook signing key never appears on a command line; it is read from its 0600 file and used without argv exposure.
- A new `test/helpers/` directory holds the first test helpers shared across suites.

## The details

- A dedicated undelivered-alerts directory holds one mode-600 record per alert in a mode-700
  directory, and a retry function replays them to the local webhook only.
- Each record is written atomically: a temp file is written, flushed, then renamed into place,
  so a reader never sees a torn entry. The encoded body and timestamp are validated before the
  record is opened, so an encoding failure fails the save instead of storing an empty record.
- The signature is computed by a small HMAC-SHA256 signer that takes the key in process memory
  and hashes only the message bytes, so the key is never passed as a command-line argument. Its
  output is pinned byte-identical to the reference `openssl dgst -hmac` on both BSD (LibreSSL)
  and GNU (OpenSSL) toolchains.
- The shared helpers return their results through nameref output parameters and reject colliding
  or reserved destination names, so a caller cannot accidentally alias its own variables.
- The placement checker now permits `test/helpers/` under the same rule as a suite's helpers:
  non-executable sourced `.sh` only, with executable files and test files there rejected.
- Two tests cover the library: an integration test for severity routing and body shape, and an
  end-to-end test for the save, retry, ordering, and key-safety behaviors.

## Effect of merging

The dispatch library and its tests land under the libexec home. The periodic retry drainer that
calls the retry function on a schedule arrives with the alerter in a later slice, so this change
is inert on its own beyond the library and its tests. There is no live-machine impact: dresden
applies from `integration/modernization` until D1.
