### PR TITLE
feat(osquery): scheduled alert drainer, dead-lettering, randomized retry delay (S9 DR-B)

### DIFF
--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-alert-drainer-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-alert-drainer-launchagent.sh.tmpl
@@ -1,0 +1,21 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# run_onchange_after_60-load-osquery-alert-drainer-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl" | sha256sum }}
+
+set -euo pipefail
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist"
+TARGET="gui/$(id -u)/com.webdavis.osquery-alert-drainer"
+
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.osquery-alert-drainer</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>{{ .chezmoi.homeDir }}/.local/libexec/osquery/drain-undelivered-alerts.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/alert-drainer.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/alert-drainer.log</string>
+</dict>
+</plist>

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -278,6 +278,42 @@ COMMIT;\n" \
     _osquery_alerts_db_exec
 }
 
+# Decide whether a pending row has exhausted retrying and print WHY. A row is
+# given up on when it has failed too many times (attempts at or past the max) or
+# has sat undelivered too long (created_at older than the max age). Both ceilings
+# are env-overridable and default to sane values: 20 attempts, which with the
+# linear retry backoff is a few hours of trying, and 7 days of age, the outer
+# limit past which a page nobody could deliver in a week is not worth keeping.
+# Prints a plain-language reason and returns 0 when the row is over a threshold,
+# prints nothing and returns 1 when it is still worth retrying. The attempts
+# check comes first so a maxed-out row names attempts even if it is also old.
+_osquery_row_over_threshold_reason() { # <attempts> <created_at>
+  local attempts="$1" created_at="$2"
+  local max_attempts="${OSQUERY_DRAIN_MAX_ATTEMPTS:-20}"
+  local max_age="${OSQUERY_DRAIN_MAX_AGE_SECONDS:-604800}"
+  [[ $attempts =~ ^[0-9]+$ ]] || attempts=0
+  [[ $created_at =~ ^[0-9]+$ ]] || created_at=0
+  [[ $max_attempts =~ ^[0-9]+$ ]] || max_attempts=20
+  [[ $max_age =~ ^[0-9]+$ ]] || max_age=604800
+  if ((attempts >= max_attempts)); then
+    printf 'exceeded max delivery attempts (%s >= %s)' "$attempts" "$max_attempts"
+    return 0
+  fi
+  local now age
+  now="$(date -u +%s)"
+  [[ $now =~ ^[0-9]+$ ]] || now=0
+  # A zero created_at (a clock glitch at store time) or a future one is treated
+  # as not-yet-aged: only a real, positive age past the ceiling gives up.
+  if ((created_at > 0)); then
+    age=$((now - created_at))
+    if ((age > max_age)); then
+      printf 'exceeded max pending age (%ss > %ss)' "$age" "$max_age"
+      return 0
+    fi
+  fi
+  return 1
+}
+
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called
 # ONLY after a confirmed 2xx (the write-ahead contract: the row is the page's
 # durable copy until delivery is confirmed). A missing DB is a clean no-op
@@ -294,33 +330,51 @@ _osquery_delete_alert_row() {
 }
 
 # Print every DUE pending row as one tab-separated line (request_id, url,
-# body_base64), ordered for the drain: occurrence time first, then the
-# insert-assigned sequence_number as the tiebreaker. The sequence tiebreaker is
-# skew-proof: equal timestamps (or a backward clock step) still drain in insert
-# order. A row whose next_attempt_after is still in the future is left out:
-# its last attempt failed transiently and its retry wait has not passed yet, so
-# the drain leaves it alone instead of hammering a failing gateway every tick.
-# Tabs cannot appear in the fields (a hex-derived request id, a base64
-# body, and a URL the localhost guard restricts), so the line format is safe.
+# body_base64, attempts, created_at), ordered for the drain: occurrence time
+# first, then the insert-assigned sequence_number as the tiebreaker. The sequence
+# tiebreaker is skew-proof: equal timestamps (or a backward clock step) still
+# drain in insert order. A row whose next_attempt_after is still in the future is
+# left out: its last attempt failed transiently and its retry wait has not passed
+# yet, so the drain leaves it alone instead of hammering a failing gateway every
+# tick. attempts and created_at ride along so the drain can give up on a row that
+# has failed too many times or sat undelivered too long (the dead-letter
+# thresholds) without a second query. Tabs cannot appear in the fields (a
+# hex-derived request id, a base64 body, a URL the localhost guard restricts, and
+# two integers), so the line format is safe.
 _osquery_pending_alert_rows() {
   {
     printf '.separator "\\t"\n'
-    printf "SELECT request_id, url, body_base64 FROM pending_alerts
+    printf "SELECT request_id, url, body_base64, attempts, created_at FROM pending_alerts
   WHERE next_attempt_after <= CAST(strftime('%%s','now') AS INTEGER)
   ORDER BY occurrence_ts, sequence_number;\n"
   } | _osquery_alerts_db_exec
 }
 
