### PR TITLE
Store undelivered osquery alerts in SQLite

### DIFF
--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -159,65 +159,58 @@ _osquery_alerts_db_exec() {
   return "$sqlite3_status"
 }
 
-# Create the store lazily and idempotently: the mode-700 parent, the
-# pending_alerts table (CREATE TABLE IF NOT EXISTS, so a second call is a no-op),
-# and the mode-600 DB file. Returns nonzero when the parent cannot be made, the
-# schema statement fails, or the DB file does not exist afterward, so a caller
-# treats a store it could not stand up as a hard persist failure.
-_osquery_ensure_alerts_db() {
-  local database_directory
+# Persist one undelivered page as a pending_alerts row and report success. The
+# lazy schema bootstrap and THIS alert's INSERT run in ONE atomic sqlite3 batch
+# (BEGIN IMMEDIATE ... COMMIT), so a crash or kill at any instant leaves either
+# the row fully present or no committed change at all; there is no window where
+# the schema exists but this alert vanished. Only a successful COMMIT reports
+# success; any failure rolls back and returns nonzero so the caller treats it
+# as the loud hard failure.
+#
+# Same occurrence re-stored is idempotent (ON CONFLICT(request_id) DO NOTHING),
+# so a retry of one occurrence stays one row while two DISTINCT occurrences
+# never collide. sequence_number is omitted deliberately: the AUTOINCREMENT
+# primary key assigns it inside the insert, race-free under concurrent
+# producers, and serves as the skew-proof drain-order tiebreaker. attempts and
+# next_attempt_after are written by DR-A but consumed by DR-B; storing them now
+# avoids a schema migration one slice later. The text fields are single-quoted
+# with any embedded quote doubled; the values are non-secret and quote-free by
+# construction (a hex request id, a base64 body, a fixed localhost url), and
+# the escape keeps the statement injection-safe regardless.
+_osquery_store_alert_row() {
+  local occurrence_timestamp="$1" request_id="$2" url="$3" encoded_body="$4" created_at database_directory
   database_directory="$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
   mkdir -p "$database_directory" 2>/dev/null || return 1
   chmod 700 "$database_directory" 2>/dev/null || true
-  # attempts and next_attempt_after are written by DR-A but consumed by DR-B;
-  # storing them now avoids a schema migration one slice later. sequence_number
-  # is the AUTOINCREMENT primary key, so SQLite assigns it atomically inside the
-  # insert (race-free under concurrent producers) and it serves as the
-  # skew-proof drain-order tiebreaker. request_id keeps its uniqueness through
-  # the UNIQUE constraint, which is the ON CONFLICT target for idempotent
-  # re-stores of the same occurrence.
-  if ! printf '%s' 'CREATE TABLE IF NOT EXISTS pending_alerts (
-      sequence_number    INTEGER PRIMARY KEY AUTOINCREMENT,
-      request_id         TEXT UNIQUE NOT NULL,
-      occurrence_ts      INTEGER NOT NULL,
-      url                TEXT NOT NULL,
-      body_base64        TEXT NOT NULL,
-      attempts           INTEGER NOT NULL DEFAULT 0,
-      next_attempt_after INTEGER NOT NULL DEFAULT 0,
-      created_at         INTEGER NOT NULL
-    );' | _osquery_alerts_db_exec; then
-    return 1
-  fi
-  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 1
-  chmod 600 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>/dev/null || true
-  return 0
-}
-
-# Persist one undelivered page as a pending_alerts row and report success. Same
-# occurrence re-stored is idempotent (ON CONFLICT(request_id) DO NOTHING), so a
-# retry of one occurrence stays one row while two DISTINCT occurrences never
-# collide. sequence_number is omitted deliberately: the AUTOINCREMENT primary
-# key assigns it inside the insert, race-free under concurrent producers. The
-# text fields are single-quoted with any embedded quote doubled; the values are
-# non-secret and quote-free by construction (a hex request id, a base64 body, a
-# fixed localhost url), and the escape keeps the statement injection-safe
-# regardless. Returns nonzero on any persistence failure so the caller treats
-# it as a hard failure.
-_osquery_store_alert_row() {
-  local occurrence_timestamp="$1" request_id="$2" url="$3" encoded_body="$4" created_at
-  _osquery_ensure_alerts_db || return 1
   created_at="$(date -u +%s)"
   [[ $created_at =~ ^[0-9]+$ ]] || created_at=0
   local request_id_sql url_sql body_sql
   request_id_sql="${request_id//\'/\'\'}"
   url_sql="${url//\'/\'\'}"
   body_sql="${encoded_body//\'/\'\'}"
-  printf "INSERT INTO pending_alerts
-      (request_id, occurrence_ts, url, body_base64, attempts, next_attempt_after, created_at)
-    VALUES
-      ('%s', %s, '%s', '%s', 0, 0, %s)
-    ON CONFLICT(request_id) DO NOTHING;\n" \
-    "$request_id_sql" "$occurrence_timestamp" "$url_sql" "$body_sql" "$created_at" | _osquery_alerts_db_exec
+  if ! printf "BEGIN IMMEDIATE;
+CREATE TABLE IF NOT EXISTS pending_alerts (
+  sequence_number    INTEGER PRIMARY KEY AUTOINCREMENT,
+  request_id         TEXT UNIQUE NOT NULL,
+  occurrence_ts      INTEGER NOT NULL,
+  url                TEXT NOT NULL,
+  body_base64        TEXT NOT NULL,
+  attempts           INTEGER NOT NULL DEFAULT 0,
+  next_attempt_after INTEGER NOT NULL DEFAULT 0,
+  created_at         INTEGER NOT NULL
+);
+INSERT INTO pending_alerts
+    (request_id, occurrence_ts, url, body_base64, attempts, next_attempt_after, created_at)
+  VALUES
+    ('%s', %s, '%s', '%s', 0, 0, %s)
+  ON CONFLICT(request_id) DO NOTHING;
+COMMIT;\n" \
+    "$request_id_sql" "$occurrence_timestamp" "$url_sql" "$body_sql" "$created_at" | _osquery_alerts_db_exec; then
+    return 1
+  fi
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 1
+  chmod 600 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>/dev/null || true
+  return 0
 }
 
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -244,16 +244,23 @@ _osquery_pending_alert_rows() {
 # Deliver ONE pending row: skip a non-localhost url (never send an off-box
 # page), decode and sign the stored body, POST it (stored request_id verbatim so
 # the gateway dedups), and delete the row only on a confirmed 2xx. Fully
-# set -e-safe: any malformed field returns 0 so the drain continues.
+# set -e-safe: a malformed row returns 0 so the drain continues, but NEVER
+# silently: a MALFORMED-ROW log line names the stuck row and the reason, so a
+# row the drain can never deliver is visible instead of invisible forever.
 _deliver_pending_alert_row() {
   local request_id="$1" url="$2" encoded_body="$3" secret="$4" body signature http_status
-  [[ -n $request_id && -n $url && -n $encoded_body ]] || return 0
+  if [[ -z $request_id || -z $url || -z $encoded_body ]]; then
+    _osquery_log "MALFORMED-ROW drain skipped an unreadable row: request_id=${request_id:-unknown} (a required field is empty; row retained)"
+    return 0
+  fi
   case "$url" in
     http://127.0.0.1:8644/*) ;;
     *) return 0 ;;
   esac
-  body="$(printf '%s' "$encoded_body" | base64 -d 2>/dev/null)" || return 0
-  [[ -n $body ]] || return 0
+  if ! body="$(printf '%s' "$encoded_body" | base64 -d 2>/dev/null)" || [[ -z $body ]]; then
+    _osquery_log "MALFORMED-ROW drain skipped an undecodable row: request_id=$request_id (body_base64 does not decode; row retained)"
+    return 0
+  fi
   # Same signing check as the send path: a failed or empty signature must never
   # go on the wire. The row stays put and a later drain retries it.
   if ! signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")" || [[ -z $signature ]]; then
@@ -296,6 +303,15 @@ _store_undelivered_alert() {
   local occurrence_timestamp="$1" request_id="$2" url="$3" body="$4" encoded_body
   [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || return 1
   [[ -n $request_id ]] || return 1
+  # A URL carrying whitespace or a control character must never enter durable
+  # storage: the drain's row export is tab-separated, so an embedded separator
+  # would garble the row into an undeliverable, undiagnosed shape. Refusing at
+  # persist time turns a misconfigured URL into the loud hard-fail instead of a
+  # silently stuck row.
+  [[ -n $url ]] || return 1
+  case "$url" in
+    *[[:space:][:cntrl:]]*) return 1 ;;
+  esac
   # pipefail inside the subshell so a base64 failure is the assignment's status,
   # not masked by the trailing tr; then reject an empty result defensively.
   if ! encoded_body="$(

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -631,9 +631,9 @@ send_alert() {
   # is a HARD failure (loud + nonzero): the page can be neither delivered nor
   # stored, and the caller must not advance its cursor past it.
   if ! _store_undelivered_alert "$occurrence_timestamp" "$request_id" "$url" "$body"; then
-    _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DIR)"
+    _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB or $OSQUERY_UNDELIVERED_ALERTS_DIR)"
     _loud_local "osquery paging FAILED, page LOST" \
-      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DIR."
+      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB (or $OSQUERY_UNDELIVERED_ALERTS_DIR)."
     return 1
   fi
   local stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -32,6 +32,12 @@ OSQUERY_DELIVERY_LOG="${OSQUERY_DELIVERY_LOG:-$HOME/.local/log/osquery/webhook-d
 # directory, so a transient gateway outage never loses a page.
 # retry_undelivered_alerts replays them in occurrence-time order.
 OSQUERY_UNDELIVERED_ALERTS_DIR="${OSQUERY_UNDELIVERED_ALERTS_DIR:-$HOME/.local/state/osquery-undelivered-alerts}"
+# The SQLite-backed undelivered-alerts store: one pending_alerts row per page,
+# committed crash-atomically, mode 600 in a mode-700 parent. This is the store
+# DR-A is migrating to; the file store above stays the delete and drain path
+# until later slices move those over. sqlite3 is the OS-provided binary, and its
+# absence is a hard persist failure (verified fail-closed), never a lost page.
+OSQUERY_UNDELIVERED_ALERTS_DB="${OSQUERY_UNDELIVERED_ALERTS_DB:-$HOME/.local/state/osquery-undelivered-alerts.sqlite3}"
 
 # A monotonic per-process sequence so the fallback request id (when no occurrence
 # identity is threaded) is unique across calls in one process.
@@ -88,6 +94,97 @@ _hmac_sha256_hex() {
   printf "$opad_format$inner_format" | _sha256_hex_of_stdin
 }
 
+# Print the path to the sqlite3 CLI, preferring the OS-provided binary. The
+# store is a darwin-only pipeline and macOS always ships /usr/bin/sqlite3; the
+# PATH fallback keeps the library runnable from a test harness on another OS.
+# Prints nothing and returns nonzero when no sqlite3 is found, so the caller can
+# fail the persist closed rather than silently drop the page.
+_osquery_sqlite3_bin() {
+  if [[ -x /usr/bin/sqlite3 ]]; then
+    printf '/usr/bin/sqlite3'
+    return 0
+  fi
+  local found
+  found="$(command -v sqlite3 2>/dev/null)" || return 1
+  [[ -n $found ]] || return 1
+  printf '%s' "$found"
+}
+
+# Run the SQL arriving on STDIN against the undelivered-alerts DB, applying the
+# connection pragmas first: WAL for crash-atomic commits, and a busy_timeout so
+# the several producers (results-alerter, firewall-gatekeeper, watchdog, digest,
+# tailscale) serialize briefly under contention instead of failing outright. The
+# pragmas' own chatter is routed to /dev/null so only the SQL's rows reach
+# stdout. Only non-secret alert fields ever flow through here; the webhook secret
+# is never passed to SQL. Returns sqlite3's exit status.
+_osquery_alerts_db_exec() {
+  local sqlite3_bin
+  sqlite3_bin="$(_osquery_sqlite3_bin)" || return 1
+  {
+    printf '.output /dev/null\n'
+    printf 'PRAGMA busy_timeout=5000;\n'
+    printf 'PRAGMA journal_mode=WAL;\n'
+    printf '.output\n'
+    cat
+  } | "$sqlite3_bin" "$OSQUERY_UNDELIVERED_ALERTS_DB"
+}
+
+# Create the store lazily and idempotently: the mode-700 parent, the
+# pending_alerts table (CREATE TABLE IF NOT EXISTS, so a second call is a no-op),
+# and the mode-600 DB file. Returns nonzero when the parent cannot be made, the
+# schema statement fails, or the DB file does not exist afterward, so a caller
+# treats a store it could not stand up as a hard persist failure.
+_osquery_ensure_alerts_db() {
+  local database_directory
+  database_directory="$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+  mkdir -p "$database_directory" 2>/dev/null || return 1
+  chmod 700 "$database_directory" 2>/dev/null || true
+  # attempts and next_attempt_after are written by DR-A but consumed by DR-B;
+  # storing them now avoids a schema migration one slice later. sequence_number
+  # is a skew-proof tiebreaker for the drain ordering (a later slice's concern).
+  if ! printf '%s' 'CREATE TABLE IF NOT EXISTS pending_alerts (
+      request_id         TEXT PRIMARY KEY,
+      sequence_number    INTEGER UNIQUE,
+      occurrence_ts      INTEGER NOT NULL,
+      url                TEXT NOT NULL,
+      body_base64        TEXT NOT NULL,
+      attempts           INTEGER NOT NULL DEFAULT 0,
+      next_attempt_after INTEGER NOT NULL DEFAULT 0,
+      created_at         INTEGER NOT NULL
+    );' | _osquery_alerts_db_exec; then
+    return 1
+  fi
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 1
+  chmod 600 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>/dev/null || true
+  return 0
+}
+
+# Persist one undelivered page as a pending_alerts row and report success. Same
+# occurrence re-stored is idempotent (ON CONFLICT(request_id) DO NOTHING), so a
+# retry of one occurrence stays one row while two DISTINCT occurrences never
+# collide. sequence_number is the next value above the current maximum, an
+# insert-order tiebreaker that does not depend on the clock. The text fields are
+# single-quoted with any embedded quote doubled; the values are non-secret and
+# quote-free by construction (a hex request id, a base64 body, a fixed localhost
+# url), and the escape keeps the statement injection-safe regardless. Returns
+# nonzero on any persistence failure so the caller treats it as a hard failure.
+_osquery_store_alert_row() {
+  local occurrence_timestamp="$1" request_id="$2" url="$3" encoded_body="$4" created_at
+  _osquery_ensure_alerts_db || return 1
+  created_at="$(date -u +%s)"
+  [[ $created_at =~ ^[0-9]+$ ]] || created_at=0
+  local request_id_sql url_sql body_sql
+  request_id_sql="${request_id//\'/\'\'}"
+  url_sql="${url//\'/\'\'}"
+  body_sql="${encoded_body//\'/\'\'}"
+  printf "INSERT INTO pending_alerts
+      (request_id, sequence_number, occurrence_ts, url, body_base64, attempts, next_attempt_after, created_at)
+    VALUES
+      ('%s', (SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM pending_alerts), %s, '%s', '%s', 0, 0, %s)
+    ON CONFLICT(request_id) DO NOTHING;\n" \
+    "$request_id_sql" "$occurrence_timestamp" "$url_sql" "$body_sql" "$created_at" | _osquery_alerts_db_exec
+}
+
 # Store one undelivered page and REPORT persistence success. The file is named by
 # the occurrence-unique request_id, so re-storing the same occurrence is
 # idempotent while two DISTINCT occurrences never collide. The encoded body and