-# Deliver ONE pending row: skip a non-localhost url (never send an off-box
-# page), decode and sign the stored body, POST it (stored request_id verbatim so
-# the gateway dedups), and delete the row only on a confirmed 2xx. Fully
-# set -e-safe: a malformed row returns 0 so the drain continues, but NEVER
-# silently: a MALFORMED-ROW log line names the stuck row and the reason, so a
-# row the drain can never deliver is visible instead of invisible forever.
+# Deliver ONE pending row: give up on a row past a dead-letter threshold, skip a
+# non-localhost url (never send an off-box page), decode and sign the stored
+# body, POST it (stored request_id verbatim so the gateway dedups), and delete
+# the row only on a confirmed 2xx. Fully set -e-safe: a malformed row returns 0
+# so the drain continues, but NEVER silently: a MALFORMED-ROW log line names the
+# stuck row and the reason, so a row the drain can never deliver is visible
+# instead of invisible forever. RETURN CONTRACT: 0 when the row was delivered,
+# deferred, or skipped; NONZERO when this call MOVED the row to dead_letter (a
+# permanent status or a crossed threshold), so the drain loop can count the
+# pass's dead-letters for a single end-of-pass CRIT.
 _deliver_pending_alert_row() {
-  local request_id="$1" url="$2" encoded_body="$3" secret="$4" body signature http_status
+  local request_id="$1" url="$2" encoded_body="$3" attempts="$4" created_at="$5" secret="$6"
+  local body signature http_status threshold_reason
   if [[ -z $request_id || -z $url || -z $encoded_body ]]; then
     _osquery_log "MALFORMED-ROW drain skipped an unreadable row: request_id=${request_id:-unknown} (a required field is empty; row retained)"
+    return 0
+  fi
+  # Give up BEFORE any send on a row that has failed too many times or aged out:
+  # a retry cannot help, so move it to dead_letter now instead of POSTing again.
+  if threshold_reason="$(_osquery_row_over_threshold_reason "$attempts" "$created_at")"; then
+    if _osquery_dead_letter_alert_row "$request_id" "none" "$threshold_reason"; then
+      _osquery_log "DEAD-LETTERED request_id=$request_id ($threshold_reason; moved to dead_letter_alerts)"
+      return 1
+    fi
+    _osquery_log "DEAD-LETTER-FAILED request_id=$request_id ($threshold_reason; move failed; row retained in pending_alerts)"
     return 0
   fi
   case "$url" in
@@ -346,12 +400,13 @@ _deliver_pending_alert_row() {
       # A permanent status: the gateway understood the request and refused it
       # outright, so no number of retries can ever succeed. Move the record to
       # the dead-letter table NOW, loudly, so the drain stops re-sending it
-      # forever and the operator can still read the full page there.
+      # forever and the operator can still read the full page there. A moved row
+      # returns nonzero so the drain loop counts it toward the pass's one CRIT.
       if _osquery_dead_letter_alert_row "$request_id" "$http_status" "permanent HTTP status $http_status"; then
         _osquery_log "DEAD-LETTERED request_id=$request_id http=$http_status (permanent status; moved to dead_letter_alerts)"
-      else
-        _osquery_log "DEAD-LETTER-FAILED request_id=$request_id http=$http_status (move failed; row retained in pending_alerts)"
+        return 1
       fi
+      _osquery_log "DEAD-LETTER-FAILED request_id=$request_id http=$http_status (move failed; row retained in pending_alerts)"
       ;;
     *)
       # A transient failure (429, 5xx, or a transport error): count the
@@ -364,17 +419,33 @@ _deliver_pending_alert_row() {
   return 0
 }
 
-# Drain the SQLite store: deliver every pending row in occurrence-time order
+# Drain the SQLite store: deliver every DUE pending row in occurrence-time order
 # with the sequence tiebreaker. A query failure or an empty store is a quiet
-# no-op; a malformed row is skipped. Never returns nonzero (set -e-safe).
+# no-op; a malformed row is skipped. PRINTS the number of rows this pass moved to
+# dead_letter (permanent status or crossed threshold) so the caller can fire ONE
+# summary CRIT for the whole pass instead of one per record; the count is the
+# ONLY thing written to stdout. Never returns nonzero (set -e-safe): each row's
+# delivery runs inside an `if` so a per-row dead-letter signal cannot abort the
+# loop, and the loop keeps going past a failing row (skip-and-continue).
 _drain_pending_alert_rows() {
-  local secret="$1" rows request_id url encoded_body
-  rows="$(_osquery_pending_alert_rows)" || return 0
-  [[ -n $rows ]] || return 0
-  while IFS=$'\t' read -r request_id url encoded_body; do
+  local secret="$1" rows request_id url encoded_body attempts created_at dead_letter_count=0
+  rows="$(_osquery_pending_alert_rows)" || {
+    printf '0'
+    return 0
+  }
+  [[ -n $rows ]] || {
+    printf '0'
+    return 0
+  }
+  while IFS=$'\t' read -r request_id url encoded_body attempts created_at; do
     [[ -n $request_id ]] || continue
-    _deliver_pending_alert_row "$request_id" "$url" "$encoded_body" "$secret"
+    if _deliver_pending_alert_row "$request_id" "$url" "$encoded_body" "$attempts" "$created_at" "$secret"; then
+      : # delivered, deferred, or skipped
+    else
+      dead_letter_count=$((dead_letter_count + 1))
+    fi
   done <<<"$rows"
+  printf '%s' "$dead_letter_count"
   return 0
 }
 
@@ -490,7 +561,19 @@ retry_undelivered_alerts() {
   local secret
   secret="$(_read_webhook_secret)"
   [[ -n $secret ]] || return 0
-  _drain_pending_alert_rows "$secret"
+  # The drain reports how many records it moved to dead_letter this pass. Fire
+  # exactly ONE loud local CRIT when that count is positive, never one per
+  # record: a dead-lettered page means the delivery pipeline is degraded, and
+  # the operator needs one clear signal to investigate, not a notification
+  # storm. Zero dead-letters is a healthy pass and stays silent.
+  local dead_letter_count
+  dead_letter_count="$(_drain_pending_alert_rows "$secret")"
+  [[ $dead_letter_count =~ ^[0-9]+$ ]] || dead_letter_count=0
+  if ((dead_letter_count > 0)); then
+    _osquery_log "PIPELINE-DEGRADED $dead_letter_count record(s) dead-lettered this drain pass"
+    _loud_local "osquery alert delivery pipeline degraded" \
+      "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention."
+  fi
   return 0
 }
 

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -337,8 +337,17 @@ _osquery_row_over_threshold_reason() { # <attempts> <created_at>
 # the two public queue-health counters below. A missing database (nothing ever
 # stored), a missing table (bootstrapped later), or an absent sqlite3 all read
 # as zero, printed as a bare integer, never an error: a health probe must report
-# a number, not fail. Uses a READ-ONLY connection so a probe never creates the
-# file, the schema, or a WAL sidecar. The table name is a fixed internal literal
+# a number, not fail.
+#
+# The connection is READ-ONLY (sqlite3 -readonly): it never modifies committed
+# data and never creates the main database when it is absent (the -f guard also
+# short-circuits that case). It is NOT free of all filesystem effects, though:
+# reading a LIVE WAL-mode database may open or touch its normal -wal/-shm
+# companion files exactly like any other reader. That plain read-only open is
+# deliberate and correct: it counts committed rows still sitting in the WAL that
+# a checkpoint has not folded back into the main file yet. An immutable=1 open
+# would skip the WAL and MISS those uncheckpointed committed rows, undercounting
+# a live queue, so it is NOT used. The table name is a fixed internal literal
 # (SQLite cannot parameterize an identifier), so there is no injection surface.
 _osquery_alert_row_count() { # <table>
   local table="$1" sqlite3_bin count
@@ -621,7 +630,8 @@ retry_undelivered_alerts() {
 # Print how many undelivered pages are still queued in pending_alerts. A public,
 # read-only counter the watchdog polls to tell a healthy-quiet pipeline (zero
 # queued) from one silently backing up. Zero before anything is stored; a bare
-# integer on stdout; never an error and never a side effect.
+# integer on stdout; never an error and never a change to stored data (see
+# _osquery_alert_row_count for the exact read-only contract).
 osquery_pending_alert_count() {
   _osquery_alert_row_count pending_alerts
 }
@@ -630,7 +640,7 @@ osquery_pending_alert_count() {
 # public, read-only counter the watchdog polls: a nonzero count means delivery
 # permanently failed for at least one page and the pipeline needs attention.
 # Zero before anything is dead-lettered; a bare integer on stdout; never an error
-# and never a side effect.
+# and never a change to stored data (see _osquery_alert_row_count).
 osquery_dead_letter_count() {
   _osquery_alert_row_count dead_letter_alerts
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -213,6 +213,71 @@ COMMIT;\n" \
   return 0
 }
 
+# Record one FAILED-but-retryable delivery attempt on a pending row: attempts
+# goes up by one and next_attempt_after moves into the future, so the drain
+# leaves the row alone until its wait has passed instead of hammering a failing
+# gateway on every tick. The wait grows with the attempt count (base seconds
+# times the new attempt number; the base is overridable for tests, and DR-B T6
+# adds a random wobble on top). The clock and the arithmetic both live inside
+# the one UPDATE, so the read-modify-write is atomic under concurrent drains.
+# A failed update is reported nonzero for the caller to log but never fail on:
+# the row is still pending, and the only cost is a retry that comes sooner.
+_osquery_record_transient_failure() {
+  local request_id="$1" base="${OSQUERY_DRAIN_RETRY_BASE_SECONDS:-60}"
+  [[ $base =~ ^[0-9]+$ ]] || base=60
+  local request_id_sql="${request_id//\'/\'\'}"
+  printf "UPDATE pending_alerts
+  SET attempts = attempts + 1,
+      next_attempt_after = CAST(strftime('%%s','now') AS INTEGER) + %s * (attempts + 1)
+  WHERE request_id = '%s';\n" "$base" "$request_id_sql" | _osquery_alerts_db_exec
+}
+
+# Move one pending row into the dead_letter_alerts table, in ONE transaction:
+# the insert and the delete commit together, so a crash at any instant leaves
+# the record in exactly one of the two tables, never in neither. Used when
+# delivery can never succeed (a permanent HTTP status; DR-B T4 adds the
+# attempts/age thresholds). The table is bootstrapped lazily inside the same
+# transaction, mirroring the pending_alerts bootstrap. The batch is idempotent
+# (INSERT OR IGNORE plus a DELETE that fires only once the dead-letter copy
+# exists), so the locked-database retry in _osquery_alerts_db_exec may replay
+# it safely, and the delete can never remove a page the insert did not keep.
+_osquery_dead_letter_alert_row() { # <request_id> <last_http_status> <reason>
+  local request_id="$1" last_http_status="$2" reason="$3" dead_lettered_at
+  dead_lettered_at="$(date -u +%s)"
+  [[ $dead_lettered_at =~ ^[0-9]+$ ]] || dead_lettered_at=0
+  local request_id_sql="${request_id//\'/\'\'}"
+  local status_sql="${last_http_status//\'/\'\'}"
+  local reason_sql="${reason//\'/\'\'}"
+  printf "BEGIN IMMEDIATE;
+CREATE TABLE IF NOT EXISTS dead_letter_alerts (
+  sequence_number    INTEGER PRIMARY KEY,
+  request_id         TEXT UNIQUE NOT NULL,
+  occurrence_ts      INTEGER NOT NULL,
+  url                TEXT NOT NULL,
+  body_base64        TEXT NOT NULL,
+  attempts           INTEGER NOT NULL,
+  next_attempt_after INTEGER NOT NULL,
+  created_at         INTEGER NOT NULL,
+  dead_lettered_at   INTEGER NOT NULL,
+  last_http_status   TEXT NOT NULL,
+  reason             TEXT NOT NULL
+);
+INSERT OR IGNORE INTO dead_letter_alerts
+    (sequence_number, request_id, occurrence_ts, url, body_base64,
+     attempts, next_attempt_after, created_at,
+     dead_lettered_at, last_http_status, reason)
+  SELECT sequence_number, request_id, occurrence_ts, url, body_base64,
+         attempts, next_attempt_after, created_at,
+         %s, '%s', '%s'
+    FROM pending_alerts WHERE request_id = '%s';
+DELETE FROM pending_alerts
+  WHERE request_id = '%s'
+    AND request_id IN (SELECT request_id FROM dead_letter_alerts);
+COMMIT;\n" \
+    "$dead_lettered_at" "$status_sql" "$reason_sql" "$request_id_sql" "$request_id_sql" |
+    _osquery_alerts_db_exec
+}
+
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called
 # ONLY after a confirmed 2xx (the write-ahead contract: the row is the page's
 # durable copy until delivery is confirmed). A missing DB is a clean no-op
@@ -228,16 +293,21 @@ _osquery_delete_alert_row() {
   printf "DELETE FROM pending_alerts WHERE request_id = '%s';\n" "$request_id_sql" | _osquery_alerts_db_exec
 }
 
-# Print every pending row as one tab-separated line (request_id, url,
+# Print every DUE pending row as one tab-separated line (request_id, url,
 # body_base64), ordered for the drain: occurrence time first, then the
 # insert-assigned sequence_number as the tiebreaker. The sequence tiebreaker is
 # skew-proof: equal timestamps (or a backward clock step) still drain in insert
-# order. Tabs cannot appear in the fields (a hex-derived request id, a base64
+# order. A row whose next_attempt_after is still in the future is left out:
+# its last attempt failed transiently and its retry wait has not passed yet, so
+# the drain leaves it alone instead of hammering a failing gateway every tick.
+# Tabs cannot appear in the fields (a hex-derived request id, a base64
 # body, and a URL the localhost guard restricts), so the line format is safe.
 _osquery_pending_alert_rows() {
   {
     printf '.separator "\\t"\n'
-    printf 'SELECT request_id, url, body_base64 FROM pending_alerts ORDER BY occurrence_ts, sequence_number;\n'
+    printf "SELECT request_id, url, body_base64 FROM pending_alerts
+  WHERE next_attempt_after <= CAST(strftime('%%s','now') AS INTEGER)
+  ORDER BY occurrence_ts, sequence_number;\n"
   } | _osquery_alerts_db_exec
 }
 
@@ -272,7 +342,24 @@ _deliver_pending_alert_row() {
       _osquery_delete_alert_row "$request_id" ||
         _osquery_log "ROW-DELETE-FAILED delivered page kept a pending row: request_id=$request_id (gateway dedups the re-post)"
       ;;
-    *) : ;;
+    401 | 403 | 404 | 413)
+      # A permanent status: the gateway understood the request and refused it
+      # outright, so no number of retries can ever succeed. Move the record to
+      # the dead-letter table NOW, loudly, so the drain stops re-sending it
+      # forever and the operator can still read the full page there.
+      if _osquery_dead_letter_alert_row "$request_id" "$http_status" "permanent HTTP status $http_status"; then
+        _osquery_log "DEAD-LETTERED request_id=$request_id http=$http_status (permanent status; moved to dead_letter_alerts)"
+      else
+        _osquery_log "DEAD-LETTER-FAILED request_id=$request_id http=$http_status (move failed; row retained in pending_alerts)"
+      fi
+      ;;
+    *)
+      # A transient failure (429, 5xx, or a transport error): count the
+      # attempt and push this row's next try into the future, so the row waits
+      # out its delay instead of being re-POSTed by every drain tick.
+      _osquery_record_transient_failure "$request_id" ||
+        _osquery_log "RETRY-BOOKKEEPING-FAILED request_id=$request_id (attempts not recorded; the row simply retries sooner)"
+      ;;
   esac
   return 0
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -333,6 +333,28 @@ _osquery_row_over_threshold_reason() { # <attempts> <created_at>
   return 1
 }
 
+# Print the number of rows in one alert table, read-only and fail-soft. Backs
+# the two public queue-health counters below. A missing database (nothing ever
+# stored), a missing table (bootstrapped later), or an absent sqlite3 all read
+# as zero, printed as a bare integer, never an error: a health probe must report
+# a number, not fail. Uses a READ-ONLY connection so a probe never creates the
+# file, the schema, or a WAL sidecar. The table name is a fixed internal literal
+# (SQLite cannot parameterize an identifier), so there is no injection surface.
+_osquery_alert_row_count() { # <table>
+  local table="$1" sqlite3_bin count
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || {
+    printf '0'
+    return 0
+  }
+  sqlite3_bin="$(_osquery_sqlite3_bin)" || {
+    printf '0'
+    return 0
+  }
+  count="$("$sqlite3_bin" -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" "SELECT COUNT(*) FROM $table;" 2>/dev/null)" || count=0
+  [[ $count =~ ^[0-9]+$ ]] || count=0
+  printf '%s' "$count"
+}
+
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called
 # ONLY after a confirmed 2xx (the write-ahead contract: the row is the page's
 # durable copy until delivery is confirmed). A missing DB is a clean no-op
@@ -594,6 +616,23 @@ retry_undelivered_alerts() {
       "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention."
   fi
   return 0
+}
+
+# Print how many undelivered pages are still queued in pending_alerts. A public,
+# read-only counter the watchdog polls to tell a healthy-quiet pipeline (zero
+# queued) from one silently backing up. Zero before anything is stored; a bare
+# integer on stdout; never an error and never a side effect.
+osquery_pending_alert_count() {
+  _osquery_alert_row_count pending_alerts
+}
+
+# Print how many pages the drain has given up on (dead_letter_alerts rows). A
+# public, read-only counter the watchdog polls: a nonzero count means delivery
+# permanently failed for at least one page and the pipeline needs attention.
+# Zero before anything is dead-lettered; a bare integer on stdout; never an error
+# and never a side effect.
+osquery_dead_letter_count() {
+  _osquery_alert_row_count dead_letter_alerts
 }
 
 # Build the signed webhook body for one CRIT page and print it. tier: a page is

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -217,19 +217,38 @@ COMMIT;\n" \
 # goes up by one and next_attempt_after moves into the future, so the drain
 # leaves the row alone until its wait has passed instead of hammering a failing
 # gateway on every tick. The wait grows with the attempt count (base seconds
-# times the new attempt number; the base is overridable for tests, and DR-B T6
-# adds a random wobble on top). The clock and the arithmetic both live inside
-# the one UPDATE, so the read-modify-write is atomic under concurrent drains.
-# A failed update is reported nonzero for the caller to log but never fail on:
-# the row is still pending, and the only cost is a retry that comes sooner.
+# times the new attempt number; the base is overridable for tests) plus a
+# bounded RANDOMIZED RETRY DELAY on top.
+#
+# The randomized delay breaks lockstep: when a gateway outage fails a whole
+# batch of rows in the same pass, an identical fixed schedule would make every
+# row come due at the same instant and retry in one synchronized storm the
+# moment the gateway might be recovering. A small random offset added to each
+# row's schedule staggers them so they come back gradually instead. The offset
+# is a non-negative number of seconds in [0, max], so it only ever DELAYS a
+# retry, never pulls one earlier than the base schedule. The max defaults to the
+# base (the spec's "bounded by the base"): a full base-width spread, and setting
+# OSQUERY_DRAIN_RETRY_RANDOM_SECONDS=0 disables it for a deterministic schedule.
+# $RANDOM is the source (portable, no external tool); its 15-bit range caps the
+# effective spread at 32767 seconds, which is well past any useful stagger.
+#
+# The clock and the arithmetic both live inside the one UPDATE, so the
+# read-modify-write is atomic under concurrent drains; the offset is drawn once
+# per call, so two rows failing in the same pass get independent offsets. A
+# failed update is reported nonzero for the caller to log but never fail on: the
+# row is still pending, and the only cost is a retry that comes sooner.
 _osquery_record_transient_failure() {
   local request_id="$1" base="${OSQUERY_DRAIN_RETRY_BASE_SECONDS:-60}"
   [[ $base =~ ^[0-9]+$ ]] || base=60
+  local random_max="${OSQUERY_DRAIN_RETRY_RANDOM_SECONDS:-$base}"
+  [[ $random_max =~ ^[0-9]+$ ]] || random_max="$base"
+  local random_offset=0
+  ((random_max > 0)) && random_offset=$((RANDOM % (random_max + 1)))
   local request_id_sql="${request_id//\'/\'\'}"
   printf "UPDATE pending_alerts
   SET attempts = attempts + 1,
-      next_attempt_after = CAST(strftime('%%s','now') AS INTEGER) + %s * (attempts + 1)
-  WHERE request_id = '%s';\n" "$base" "$request_id_sql" | _osquery_alerts_db_exec
+      next_attempt_after = CAST(strftime('%%s','now') AS INTEGER) + %s * (attempts + 1) + %s
+  WHERE request_id = '%s';\n" "$base" "$random_offset" "$request_id_sql" | _osquery_alerts_db_exec
 }
 
 # Move one pending row into the dead_letter_alerts table, in ONE transaction:

--- a/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
+++ b/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# drain-undelivered-alerts.sh, run on a timer by launchd (StartInterval 300).
+# Sources the shared dispatch library and drains the undelivered-alerts SQLite
+# store: every stored CRIT page that has not yet reached the hermes #priority
+# webhook is replayed in occurrence order, and each delivered row is removed.
+# Nothing else runs this drain on a schedule, so without it a page stored during
+# a gateway outage would sit undelivered until a producer happened to fire again.
+#
+# A single-instance lock guards the case where one drain runs longer than the
+# 300-second timer interval and the next tick fires while it is still going. The
+# two runs would otherwise read the same row snapshot and POST every page twice.
+# The lock lets exactly one drain run at a time; an overlapping run exits 0
+# immediately, because the drain that holds the lock already sweeps every stored
+# row and a second concurrent drain has nothing to add.
+#
+# Exit status is always 0: a drain is a best-effort background sweep, and a
+# failure inside it must never surface as a launchd job error. The library's
+# retry_undelivered_alerts is itself set -e-safe (an empty store, a missing
+# database, or a malformed row is a quiet no-op), so all this wrapper adds is the
+# single-instance lock and the always-zero exit.
+
+set -euo pipefail
+
+# The shared dispatch library provides retry_undelivered_alerts and the SQLite
+# store helpers. Source it from the same deployed path the three producers
+# (results-alerter, firewall-gatekeeper-monitor, uptime-watchdog) use, so all
+# four agree on one implementation of the store and its drain.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+
+# The single-instance lock file sits beside the store it guards, so every
+# drainer invocation contends on one lock no matter what launched it. The
+# default is derived from the store path (itself overridable for tests), so
+# there is never a second path to keep in sync with the first.
+OSQUERY_DRAIN_LOCK_FILE="${OSQUERY_DRAIN_LOCK_FILE:-${OSQUERY_UNDELIVERED_ALERTS_DB}.drain.lock}"
+
+# Take the single-instance lock and report whether this run may proceed (0 to
+# proceed, nonzero to skip). Uses the kernel lock /usr/bin/lockf on a held file
+# descriptor: the kernel releases it on ANY exit, normal or crash, so a drain
+# SIGKILLed mid-run can never wedge the lock and block every later drain (there
+# is no stale-lock state to clean up). The acquire is non-blocking (-t 0): an
+# overlapping run fails to take the lock and returns nonzero, so the caller skips
+# rather than queueing behind the running drain. A host without /usr/bin/lockf
+# (any non-darwin test box) runs unlocked, matching the library's darwin-only
+# runtime. House precedent: hue-pulse.sh, homebrew-weekly-upgrade.sh, and
+# update-skills.sh all guard with this same kernel-lock shape.
+take_single_instance_lock() {
+  local lock_directory
+  lock_directory="$(dirname "$OSQUERY_DRAIN_LOCK_FILE")"
+  mkdir -p "$lock_directory" 2>/dev/null || true
+  [[ -x /usr/bin/lockf ]] || return 0
+  exec 9>>"$OSQUERY_DRAIN_LOCK_FILE" 2>/dev/null || return 0
+  /usr/bin/lockf -s -t 0 9
+}
+
+# main -- take the single-instance lock, drain the store once, and exit 0.
+main() {
+  if ! take_single_instance_lock; then
+    # Another drain already holds the lock and covers every stored row; skip.
+    return 0
+  fi
+  retry_undelivered_alerts
+  return 0
+}
+
+main "$@"

--- a/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
+++ b/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
@@ -41,17 +41,30 @@ OSQUERY_DRAIN_LOCK_FILE="${OSQUERY_DRAIN_LOCK_FILE:-${OSQUERY_UNDELIVERED_ALERTS
 # SIGKILLed mid-run can never wedge the lock and block every later drain (there
 # is no stale-lock state to clean up). The acquire is non-blocking (-t 0): an
 # overlapping run fails to take the lock and returns nonzero, so the caller skips
-# rather than queueing behind the running drain. A host without /usr/bin/lockf
-# (any non-darwin test box) runs unlocked, matching the library's darwin-only
-# runtime. House precedent: hue-pulse.sh, homebrew-weekly-upgrade.sh, and
-# update-skills.sh all guard with this same kernel-lock shape.
+# rather than queueing behind the running drain. House precedent: hue-pulse.sh,
+# homebrew-weekly-upgrade.sh, and update-skills.sh all guard with this same
+# kernel-lock shape. The lockf binary path is overridable (OSQUERY_DRAIN_LOCKF_BIN)
+# so the platform-fallback and fail-closed paths can be exercised in tests.
+#
+# The lock is MUTUAL EXCLUSION, so on a genuine setup error it must fail CLOSED
+# (return nonzero, the caller skips this sweep), NEVER fall through and run the
+# sweep unlocked: two overlapping launchd runs sweeping at once would each read
+# the same row snapshot and double-POST every page, the exact race this lock
+# exists to prevent. A skipped sweep loses nothing; the next 300-second tick
+# retries. The ONE exception is a host with no lockf at all (any non-darwin box,
+# e.g. Linux CI): there is no kernel lock to take, so the drain proceeds unlocked
+# by design, matching the library's darwin-only runtime.
 take_single_instance_lock() {
+  local lockf_bin="${OSQUERY_DRAIN_LOCKF_BIN:-/usr/bin/lockf}"
+  # No lockf available: the documented non-darwin fallback. Proceed unlocked so
+  # the drain still runs; there is no lock to fail closed on.
+  [[ -x $lockf_bin ]] || return 0
+  # From here the lock is REQUIRED. Any failure to set it up fails CLOSED.
   local lock_directory
   lock_directory="$(dirname "$OSQUERY_DRAIN_LOCK_FILE")"
-  mkdir -p "$lock_directory" 2>/dev/null || true
-  [[ -x /usr/bin/lockf ]] || return 0
-  exec 9>>"$OSQUERY_DRAIN_LOCK_FILE" 2>/dev/null || return 0
-  /usr/bin/lockf -s -t 0 9
+  mkdir -p "$lock_directory" 2>/dev/null || return 1
+  exec 9>>"$OSQUERY_DRAIN_LOCK_FILE" 2>/dev/null || return 1
+  "$lockf_bin" -s -t 0 9
 }
 
 # main -- take the single-instance lock, drain the store once, and exit 0.

--- a/test/e2e/osquery-alert-drainer.bats
+++ b/test/e2e/osquery-alert-drainer.bats
@@ -77,3 +77,67 @@ STUB
   # Delivery really happened: the store is empty, no row left behind.
   assert_pending_alert_count 0
 }
+
+# --- fail-closed lock setup (a mutual-exclusion lock must never run unlocked) ---
+
+# Seed one deliverable page and queue a 200: if the sweep RUNS it delivers, if it
+# is SKIPPED nothing is POSTed and the row is retained. Sets a present lockf stub
+# so the "lock required" path is reached on any platform (the stub is never
+# actually called; the setup failure happens before the acquire).
+_seed_one_page_and_require_lock() {
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-failclosed "$url" "$body_b64"
+  : >"$CURL_LOG"
+  set_curl_codes 200
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$HARNESS_HOME/bin/lockf-stub"
+  chmod +x "$HARNESS_HOME/bin/lockf-stub"
+  export OSQUERY_DRAIN_LOCKF_BIN="$HARNESS_HOME/bin/lockf-stub"
+}
+
+@test "T-DRAIN-lock-failclosed-exec: a lockfile that cannot be opened SKIPS the sweep, never runs unlocked" {
+  _seed_one_page_and_require_lock
+  # Point the lock file at a DIRECTORY so `exec 9>>` cannot open it for writing:
+  # a genuine lock-setup failure. A fail-closed lock must SKIP the sweep rather
+  # than fall through and run unlocked (two overlapping runs would double-POST).
+  export OSQUERY_DRAIN_LOCK_FILE="$HARNESS_HOME/lock-is-a-directory"
+  mkdir -p "$OSQUERY_DRAIN_LOCK_FILE"
+
+  run bash "$DRAINER"
+
+  [[ $status -eq 0 ]]          # main still exits 0 (a skip is a clean no-op, not an error)
+  assert_no_post               # the sweep was SKIPPED, not run unlocked
+  assert_pending_alert_count 1 # the row is retained for the next 300s tick
+}
+
+@test "T-DRAIN-lock-failclosed-mkdir: a lock dir that cannot be created SKIPS the sweep, never runs unlocked" {
+  _seed_one_page_and_require_lock
+  # Put the lock file UNDER a regular file, so mkdir -p of its parent fails.
+  printf 'i am a file, not a directory\n' >"$HARNESS_HOME/a-file"
+  export OSQUERY_DRAIN_LOCK_FILE="$HARNESS_HOME/a-file/drain.lock"
+
+  run bash "$DRAINER"
+
+  [[ $status -eq 0 ]]
+  assert_no_post
+  assert_pending_alert_count 1
+}
+
+@test "T-DRAIN-lock-absent-proceeds: with no lockf available the drain proceeds UNLOCKED (platform fallback)" {
+  # On a non-darwin host /usr/bin/lockf is absent and the drain must still run,
+  # unlocked, or the Linux path would never drain. Simulate absence via the
+  # lockf-binary override so the documented fallback is pinned on any platform.
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-noflockf "$url" "$body_b64"
+  : >"$CURL_LOG"
+  set_curl_codes 200
+  export OSQUERY_DRAIN_LOCKF_BIN="$HARNESS_HOME/bin/nonexistent-lockf" # not executable -> absent
+
+  run bash "$DRAINER"
+
+  [[ $status -eq 0 ]]
+  # The drain PROCEEDED unlocked: the page was delivered and the store cleared.
+  grep -qF 'X-Request-ID: osquery-noflockf' "$CURL_LOG"
+  assert_pending_alert_count 0
+}

--- a/test/e2e/osquery-alert-drainer.bats
+++ b/test/e2e/osquery-alert-drainer.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# The scheduled drainer (executable_drain-undelivered-alerts.sh) sweeps the
+# undelivered-alerts SQLite store on a timer. Two drains that overlap -- the
+# StartInterval fires again while a slow drain is still running -- must never
+# both replay the same stored page: a single-instance lock serializes them so
+# each stored page reaches the webhook AT MOST ONCE across the overlapping runs.
+# Without the lock both runs read the same row snapshot and double-send every
+# page. This runs the drainer as a real subprocess and widens the delivery
+# window with a slow POST stub, so it is a whole-script, timing-bound flow (the
+# e2e suite, beside the osquery durability suite it builds on).
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  build_dispatch_harness
+  # The drainer sources the library from its DEPLOYED path
+  # ($HOME/.local/libexec/osquery/alert-dispatch.sh, the same path the three
+  # producers use). Mirror a chezmoi apply by copying the source library (with
+  # its executable_ prefix stripped) into the harness HOME, so the drainer
+  # subprocess finds it exactly where it will in production.
+  mkdir -p "$HARNESS_HOME/.local/libexec/osquery"
+  cp "$DISPATCH" "$HARNESS_HOME/.local/libexec/osquery/alert-dispatch.sh"
+  DRAINER="$BATS_TEST_DIRNAME/../../dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh"
+}
+teardown() { teardown_dispatch_harness; }
+
+@test "T-DRAIN-lock-single-send: two overlapping drains deliver each stored page exactly once" {
+  # The single-instance lock is a kernel lock (/usr/bin/lockf). A host without
+  # it (any non-darwin box) runs the drain unlocked by design, so the lock
+  # cannot be exercised there; skip rather than assert a guarantee the platform
+  # does not provide.
+  [[ -x /usr/bin/lockf ]] || skip "no /usr/bin/lockf; the single-instance lock is a darwin-only guarantee"
+
+  # Seed three undelivered pages directly as pending_alerts rows.
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-drain-a "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-drain-b "$url" "$body_b64"
+  _osquery_store_alert_row 3000 osquery-drain-c "$url" "$body_b64"
+
+  # A deliberately slow POST holds the delivery window open long enough that an
+  # UNLOCKED pair of drains reliably overlaps and double-sends. Each POST is
+  # logged and returns 200 so the winning drain clears every row.
+  cat >"$HARNESS_HOME/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_LOG"
+sleep 0.3
+printf '200'
+STUB
+  chmod +x "$HARNESS_HOME/bin/curl"
+  : >"$CURL_LOG"
+
+  # Fire two overlapping drain runs, exactly as two StartInterval ticks would.
+  bash "$DRAINER" &
+  local first_pid=$!
+  bash "$DRAINER" &
+  local second_pid=$!
+  local first_status=0 second_status=0
+  wait "$first_pid" || first_status=$?
+  wait "$second_pid" || second_status=$?
+  [[ $first_status -eq 0 ]]  # a drain always exits 0 (best-effort background sweep)
+  [[ $second_status -eq 0 ]]
+
+  # The bound: every seeded page reached the webhook exactly once across BOTH
+  # runs. The winner (whichever drain took the lock) delivers all three; the
+  # other skips immediately, so no page is POSTed twice.
+  local page post_count
+  for page in osquery-drain-a osquery-drain-b osquery-drain-c; do
+    post_count=$(grep -cF "X-Request-ID: $page" "$CURL_LOG" || true)
+    if [[ $post_count -ne 1 ]]; then
+      printf 'page %s was POSTed %s time(s), expected exactly 1: the drains were not serialized\n' \
+        "$page" "$post_count" >&2
+      return 1
+    fi
+  done
+  # Delivery really happened: the store is empty, no row left behind.
+  assert_pending_alert_count 0
+}

--- a/test/integration/osquery-dead-letter.bats
+++ b/test/integration/osquery-dead-letter.bats
@@ -13,6 +13,8 @@ setup() {
   local helpers="$BATS_TEST_DIRNAME/../helpers"
   # shellcheck source=test/helpers/build-dispatch-harness.sh
   source "$helpers/build-dispatch-harness.sh"
+  # shellcheck source=test/helpers/wait-for-log-line.sh
+  source "$helpers/wait-for-log-line.sh"
   build_dispatch_harness
 }
 teardown() { teardown_dispatch_harness; }
@@ -126,4 +128,119 @@ dead_letter_count() {
   # Dead-lettering is loud in the delivery log, never a silent disappearance.
   grep -q 'DEAD-LETTERED' "$OSQUERY_DELIVERY_LOG"
   grep -q 'osquery-perm-401' "$OSQUERY_DELIVERY_LOG"
+}
+
+# --- DR-B T4: attempt/age thresholds + one batched CRIT per pass ---------------
+
+@test "T-DLQ-attempts-threshold: a row that has failed the max number of times dead-letters with an attempts reason, not another POST" {
+  # A transient row is not retried forever: once its attempts reach the max, the
+  # drain gives up and moves it to dead_letter instead of POSTing yet again.
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=5
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800 # large, so ONLY the attempts trigger fires
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-maxed "$url" "$body_b64"
+  # Stand the row up as one that has already failed the max number of times.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET attempts=5 WHERE request_id='osquery-maxed';"
+  : >"$CURL_LOG"
+  # A 200 is queued on purpose: if the row WERE POSTed it would succeed and be
+  # deleted (dead_letter stays empty). A surviving dead_letter row therefore
+  # proves the give-up happened BEFORE any send.
+  set_curl_codes 200
+
+  retry_undelivered_alerts
+
+  assert_pending_alert_count 0
+  [[ "$(dead_letter_count)" == "1" ]]
+  ! grep -qF 'X-Request-ID: osquery-maxed' "$CURL_LOG" # never POSTed again
+  local reason
+  reason="$(sqlite3_query "SELECT reason FROM dead_letter_alerts WHERE request_id='osquery-maxed';")"
+  [[ $reason == *attempt* ]] # the reason names the attempts threshold it crossed
+  [[ "$(sqlite3_query "SELECT attempts FROM dead_letter_alerts WHERE request_id='osquery-maxed';")" == "5" ]]
+  grep -q 'DEAD-LETTERED' "$OSQUERY_DELIVERY_LOG"
+}
+
+@test "T-DLQ-age-threshold: a row older than the max age dead-letters with an age reason, not another POST" {
+  # A row that has sat undelivered longer than the max age is given up on even
+  # if its attempts count is low: a page nobody could deliver in a week is not
+  # worth retrying forever.
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=1000 # large, so ONLY the age trigger fires
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=100
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-stale "$url" "$body_b64"
+  # Age its created_at well past the 100s limit.
+  local old_created_at
+  old_created_at=$(($(date -u +%s) - 100000))
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET created_at=$old_created_at WHERE request_id='osquery-stale';"
+  : >"$CURL_LOG"
+  set_curl_codes 200
+
+  retry_undelivered_alerts
+
+  assert_pending_alert_count 0
+  [[ "$(dead_letter_count)" == "1" ]]
+  ! grep -qF 'X-Request-ID: osquery-stale' "$CURL_LOG" # never POSTed again
+  local reason
+  reason="$(sqlite3_query "SELECT reason FROM dead_letter_alerts WHERE request_id='osquery-stale';")"
+  [[ $reason == *age* ]] # the reason names the age threshold it crossed
+  grep -q 'DEAD-LETTERED' "$OSQUERY_DELIVERY_LOG"
+}
+
+@test "T-DLQ-one-crit-per-pass: several dead-letters in one pass fire exactly ONE summary CRIT naming the count" {
+  # Whether one record or many dead-letter in a pass, the operator gets exactly
+  # ONE local CRIT summarizing the pass, never one alert per record.
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=5
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  # Two permanent-status rows plus one attempts-maxed row: three dead-letters,
+  # a permanent-and-threshold mix, all in one drain pass.
+  _osquery_store_alert_row 1000 osquery-perm-a "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-perm-b "$url" "$body_b64"
+  _osquery_store_alert_row 3000 osquery-maxed "$url" "$body_b64"
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET attempts=5 WHERE request_id='osquery-maxed';"
+  : >"$ALERTER_LOG"
+  : >"$CURL_LOG"
+  set_curl_codes 401 403 # the two permanent rows; the maxed row never POSTs
+
+  retry_undelivered_alerts
+
+  assert_pending_alert_count 0
+  [[ "$(dead_letter_count)" == "3" ]]
+  # Exactly ONE loud local notification for the whole pass (the alerter stub
+  # logs one line per invocation), and it summarizes the count (3).
+  wait_for_log_line 'dead-letter' "$ALERTER_LOG"
+  local crit_lines
+  crit_lines=$(grep -ciF 'dead-letter' "$ALERTER_LOG")
+  if [[ $crit_lines -ne 1 ]]; then
+    printf 'expected exactly ONE summary CRIT, got %s lines:\n%s\n' "$crit_lines" "$(cat "$ALERTER_LOG")" >&2
+    return 1
+  fi
+  grep -qE '(^|[^0-9])3([^0-9]|$)' "$ALERTER_LOG" # the one CRIT names N=3
+}
+
+@test "T-DLQ-no-crit-on-transient: a pass that dead-letters nothing fires no CRIT" {
+  # Transient failures are NOT dead-letters: a pass where every failure is
+  # retryable must leave the CRIT silent (no dead-letter, no pipeline alert).
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=20
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=0
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-soft-a "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-soft-b "$url" "$body_b64"
+  : >"$ALERTER_LOG"
+  set_curl_codes 503 503
+
+  retry_undelivered_alerts
+
+  assert_pending_alert_count 2 # transient: retained, not dead-lettered
+  [[ "$(dead_letter_count)" == "0" ]]
+  # No dead-letter this pass, so the summary CRIT never fires. Nothing spawns a
+  # background notifier, so an immediate emptiness check is race-free.
+  [[ ! -s $ALERTER_LOG ]]
 }