@@ -129,6 +226,14 @@ _store_undelivered_alert() {
   sync "$temporary_file" 2>/dev/null || sync 2>/dev/null || true
   if ! mv -f "$temporary_file" "$stored_file" 2>/dev/null; then
     rm -f "$temporary_file" 2>/dev/null || true
+    return 1
+  fi
+  # Also persist the page as a pending_alerts row in the SQLite store DR-A is
+  # migrating to. A DB persist failure is a hard failure, exactly as a file
+  # persist failure is: the caller must never treat an unpersisted page as
+  # stored. (The file store above remains the delete and drain path until later
+  # slices move those onto the DB.)
+  if ! _osquery_store_alert_row "$occurrence_timestamp" "$request_id" "$url" "$encoded_body"; then
     return 1
   fi
   return 0

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -7,12 +7,13 @@
 # producers (results-alerter.sh, firewall-gatekeeper-monitor.sh, and
 # uptime-watchdog.sh) share one implementation.
 #
-# The undelivered-alerts store is WRITE-AHEAD: send_alert persists the page to
-# disk BEFORE the first network attempt and deletes it only after a confirmed 2xx.
-# A crash or kill anywhere between persist and success therefore leaves a
-# recoverable record for the next drain. Durability matters this much because a
-# page that vanishes leaves no trace: the operator sees a quiet system and has no
-# way to tell a lost alert apart from genuinely good news.
+# The undelivered-alerts store is WRITE-AHEAD: send_alert persists the page as a
+# row in a local SQLite database BEFORE the first network attempt and deletes it
+# only after a confirmed 2xx. A crash or kill anywhere between persist and
+# success therefore leaves a recoverable row for the next drain. Durability
+# matters this much because a page that vanishes leaves no trace: the operator
+# sees a quiet system and has no way to tell a lost alert apart from genuinely
+# good news.
 #
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -28,15 +29,12 @@ OSQUERY_HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:864
 # each side owns its own copy. Single-value file, mode 600, runtime (not tracked).
 OSQUERY_WEBHOOK_SECRET_FILE="${OSQUERY_WEBHOOK_SECRET_FILE:-$HOME/.config/osquery/webhook-secret}"
 OSQUERY_DELIVERY_LOG="${OSQUERY_DELIVERY_LOG:-$HOME/.local/log/osquery/webhook-delivery.log}"
-# Undelivered pages are stored here, one mode-600 file per page in a mode-700
-# directory, so a transient gateway outage never loses a page.
-# retry_undelivered_alerts replays them in occurrence-time order.
-OSQUERY_UNDELIVERED_ALERTS_DIR="${OSQUERY_UNDELIVERED_ALERTS_DIR:-$HOME/.local/state/osquery-undelivered-alerts}"
-# The SQLite-backed undelivered-alerts store: one pending_alerts row per page,
-# committed crash-atomically, mode 600 in a mode-700 parent. This is the store
-# DR-A is migrating to; the file store above stays the delete and drain path
-# until later slices move those over. sqlite3 is the OS-provided binary, and its
-# absence is a hard persist failure (verified fail-closed), never a lost page.
+# The undelivered-alerts store: one pending_alerts row per page in a SQLite
+# database, committed crash-atomically, the file mode 600 in a mode-700 parent,
+# so a transient gateway outage never loses a page. retry_undelivered_alerts
+# replays the rows in occurrence-time order. sqlite3 is the OS-provided binary,
+# and its absence is a hard persist failure (verified fail-closed), never a
+# lost page.
 OSQUERY_UNDELIVERED_ALERTS_DB="${OSQUERY_UNDELIVERED_ALERTS_DB:-$HOME/.local/state/osquery-undelivered-alerts.sqlite3}"
 
 # A monotonic per-process sequence so the fallback request id (when no occurrence
@@ -224,8 +222,8 @@ _osquery_store_alert_row() {
 
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called
 # ONLY after a confirmed 2xx (the write-ahead contract: the row is the page's
-# durable copy until delivery is confirmed). A missing DB is a clean no-op (a
-# drain can replay records that predate the SQLite store). A failed delete is
+# durable copy until delivery is confirmed). A missing DB is a clean no-op
+# (nothing was ever stored, so there is nothing to delete). A failed delete is
 # reported nonzero for the caller to LOG but never to fail on: the page was
 # delivered, and a leaked row costs one deduplicated re-post on a later drain
 # (the gateway drops the duplicate by request_id), while failing the caller
@@ -252,9 +250,8 @@ _osquery_pending_alert_rows() {
 
 # Deliver ONE pending row: skip a non-localhost url (never send an off-box
 # page), decode and sign the stored body, POST it (stored request_id verbatim so
-# the gateway dedups), and delete the row only on a confirmed 2xx. The matching
-# legacy store file is removed with it so the interim file store stays in step.
-# Fully set -e-safe: any malformed field returns 0 so the drain continues.
+# the gateway dedups), and delete the row only on a confirmed 2xx. Fully
+# set -e-safe: any malformed field returns 0 so the drain continues.
 _deliver_pending_alert_row() {
   local request_id="$1" url="$2" encoded_body="$3" secret="$4" body signature http_status
   [[ -n $request_id && -n $url && -n $encoded_body ]] || return 0
@@ -274,7 +271,6 @@ _deliver_pending_alert_row() {
     2*)
       _osquery_delete_alert_row "$request_id" ||
         _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
-      rm -f "$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id" 2>/dev/null || true
       ;;
     *) : ;;
   esac
@@ -295,18 +291,16 @@ _drain_pending_alert_rows() {
   return 0
 }
 
-# Store one undelivered page and REPORT persistence success. The file is named by
+# Store one undelivered page and REPORT persistence success. The row is keyed by
 # the occurrence-unique request_id, so re-storing the same occurrence is
 # idempotent while two DISTINCT occurrences never collide. The encoded body and
-# the occurrence timestamp are computed and VALIDATED in checked assignments
-# BEFORE the record file is opened, so an encoder failure fails the store instead
-# of writing an empty body that a later drain would silently skip. Written through
-# a checked temporary file, flushed, then atomically renamed, and it RETURNS
-# NONZERO on any persistence failure so the caller treats a failed store as a
-# hard delivery failure (never "stored" when the file does not exist).
-# Line: <occurrence_timestamp>\t<request_id>\t<url>\t<base64(body)>.
+# the occurrence timestamp are VALIDATED in checked assignments BEFORE the row is
+# written, so an encoder failure fails the store instead of persisting an empty
+# body that a later drain would silently skip. RETURNS NONZERO on any persistence
+# failure so the caller treats a failed store as a hard delivery failure (never
+# "stored" when the row does not exist).
 _store_undelivered_alert() {
-  local occurrence_timestamp="$1" request_id="$2" url="$3" body="$4" stored_file temporary_file encoded_body
+  local occurrence_timestamp="$1" request_id="$2" url="$3" body="$4" encoded_body
   [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || return 1
   [[ -n $request_id ]] || return 1
   # pipefail inside the subshell so a base64 failure is the assignment's status,
@@ -318,58 +312,7 @@ _store_undelivered_alert() {
     return 1
   fi
   [[ -n $encoded_body ]] || return 1
-  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || return 1
-  chmod 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null || true
-  stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
-  temporary_file="$stored_file.tmp.$$"
-  if ! printf '%s\t%s\t%s\t%s\n' "$occurrence_timestamp" "$request_id" "$url" "$encoded_body" >"$temporary_file" 2>/dev/null; then
-    rm -f "$temporary_file" 2>/dev/null || true
-    return 1
-  fi
-  chmod 600 "$temporary_file" 2>/dev/null || true
-  # Flush the record's bytes before the rename so a crash right after the rename
-  # cannot leave a present-but-empty file. GNU `sync FILE` flushes just this
-  # file; BSD sync takes no argument and flushes everything. If both forms fail
-  # the write continues anyway: the rename below still lands a complete record
-  # in the common case, and refusing to store over a failed flush would trade a
-  # rare torn record for a certain lost page.
-  sync "$temporary_file" 2>/dev/null || sync 2>/dev/null || true
-  if ! mv -f "$temporary_file" "$stored_file" 2>/dev/null; then
-    rm -f "$temporary_file" 2>/dev/null || true
-    return 1
-  fi
-  # Also persist the page as a pending_alerts row in the SQLite store DR-A is
-  # migrating to. A DB persist failure is a hard failure, exactly as a file
-  # persist failure is: the caller must never treat an unpersisted page as
-  # stored. (The file store above remains the delete and drain path until later
-  # slices move those onto the DB.)
-  if ! _osquery_store_alert_row "$occurrence_timestamp" "$request_id" "$url" "$encoded_body"; then
-    return 1
-  fi
-  return 0
-}
-
-# Move any crashed *.tmp.* partial (a temporary file whose writer process is
-# gone) OUT of the store, into a sibling quarantine directory, so a torn write is
-# never replayed and never skipped forever. A temporary file whose writer process
-# is still alive is an in-flight write and is left alone. If the quarantine
-# directory cannot be created or a move fails, the file simply stays where it was
-# and this function still returns 0; the next drain retries the quarantine, and
-# the drain itself must never abort over housekeeping.
-_quarantine_stale_partials() {
-  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
-  local temporary_file writer_process_id quarantine_directory
-  quarantine_directory="${OSQUERY_UNDELIVERED_ALERTS_DIR%/}.quarantine"
-  for temporary_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*.tmp.*; do
-    [[ -f $temporary_file ]] || continue
-    writer_process_id="${temporary_file##*.tmp.}"
-    if [[ $writer_process_id =~ ^[0-9]+$ ]] && kill -0 "$writer_process_id" 2>/dev/null; then
-      continue # a live writer still owns this temporary file
-    fi
-    mkdir -p "$quarantine_directory" 2>/dev/null || continue
-    mv -f "$temporary_file" "$quarantine_directory/${temporary_file##*/}" 2>/dev/null || true
-  done
-  return 0
+  _osquery_store_alert_row "$occurrence_timestamp" "$request_id" "$url" "$encoded_body"
 }
 
 # Fire the ordinary local macOS notification for one alert (alerter, with an
@@ -440,90 +383,18 @@ _post_alert_to_webhook() { # <url> <request_id> <signature> <body>
     --data "$4"
 }
 
-# Deliver ONE stored record: read it, skip a non-localhost url (never send an
-# off-box page), decode and sign the stored body, POST it (stored request_id
-# verbatim so the gateway dedups), and delete the record only on a confirmed 2xx.
-# Fully set -e-safe: any malformed field returns 0 so the drain continues.
-_deliver_stored_record() {
-  local stored_file="$1" secret="$2" occurrence_timestamp request_id url body signature http_status
-  IFS=$'\t' read -r occurrence_timestamp request_id url body <"$stored_file" || return 0
-  [[ -n $request_id && -n $url && -n $body ]] || return 0
-  case "$url" in
-    http://127.0.0.1:8644/*) ;;
-    *) return 0 ;;
-  esac
-  body="$(printf '%s' "$body" | base64 -d 2>/dev/null)" || return 0
-  [[ -n $body ]] || return 0
-  # Same signing check as the send path: a failed or empty signature must never
-  # go on the wire. The record stays put and a later drain retries it.
-  if ! signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")" || [[ -z $signature ]]; then
-    return 0
-  fi
-  http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
-  case "$http_status" in
-    2*)
-      # Confirmed delivery: clear BOTH stores. SQLite is authoritative for
-      # delete semantics; the file removal keeps the interim file store in step
-      # until the file machinery is retired. A failed row delete is logged, not
-      # fatal: the page was delivered, and the gateway dedups a leaked row's
-      # re-post by request_id.
-      rm -f "$stored_file"
-      _osquery_delete_alert_row "$request_id" ||
-        _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
-      ;;
-    *) : ;;
-  esac
-  return 0
-}
-
-# Drain the LEGACY file store: replay stored record files in occurrence-time
-# order (earliest first, with the file path as a deterministic tie-breaker).
-# Kept only as the fallback for a store that predates the SQLite database; the
-# file machinery retires once the migration completes. Fully set -e-safe.
-_drain_undelivered_alert_files() {
-  local secret="$1"
-  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
-
-  # Collect "<occurrence_timestamp>\t<file>" for every well-formed record, then
-  # sort by occurrence time (numeric) with the path as the tie-breaker.
-  local records="" stored_file occurrence_timestamp
-  for stored_file in "$OSQUERY_UNDELIVERED_ALERTS_DIR"/*; do
-    [[ -f $stored_file ]] || continue
-    case "$stored_file" in
-      *.tmp.*) continue ;; # an in-flight write; quarantine handles crashed ones
-    esac
-    IFS=$'\t' read -r occurrence_timestamp _ <"$stored_file" || continue
-    [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || continue
-    records+="$occurrence_timestamp	$stored_file"$'\n'
-  done
-  [[ -n $records ]] || return 0
-
-  local sorted
-  sorted="$(printf '%s' "$records" | sort -t$'\t' -k1,1n -k2,2)" || return 0
-  while IFS=$'\t' read -r _ stored_file; do
-    [[ -n $stored_file ]] || continue
-    _deliver_stored_record "$stored_file" "$secret"
-  done <<<"$sorted"
-  return 0
-}
-
 # Replay stored undelivered pages in OCCURRENCE-TIME order, so a backlog
-# delivers in the order events happened. The SQLite store is the authoritative
-# read path (ORDER BY occurrence_ts, sequence_number, skew-proof); the file
-# store is drained only when no database exists (records predating the SQLite
-# store). Crashed file-store partials are quarantined first in either case.
-# Localhost only. Fully set -e-safe: a malformed entry or an empty store must
-# NEVER abort the caller (a delivery feature must not cause a detection outage).
+# delivers in the order events happened (ORDER BY occurrence_ts,
+# sequence_number, skew-proof). A missing database means nothing was ever
+# stored, a quiet no-op. Localhost only. Fully set -e-safe: a malformed entry or
+# an empty store must NEVER abort the caller (a delivery feature must not cause
+# a detection outage).
 retry_undelivered_alerts() {
-  _quarantine_stale_partials
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 0
   local secret
   secret="$(_read_webhook_secret)"
   [[ -n $secret ]] || return 0
-  if [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
-    _drain_pending_alert_rows "$secret"
-  else
-    _drain_undelivered_alert_files "$secret"
-  fi
+  _drain_pending_alert_rows "$secret"
   return 0
 }
 
@@ -631,12 +502,11 @@ send_alert() {
   # is a HARD failure (loud + nonzero): the page can be neither delivered nor
   # stored, and the caller must not advance its cursor past it.
   if ! _store_undelivered_alert "$occurrence_timestamp" "$request_id" "$url" "$body"; then
-    _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB or $OSQUERY_UNDELIVERED_ALERTS_DIR)"
+    _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB)"
     _loud_local "osquery paging FAILED, page LOST" \
-      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB (or $OSQUERY_UNDELIVERED_ALERTS_DIR)."
+      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB."
     return 1
   fi
-  local stored_file="$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id"
 
   # Deliver via the hermes webhook (the page is already safe on disk, so a
   # failed delivery here costs latency, not the page). No key means no send: the
@@ -652,19 +522,16 @@ send_alert() {
 
   local http_status
   if http_status="$(_attempt_alert_delivery "$url" "$request_id" "$secret" "$body")"; then
-    # Delete ONLY after a confirmed 2xx, from BOTH stores. SQLite is
-    # authoritative for delete semantics; the file removal keeps the interim
-    # file store in step until the file machinery is retired. A failed row
-    # delete is logged, not fatal: the page was delivered, and the gateway
-    # dedups a leaked row's re-post by request_id.
-    rm -f "$stored_file"
+    # Delete ONLY after a confirmed 2xx. A failed row delete is logged, not
+    # fatal: the page was delivered, and the gateway dedups a leaked row's
+    # re-post by request_id.
     _osquery_delete_alert_row "$request_id" ||
       _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
     return 0
   fi
-  # Delivery failed after retries: the write-ahead record REMAINS on disk and the
-  # next drain retries it, so send_alert still returns 0. A down gateway delays
-  # the page; it never fails the caller and never loses the page.
+  # Delivery failed after retries: the write-ahead row REMAINS in the store and
+  # the next drain retries it, so send_alert still returns 0. A down gateway
+  # delays the page; it never fails the caller and never loses the page.
   _osquery_log "STORED webhook delivery pending: request_id=$request_id http=$http_status (retained for retry)"
   return 0
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -141,10 +141,14 @@ _osquery_ensure_alerts_db() {
   chmod 700 "$database_directory" 2>/dev/null || true
   # attempts and next_attempt_after are written by DR-A but consumed by DR-B;
   # storing them now avoids a schema migration one slice later. sequence_number
-  # is a skew-proof tiebreaker for the drain ordering (a later slice's concern).
+  # is the AUTOINCREMENT primary key, so SQLite assigns it atomically inside the
+  # insert (race-free under concurrent producers) and it serves as the
+  # skew-proof drain-order tiebreaker. request_id keeps its uniqueness through
+  # the UNIQUE constraint, which is the ON CONFLICT target for idempotent
+  # re-stores of the same occurrence.
   if ! printf '%s' 'CREATE TABLE IF NOT EXISTS pending_alerts (
-      request_id         TEXT PRIMARY KEY,
-      sequence_number    INTEGER UNIQUE,
+      sequence_number    INTEGER PRIMARY KEY AUTOINCREMENT,
+      request_id         TEXT UNIQUE NOT NULL,
       occurrence_ts      INTEGER NOT NULL,
       url                TEXT NOT NULL,
       body_base64        TEXT NOT NULL,
@@ -162,12 +166,13 @@ _osquery_ensure_alerts_db() {
 # Persist one undelivered page as a pending_alerts row and report success. Same
 # occurrence re-stored is idempotent (ON CONFLICT(request_id) DO NOTHING), so a
 # retry of one occurrence stays one row while two DISTINCT occurrences never
-# collide. sequence_number is the next value above the current maximum, an
-# insert-order tiebreaker that does not depend on the clock. The text fields are
-# single-quoted with any embedded quote doubled; the values are non-secret and
-# quote-free by construction (a hex request id, a base64 body, a fixed localhost
-# url), and the escape keeps the statement injection-safe regardless. Returns
-# nonzero on any persistence failure so the caller treats it as a hard failure.
+# collide. sequence_number is omitted deliberately: the AUTOINCREMENT primary
+# key assigns it inside the insert, race-free under concurrent producers. The
+# text fields are single-quoted with any embedded quote doubled; the values are
+# non-secret and quote-free by construction (a hex request id, a base64 body, a
+# fixed localhost url), and the escape keeps the statement injection-safe
+# regardless. Returns nonzero on any persistence failure so the caller treats
+# it as a hard failure.
 _osquery_store_alert_row() {
   local occurrence_timestamp="$1" request_id="$2" url="$3" encoded_body="$4" created_at
   _osquery_ensure_alerts_db || return 1
@@ -178,9 +183,9 @@ _osquery_store_alert_row() {
   url_sql="${url//\'/\'\'}"
   body_sql="${encoded_body//\'/\'\'}"
   printf "INSERT INTO pending_alerts
-      (request_id, sequence_number, occurrence_ts, url, body_base64, attempts, next_attempt_after, created_at)
+      (request_id, occurrence_ts, url, body_base64, attempts, next_attempt_after, created_at)
     VALUES
-      ('%s', (SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM pending_alerts), %s, '%s', '%s', 0, 0, %s)
+      ('%s', %s, '%s', '%s', 0, 0, %s)
     ON CONFLICT(request_id) DO NOTHING;\n" \
     "$request_id_sql" "$occurrence_timestamp" "$url_sql" "$body_sql" "$created_at" | _osquery_alerts_db_exec
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -190,6 +190,21 @@ _osquery_store_alert_row() {
     "$request_id_sql" "$occurrence_timestamp" "$url_sql" "$body_sql" "$created_at" | _osquery_alerts_db_exec
 }
 
+# Delete one delivered page's pending_alerts row, keyed by request_id. Called
+# ONLY after a confirmed 2xx (the write-ahead contract: the row is the page's
+# durable copy until delivery is confirmed). A missing DB is a clean no-op (a
+# drain can replay records that predate the SQLite store). A failed delete is
+# reported nonzero for the caller to LOG but never to fail on: the page was
+# delivered, and a leaked row costs one deduplicated re-post on a later drain
+# (the gateway drops the duplicate by request_id), while failing the caller
+# would wrongly report a delivered page as lost.
+_osquery_delete_alert_row() {
+  local request_id="$1"
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 0
+  local request_id_sql="${request_id//\'/\'\'}"
+  printf "DELETE FROM pending_alerts WHERE request_id = '%s';\n" "$request_id_sql" | _osquery_alerts_db_exec
+}
+
 # Store one undelivered page and REPORT persistence success. The file is named by
 # the occurrence-unique request_id, so re-storing the same occurrence is
 # idempotent while two DISTINCT occurrences never collide. The encoded body and
@@ -356,7 +371,16 @@ _deliver_stored_record() {
   fi
   http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
   case "$http_status" in
-    2*) rm -f "$stored_file" ;;
+    2*)
+      # Confirmed delivery: clear BOTH stores. SQLite is authoritative for
+      # delete semantics; the file removal keeps the interim file store in step
+      # until the file machinery is retired. A failed row delete is logged, not
+      # fatal: the page was delivered, and the gateway dedups a leaked row's
+      # re-post by request_id.
+      rm -f "$stored_file"
+      _osquery_delete_alert_row "$request_id" ||
+        _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
+      ;;
     *) : ;;
   esac
   return 0
@@ -523,7 +547,14 @@ send_alert() {
 
   local http_status
   if http_status="$(_attempt_alert_delivery "$url" "$request_id" "$secret" "$body")"; then
-    rm -f "$stored_file" # delete ONLY after a confirmed 2xx
+    # Delete ONLY after a confirmed 2xx, from BOTH stores. SQLite is
+    # authoritative for delete semantics; the file removal keeps the interim
+    # file store in step until the file machinery is retired. A failed row
+    # delete is logged, not fatal: the page was delivered, and the gateway
+    # dedups a leaked row's re-post by request_id.
+    rm -f "$stored_file"
+    _osquery_delete_alert_row "$request_id" ||
+      _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
     return 0
   fi
   # Delivery failed after retries: the write-ahead record REMAINS on disk and the

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -117,16 +117,48 @@ _osquery_sqlite3_bin() {
 # pragmas' own chatter is routed to /dev/null so only the SQL's rows reach
 # stdout. Only non-secret alert fields ever flow through here; the webhook secret
 # is never passed to SQL. Returns sqlite3's exit status.
+#
+# One lock the busy_timeout does NOT absorb: a brand-new database's first
+# conversion into WAL takes an exclusive lock, and when concurrent first-opens
+# race it SQLite reports "database is locked" (SQLITE_BUSY) immediately instead
+# of waiting (observed under an eight-producer stress; the busy handler is not
+# consulted for that transition). A locked failure is therefore retried a few
+# times with a short pause. The retry replays the WHOLE statement batch, which
+# is safe because every statement this library issues is idempotent (CREATE IF
+# NOT EXISTS, INSERT ON CONFLICT DO NOTHING, DELETE by key, SELECT). Query rows
+# are buffered and printed only after a fully successful run, so a failed
+# partial attempt can never leak rows to the caller, and `.bail on` makes an
+# attempt stop cleanly at its first error.
 _osquery_alerts_db_exec() {
-  local sqlite3_bin
+  local sqlite3_bin sql_text query_output error_file sqlite3_status attempt
   sqlite3_bin="$(_osquery_sqlite3_bin)" || return 1
-  {
-    printf '.output /dev/null\n'
-    printf 'PRAGMA busy_timeout=5000;\n'
-    printf 'PRAGMA journal_mode=WAL;\n'
-    printf '.output\n'
-    cat
-  } | "$sqlite3_bin" "$OSQUERY_UNDELIVERED_ALERTS_DB"
+  sql_text="$(cat)"
+  error_file="$(mktemp "${TMPDIR:-/tmp}/osquery-alerts-db-error.XXXXXX")" || return 1
+  for attempt in 1 2 3 4 5; do
+    sqlite3_status=0
+    query_output="$(
+      {
+        printf '.bail on\n'
+        printf '.output /dev/null\n'
+        printf 'PRAGMA busy_timeout=5000;\n'
+        printf 'PRAGMA journal_mode=WAL;\n'
+        printf '.output\n'
+        printf '%s\n' "$sql_text"
+      } | "$sqlite3_bin" "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>"$error_file"
+    )" || sqlite3_status=$?
+    if [[ $sqlite3_status -eq 0 ]]; then
+      rm -f "$error_file" 2>/dev/null || true
+      [[ -n $query_output ]] && printf '%s\n' "$query_output"
+      return 0
+    fi
+    if [[ $attempt -eq 5 ]] || ! grep -qi 'database is locked' "$error_file"; then
+      break
+    fi
+    sleep 0.1 2>/dev/null || sleep 1
+  done
+  cat "$error_file" >&2 2>/dev/null || true
+  rm -f "$error_file" 2>/dev/null || true
+  return "$sqlite3_status"
 }
 
 # Create the store lazily and idempotently: the mode-700 parent, the

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -205,6 +205,64 @@ _osquery_delete_alert_row() {
   printf "DELETE FROM pending_alerts WHERE request_id = '%s';\n" "$request_id_sql" | _osquery_alerts_db_exec
 }
 
+# Print every pending row as one tab-separated line (request_id, url,
+# body_base64), ordered for the drain: occurrence time first, then the
+# insert-assigned sequence_number as the tiebreaker. The sequence tiebreaker is
+# skew-proof: equal timestamps (or a backward clock step) still drain in insert
+# order. Tabs cannot appear in the fields (a hex-derived request id, a base64
+# body, and a URL the localhost guard restricts), so the line format is safe.
+_osquery_pending_alert_rows() {
+  {
+    printf '.separator "\\t"\n'
+    printf 'SELECT request_id, url, body_base64 FROM pending_alerts ORDER BY occurrence_ts, sequence_number;\n'
+  } | _osquery_alerts_db_exec
+}
+
+# Deliver ONE pending row: skip a non-localhost url (never send an off-box
+# page), decode and sign the stored body, POST it (stored request_id verbatim so
+# the gateway dedups), and delete the row only on a confirmed 2xx. The matching
+# legacy store file is removed with it so the interim file store stays in step.
+# Fully set -e-safe: any malformed field returns 0 so the drain continues.
+_deliver_pending_alert_row() {
+  local request_id="$1" url="$2" encoded_body="$3" secret="$4" body signature http_status
+  [[ -n $request_id && -n $url && -n $encoded_body ]] || return 0
+  case "$url" in
+    http://127.0.0.1:8644/*) ;;
+    *) return 0 ;;
+  esac
+  body="$(printf '%s' "$encoded_body" | base64 -d 2>/dev/null)" || return 0
+  [[ -n $body ]] || return 0
+  # Same signing check as the send path: a failed or empty signature must never
+  # go on the wire. The row stays put and a later drain retries it.
+  if ! signature="$(printf '%s' "$body" | _hmac_sha256_hex "$secret")" || [[ -z $signature ]]; then
+    return 0
+  fi
+  http_status="$(_post_alert_to_webhook "$url" "$request_id" "$signature" "$body")" || http_status=000
+  case "$http_status" in
+    2*)
+      _osquery_delete_alert_row "$request_id" ||
+        _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
+      rm -f "$OSQUERY_UNDELIVERED_ALERTS_DIR/$request_id" 2>/dev/null || true
+      ;;
+    *) : ;;
+  esac
+  return 0
+}
+
+# Drain the SQLite store: deliver every pending row in occurrence-time order
+# with the sequence tiebreaker. A query failure or an empty store is a quiet
+# no-op; a malformed row is skipped. Never returns nonzero (set -e-safe).
+_drain_pending_alert_rows() {
+  local secret="$1" rows request_id url encoded_body
+  rows="$(_osquery_pending_alert_rows)" || return 0
+  [[ -n $rows ]] || return 0
+  while IFS=$'\t' read -r request_id url encoded_body; do
+    [[ -n $request_id ]] || continue
+    _deliver_pending_alert_row "$request_id" "$url" "$encoded_body" "$secret"
+  done <<<"$rows"
+  return 0
+}
+
 # Store one undelivered page and REPORT persistence success. The file is named by
 # the occurrence-unique request_id, so re-storing the same occurrence is
 # idempotent while two DISTINCT occurrences never collide. The encoded body and
@@ -386,18 +444,13 @@ _deliver_stored_record() {
   return 0
 }
 
-# Replay stored undelivered pages in OCCURRENCE-TIME order (earliest first, with
-# the file path as a deterministic tie-breaker), so a backlog delivers in the
-# order events happened, not in SHA-derived filename order. Crashed partials are
-# quarantined first. Localhost only. Fully set -e-safe: a malformed entry or an
-# empty directory must NEVER abort the caller (a delivery feature must not cause
-# a detection outage).
-retry_undelivered_alerts() {
+# Drain the LEGACY file store: replay stored record files in occurrence-time
+# order (earliest first, with the file path as a deterministic tie-breaker).
+# Kept only as the fallback for a store that predates the SQLite database; the
+# file machinery retires once the migration completes. Fully set -e-safe.
+_drain_undelivered_alert_files() {
+  local secret="$1"
   [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] || return 0
-  _quarantine_stale_partials
-  local secret
-  secret="$(_read_webhook_secret)"
-  [[ -n $secret ]] || return 0
 
   # Collect "<occurrence_timestamp>\t<file>" for every well-formed record, then
   # sort by occurrence time (numeric) with the path as the tie-breaker.
@@ -419,6 +472,26 @@ retry_undelivered_alerts() {
     [[ -n $stored_file ]] || continue
     _deliver_stored_record "$stored_file" "$secret"
   done <<<"$sorted"
+  return 0
+}
+
+# Replay stored undelivered pages in OCCURRENCE-TIME order, so a backlog
+# delivers in the order events happened. The SQLite store is the authoritative
+# read path (ORDER BY occurrence_ts, sequence_number, skew-proof); the file
+# store is drained only when no database exists (records predating the SQLite
+# store). Crashed file-store partials are quarantined first in either case.
+# Localhost only. Fully set -e-safe: a malformed entry or an empty store must
+# NEVER abort the caller (a delivery feature must not cause a detection outage).
+retry_undelivered_alerts() {
+  _quarantine_stale_partials
+  local secret
+  secret="$(_read_webhook_secret)"
+  [[ -n $secret ]] || return 0
+  if [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+    _drain_pending_alert_rows "$secret"
+  else
+    _drain_undelivered_alert_files "$secret"
+  fi
   return 0
 }
 

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -99,7 +99,10 @@ teardown() { teardown_dispatch_harness; }
 
   assert_pending_alert_count 1 # stored as a row, not lost
 
-  # The schema carries every column DR-B will consume, with request_id the PK.
+  # The schema carries every column DR-B will consume. sequence_number is the
+  # AUTOINCREMENT primary key (assigned atomically inside the insert, race-free
+  # under concurrent producers); request_id keeps uniqueness through a UNIQUE
+  # constraint, the ON CONFLICT target for idempotent re-stores.
   local columns column
   columns=$(sqlite3_query "SELECT group_concat(name, ',') FROM pragma_table_info('pending_alerts');")
   for column in request_id sequence_number occurrence_ts url body_base64 attempts next_attempt_after created_at; do
@@ -110,7 +113,10 @@ teardown() { teardown_dispatch_harness; }
   done
   local primary_key
   primary_key=$(sqlite3_query "SELECT name FROM pragma_table_info('pending_alerts') WHERE pk=1;")
-  [[ $primary_key == "request_id" ]]
+  [[ $primary_key == "sequence_number" ]]
+  local unique_column
+  unique_column=$(sqlite3_query "SELECT ii.name FROM pragma_index_list('pending_alerts') il JOIN pragma_index_info(il.name) ii WHERE il.origin='u';")
+  [[ $unique_column == "request_id" ]]
 
   # The connection runs in WAL journal mode (crash-atomic commits).
   local journal_mode

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -18,31 +18,31 @@ teardown() { teardown_dispatch_harness; }
   set_curl_codes 503 503 503
   run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
   [[ $send_status -eq 0 ]] # a down gateway never fails the caller
-  assert_undelivered_alert_count 1 # stored, not lost
-  assert_mode 700 "$OSQUERY_UNDELIVERED_ALERTS_DIR"
-  assert_mode 600 "$(first_undelivered_alert_file)"
+  assert_pending_alert_count 1 # stored, not lost
+  assert_mode 700 "$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+  assert_mode 600 "$OSQUERY_UNDELIVERED_ALERTS_DB"
   grep -q STORED "$OSQUERY_DELIVERY_LOG"
   # gateway recovers: the drain delivers and clears the stored alert
   run_retry_undelivered_alerts drain_output drain_status
-  assert_undelivered_alert_count 0
+  assert_pending_alert_count 0
 }
 
-@test "T-SEC-undelivered-idem: re-storing the SAME occurrence stays one file; drain replays once (R2-4)" {
+@test "T-SEC-undelivered-idem: re-storing the SAME occurrence stays one row; drain replays once (R2-4)" {
   # Idempotency is keyed on OCCURRENCE IDENTITY, not body content (R2-4): the SAME
-  # occurrence re-stored stays one file and reuses one request_id, so the gateway
+  # occurrence re-stored stays one row and reuses one request_id, so the gateway
   # dedups a retry. (Two DISTINCT occurrences that render the same body get two
-  # files, the collapse bug this design fixes.)
+  # rows, the collapse bug this design fixes.)
   set_curl_codes 503 503 503 503 503 503
   send_alert CRIT "🔴 title" "same detail" "Sosumi" "occ:disk3:900:1000"
   send_alert CRIT "🔴 title" "same detail" "Sosumi" "occ:disk3:900:1000" # same occurrence, same request_id
-  assert_undelivered_alert_count 1
+  assert_pending_alert_count 1
   local stored_request_id
-  stored_request_id=$(cut -f2 "$(first_undelivered_alert_file)")
+  stored_request_id=$(sqlite3_query 'SELECT request_id FROM pending_alerts;')
   : >"$CURL_LOG"
   retry_undelivered_alerts
   assert_post_count 1
   grep -qF "X-Request-ID: $stored_request_id" "$CURL_LOG" # the stored request_id is reused verbatim
-  assert_undelivered_alert_count 0                        # so the gateway dedups instead of double-posting
+  assert_pending_alert_count 0                            # so the gateway dedups instead of double-posting
   : >"$CURL_LOG"
   retry_undelivered_alerts # nothing left
   assert_post_count 0
@@ -64,26 +64,24 @@ teardown() { teardown_dispatch_harness; }
   assert_pending_alert_count 1     # the off-box entry is RETAINED (skipped), not silently dropped
 }
 
-@test "T-SEC-drain-setE: drain is set -e-safe on empty or malformed input" {
-  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
-  printf 'garbage-no-tabs\n' >"$OSQUERY_UNDELIVERED_ALERTS_DIR/bad"
-  printf '%s\t%s\n' 123 incomplete >"$OSQUERY_UNDELIVERED_ALERTS_DIR/short"
+@test "T-SEC-drain-setE: drain is set -e-safe on an absent, corrupt, or malformed store" {
+  # An absent database (nothing ever stored) is a quiet no-op.
   run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
   [[ $status -eq 0 ]]
   [[ $output == *DONE* ]]
-}
-
-@test "T-SEC-write-ahead: the record is persisted BEFORE the first send attempt" {
-  # The curl stub records the stored-record count seen at each POST. Under the
-  # write-ahead store the FIRST POST must already see the record on disk (count
-  # >= 1); the old attempt-then-persist path showed 0 at the first POST, so a
-  # crash between the attempt and success would have lost the page.
-  set_curl_codes 503 503 503
-  send_alert CRIT "🔴 title" "detail body" "Sosumi" "occ:wa:1"
-  local first_witnessed_count
-  first_witnessed_count=$(head -1 "$CURL_PERSIST_WITNESS")
-  [[ $first_witnessed_count =~ ^[0-9]+$ ]]
-  [[ $first_witnessed_count -ge 1 ]]
+  # A corrupt database file (not SQLite at all) must not abort the caller.
+  mkdir -p "$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+  printf 'this is not a sqlite database\n' >"$OSQUERY_UNDELIVERED_ALERTS_DB"
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]
+  [[ $output == *DONE* ]]
+  # A malformed row (a body that is not decodable base64) is skipped, and the
+  # drain continues to completion.
+  rm -f "$OSQUERY_UNDELIVERED_ALERTS_DB"
+  _osquery_store_alert_row 1000 osquery-malformed 'http://127.0.0.1:8644/webhooks/osquery-priority' '%%%not-base64%%%'
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]
+  [[ $output == *DONE* ]]
 }
 
 @test "T-SEC-sqlite-write-ahead: a failing CRIT lands as a pending_alerts row (schema, WAL, 600/700) BEFORE the first curl" {
@@ -179,40 +177,11 @@ teardown() { teardown_dispatch_harness; }
   assert_pending_alert_count 0 # every delivered row was deleted
 }
 
-@test "T-SEC-quarantine-partial: a crashed *.tmp.* partial is quarantined on the next drain, not skipped forever" {
-  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
-  # A leftover temp from a dead writer (a pid that is not running).
-  printf '%s\tosquery-crash\thttp://127.0.0.1:8644/x\tYm9keQ==\n' "$(date -u +%s)" \
-    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-crash.tmp.999999"
-  retry_undelivered_alerts
-  # No *.tmp.* remains in the store dir (it is not skipped and left forever)...
-  [[ -z "$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -maxdepth 1 -name '*.tmp.*' 2>/dev/null)" ]]
-  # ...it was moved into the quarantine sibling, not silently deleted.
-  [[ -n "$(find "${OSQUERY_UNDELIVERED_ALERTS_DIR}.quarantine" -type f 2>/dev/null)" ]]
-}
-
-@test "T-SEC-drain-order: the drain delivers in occurrence-time order, not filename order" {
-  mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
-  # Two records: z-old has the EARLIER occurrence ts, a-new the later. By filename
-  # glob order a-new sorts first; by occurrence time z-old must deliver first.
-  local body_b64
-  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
-  printf '%s\t%s\t%s\t%s\n' 1000 osquery-z-old 'http://127.0.0.1:8644/webhooks/osquery-priority' "$body_b64" \
-    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-z-old"
-  printf '%s\t%s\t%s\t%s\n' 2000 osquery-a-new 'http://127.0.0.1:8644/webhooks/osquery-priority' "$body_b64" \
-    >"$OSQUERY_UNDELIVERED_ALERTS_DIR/osquery-a-new"
-  set_curl_codes 200 200
-  retry_undelivered_alerts
-  local first_posted_request_id
-  first_posted_request_id=$(grep -oE 'X-Request-ID: osquery-[a-z-]+' "$CURL_LOG" | head -1)
-  [[ $first_posted_request_id == "X-Request-ID: osquery-z-old" ]]
-}
-
-@test "T-SEC-no-secret-log: the webhook secret never appears in any log or stored file" {
+@test "T-SEC-no-secret-log: the webhook secret never appears in any log or the stored database" {
   export OSQUERY_WEBHOOK_SECRET="SUPERSECRET123"
   set_curl_codes 503 503 503
   send_alert CRIT "🔴 title" "detail" "Sosumi"
   retry_undelivered_alerts || true
   ! grep -rqF "SUPERSECRET123" \
-    "$HARNESS_HOME/.local" "$OSQUERY_UNDELIVERED_ALERTS_DIR" "$CURL_LOG" "$OSQUERY_DELIVERY_LOG" 2>/dev/null
+    "$HARNESS_HOME/.local" "$OSQUERY_UNDELIVERED_ALERTS_DB" "$CURL_LOG" "$OSQUERY_DELIVERY_LOG" 2>/dev/null
 }

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -87,6 +87,47 @@ teardown() { teardown_dispatch_harness; }
   [[ $first_witnessed_count -ge 1 ]]
 }
 
+@test "T-SEC-sqlite-write-ahead: a failing CRIT lands as a pending_alerts row (schema, WAL, 600/700) BEFORE the first curl" {
+  # DR-A moves the undelivered-alerts store into SQLite. A CRIT whose send fails
+  # must land as a ROW in the pending_alerts table, write-ahead: the row is
+  # present when the FIRST POST fires, so a crash between persist and success
+  # leaves a recoverable record. This pins the schema, the WAL journal mode, and
+  # the 600-file/700-parent permission bits the security invariants require.
+  set_curl_codes 503 503 503
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:sqlite:1"
+  [[ $send_status -eq 0 ]] # a down gateway never fails the caller
+
+  assert_pending_alert_count 1 # stored as a row, not lost
+
+  # The schema carries every column DR-B will consume, with request_id the PK.
+  local columns column
+  columns=$(sqlite3_query "SELECT group_concat(name, ',') FROM pragma_table_info('pending_alerts');")
+  for column in request_id sequence_number occurrence_ts url body_base64 attempts next_attempt_after created_at; do
+    if [[ ",$columns," != *",$column,"* ]]; then
+      printf 'schema is missing column %s (got: %s)\n' "$column" "$columns" >&2
+      return 1
+    fi
+  done
+  local primary_key
+  primary_key=$(sqlite3_query "SELECT name FROM pragma_table_info('pending_alerts') WHERE pk=1;")
+  [[ $primary_key == "request_id" ]]
+
+  # The connection runs in WAL journal mode (crash-atomic commits).
+  local journal_mode
+  journal_mode=$(sqlite3_query "PRAGMA journal_mode;")
+  [[ $journal_mode == "wal" ]]
+
+  # The DB file is mode 600 inside a mode-700 parent, as the file store was.
+  assert_mode 600 "$OSQUERY_UNDELIVERED_ALERTS_DB"
+  assert_mode 700 "$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+
+  # Write-ahead: the row was already present when the FIRST POST was attempted.
+  local first_witnessed_count
+  first_witnessed_count=$(head -1 "$CURL_DB_PERSIST_WITNESS")
+  [[ $first_witnessed_count =~ ^[0-9]+$ ]]
+  [[ $first_witnessed_count -ge 1 ]]
+}
+
 @test "T-SEC-quarantine-partial: a crashed *.tmp.* partial is quarantined on the next drain, not skipped forever" {
   mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
   # A leftover temp from a dead writer (a pid that is not running).

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -177,6 +177,41 @@ teardown() { teardown_dispatch_harness; }
   assert_pending_alert_count 0 # every delivered row was deleted
 }
 
+@test "T-SEC-atomic-persist: a kill during persist never leaves a bootstrapped store missing the alert (F1)" {
+  # The persist must be atomic end-to-end: the schema bootstrap and this alert's
+  # INSERT commit together, so a kill at ANY instant leaves either no schema at
+  # all (the persist never completed and send_alert never reported success) or
+  # the row fully present. The forbidden half-state is a bootstrapped table
+  # without the alert: that page would be gone with no diagnostic. The killer
+  # fires the moment the schema becomes visible; a non-atomic persist (schema
+  # committed first, row in a second sqlite3 invocation) gets caught in the gap.
+  cat >"$HARNESS_HOME/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_LOG"
+printf '503'
+STUB
+  chmod +x "$HARNESS_HOME/bin/curl"
+  local iteration send_pid schema_present
+  for iteration in 1 2 3 4 5 6 7 8 9 10; do
+    rm -f "$OSQUERY_UNDELIVERED_ALERTS_DB" "$OSQUERY_UNDELIVERED_ALERTS_DB"-*
+    (send_alert CRIT "🔴 kill $iteration" "detail" "Sosumi" "occ:kill:$iteration" >/dev/null 2>&1) &
+    send_pid=$!
+    while kill -0 "$send_pid" 2>/dev/null; do
+      schema_present="$(sqlite3_query "SELECT count(*) FROM sqlite_master WHERE name='pending_alerts';" 2>/dev/null)" || schema_present=""
+      if [[ $schema_present == "1" ]]; then
+        kill -KILL "$send_pid" 2>/dev/null || true
+        break
+      fi
+    done
+    wait "$send_pid" 2>/dev/null || true
+    sleep 0.2 # let any in-flight sqlite3 child of the killed sender settle
+    schema_present="$(sqlite3_query "SELECT count(*) FROM sqlite_master WHERE name='pending_alerts';" 2>/dev/null)" || schema_present=""
+    if [[ $schema_present == "1" ]]; then
+      assert_pending_alert_count 1 # a visible schema MUST mean the row committed with it
+    fi
+  done
+}
+
 @test "T-SEC-no-secret-log: the webhook secret never appears in any log or the stored database" {
   export OSQUERY_WEBHOOK_SECRET="SUPERSECRET123"
   set_curl_codes 503 503 503

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -55,14 +55,13 @@ teardown() { teardown_dispatch_harness; }
   assert_posted_to '127.0.0.1:8644'
   run grep -v '127.0.0.1:8644' "$CURL_LOG"
   [[ -z $output ]] # ...and every send POST was to loopback, nothing else
-  local stored_file
-  stored_file=$(first_undelivered_alert_file)
-  awk 'BEGIN{FS=OFS="\t"} {$3="http://10.0.0.5:8644/webhooks/osquery-priority"; print}' \
-    "$stored_file" >"$stored_file.t" && mv "$stored_file.t" "$stored_file"
+  # Tamper the AUTHORITATIVE store (the pending_alerts row) with an off-box url.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET url='http://10.0.0.5:8644/webhooks/osquery-priority';"
   : >"$CURL_LOG"
   retry_undelivered_alerts
-  ! grep -q '10.0.0.5' "$CURL_LOG"     # never sent off-box
-  assert_undelivered_alert_count 1 # the off-box entry is RETAINED (skipped), not silently dropped
+  ! grep -q '10.0.0.5' "$CURL_LOG" # never sent off-box
+  assert_pending_alert_count 1     # the off-box entry is RETAINED (skipped), not silently dropped
 }
 
 @test "T-SEC-drain-setE: drain is set -e-safe on empty or malformed input" {
@@ -157,6 +156,27 @@ teardown() { teardown_dispatch_harness; }
   run_retry_undelivered_alerts drain_output drain_status
   [[ $drain_status -eq 0 ]]
   assert_pending_alert_count 0 # deleted only after the drain's confirmed 2xx
+}
+
+@test "T-SEC-sqlite-drain-order: rows drain by occurrence_ts then sequence_number, not insert or name order" {
+  # The drain must read the SQLite store and order by occurrence time with the
+  # insert-assigned sequence_number as the tiebreaker. Seeding contradicts every
+  # wrong ordering: the OLDER occurrence is inserted LATER (a backward clock
+  # step), and the equal-timestamp pair is named so lexical order (aa before zz)
+  # contradicts insert order (zz first). Only ORDER BY occurrence_ts,
+  # sequence_number yields the expected delivery sequence.
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 2000 osquery-inserted-first-newer "$url" "$body_b64"
+  _osquery_store_alert_row 1000 osquery-inserted-second-older "$url" "$body_b64" # clock stepped back
+  _osquery_store_alert_row 3000 osquery-zz-tie "$url" "$body_b64"                # equal ts, lower sequence
+  _osquery_store_alert_row 3000 osquery-aa-tie "$url" "$body_b64"                # equal ts, higher sequence
+  set_curl_codes 200 200 200 200
+  retry_undelivered_alerts
+  local posted_order
+  posted_order=$(grep -oE 'X-Request-ID: osquery-[a-z-]+' "$CURL_LOG" | sed 's/X-Request-ID: //' | paste -sd, -)
+  [[ $posted_order == "osquery-inserted-second-older,osquery-inserted-first-newer,osquery-zz-tie,osquery-aa-tie" ]]
+  assert_pending_alert_count 0 # every delivered row was deleted
 }
 
 @test "T-SEC-quarantine-partial: a crashed *.tmp.* partial is quarantined on the next drain, not skipped forever" {

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -134,6 +134,31 @@ teardown() { teardown_dispatch_harness; }
   [[ $first_witnessed_count -ge 1 ]]
 }
 
+@test "T-SEC-sqlite-delete-send: a confirmed 2xx on the SEND path deletes the pending_alerts row" {
+  # Delete only after a confirmed 2xx: a page delivered on the first attempt
+  # must leave ZERO rows behind, or the store grows a leaked row per delivered
+  # page and a later drain re-posts already-delivered pages forever.
+  set_curl_codes 200
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:del-send:1"
+  [[ $send_status -eq 0 ]]
+  assert_post_count 1 # the 2xx really happened (positive anchor)
+  assert_pending_alert_count 0
+}
+
+@test "T-SEC-sqlite-delete-drain: a failed delivery RETAINS the row; the drain's 2xx deletes it" {
+  # Failure retains: the row must survive every failed attempt (it is the only
+  # durable copy of the page). Recovery deletes: once the drain gets its 2xx the
+  # row is gone, so the next drain has nothing to re-post.
+  set_curl_codes 503 503 503
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:del-drain:1"
+  [[ $send_status -eq 0 ]]
+  assert_pending_alert_count 1 # retained across the failed attempts
+  set_curl_codes 200
+  run_retry_undelivered_alerts drain_output drain_status
+  [[ $drain_status -eq 0 ]]
+  assert_pending_alert_count 0 # deleted only after the drain's confirmed 2xx
+}
+
 @test "T-SEC-quarantine-partial: a crashed *.tmp.* partial is quarantined on the next drain, not skipped forever" {
   mkdir -p "$OSQUERY_UNDELIVERED_ALERTS_DIR"
   # A leftover temp from a dead writer (a pid that is not running).

--- a/test/e2e/osquery-undelivered-alerts.bats
+++ b/test/e2e/osquery-undelivered-alerts.bats
@@ -177,6 +177,23 @@ teardown() { teardown_dispatch_harness; }
   assert_pending_alert_count 0 # every delivered row was deleted
 }
 
+@test "T-SEC-malformed-row-diagnostic: a row the drain cannot decode is skipped LOUDLY, later rows still drain (F3)" {
+  # A hand-corrupted row (a body that is not decodable base64) must never be
+  # skipped in silence: a silently stuck row is invisible forever. The drain
+  # logs a MALFORMED-ROW line naming the request_id and keeps draining the
+  # rows after it.
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-corrupt "$url" '####'
+  _osquery_store_alert_row 2000 osquery-good "$url" "$body_b64"
+  set_curl_codes 200 200
+  retry_undelivered_alerts
+  grep -q 'MALFORMED-ROW' "$OSQUERY_DELIVERY_LOG"     # loud, never silent
+  grep -q 'osquery-corrupt' "$OSQUERY_DELIVERY_LOG"   # names the stuck row
+  grep -qF 'X-Request-ID: osquery-good' "$CURL_LOG"   # the drain continued past it
+  assert_pending_alert_count 1                        # corrupt retained, good delivered
+}
+
 @test "T-SEC-atomic-persist: a kill during persist never leaves a bootstrapped store missing the alert (F1)" {
   # The persist must be atomic end-to-end: the schema bootstrap and this alert's
   # INSERT commit together, so a kill at ANY instant leaves either no schema at

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -28,17 +28,14 @@ build_dispatch_harness() {
   : >"$ALERTER_LOG"
   printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"%s"\nexit 0\n' "$ALERTER_LOG" >"$HARNESS_HOME/bin/alerter"
 
-  # curl stub: record the invocation and the count of stored undelivered-alert
-  # files AT CALL TIME (so a test can prove the write-ahead record already existed
-  # when the first POST was attempted), then emit the next queued HTTP code (one
-  # per line in $CURL_CODES_FILE, popped per call), defaulting to 200 when the
-  # queue is empty.
+  # curl stub: record the invocation and the count of stored pending_alerts rows
+  # AT CALL TIME (so a test can prove the write-ahead row already existed when
+  # the first POST was attempted), then emit the next queued HTTP code (one per
+  # line in $CURL_CODES_FILE, popped per call), defaulting to 200 when the queue
+  # is empty.
   cat >"$HARNESS_HOME/bin/curl" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$CURL_LOG"
-if [[ -n "${CURL_PERSIST_WITNESS:-}" ]]; then
-  find "${OSQUERY_UNDELIVERED_ALERTS_DIR:-/nonexistent}" -type f 2>/dev/null | wc -l | tr -d ' ' >>"$CURL_PERSIST_WITNESS"
-fi
 if [[ -n "${CURL_DB_PERSIST_WITNESS:-}" && -f "${OSQUERY_UNDELIVERED_ALERTS_DB:-/nonexistent}" ]]; then
   sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" 'SELECT COUNT(*) FROM pending_alerts;' 2>/dev/null >>"$CURL_DB_PERSIST_WITNESS" || true
 fi
@@ -55,13 +52,8 @@ STUB
   : >"$CURL_LOG"
   export CURL_CODES_FILE="$HARNESS_HOME/curl_codes"
   : >"$CURL_CODES_FILE"
-  # The write-ahead witness: the curl stub appends the stored-record count seen at
-  # each POST here, one line per call. Empty until a test opts in by pointing it
-  # at a file.
-  export CURL_PERSIST_WITNESS="$HARNESS_HOME/curl_persist_witness"
-  : >"$CURL_PERSIST_WITNESS"
-  # The SQLite write-ahead witness: the curl stub appends the pending_alerts row
-  # count seen at each POST here, one line per call. Empty until a test opts in.
+  # The write-ahead witness: the curl stub appends the pending_alerts row count
+  # seen at each POST here, one line per call.
   export CURL_DB_PERSIST_WITNESS="$HARNESS_HOME/curl_db_persist_witness"
   : >"$CURL_DB_PERSIST_WITNESS"
   export PATH="$HARNESS_HOME/bin:$PATH"
@@ -69,7 +61,6 @@ STUB
 
   export OSQUERY_WEBHOOK_SECRET="testsecret"
   export OSQUERY_DELIVERY_LOG="$HARNESS_HOME/.local/log/osquery/webhook-delivery.log"
-  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/.local/state/osquery-undelivered-alerts"
   export OSQUERY_UNDELIVERED_ALERTS_DB="$HARNESS_HOME/.local/state/osquery-undelivered-alerts.sqlite3"
   export OSQUERY_RETRY_BACKOFF_BASE=0 # do not really sleep between retries in tests
 
@@ -93,12 +84,6 @@ set_curl_codes() {
   printf '%s\n' "$@" >"$CURL_CODES_FILE"
 }
 
-# first_undelivered_alert_file -- print the path of one stored undelivered-alert
-# file, or nothing when none exist.
-first_undelivered_alert_file() {
-  find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -type f 2>/dev/null | head -1
-}
-
 # sqlite3_query <sql> -- run a read-only query against the undelivered-alerts DB
 # and print its output. The inspection path for the SQLite store: a fresh
 # read-only connection never mutates what the library persisted.
@@ -115,18 +100,6 @@ assert_pending_alert_count() {
   fi
   if [[ $count -ne $1 ]]; then
     printf 'expected %s pending_alerts row(s), got %s\n' "$1" "$count" >&2
-    return 1
-  fi
-}
-
-# assert_undelivered_alert_count <n> -- exactly <n> undelivered-alert files exist.
-assert_undelivered_alert_count() {
-  local count=0
-  [[ -d $OSQUERY_UNDELIVERED_ALERTS_DIR ]] &&
-    count=$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
-  if [[ $count -ne $1 ]]; then
-    printf 'expected %s undelivered-alert file(s), got %s: %s\n' \
-      "$1" "$count" "$(ls -la "$OSQUERY_UNDELIVERED_ALERTS_DIR" 2>/dev/null)" >&2
     return 1
   fi
 }

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -39,6 +39,9 @@ printf '%s\n' "$*" >>"$CURL_LOG"
 if [[ -n "${CURL_PERSIST_WITNESS:-}" ]]; then
   find "${OSQUERY_UNDELIVERED_ALERTS_DIR:-/nonexistent}" -type f 2>/dev/null | wc -l | tr -d ' ' >>"$CURL_PERSIST_WITNESS"
 fi
+if [[ -n "${CURL_DB_PERSIST_WITNESS:-}" && -f "${OSQUERY_UNDELIVERED_ALERTS_DB:-/nonexistent}" ]]; then
+  sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" 'SELECT COUNT(*) FROM pending_alerts;' 2>/dev/null >>"$CURL_DB_PERSIST_WITNESS" || true
+fi
 code=200
 if [[ -s "$CURL_CODES_FILE" ]]; then
   code=$(head -1 "$CURL_CODES_FILE")
@@ -57,12 +60,17 @@ STUB
   # at a file.
   export CURL_PERSIST_WITNESS="$HARNESS_HOME/curl_persist_witness"
   : >"$CURL_PERSIST_WITNESS"
+  # The SQLite write-ahead witness: the curl stub appends the pending_alerts row
+  # count seen at each POST here, one line per call. Empty until a test opts in.
+  export CURL_DB_PERSIST_WITNESS="$HARNESS_HOME/curl_db_persist_witness"
+  : >"$CURL_DB_PERSIST_WITNESS"
   export PATH="$HARNESS_HOME/bin:$PATH"
   export HOME="$HARNESS_HOME"
 
   export OSQUERY_WEBHOOK_SECRET="testsecret"
   export OSQUERY_DELIVERY_LOG="$HARNESS_HOME/.local/log/osquery/webhook-delivery.log"
   export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/.local/state/osquery-undelivered-alerts"
+  export OSQUERY_UNDELIVERED_ALERTS_DB="$HARNESS_HOME/.local/state/osquery-undelivered-alerts.sqlite3"
   export OSQUERY_RETRY_BACKOFF_BASE=0 # do not really sleep between retries in tests
 
   DISPATCH="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_alert-dispatch.sh"
@@ -89,6 +97,26 @@ set_curl_codes() {
 # file, or nothing when none exist.
 first_undelivered_alert_file() {
   find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -type f 2>/dev/null | head -1
+}
+
+# sqlite3_query <sql> -- run a read-only query against the undelivered-alerts DB
+# and print its output. The inspection path for the SQLite store: a fresh
+# read-only connection never mutates what the library persisted.
+sqlite3_query() {
+  sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" "$1"
+}
+
+# assert_pending_alert_count <n> -- exactly <n> rows sit in the pending_alerts
+# table. A missing DB counts as zero rows (nothing has been stored yet).
+assert_pending_alert_count() {
+  local count=0
+  if [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+    count=$(sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" 'SELECT COUNT(*) FROM pending_alerts;' 2>/dev/null || echo 0)
+  fi
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s pending_alerts row(s), got %s\n' "$1" "$count" >&2
+    return 1
+  fi
 }
 
 # assert_undelivered_alert_count <n> -- exactly <n> undelivered-alert files exist.

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -133,6 +133,22 @@ teardown() { teardown_dispatch_harness; }
 # can map to a suppressed notification: a page (non-empty sound) is tier=page, a
 # muted digest/heartbeat (empty sound) is tier=muted. Both still POST (both CRIT).
 
+@test "T-DISP-url-whitespace-hardfail: a URL containing whitespace is refused at persist time (F3)" {
+  # The drain's row export is tab-separated, so a URL carrying a tab (or any
+  # whitespace/control character) would garble its row into an undeliverable,
+  # undiagnosed shape. A malformed URL must never enter durable storage: the
+  # persist refuses it with the loud hard-fail, before any network attempt.
+  : >"$ALERTER_LOG"
+  set_curl_codes 503 503 503
+  export OSQUERY_HERMES_PRIORITY_URL=$'http://127.0.0.1:8644/webhooks/osquery\tpriority'
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:taburl:1"
+  [[ $send_status -ne 0 ]] # refused, not silently stored malformed
+  assert_pending_alert_count 0
+  assert_no_post
+  grep -qE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"
+  wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
+}
+
 @test "T-DISP-tier-page: a real page (non-empty sound) POSTs tier=page (R2-11)" {
   send_alert CRIT "🔴 title" "detail" "Sosumi"
   assert_post_count 1

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -45,9 +45,9 @@ teardown() { teardown_dispatch_harness; }
   unset OSQUERY_WEBHOOK_SECRET
   : >"$ALERTER_LOG"
   run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
-  [[ $send_status -eq 0 ]]          # still fire-and-forget for its callers
-  assert_undelivered_alert_count 1  # durably stored, not dropped
-  assert_no_post                    # nothing signed/POSTed without a key
+  [[ $send_status -eq 0 ]]        # still fire-and-forget for its callers
+  assert_pending_alert_count 1    # durably stored, not dropped
+  assert_no_post                  # nothing signed/POSTed without a key
   grep -qiE 'secret|degraded|broken' "$OSQUERY_DELIVERY_LOG"
   # The loud local notice fires via a backgrounded alerter (& so it never blocks
   # dispatch), so poll rather than grep once.
@@ -60,48 +60,36 @@ teardown() { teardown_dispatch_harness; }
 # store (the filename is the id). The id must derive from OCCURRENCE IDENTITY, so
 # two same-body incidents survive as two stored files.
 
-@test "T-DISP-occurrence-distinct: two same-body incidents at different occurrences store as TWO files (R2-4)" {
+@test "T-DISP-occurrence-distinct: two same-body incidents at different occurrences store as TWO rows (R2-4)" {
   set_curl_codes 503 503 503 503 503 503
   send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
   send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:200:300"
-  assert_undelivered_alert_count 2 # both incidents survive, a later same-body incident does not clobber the earlier
+  assert_pending_alert_count 2 # both incidents survive, a later same-body incident does not clobber the earlier
 }
 
 @test "T-DISP-occurrence-retry-stable: the SAME occurrence retried reuses one id (idempotent store) (R2-4)" {
   set_curl_codes 503 503 503 503 503 503
   send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
   send_alert CRIT "🔴 firewall" "Firewall turned OFF" "Sosumi" "inode7:100:200"
-  assert_undelivered_alert_count 1
+  assert_pending_alert_count 1
 }
 
 # --- a store failure is a HARD failure, not a silent success (R2-6) ---------------
-@test "T-DISP-store-hardfail: an unwritable store dir + no secret returns nonzero and loudly alerts (R2-6)" {
-  # Point the store at a path whose parent is a FILE, so mkdir cannot succeed for
+@test "T-DISP-store-hardfail: an unwritable store + no secret returns nonzero and loudly alerts (R2-6)" {
+  # Point the DB at a path whose parent is a FILE, so mkdir cannot succeed for
   # any uid (deterministic, not permission/uid-dependent). With no secret the page
   # cannot be signed either, so it can be neither delivered NOR stored, which MUST
   # be loud and nonzero.
   unset OSQUERY_WEBHOOK_SECRET
   : >"$ALERTER_LOG"
   touch "$HARNESS_HOME/notadir"
-  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/notadir/store"
+  export OSQUERY_UNDELIVERED_ALERTS_DB="$HARNESS_HOME/notadir/store.sqlite3"
   run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
   [[ $send_status -ne 0 ]]                          # hard delivery failure, NOT a silent success
-  assert_undelivered_alert_count 0                  # nothing was stored
+  assert_pending_alert_count 0                      # nothing was stored
   assert_no_post                                    # nothing signed/POSTed without a key
   grep -qiE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"  # synchronous: the hard failure is recorded
   wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG" # the loud local alert fired
-}
-
-@test "T-DISP-store-hardfail-delivery: delivery failure + unwritable store returns nonzero and loudly alerts (R2-6)" {
-  : >"$ALERTER_LOG"
-  set_curl_codes 503 503 503
-  touch "$HARNESS_HOME/notadir2"
-  export OSQUERY_UNDELIVERED_ALERTS_DIR="$HARNESS_HOME/notadir2/store"
-  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi"
-  [[ $send_status -ne 0 ]]
-  assert_undelivered_alert_count 0
-  grep -qiE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"
-  wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
 }
 
 @test "T-DISP-row-idempotent: the SAME occurrence stored twice keeps exactly ONE pending_alerts row (T5)" {
@@ -135,19 +123,6 @@ teardown() { teardown_dispatch_harness; }
   # The failure must name the DB path so the operator fixes the RIGHT storage.
   grep -qF "$OSQUERY_UNDELIVERED_ALERTS_DB" "$OSQUERY_DELIVERY_LOG"
   wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
-}
-
-@test "T-DISP-store-atomic: a stored page is written atomically and drains on recovery (R2-6)" {
-  # A store file appears (delivery failed) and drains clean once curl recovers,
-  # proving the temp+rename path produces a well-formed, replayable entry (no torn
-  # temp left behind).
-  set_curl_codes 503 503 503
-  send_alert CRIT "🔴 title" "detail body" "Sosumi" "occ:1:2"
-  assert_undelivered_alert_count 1
-  [[ -z "$(find "$OSQUERY_UNDELIVERED_ALERTS_DIR" -name '*.tmp.*' 2>/dev/null)" ]] # no torn temp file left
-  set_curl_codes 200
-  retry_undelivered_alerts
-  assert_undelivered_alert_count 0
 }
 
 # --- digest/heartbeat traffic DOES reach the remote POST; mark its tier (R2-11) ---
@@ -283,9 +258,9 @@ STUB
   # attempt stops before any POST, leaving the record for a later drain.
   _hmac_sha256_hex() { return 17; }
   run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:signfail:1"
-  [[ $send_status -eq 0 ]] # the record is retained, so this is not a hard failure
+  [[ $send_status -eq 0 ]] # the row is retained, so this is not a hard failure
   assert_no_post
-  assert_undelivered_alert_count 1
+  assert_pending_alert_count 1
 }
 
 @test "T-DISP-sign-matches-openssl: the argv-free signer equals openssl's HMAC output (F-B)" {

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -146,6 +146,82 @@ teardown() { teardown_dispatch_harness; }
   [[ $status -eq 0 ]]
 }
 
+@test "T-DISP-store-concurrency: parallel producers and drains lose no rows under WAL plus busy_timeout (T4)" {
+  # Eight producers with distinct occurrences send in parallel against an
+  # always-failing sender while two drains run alongside them. Every send must
+  # report success (a swallowed SQLITE_BUSY would surface as send_alert's hard
+  # failure), no writer may hit an unabsorbed lock, and the store must end with
+  # EXACTLY eight rows: no lost insert, no unique-constraint collision, and
+  # eight distinct ids and sequence numbers. The queued-codes curl stub pops its
+  # queue non-atomically, so a deterministic always-503 stub replaces it here.
+  cat >"$HARNESS_HOME/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_LOG"
+printf '503'
+STUB
+  chmod +x "$HARNESS_HOME/bin/curl"
+
+  local producer_count=8 i
+  local status_dir="$HARNESS_HOME/stress-status"
+  mkdir -p "$status_dir"
+  for ((i = 1; i <= producer_count; i++)); do
+    (
+      send_alert CRIT "🔴 stress $i" "detail $i" "Sosumi" "occ:stress:$i" \
+        2>"$status_dir/producer-$i.err"
+      echo $? >"$status_dir/producer-$i.status"
+    ) &
+  done
+  for i in 1 2; do
+    (
+      retry_undelivered_alerts 2>"$status_dir/drain-$i.err"
+      echo $? >"$status_dir/drain-$i.status"
+    ) &
+  done
+  wait
+
+  for ((i = 1; i <= producer_count; i++)); do
+    [[ "$(cat "$status_dir/producer-$i.status")" == "0" ]]
+  done
+  for i in 1 2; do
+    [[ "$(cat "$status_dir/drain-$i.status")" == "0" ]]
+  done
+  ! grep -rqi 'database is locked' "$status_dir" # busy_timeout serializes, never errors
+  [[ "$(sqlite3_query 'SELECT COUNT(*) FROM pending_alerts;')" == "$producer_count" ]]
+  [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT request_id) FROM pending_alerts;')" == "$producer_count" ]]
+  [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT sequence_number) FROM pending_alerts;')" == "$producer_count" ]]
+
+  # Recovery under parallel drains: with the sender succeeding, two drains run
+  # at once. Both must exit 0, the store must fully clear, every page must
+  # deliver at least once, and no request_id may be posted more than once PER
+  # DRAIN PASS (each pass reads its row list once and never re-posts within
+  # itself, so two passes bound the count at two; the gateway dedups by id).
+  local stored_request_ids
+  stored_request_ids="$(sqlite3_query 'SELECT request_id FROM pending_alerts;')"
+  cat >"$HARNESS_HOME/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_LOG"
+printf '200'
+STUB
+  chmod +x "$HARNESS_HOME/bin/curl"
+  : >"$CURL_LOG"
+  for i in 3 4; do
+    (
+      retry_undelivered_alerts 2>"$status_dir/drain-$i.err"
+      echo $? >"$status_dir/drain-$i.status"
+    ) &
+  done
+  wait
+  [[ "$(cat "$status_dir/drain-3.status")" == "0" ]]
+  [[ "$(cat "$status_dir/drain-4.status")" == "0" ]]
+  assert_pending_alert_count 0
+  local request_id post_count
+  while read -r request_id; do
+    [[ -n $request_id ]] || continue
+    post_count=$(grep -cF "X-Request-ID: $request_id" "$CURL_LOG" || true)
+    [[ $post_count -ge 1 && $post_count -le 2 ]]
+  done <<<"$stored_request_ids"
+}
+
 @test "T-DISP-secret-not-in-argv: the signing key never reaches any openssl argv (F-B)" {
   # Shim openssl to log its full argv, then delegate to the real one so signing
   # still works. A CRIT send must never pass the secret as an openssl argument,

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -104,6 +104,39 @@ teardown() { teardown_dispatch_harness; }
   wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
 }
 
+@test "T-DISP-row-idempotent: the SAME occurrence stored twice keeps exactly ONE pending_alerts row (T5)" {
+  # A producer retrying the same occurrence re-stores the same request_id; the
+  # ON CONFLICT(request_id) DO NOTHING insert must keep exactly one row, and the
+  # re-store is a normal success for the caller, never an error.
+  set_curl_codes 503 503 503 503 503 503
+  run_dispatch send_output send_status CRIT "🔴 title" "same detail" "Sosumi" "occ:row-idem:1"
+  [[ $send_status -eq 0 ]]
+  run_dispatch send_output send_status CRIT "🔴 title" "same detail" "Sosumi" "occ:row-idem:1"
+  [[ $send_status -eq 0 ]] # the idempotent re-store reports success
+  assert_pending_alert_count 1
+  [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT request_id) FROM pending_alerts;')" == "1" ]]
+}
+
+@test "T-DISP-db-store-hardfail: an unwritable DB path returns nonzero and loudly alerts (T5)" {
+  # The DB parent is a FILE, so its mkdir fails for any uid (deterministic, the
+  # same trick as the file-store hard-fail pins). The write-ahead persist cannot
+  # complete, which must keep the file-store era contract: nonzero return, the
+  # STORE-FAILED log line, the loud local fallback, and NO network attempt (the
+  # write-ahead order forbids a send before a completed persist).
+  : >"$ALERTER_LOG"
+  set_curl_codes 503 503 503
+  touch "$HARNESS_HOME/dbnotdir"
+  export OSQUERY_UNDELIVERED_ALERTS_DB="$HARNESS_HOME/dbnotdir/store.sqlite3"
+  run_dispatch send_output send_status CRIT "🔴 title" "detail body" "Sosumi" "occ:db-hardfail:1"
+  [[ $send_status -ne 0 ]] # hard delivery failure, NOT a silent success
+  assert_pending_alert_count 0
+  assert_no_post
+  grep -qE 'STORE-FAILED' "$OSQUERY_DELIVERY_LOG"
+  # The failure must name the DB path so the operator fixes the RIGHT storage.
+  grep -qF "$OSQUERY_UNDELIVERED_ALERTS_DB" "$OSQUERY_DELIVERY_LOG"
+  wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
+}
+
 @test "T-DISP-store-atomic: a stored page is written atomically and drains on recovery (R2-6)" {
   # A store file appears (delivery failed) and drains clean once curl recovers,
   # proving the temp+rename path produces a well-formed, replayable entry (no torn


### PR DESCRIPTION
## What this PR does

The osquery dispatcher now keeps its undelivered CRIT alerts in a small SQLite database instead of one file per alert. The delivery behavior is unchanged; only the storage underneath is sturdier. This is part of the S9 delivery-robustness work.

## Why SQLite

Crash-atomic writes and ordered draining come for free from the database, instead of being hand-built out of temporary files, flush-and-rename dances, and directory scans. The per-alert bookkeeping the next slices need (attempt counts, retry scheduling) is a natural fit for columns on a row. And the backlog is countable with a single query, which the health checks can lean on.

## Summary

- A SQLite store replaces the file-per-alert store for undelivered CRIT alerts.
- The write-ahead guarantee is unchanged: save before sending, delete only after a confirmed success.
- Alerts drain oldest-first by when they occurred, stable even if the clock jumps backward.
- Concurrent producers never lose a write, via write-ahead logging and a short lock-retry.
- A malformed priority URL is refused before storage, and unparseable rows are logged, never left silently stuck.
- The old file-based storage machinery is fully removed.

## Effect of merging

Callers of the dispatcher see no behavior change; the public `send_alert` contract is identical. Undelivered alerts now live in the SQLite database rather than in per-alert files. The periodic drainer and dead-lettering arrive in the next slice. There is no live-machine impact: dresden applies from `integration/modernization` until the D1 cutover, so nothing on a running host changes when this merges.