--- a/test/integration/osquery-dead-letter.bats
+++ b/test/integration/osquery-dead-letter.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Drain-time failure classification (DR-B T3): a failing POST is not one thing.
+# A TRANSIENT status (429, 5xx, or a transport failure) can succeed later, so
+# the row stays pending, its attempts count goes up by one, and its
+# next_attempt_after moves into the future so the drain stops hammering a
+# failing gateway on every tick. A PERMANENT status (401, 403, 404, 413) can
+# never succeed by retrying, so the row moves to the dead_letter_alerts table
+# immediately, with the status recorded in its reason, instead of being retried
+# forever. The batch dead-letter thresholds and their single CRIT are T4; the
+# full head-of-line pins are T5.
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  build_dispatch_harness
+}
+teardown() { teardown_dispatch_harness; }
+
+# Count dead_letter_alerts rows; a store without the table yet counts as zero
+# (nothing has ever been dead-lettered).
+dead_letter_count() {
+  sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    'SELECT COUNT(*) FROM dead_letter_alerts;' 2>/dev/null || echo 0
+}
+
+@test "T-DLQ-transient-bookkeeping: a transient failure stays pending with attempts+1 and a future next_attempt_after that the drain respects" {
+  # A long retry base makes "future" unmistakable: after one failed attempt the
+  # row must not be eligible again for about an hour, so an immediate re-drain
+  # proves the wait is respected, not just written.
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=3600
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  # One row per transient shape: a 5xx, a 429, and a transport failure (000).
+  _osquery_store_alert_row 1000 osquery-transient-503 "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-transient-429 "$url" "$body_b64"
+  _osquery_store_alert_row 3000 osquery-transient-000 "$url" "$body_b64"
+  set_curl_codes 503 429 000
+
+  local before_drain
+  before_drain="$(date -u +%s)"
+  retry_undelivered_alerts
+
+  # All three rows are still pending (a transient failure never loses a page)
+  # and none was dead-lettered.
+  assert_pending_alert_count 3
+  [[ "$(dead_letter_count)" == "0" ]]
+
+  # Each row counted its failed attempt and scheduled its next try well into
+  # the future (base 3600 * attempt 1, so comfortably past +1800 even with
+  # clock slop between the drain and this assert).
+  local request_id attempts next_attempt_after
+  for request_id in osquery-transient-503 osquery-transient-429 osquery-transient-000; do
+    attempts="$(sqlite3_query "SELECT attempts FROM pending_alerts WHERE request_id='$request_id';")"
+    if [[ $attempts != "1" ]]; then
+      printf '%s: expected attempts=1 after one transient failure, got %s\n' "$request_id" "$attempts" >&2
+      return 1
+    fi
+    next_attempt_after="$(sqlite3_query "SELECT next_attempt_after FROM pending_alerts WHERE request_id='$request_id';")"
+    if [[ ! $next_attempt_after -gt $((before_drain + 1800)) ]]; then
+      printf '%s: expected a future next_attempt_after (> %s), got %s\n' \
+        "$request_id" "$((before_drain + 1800))" "$next_attempt_after" >&2
+      return 1
+    fi
+  done
+
+  # The wait is RESPECTED: an immediate re-drain (gateway now healthy) must
+  # skip all three rows, because none of their retry times has arrived. No
+  # POST fires and the bookkeeping is untouched by the skipped pass.
+  : >"$CURL_LOG"
+  set_curl_codes 200 200 200
+  retry_undelivered_alerts
+  assert_post_count 0
+  assert_pending_alert_count 3
+  [[ "$(sqlite3_query 'SELECT COUNT(*) FROM pending_alerts WHERE attempts=1;')" == "3" ]]
+}
+
+@test "T-DLQ-permanent-immediate: a 401/403/404/413 row moves to dead_letter_alerts at once, with the status in reason, and the drain continues" {
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=3600
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  # Four permanent rows (occurrence order = drain order), then a transient row
+  # BEHIND them, so the drain reaching it proves a permanent failure never
+  # stops the pass.
+  _osquery_store_alert_row 1000 osquery-perm-401 "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-perm-403 "$url" "$body_b64"
+  _osquery_store_alert_row 3000 osquery-perm-404 "$url" "$body_b64"
+  _osquery_store_alert_row 4000 osquery-perm-413 "$url" "$body_b64"
+  _osquery_store_alert_row 5000 osquery-behind-them "$url" "$body_b64"
+  set_curl_codes 401 403 404 413 503
+
+  local before_drain
+  before_drain="$(date -u +%s)"
+  retry_undelivered_alerts
+
+  # Only the transient row is still pending; the four permanent rows are gone
+  # from the retry queue (never retried like a transient)...
+  assert_pending_alert_count 1
+  [[ "$(sqlite3_query 'SELECT request_id FROM pending_alerts;')" == "osquery-behind-them" ]]
+  # ...and each landed in dead_letter_alerts exactly once, its payload intact,
+  # with the failing status recorded in last_http_status AND readable in the
+  # reason, plus a real dead-letter timestamp.
+  [[ "$(dead_letter_count)" == "4" ]]
+  local status row
+  for status in 401 403 404 413; do
+    row="$(sqlite3_query "SELECT last_http_status, reason, url, body_base64, occurrence_ts, dead_lettered_at
+                            FROM dead_letter_alerts WHERE request_id='osquery-perm-$status';")"
+    [[ -n $row ]] || {
+      printf 'osquery-perm-%s never reached dead_letter_alerts\n' "$status" >&2
+      return 1
+    }
+    IFS='|' read -r dl_status dl_reason dl_url dl_body dl_occurrence dl_at <<<"$row"
+    [[ $dl_status == "$status" ]]
+    [[ $dl_reason == *"$status"* ]] # the reason names the failing status
+    [[ $dl_url == "$url" ]]
+    [[ $dl_body == "$body_b64" ]]
+    [[ $dl_occurrence -ge 1000 && $dl_occurrence -le 4000 ]]
+    [[ $dl_at -ge $before_drain ]]
+  done
+
+  # The transient row behind the permanent ones WAS attempted in the same pass
+  # (its 503 is in the curl log) and got its bookkeeping.
+  grep -qF 'X-Request-ID: osquery-behind-them' "$CURL_LOG"
+  [[ "$(sqlite3_query "SELECT attempts FROM pending_alerts WHERE request_id='osquery-behind-them';")" == "1" ]]
+
+  # Dead-lettering is loud in the delivery log, never a silent disappearance.
+  grep -q 'DEAD-LETTERED' "$OSQUERY_DELIVERY_LOG"
+  grep -q 'osquery-perm-401' "$OSQUERY_DELIVERY_LOG"
+}

--- a/test/integration/osquery-dead-letter.bats
+++ b/test/integration/osquery-dead-letter.bats
@@ -244,3 +244,67 @@ dead_letter_count() {
   # background notifier, so an immediate emptiness check is race-free.
   [[ ! -s $ALERTER_LOG ]]
 }
+
+# --- DR-B T6: randomized retry delay (breaks synchronized retry storms) --------
+
+@test "T-DLQ-random-delay-spread: rows failing transiently in one pass get spread-out next_attempt_after, not identical" {
+  # A batch of rows that all fail in the SAME pass must not schedule an identical
+  # retry time, or they retry in one synchronized storm. The randomized delay
+  # staggers them. Base is 0 here so the ONLY source of spread is the random
+  # offset, and the bound is wide so the spread is unmistakable (clock drift
+  # across a sub-second pass could account for at most a second or two).
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=0
+  export OSQUERY_DRAIN_RETRY_RANDOM_SECONDS=20000
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=1000 # keep every row a transient, none dead-lettered
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64 i
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  for i in 1 2 3 4 5 6 7 8; do
+    _osquery_store_alert_row "$((1000 + i))" "osquery-lockstep-$i" "$url" "$body_b64"
+  done
+  set_curl_codes 503 503 503 503 503 503 503 503
+
+  retry_undelivered_alerts
+
+  assert_pending_alert_count 8 # all retained as transients
+  # The eight scheduled times must span a wide window; with base 0 that spread is
+  # the randomized delay itself, not the base schedule or clock drift.
+  local spread
+  spread=$(sqlite3_query 'SELECT MAX(next_attempt_after) - MIN(next_attempt_after) FROM pending_alerts;')
+  if [[ ! $spread -ge 60 ]]; then
+    printf 'expected the randomized delay to spread next_attempt_after by >= 60s, got spread=%s\n' "$spread" >&2
+    return 1
+  fi
+  # ...and more than one distinct scheduled time (no lockstep).
+  [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT next_attempt_after) FROM pending_alerts;')" -gt 1 ]]
+}
+
+@test "T-DLQ-random-delay-zero-deterministic: with the random knob at 0 the schedule is exactly base*attempt, no offset" {
+  # Setting the random bound to 0 must reproduce the pure deterministic schedule
+  # the earlier tests rely on: next_attempt_after = update_time + base*attempt,
+  # with no offset added.
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=1000
+  export OSQUERY_DRAIN_RETRY_RANDOM_SECONDS=0
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=1000
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-det "$url" "$body_b64"
+  set_curl_codes 503
+
+  local before after next_attempt
+  before=$(date -u +%s)
+  retry_undelivered_alerts
+  after=$(date -u +%s)
+
+  [[ "$(sqlite3_query "SELECT attempts FROM pending_alerts WHERE request_id='osquery-det';")" == "1" ]]
+  next_attempt=$(sqlite3_query "SELECT next_attempt_after FROM pending_alerts WHERE request_id='osquery-det';")
+  # With no offset, next_attempt = update_time + 1000, and update_time is inside
+  # the [before, after] pass window. A nonzero offset would push it past after+1000.
+  local implied_update_time=$((next_attempt - 1000))
+  if [[ ! ($implied_update_time -ge $before && $implied_update_time -le $after) ]]; then
+    printf 'expected next_attempt = update_time + 1000 with NO random offset; before=%s after=%s next_attempt=%s (implied update_time=%s)\n' \
+      "$before" "$after" "$next_attempt" "$implied_update_time" >&2
+    return 1
+  fi
+}

--- a/test/integration/osquery-drain-continuation.bats
+++ b/test/integration/osquery-drain-continuation.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# Head-of-line skip-and-continue (DR-B T5): a single poison record must never
+# starve the rest of the queue. Whatever a row's fate -- delivered, deferred as
+# transient, dead-lettered as permanent or over-threshold, or skipped as
+# malformed -- the drain visits EVERY due row in one pass and a row's outcome
+# never blocks the rows behind it. The drain is errexit-safe: a failing record
+# is logged and the loop continues, never aborting and never swallowing the
+# failure silently.
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  # shellcheck source=test/helpers/wait-for-log-line.sh
+  source "$helpers/wait-for-log-line.sh"
+  build_dispatch_harness
+}
+teardown() { teardown_dispatch_harness; }
+
+# Count dead_letter_alerts rows; a store without the table yet counts as zero.
+dead_letter_count() {
+  sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    'SELECT COUNT(*) FROM dead_letter_alerts;' 2>/dev/null || echo 0
+}
+
+@test "T-DRAIN-continue-past-permanent: a permanent poison row in the middle does not starve the rows behind it" {
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=20
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-front "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-poison "$url" "$body_b64"
+  _osquery_store_alert_row 3000 osquery-back "$url" "$body_b64"
+  : >"$CURL_LOG"
+  set_curl_codes 200 403 200 # front delivers, poison is refused, back delivers
+
+  retry_undelivered_alerts
+
+  # The row BEHIND the poison was delivered in the SAME pass.
+  grep -qF 'X-Request-ID: osquery-back' "$CURL_LOG"
+  # front and back delivered (gone); poison moved to dead_letter.
+  assert_pending_alert_count 0
+  [[ "$(dead_letter_count)" == "1" ]]
+  [[ -n "$(sqlite3_query "SELECT 1 FROM dead_letter_alerts WHERE request_id='osquery-poison';")" ]]
+  # Positive anchor: every row was visited (all three POSTed).
+  assert_post_count 3
+}
+
+@test "T-DRAIN-continue-past-malformed: an undecodable poison row in the middle is skipped and the rows behind it still deliver" {
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' good_body
+  good_body=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-a "$url" "$good_body"
+  _osquery_store_alert_row 2000 osquery-corrupt "$url" '####' # not decodable base64
+  _osquery_store_alert_row 3000 osquery-b "$url" "$good_body"
+  : >"$CURL_LOG"
+  set_curl_codes 200 200 # only a and b POST; corrupt is skipped before any POST
+
+  retry_undelivered_alerts
+
+  grep -qF 'X-Request-ID: osquery-b' "$CURL_LOG"       # behind the poison, still delivered
+  ! grep -qF 'X-Request-ID: osquery-corrupt' "$CURL_LOG" # never POSTed
+  assert_pending_alert_count 1                         # corrupt retained, a and b delivered
+  [[ "$(sqlite3_query 'SELECT request_id FROM pending_alerts;')" == "osquery-corrupt" ]]
+  grep -q 'MALFORMED-ROW' "$OSQUERY_DELIVERY_LOG"      # logged, not silently swallowed
+  [[ "$(dead_letter_count)" == "0" ]]                  # a malformed row is retained, not dead-lettered
+}
+
+@test "T-DRAIN-mixed-batch-full-drain: a mixed batch drains completely in one pass, each row handled by class, none starved" {
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=50
+  export OSQUERY_DRAIN_MAX_AGE_SECONDS=604800
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=3600 # so the transient row defers, not redelivers
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  # Interleave the four classes by occurrence order, a deliverable at each end.
+  _osquery_store_alert_row 1000 osquery-deliver-1 "$url" "$body_b64" # 2xx
+  _osquery_store_alert_row 2000 osquery-transient "$url" "$body_b64" # 503 -> defer
+  _osquery_store_alert_row 3000 osquery-permanent "$url" "$body_b64" # 403 -> dead-letter
+  _osquery_store_alert_row 4000 osquery-threshold "$url" "$body_b64" # attempts-maxed -> dead-letter pre-POST
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET attempts=99 WHERE request_id='osquery-threshold';"
+  _osquery_store_alert_row 5000 osquery-deliver-2 "$url" "$body_b64" # 2xx, LAST (behind every failure)
+  : >"$CURL_LOG"
+  : >"$ALERTER_LOG"
+  # POST order: deliver-1(200), transient(503), permanent(403), [threshold pre-POST skip], deliver-2(200).
+  set_curl_codes 200 503 403 200
+
+  retry_undelivered_alerts
+
+  # Both deliverables delivered, including the LAST row sitting behind every failure.
+  grep -qF 'X-Request-ID: osquery-deliver-1' "$CURL_LOG"
+  grep -qF 'X-Request-ID: osquery-deliver-2' "$CURL_LOG"
+  # Each failing row handled by its own class:
+  [[ "$(sqlite3_query "SELECT attempts FROM pending_alerts WHERE request_id='osquery-transient';")" == "1" ]]
+  [[ -n "$(sqlite3_query "SELECT 1 FROM dead_letter_alerts WHERE request_id='osquery-permanent';")" ]]
+  [[ -n "$(sqlite3_query "SELECT 1 FROM dead_letter_alerts WHERE request_id='osquery-threshold';")" ]]
+  ! grep -qF 'X-Request-ID: osquery-threshold' "$CURL_LOG" # pre-send give-up, never POSTed
+  # Final tallies: only the transient remains pending; two dead-lettered.
+  assert_pending_alert_count 1
+  [[ "$(sqlite3_query 'SELECT request_id FROM pending_alerts;')" == "osquery-transient" ]]
+  [[ "$(dead_letter_count)" == "2" ]]
+  # The whole queue was visited: four POSTs (the threshold row alone is pre-POST).
+  assert_post_count 4
+  # Exactly ONE summary CRIT for the pass (two dead-letters), not one per row.
+  wait_for_log_line 'dead-letter' "$ALERTER_LOG"
+  [[ "$(grep -ciF 'dead-letter' "$ALERTER_LOG")" == "1" ]]
+}
+
+@test "T-DRAIN-errexit-first-row-failure: under set -e a failing FIRST record does not abort the drain; the queue finishes and exit is 0" {
+  # The library is sourced into scripts that run under `set -euo pipefail` (the
+  # drainer executable). A failing FIRST record must not abort the pass: the
+  # per-row delivery runs inside an `if`, so its nonzero return is consumed and
+  # the loop keeps going. Runs the drain in a real errexit subshell to prove it.
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-poison-first "$url" "$body_b64"
+  _osquery_store_alert_row 2000 osquery-tail "$url" "$body_b64"
+  : >"$CURL_LOG"
+  set_curl_codes 403 200 # first row refused (dead-letter), tail delivers
+
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]     # the drain did not abort on the first failing record
+  [[ $output == *DONE* ]] # ...and ran to completion
+
+  grep -qF 'X-Request-ID: osquery-tail' "$CURL_LOG" # the tail behind the poison delivered
+  assert_pending_alert_count 0
+  [[ "$(dead_letter_count)" == "1" ]] # the first record was dead-lettered, not retried forever
+}

--- a/test/integration/osquery-queue-counts-wal.sh
+++ b/test/integration/osquery-queue-counts-wal.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# The queue-health counters must count CORRECTLY against a live WAL-mode store:
+# a reader has to see rows that are committed but still in the write-ahead log,
+# not yet checkpointed back into the main database file. This is exactly the
+# state a busy store is in between the drain's writes and the next checkpoint, so
+# a counter that missed WAL rows would under-report a backed-up queue and the
+# watchdog would read a degraded pipeline as healthy.
+#
+# The counters use a plain `sqlite3 -readonly` connection, which reads committed
+# WAL frames like any reader. An `immutable=1` open would skip the WAL and miss
+# them; this test would catch that regression (verified by the reviewer). It
+# stands up a real WAL database, keeps a concurrent connection OPEN so the
+# committed frames stay in the -wal uncheckpointed, and asserts the counts.
+#
+# Integration, not unit: it holds a live second database connection (a coproc)
+# to keep the WAL uncheckpointed. The synchronization is a blocking read on that
+# connection's output, so there is no sleep and no flakiness.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCH="$REPO_ROOT/dot_local/libexec/osquery/executable_alert-dispatch.sh"
+
+fail() {
+  printf 'osquery-queue-counts-wal: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH; cannot exercise the WAL counters\n'
+  exit 0
+}
+[[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
+
+work="$(mktemp -d)"
+export OSQUERY_UNDELIVERED_ALERTS_DB="$work/undelivered.sqlite3"
+
+# shellcheck source=/dev/null
+source "$DISPATCH"
+
+assert_eq() { # <expected> <actual> <context>
+  [[ $2 == "$1" ]] || fail "$3: expected '$1', got '$2'"
+}
+
+# Keep DB-absent no-create coverage here too (the read-only probe must not create
+# the file when it does not exist yet).
+if [[ -e $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+  fail "precondition: the DB should not exist yet"
+fi
+assert_eq 0 "$(osquery_pending_alert_count)" "no DB: pending count"
+if [[ -e $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+  fail "a read-only count probe created the DB file"
+fi
+
+# Stand up a WAL-mode store and hold a connection OPEN via a coproc so the
+# close-time checkpoint never runs and the committed rows stay in the -wal.
+coproc HOLDER { sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>&1; }
+holder_pid=$HOLDER_PID
+cleanup() {
+  printf '.quit\n' >&"${HOLDER[1]}" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+{
+  printf 'PRAGMA journal_mode=WAL;\n'
+  printf 'PRAGMA wal_autocheckpoint=0;\n'
+  printf 'CREATE TABLE pending_alerts (request_id TEXT, next_attempt_after INTEGER);\n'
+  printf 'CREATE TABLE dead_letter_alerts (request_id TEXT);\n'
+  printf "INSERT INTO pending_alerts (request_id, next_attempt_after) VALUES ('a', 0), ('b', 0), ('c', 0);\n"
+  printf "INSERT INTO dead_letter_alerts (request_id) VALUES ('x'), ('y');\n"
+  printf "SELECT 'SYNC-DONE';\n"
+} >&"${HOLDER[1]}"
+
+# Block until the holder reports it applied the inserts: deterministic, no sleep.
+# By the time SYNC-DONE arrives the rows are committed into the WAL, and the
+# holder still owns the connection, so no checkpoint has folded them away.
+sync_seen=0
+while IFS= read -r line <&"${HOLDER[0]}"; do
+  if [[ $line == *SYNC-DONE* ]]; then
+    sync_seen=1
+    break
+  fi
+done
+[[ $sync_seen -eq 1 ]] || fail "the WAL holder never confirmed its inserts"
+
+# The committed frames really are in an uncheckpointed -wal companion file.
+if [[ ! -s "$OSQUERY_UNDELIVERED_ALERTS_DB-wal" ]]; then
+  fail "expected a non-empty -wal (committed-but-uncheckpointed frames), found none"
+fi
+
+# The read-only counters see the committed WAL rows.
+assert_eq 3 "$(osquery_pending_alert_count)" "live WAL: pending count"
+assert_eq 2 "$(osquery_dead_letter_count)" "live WAL: dead-letter count"
+
+printf 'osquery-queue-counts-wal: OK (counts committed-but-uncheckpointed WAL rows; read-only, no DB create)\n'

--- a/test/integration/osquery-queue-counts-wal.sh
+++ b/test/integration/osquery-queue-counts-wal.sh
@@ -55,9 +55,12 @@ fi
 # Stand up a WAL-mode store and hold a connection OPEN via a coproc so the
 # close-time checkpoint never runs and the committed rows stay in the -wal.
 coproc HOLDER { sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>&1; }
+# shellcheck disable=SC2153 # HOLDER_PID is assigned implicitly by the coproc above
 holder_pid=$HOLDER_PID
 cleanup() {
-  printf '.quit\n' >&"${HOLDER[1]}" 2>/dev/null || true
+  # The braces keep the fd duplication and the stderr silence as two separate
+  # redirections (a dead holder makes the printf fail; both are best-effort).
+  { printf '.quit\n' >&"${HOLDER[1]}"; } 2>/dev/null || true
   wait "$holder_pid" 2>/dev/null || true
   rm -rf "$work"
 }

--- a/test/unit/osquery-alert-drainer-launchagent.sh
+++ b/test/unit/osquery-alert-drainer-launchagent.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# The scheduled drainer LaunchAgent: com.webdavis.osquery-alert-drainer must run
+# the deployed drainer executable every 300 seconds WITHOUT running at load time
+# (loading the agent must never fire an immediate drain), and its loader
+# chezmoiscript must be wired exactly like the sibling osquery agents (darwin
+# gate, plist-hash onchange trigger, bootout + bootstrap with the retry loop).
+# Without this agent nothing drains the undelivered-alerts store on a schedule:
+# a page stored during a gateway outage waits for the next producer accident.
+#
+# Unit test: render the plist and loader templates with the host chezmoi and
+# assert their content. No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-alert-drainer-launchagent.sh.tmpl"
+
+fail() {
+  printf 'osquery-alert-drainer-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+
+# Render both templates exactly as at apply time. --source pins the render to
+# THIS checkout (hermetic), mirroring the sibling plist tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key>
+# with the value element on the FOLLOWING line, so match the key then its next
+# line (same helper shape as the homebrew-weekly plist test).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, schedule, program path, logs -------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-alert-drainer</string>'
+assert_plist_kv StartInterval '<integer>300</integer>'
+assert_plist_kv RunAtLoad '<false/>' # loading must never fire an immediate drain
+
+# ProgramArguments runs the DEPLOYED drainer from the libexec home (the
+# executable_ prefix is a source-side chezmoi convention; the target drops it).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/drain-undelivered-alerts.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/drain-undelivered-alerts.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/alert-drainer.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/alert-drainer.log</string>"
+
+# --- the loader: darwin gate, onchange trigger, bootout + bootstrap retry ----
+
+# The loader re-runs when the plist CONTENT changes: the plist-hash include line
+# is the onchange trigger, and it must name the drainer's own plist template.
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the drainer plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+
+# The rendered loader must target the drainer's label and plist, and keep the
+# sibling loaders' bootout-then-bootstrap shape with the retry loop. The
+# needles below are literal loader lines; $HOME and $(id -u) must NOT expand
+# here (same rule as the feature-set-location test's source-line needles).
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist"' ||
+  fail "rendered loader does not point at the drainer plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-alert-drainer"' ||
+  fail "rendered loader does not target the drainer label"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-alert-drainer-launchagent: OK (label + 300s interval + RunAtLoad false; loader gated, hashed, bootout+bootstrap with retry)\n'

--- a/test/unit/osquery-queue-counts.sh
+++ b/test/unit/osquery-queue-counts.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# The dispatch library exposes two read-only queue-health counters the watchdog
+# slice will poll: osquery_pending_alert_count (undelivered pages still waiting)
+# and osquery_dead_letter_count (pages the drain gave up on). Both must be robust
+# to a not-yet-created database or table -- a health probe reports zero before
+# anything has been stored, never an error -- and must be read-only (a probe must
+# never create the file, the schema, or a WAL sidecar).
+#
+# Unit test: source the real library against a throwaway DB path and pin the
+# missing-file, missing-table, and populated cases. No network, no drain, no
+# flows.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCH="$REPO_ROOT/dot_local/libexec/osquery/executable_alert-dispatch.sh"
+
+fail() {
+  printf 'osquery-queue-counts: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH; cannot exercise the counters\n'
+  exit 0
+}
+[[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+export OSQUERY_UNDELIVERED_ALERTS_DB="$work/undelivered.sqlite3"
+
+# shellcheck source=/dev/null
+source "$DISPATCH"
+
+assert_eq() { # <expected> <actual> <context>
+  [[ $2 == "$1" ]] || fail "$3: expected '$1', got '$2'"
+}
+
+# (a) The DB file does not exist yet: both counters read zero, no error, and the
+# read-only probe must not CREATE the database.
+if [[ -e $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+  fail "precondition: the DB should not exist yet"
+fi
+assert_eq 0 "$(osquery_pending_alert_count)" "no DB: pending count"
+assert_eq 0 "$(osquery_dead_letter_count)" "no DB: dead-letter count"
+if [[ -e $OSQUERY_UNDELIVERED_ALERTS_DB ]]; then
+  fail "a read-only count probe created the DB file"
+fi
+
+# (b) The DB exists but neither counted table does: still zero, no error.
+sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" 'CREATE TABLE unrelated (x);'
+assert_eq 0 "$(osquery_pending_alert_count)" "no table: pending count"
+assert_eq 0 "$(osquery_dead_letter_count)" "no table: dead-letter count"
+
+# (c) Seed N pending and M dead-lettered rows: the counters return N and M. Only
+# COUNT(*) is exercised, so minimal tables are enough.
+sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" <<'SQL'
+CREATE TABLE pending_alerts (request_id TEXT, next_attempt_after INTEGER);
+CREATE TABLE dead_letter_alerts (request_id TEXT);
+INSERT INTO pending_alerts (request_id, next_attempt_after) VALUES ('a', 0), ('b', 0), ('c', 0);
+INSERT INTO dead_letter_alerts (request_id) VALUES ('x'), ('y');
+SQL
+assert_eq 3 "$(osquery_pending_alert_count)" "seeded: pending count"
+assert_eq 2 "$(osquery_dead_letter_count)" "seeded: dead-letter count"
+
+printf 'osquery-queue-counts: OK (missing-DB, missing-table, and populated all counted read-only)\n'


### PR DESCRIPTION
## Context

The osquery security pipeline pages the operator through a local hermes gateway that forwards CRIT alerts to Discord. PR #59 (slice DR-A) made those pages durable: a page that cannot be delivered is stored as a row in a local SQLite queue and replayed later instead of being lost. DR-A left two gaps: nothing drained that queue on a schedule, and a permanently failing page would retry forever.

This PR is slice DR-B of the S9 re-land (the staged re-landing of the osquery delivery-robustness work onto main). It adds the scheduled drainer, dead-lettering with give-up thresholds, a randomized retry delay, and two queue-health counters that a later watchdog slice will poll.

## Summary

- A launchd agent now drains the undelivered-page queue every five minutes.
- Pages the gateway rejects outright (401, 403, 404, 413) dead-letter immediately.
- Pages past 20 attempts or 7 days of age dead-letter instead of retrying forever.
- A drain pass that dead-letters anything fires exactly one local alert, not one per page.
- Failed retries back off with a randomized delay, so a batch never retries in lockstep.
- New read-only counters expose queue depth and dead-letter totals for the watchdog.

Key files:

- `dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh`
- `Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist.tmpl`
- `dot_local/libexec/osquery/executable_alert-dispatch.sh`

## What changed

- The drainer executable sources the shared dispatch library, takes a single-instance kernel lock (`/usr/bin/lockf` on a held file descriptor), calls the retry drain, and always exits 0. Overlapping runs are serialized so no page is ever sent twice; a lock-setup failure skips the sweep rather than running unlocked; a host without `lockf` (the non-darwin fallback) proceeds unlocked by design.
- The LaunchAgent (`StartInterval` 300, `RunAtLoad` false) and its loader chezmoiscript mirror the three existing osquery agents, including the plist-hash onchange trigger and the bootout-then-bootstrap retry loop.
- The dispatch library now classifies each failed POST by its HTTP (Hypertext Transfer Protocol) status: transient failures (429, 5xx, transport errors) increment an attempts counter and schedule a future retry; permanent statuses move the row to a new `dead_letter_alerts` table in one transaction, with the status recorded in a reason column. Rows past the attempt or age ceiling dead-letter before any send. Both ceilings and the retry base are environment-overridable.
- The retry schedule adds a bounded random offset (default bounded by the base) so rows that failed together come back staggered. Setting the bound to 0 restores a fully deterministic schedule.
- Two public helpers, `osquery_pending_alert_count` and `osquery_dead_letter_count`, print bare row counts over a read-only connection. They read committed rows still sitting in the WAL (write-ahead logging) journal, return 0 when the database or table does not exist yet, and never create either.
- 19 new tests across six files cover the lock (including overlap and fail-closed setup), the rendered plist and loader, failure classification, thresholds, the single-alert-per-pass rule, head-of-line continuation, the randomized delay, and counter correctness against a live WAL store.

## Effect of merging

- Merging to main has no live-machine impact. The machine (dresden) applies its dotfiles from `integration/modernization` until the D1 cutover, so the new LaunchAgent, loader, and drainer reach a running system only when that branch picks these commits up.
- Producer scripts and the `send_alert` contract are unchanged; the schema change is additive (one new table, no altered columns), so existing queues keep working.
