### PR TITLE
feat(osquery): durable local notifications with confirmed delivery and staleness policy (S9 DR-C)

### DIFF
--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -558,20 +558,45 @@ _notify_locally() {
   fi
 }
 
-# Fire ONE loud, interruptive local notification. Used when a page can be neither
-# delivered NOR durably stored: the operator MUST learn that a CRITICAL alert was
-# lost, because a dropped page leaves no trace and would otherwise read as good
-# news. If no notifier is available or the notification itself fails, nothing
-# further happens and the function still returns 0: the dispatch flow continues,
-# already in its worst case, and must not break over a notifier problem.
+# Fire ONE loud, interruptive local notification and report a TRUTHFUL outcome:
+# 0 when the notifier was successfully invoked (the banner posted, or posted and
+# already resolved), nonzero when no notifier exists or the invocation failed.
+# Used when a page can be neither delivered NOR durably stored: the operator
+# MUST learn that a CRITICAL alert was lost, because a dropped page leaves no
+# trace and would otherwise read as good news. The status is the seam durable
+# local notifications build on; a caller that cannot act on a failure guards
+# the call (|| true), a failed banner must never break the dispatch flow.
+#
+# alerter semantics (verified on 26.5): the process lives for the banner's
+# WHOLE lifetime and exits only when the banner resolves (dismissed, clicked,
+# or timed out, exit 0 in every resolved case), while a FAILED invocation exits
+# fast and nonzero (e.g. usage error 64 in ~10ms). There is no post-and-exit
+# mode, so waiting for the exit would block a caller for up to the 60-second
+# banner life, unacceptable inside a drain pass. The bounded grace window below
+# tells the two shapes apart without that wait: a process that DIED inside the
+# window reports its own exit code (nonzero = failed invocation; 0 = posted and
+# already resolved), and one still ALIVE after the window has its banner up,
+# which is success, so it is left running exactly as before.
 _loud_local() {
   local title="$1" message="$2"
   if command -v alerter >/dev/null 2>&1; then
     alerter --timeout 60 --title "$title" --message "$message" --sound Funk >/dev/null 2>&1 &
-  else
-    local escaped=${message//\"/\\\"}
-    osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1 || true
+    local notifier_pid=$!
+    for _ in 1 2 3 4 5 6; do
+      kill -0 "$notifier_pid" 2>/dev/null || break
+      sleep 0.1 2>/dev/null || sleep 1
+    done
+    if kill -0 "$notifier_pid" 2>/dev/null; then
+      return 0 # still alive after the window: the banner is up on screen
+    fi
+    local notifier_status=0
+    wait "$notifier_pid" 2>/dev/null || notifier_status=$?
+    return "$notifier_status"
   fi
+  # osascript posts the notification and returns immediately, so its own exit
+  # status IS the outcome; an absent osascript is command-not-found (nonzero).
+  local escaped=${message//\"/\\\"}
+  osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1
 }
 
 # Print the webhook signing key: the environment override when set, otherwise
@@ -621,8 +646,11 @@ retry_undelivered_alerts() {
   [[ $dead_letter_count =~ ^[0-9]+$ ]] || dead_letter_count=0
   if ((dead_letter_count > 0)); then
     _osquery_log "PIPELINE-DEGRADED $dead_letter_count record(s) dead-lettered this drain pass"
+    # _loud_local now reports a truthful status; this caller cannot act on a
+    # failed banner yet (durable local notifications consume it later), and a
+    # failed banner must never abort the drain, so the status is discarded.
     _loud_local "osquery alert delivery pipeline degraded" \
-      "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention."
+      "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention." || true
   fi
   return 0
 }
@@ -750,8 +778,11 @@ send_alert() {
   # stored, and the caller must not advance its cursor past it.
   if ! _store_undelivered_alert "$occurrence_timestamp" "$request_id" "$url" "$body"; then
     _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB)"
+    # The banner status is discarded here (guarded for errexit callers): this
+    # path is already the worst case, and the nonzero return below is the
+    # caller's real signal that the page was lost.
     _loud_local "osquery paging FAILED, page LOST" \
-      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB."
+      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB." || true
     return 1
   fi
 
@@ -762,8 +793,10 @@ send_alert() {
   secret="$(_read_webhook_secret)"
   if [[ -z $secret ]]; then
     _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
+    # Banner status discarded (guarded for errexit callers): the page is safely
+    # stored, so a failed banner here costs visibility, not the page.
     _loud_local "osquery Discord paging BROKEN" \
-      "No webhook secret. This page was stored locally and delivers when the secret is restored."
+      "No webhook secret. This page was stored locally and delivers when the secret is restored." || true
     return 0
   fi
 

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -174,9 +174,11 @@ _osquery_alerts_db_exec() {
 # producers, and serves as the skew-proof drain-order tiebreaker. attempts and
 # next_attempt_after are written by DR-A but consumed by DR-B; storing them now
 # avoids a schema migration one slice later. The text fields are single-quoted
-# with any embedded quote doubled; the values are non-secret and quote-free by
-# construction (a hex request id, a base64 body, a fixed localhost url), and
-# the escape keeps the statement injection-safe regardless.
+# with any embedded quote doubled via $single_quote (see the escape note on
+# that variable below); the values are non-secret and quote-free by
+# construction today (a hex request id, a base64 body, a localhost url), and
+# the escape now really does keep a quote-carrying value intact if that ever
+# changes (the URL comes from the environment, so it can carry one).
 _osquery_store_alert_row() {
   local occurrence_timestamp="$1" request_id="$2" url="$3" encoded_body="$4" created_at database_directory
   database_directory="$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
@@ -184,10 +186,15 @@ _osquery_store_alert_row() {
   chmod 700 "$database_directory" 2>/dev/null || true
   created_at="$(date -u +%s)"
   [[ $created_at =~ ^[0-9]+$ ]] || created_at=0
+  # Quote doubling via a helper variable: the inline spellings go wrong (an
+  # unquoted \' pattern keeps its backslash in the replacement under bash 3.2,
+  # the macOS system bash, and nested double quotes land literally), verified
+  # both ways; $single_quote expands identically on every bash.
+  local single_quote="'"
   local request_id_sql url_sql body_sql
-  request_id_sql="${request_id//\'/\'\'}"
-  url_sql="${url//\'/\'\'}"
-  body_sql="${encoded_body//\'/\'\'}"
+  request_id_sql="${request_id//$single_quote/$single_quote$single_quote}"
+  url_sql="${url//$single_quote/$single_quote$single_quote}"
+  body_sql="${encoded_body//$single_quote/$single_quote$single_quote}"
   if ! printf "BEGIN IMMEDIATE;
 CREATE TABLE IF NOT EXISTS pending_alerts (
   sequence_number    INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -301,7 +308,9 @@ _osquery_record_transient_failure() {
   [[ $random_max =~ ^[0-9]+$ ]] || random_max="$base"
   local random_offset=0
   ((random_max > 0)) && random_offset=$((RANDOM % (random_max + 1)))
-  local request_id_sql="${request_id//\'/\'\'}"
+  # Quote doubling via $single_quote: bash-version-safe (see _osquery_store_alert_row).
+  local single_quote="'"
+  local request_id_sql="${request_id//$single_quote/$single_quote$single_quote}"
   printf "UPDATE pending_alerts
   SET attempts = attempts + 1,
       next_attempt_after = CAST(strftime('%%s','now') AS INTEGER) + %s * (attempts + 1) + %s
@@ -321,9 +330,11 @@ _osquery_dead_letter_alert_row() { # <request_id> <last_http_status> <reason>
   local request_id="$1" last_http_status="$2" reason="$3" dead_lettered_at
   dead_lettered_at="$(date -u +%s)"
   [[ $dead_lettered_at =~ ^[0-9]+$ ]] || dead_lettered_at=0
-  local request_id_sql="${request_id//\'/\'\'}"
-  local status_sql="${last_http_status//\'/\'\'}"
-  local reason_sql="${reason//\'/\'\'}"
+  # Quote doubling via $single_quote: bash-version-safe (see _osquery_store_alert_row).
+  local single_quote="'"
+  local request_id_sql="${request_id//$single_quote/$single_quote$single_quote}"
+  local status_sql="${last_http_status//$single_quote/$single_quote$single_quote}"
+  local reason_sql="${reason//$single_quote/$single_quote$single_quote}"
   printf "BEGIN IMMEDIATE;
 CREATE TABLE IF NOT EXISTS dead_letter_alerts (
   sequence_number    INTEGER PRIMARY KEY,
@@ -432,7 +443,9 @@ _osquery_alert_row_count() { # <table>
 _osquery_delete_alert_row() {
   local request_id="$1"
   [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 0
-  local request_id_sql="${request_id//\'/\'\'}"
+  # Quote doubling via $single_quote: bash-version-safe (see _osquery_store_alert_row).
+  local single_quote="'"
+  local request_id_sql="${request_id//$single_quote/$single_quote$single_quote}"
   printf "DELETE FROM pending_alerts WHERE request_id = '%s';\n" "$request_id_sql" | _osquery_alerts_db_exec
 }
 

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -689,10 +689,19 @@ _loud_local() {
   # The optional third argument is the notification sound; empty or absent
   # falls back to Funk (the historical loud-path sound), so two-argument
   # callers keep their exact old behavior while the local-notification retry
-  # can replay a stored row's own sound.
-  local title="$1" message="$2" sound="${3:-Funk}"
+  # can replay a stored row's own sound. The optional fourth argument is a
+  # SUBTITLE, used by the drain retry path to render the occurrence time into
+  # a late banner; empty or absent means no subtitle line at all, so every
+  # existing caller's banner is byte-identical. Both notifier channels support
+  # it (alerter --subtitle per its help; osascript display notification's
+  # subtitle clause, verified to parse and post).
+  local title="$1" message="$2" sound="${3:-Funk}" subtitle="${4-}"
   if command -v alerter >/dev/null 2>&1; then
-    alerter --timeout 60 --title "$title" --message "$message" --sound "$sound" >/dev/null 2>&1 &
+    local alerter_arguments=(--timeout 60 --title "$title" --message "$message" --sound "$sound")
+    if [[ -n $subtitle ]]; then
+      alerter_arguments+=(--subtitle "$subtitle")
+    fi
+    alerter "${alerter_arguments[@]}" >/dev/null 2>&1 &
     local notifier_pid=$!
     for _ in 1 2 3 4 5 6; do
       kill -0 "$notifier_pid" 2>/dev/null || break
@@ -707,8 +716,15 @@ _loud_local() {
   fi
   # osascript posts the notification and returns immediately, so its own exit
   # status IS the outcome; an absent osascript is command-not-found (nonzero).
+  # The clause order (title, subtitle, sound name) is the verified-parsing one.
   local escaped=${message//\"/\\\"}
-  osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"$sound\"" >/dev/null 2>&1
+  local osascript_command="display notification \"$escaped\" with title \"$title\""
+  if [[ -n $subtitle ]]; then
+    local escaped_subtitle=${subtitle//\"/\\\"}
+    osascript_command+=" subtitle \"$escaped_subtitle\""
+  fi
+  osascript_command+=" sound name \"$sound\""
+  osascript -e "$osascript_command" >/dev/null 2>&1
 }
 
 # Fire the loud local CRIT banner DURABLY: show it via _loud_local and, ONLY
@@ -762,19 +778,31 @@ _osquery_hex_to_text() {
 }
 
 # Print every DUE pending local notification as one tab-separated line
-# (notification_id, hex(title), hex(message), hex(sound)), ordered like the
-# alert drain: occurrence time first, sequence as the skew-proof tiebreaker,
-# and rows whose retry wait has not passed are left out. The id is hex-derived
-# (separator-safe); the text fields are hex-encoded IN SQL so embedded tabs or
-# newlines cannot garble the row format (decoded by _osquery_hex_to_text).
+# (notification_id, occurrence_ts, hex(title), hex(message), hex(sound)),
+# ordered like the alert drain: occurrence time first, sequence as the
+# skew-proof tiebreaker, and rows whose retry wait has not passed are left out.
+# The id is hex-derived and occurrence_ts an integer (both separator-safe); the
+# text fields are hex-encoded IN SQL so embedded tabs or newlines cannot garble
+# the row format (decoded by _osquery_hex_to_text). occurrence_ts rides along
+# for the age-out decision and the honest-timestamp subtitle.
 _osquery_pending_local_notification_rows() {
   {
     printf '.separator "\\t"\n'
-    printf "SELECT notification_id, hex(title), hex(message), hex(COALESCE(sound, ''))
+    printf "SELECT notification_id, occurrence_ts, hex(title), hex(message), hex(COALESCE(sound, ''))
   FROM pending_local_notifications
   WHERE next_attempt_after <= CAST(strftime('%%s','now') AS INTEGER)
   ORDER BY occurrence_ts, sequence_number;\n"
   } | _osquery_alerts_db_exec
+}
+
+# Render an epoch as UTC ISO 8601 (2026-07-22T01:15:00Z). BSD date (-r, the
+# macOS runtime) first, GNU date (-d @) as the fallback, so the helper works
+# under either userland. Prints nothing when both fail.
+_osquery_epoch_to_iso8601() {
+  local epoch="$1"
+  [[ $epoch =~ ^[0-9]+$ ]] || return 1
+  date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
 }
 
 # Delete one redelivered local notification's row, keyed by notification_id.
@@ -792,22 +820,63 @@ _osquery_delete_local_notification_row() {
     "$notification_id_sql" | _osquery_alerts_db_exec
 }
 
-# Re-attempt ONE stored local notification: decode the hex fields, banner via
-# _loud_local, delete the row when the banner was shown, and count the failed
-# attempt otherwise (same base + randomized-delay schedule as the alert queue).
+# Re-attempt ONE stored local notification: expire it when it is too old to
+# matter, otherwise decode the hex fields and banner via _loud_local WITH the
+# occurrence time as the subtitle, delete the row when the banner was shown,
+# and count the failed attempt otherwise (same base + randomized-delay schedule
+# as the alert queue).
+#
+# The two staleness behaviors live here. HONEST TIMESTAMPS: a banner shown
+# minutes or hours late must not read as breaking news, so the retry renders
+# "occurred <UTC ISO 8601>" into the banner (first-attempt banners are fresh
+# and stay unmarked). AGE-OUT: past OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS
+# (default 86400, one day) the row is DELETED with a loud LOCAL-NOTIFY-EXPIRED
+# line naming the id and its age, no banner attempt: the operator has long
+# since seen the durable Discord copy, so a day-old banner is pure noise.
+# There is deliberately NO dead_letter_local table: the local payload merely
+# duplicates content the durable webhook channel already carries, nothing would
+# ever consume such a table (the no-dead-state rule), and the loud log line IS
+# the forensic record. And NO attempts cap: at one attempt per scheduled tick,
+# age is the natural bound, an attempts knob would be a second knob doing the
+# same job. A row with a zero/invalid occurrence time (a clock glitch at
+# capture) cannot have its age known, so it is retried, never expired blind,
+# and gets no made-up timestamp subtitle.
+#
 # The local channel is the FALLBACK, so its failures are LOG LINES ONLY: never
 # a webhook CRIT, never a dead-letter tally entry, alerting the broken channel
 # through itself is noise. Always returns 0 (set -e-safe, skip-and-continue).
-_redeliver_pending_local_notification() { # <notification_id> <title_hex> <message_hex> <sound_hex>
-  local notification_id="$1" title message sound
-  title="$(_osquery_hex_to_text "$2")" || title=""
-  message="$(_osquery_hex_to_text "$3")" || message=""
-  sound="$(_osquery_hex_to_text "$4")" || sound=""
+_redeliver_pending_local_notification() { # <notification_id> <occurrence_ts> <title_hex> <message_hex> <sound_hex>
+  local notification_id="$1" occurrence_ts="$2" title message sound
+  local max_age="${OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS:-86400}"
+  [[ $max_age =~ ^[0-9]+$ ]] || max_age=86400
+  local now age
+  now="$(date -u +%s)"
+  [[ $now =~ ^[0-9]+$ ]] || now=0
+  if [[ $occurrence_ts =~ ^[0-9]+$ ]] && ((occurrence_ts > 0 && now > 0)); then
+    age=$((now - occurrence_ts))
+    if ((age > max_age)); then
+      if _osquery_delete_local_notification_row "$notification_id"; then
+        _osquery_log "LOCAL-NOTIFY-EXPIRED notification too old to matter, deleted unshown: notification_id=$notification_id age=${age}s (max ${max_age}s)"
+      else
+        _osquery_log "LOCAL-NOTIFY-EXPIRE-FAILED over-age row could not be deleted: notification_id=$notification_id age=${age}s (row retained)"
+      fi
+      return 0
+    fi
+  fi
+  title="$(_osquery_hex_to_text "$3")" || title=""
+  message="$(_osquery_hex_to_text "$4")" || message=""
+  sound="$(_osquery_hex_to_text "$5")" || sound=""
   if [[ -z $title && -z $message ]]; then
     _osquery_log "MALFORMED-ROW local sweep skipped an unreadable notification: notification_id=${notification_id:-unknown} (row retained)"
     return 0
   fi
-  if _loud_local "$title" "$message" "$sound"; then
+  # The honest-timestamp subtitle: a retried banner names when its event
+  # actually occurred. An unrenderable time means no subtitle, never a made-up one.
+  local occurred_subtitle="" occurred_iso8601
+  if occurred_iso8601="$(_osquery_epoch_to_iso8601 "$occurrence_ts")" && [[ -n $occurred_iso8601 ]]; then
+    occurred_subtitle="occurred $occurred_iso8601"
+  fi
+  if _loud_local "$title" "$message" "$sound" "$occurred_subtitle"; then
     _osquery_delete_local_notification_row "$notification_id" ||
       _osquery_log "LOCAL-NOTIFY-DELETE-FAILED shown banner kept its row: notification_id=$notification_id (a later sweep re-banners it)"
     return 0
@@ -825,12 +894,12 @@ _redeliver_pending_local_notification() { # <notification_id> <title_hex> <messa
 # behind it. Never returns nonzero (set -e-safe).
 _drain_pending_local_notifications() {
   _osquery_table_exists pending_local_notifications || return 0
-  local rows notification_id title_hex message_hex sound_hex
+  local rows notification_id occurrence_ts title_hex message_hex sound_hex
   rows="$(_osquery_pending_local_notification_rows)" || return 0
   [[ -n $rows ]] || return 0
-  while IFS=$'\t' read -r notification_id title_hex message_hex sound_hex; do
+  while IFS=$'\t' read -r notification_id occurrence_ts title_hex message_hex sound_hex; do
     [[ -n $notification_id ]] || continue
-    _redeliver_pending_local_notification "$notification_id" "$title_hex" "$message_hex" "$sound_hex"
+    _redeliver_pending_local_notification "$notification_id" "$occurrence_ts" "$title_hex" "$message_hex" "$sound_hex"
   done <<<"$rows"
   return 0
 }

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -159,6 +159,21 @@ _osquery_alerts_db_exec() {
   return "$sqlite3_status"
 }
 
+# Report (by exit status) whether the named table exists in the alert store.
+# Both drain sweeps gate on this before their row SELECT: each of the two
+# queues bootstraps its table lazily on first store, so a database created by
+# one queue may legitimately lack the other's table, and a bare SELECT against
+# the missing one would spray a "no such table" error to stderr on every
+# scheduled pass. The table name is a fixed internal literal at every call
+# site, never caller data.
+_osquery_table_exists() { # <table>
+  local table="$1" found
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 1
+  found="$(printf "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='%s';\n" "$table" |
+    _osquery_alerts_db_exec)" || return 1
+  [[ $found == "1" ]]
+}
+
 # Persist one undelivered page as a pending_alerts row and report success. The
 # lazy schema bootstrap and THIS alert's INSERT run in ONE atomic sqlite3 batch
 # (BEGIN IMMEDIATE ... COMMIT), so a crash or kill at any instant leaves either
@@ -302,7 +317,18 @@ COMMIT;\n" \
 # failed update is reported nonzero for the caller to log but never fail on: the
 # row is still pending, and the only cost is a retry that comes sooner.
 _osquery_record_transient_failure() {
-  local request_id="$1" base="${OSQUERY_DRAIN_RETRY_BASE_SECONDS:-60}"
+  _osquery_record_retry_failure pending_alerts request_id "$1"
+}
+
+# The shared bookkeeping UPDATE behind _osquery_record_transient_failure (the
+# alert queue) and _osquery_record_local_notify_failure (the local-notification
+# queue): both queues wait out the same base plus randomized-delay schedule, so
+# the knob parsing and the atomic UPDATE live once. The table and key column
+# are FIXED INTERNAL LITERALS at the two call sites, never caller data, so
+# interpolating them into the SQL adds no injection surface.
+_osquery_record_retry_failure() { # <table> <key_column> <key_value>
+  local table="$1" key_column="$2" key_value="$3"
+  local base="${OSQUERY_DRAIN_RETRY_BASE_SECONDS:-60}"
   [[ $base =~ ^[0-9]+$ ]] || base=60
   local random_max="${OSQUERY_DRAIN_RETRY_RANDOM_SECONDS:-$base}"
   [[ $random_max =~ ^[0-9]+$ ]] || random_max="$base"
@@ -310,11 +336,17 @@ _osquery_record_transient_failure() {
   ((random_max > 0)) && random_offset=$((RANDOM % (random_max + 1)))
   # Quote doubling via $single_quote: bash-version-safe (see _osquery_store_alert_row).
   local single_quote="'"
-  local request_id_sql="${request_id//$single_quote/$single_quote$single_quote}"
-  printf "UPDATE pending_alerts
+  local key_value_sql="${key_value//$single_quote/$single_quote$single_quote}"
+  printf "UPDATE %s
   SET attempts = attempts + 1,
       next_attempt_after = CAST(strftime('%%s','now') AS INTEGER) + %s * (attempts + 1) + %s
-  WHERE request_id = '%s';\n" "$base" "$random_offset" "$request_id_sql" | _osquery_alerts_db_exec
+  WHERE %s = '%s';\n" "$table" "$base" "$random_offset" "$key_column" "$key_value_sql" | _osquery_alerts_db_exec
+}
+
+# Count the attempt on one still-failing local notification and push its next
+# banner try into the future (same knobs and schedule as the alert queue).
+_osquery_record_local_notify_failure() {
+  _osquery_record_retry_failure pending_local_notifications notification_id "$1"
 }
 
 # Move one pending row into the dead_letter_alerts table, in ONE transaction:
@@ -549,6 +581,12 @@ _deliver_pending_alert_row() {
 # loop, and the loop keeps going past a failing row (skip-and-continue).
 _drain_pending_alert_rows() {
   local secret="$1" rows request_id url encoded_body attempts created_at dead_letter_count=0
+  # A database created by the local-notification queue alone legitimately has
+  # no pending_alerts table yet; that is an empty alert queue, not an error.
+  _osquery_table_exists pending_alerts || {
+    printf '0'
+    return 0
+  }
   rows="$(_osquery_pending_alert_rows)" || {
     printf '0'
     return 0
@@ -648,9 +686,13 @@ _notify_locally() {
 # already resolved), and one still ALIVE after the window has its banner up,
 # which is success, so it is left running exactly as before.
 _loud_local() {
-  local title="$1" message="$2"
+  # The optional third argument is the notification sound; empty or absent
+  # falls back to Funk (the historical loud-path sound), so two-argument
+  # callers keep their exact old behavior while the local-notification retry
+  # can replay a stored row's own sound.
+  local title="$1" message="$2" sound="${3:-Funk}"
   if command -v alerter >/dev/null 2>&1; then
-    alerter --timeout 60 --title "$title" --message "$message" --sound Funk >/dev/null 2>&1 &
+    alerter --timeout 60 --title "$title" --message "$message" --sound "$sound" >/dev/null 2>&1 &
     local notifier_pid=$!
     for _ in 1 2 3 4 5 6; do
       kill -0 "$notifier_pid" 2>/dev/null || break
@@ -666,7 +708,7 @@ _loud_local() {
   # osascript posts the notification and returns immediately, so its own exit
   # status IS the outcome; an absent osascript is command-not-found (nonzero).
   local escaped=${message//\"/\\\"}
-  osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1
+  osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"$sound\"" >/dev/null 2>&1
 }
 
 # Fire the loud local CRIT banner DURABLY: show it via _loud_local and, ONLY
@@ -706,6 +748,93 @@ _osquery_notify_local_durable() { # <title> <message> [notification_seed]
   return 0
 }
 
+# Decode a stream of hex byte pairs (sqlite3's hex() output) back to text.
+# The local-notification export hex-encodes its text columns because title and
+# message are arbitrary operator-facing text: a tab or newline inside them
+# would garble a separator-based row format, while hex output is [0-9A-F] only,
+# separator-safe by construction. sed turns each pair into a \xHH escape and
+# printf %b decodes them; both are boring system tools available everywhere
+# this library runs.
+_osquery_hex_to_text() {
+  local hex_text="$1"
+  [[ -n $hex_text ]] || return 0
+  printf '%b' "$(printf '%s' "$hex_text" | sed 's/../\\x&/g')"
+}
+
+# Print every DUE pending local notification as one tab-separated line
+# (notification_id, hex(title), hex(message), hex(sound)), ordered like the
+# alert drain: occurrence time first, sequence as the skew-proof tiebreaker,
+# and rows whose retry wait has not passed are left out. The id is hex-derived
+# (separator-safe); the text fields are hex-encoded IN SQL so embedded tabs or
+# newlines cannot garble the row format (decoded by _osquery_hex_to_text).
+_osquery_pending_local_notification_rows() {
+  {
+    printf '.separator "\\t"\n'
+    printf "SELECT notification_id, hex(title), hex(message), hex(COALESCE(sound, ''))
+  FROM pending_local_notifications
+  WHERE next_attempt_after <= CAST(strftime('%%s','now') AS INTEGER)
+  ORDER BY occurrence_ts, sequence_number;\n"
+  } | _osquery_alerts_db_exec
+}
+
+# Delete one redelivered local notification's row, keyed by notification_id.
+# Called only after _loud_local reported the banner shown. A missing DB is a
+# clean no-op; a failed delete is reported nonzero for the caller to log, never
+# fail on (the banner was shown; a leaked row costs one duplicate banner on a
+# later sweep).
+_osquery_delete_local_notification_row() {
+  local notification_id="$1"
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 0
+  # Quote doubling via $single_quote: bash-version-safe (see _osquery_store_alert_row).
+  local single_quote="'"
+  local notification_id_sql="${notification_id//$single_quote/$single_quote$single_quote}"
+  printf "DELETE FROM pending_local_notifications WHERE notification_id = '%s';\n" \
+    "$notification_id_sql" | _osquery_alerts_db_exec
+}
+
+# Re-attempt ONE stored local notification: decode the hex fields, banner via
+# _loud_local, delete the row when the banner was shown, and count the failed
+# attempt otherwise (same base + randomized-delay schedule as the alert queue).
+# The local channel is the FALLBACK, so its failures are LOG LINES ONLY: never
+# a webhook CRIT, never a dead-letter tally entry, alerting the broken channel
+# through itself is noise. Always returns 0 (set -e-safe, skip-and-continue).
+_redeliver_pending_local_notification() { # <notification_id> <title_hex> <message_hex> <sound_hex>
+  local notification_id="$1" title message sound
+  title="$(_osquery_hex_to_text "$2")" || title=""
+  message="$(_osquery_hex_to_text "$3")" || message=""
+  sound="$(_osquery_hex_to_text "$4")" || sound=""
+  if [[ -z $title && -z $message ]]; then
+    _osquery_log "MALFORMED-ROW local sweep skipped an unreadable notification: notification_id=${notification_id:-unknown} (row retained)"
+    return 0
+  fi
+  if _loud_local "$title" "$message" "$sound"; then
+    _osquery_delete_local_notification_row "$notification_id" ||
+      _osquery_log "LOCAL-NOTIFY-DELETE-FAILED shown banner kept its row: notification_id=$notification_id (a later sweep re-banners it)"
+    return 0
+  fi
+  _osquery_record_local_notify_failure "$notification_id" ||
+    _osquery_log "LOCAL-NOTIFY-BOOKKEEPING-FAILED attempts not recorded: notification_id=$notification_id (the row simply retries sooner)"
+  _osquery_log "LOCAL-NOTIFY-RETRY-FAILED banner still failing: notification_id=$notification_id (row retained)"
+  return 0
+}
+
+# Sweep the stored local notifications: re-banner every DUE row in occurrence
+# order. Runs from the same scheduled drain as the alert queue (one liveness
+# owner, one lock). A missing table (nothing ever captured), a query failure,
+# or an empty queue is a quiet no-op; a failing row never blocks the rows
+# behind it. Never returns nonzero (set -e-safe).
+_drain_pending_local_notifications() {
+  _osquery_table_exists pending_local_notifications || return 0
+  local rows notification_id title_hex message_hex sound_hex
+  rows="$(_osquery_pending_local_notification_rows)" || return 0
+  [[ -n $rows ]] || return 0
+  while IFS=$'\t' read -r notification_id title_hex message_hex sound_hex; do
+    [[ -n $notification_id ]] || continue
+    _redeliver_pending_local_notification "$notification_id" "$title_hex" "$message_hex" "$sound_hex"
+  done <<<"$rows"
+  return 0
+}
+
 # Print the webhook signing key: the environment override when set, otherwise
 # the first line of the notifier's own secret file with any carriage return
 # stripped (so a CRLF file cannot corrupt the key). Prints nothing when no key
@@ -740,6 +869,13 @@ _post_alert_to_webhook() { # <url> <request_id> <signature> <body>
 # a detection outage).
 retry_undelivered_alerts() {
   [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 0
+  # Sweep the stored LOCAL notifications FIRST, and before the secret gate
+  # below (a banner needs no webhook secret). Local-first ordering matters:
+  # the alert drain's degraded-pipeline CRIT can persist a NEW local row
+  # mid-pass (via _osquery_notify_local_durable), and with the local sweep
+  # already done that fresh row simply waits for the next scheduled tick
+  # instead of being attempted twice in one pass.
+  _drain_pending_local_notifications
   local secret
   secret="$(_read_webhook_secret)"
   [[ -n $secret ]] || return 0

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -873,49 +873,62 @@ _osquery_delete_local_notification_row() {
     "$notification_id_sql" | _osquery_alerts_db_exec
 }
 
-# Re-attempt ONE stored local notification: expire it when it is too old to
-# matter, otherwise decode the hex fields and banner via _loud_local WITH the
-# occurrence time as the subtitle, delete the row when the banner was shown,
-# and count the failed attempt otherwise (same base + randomized-delay schedule
-# as the alert queue).
+# Expire every local notification too old to matter, INDEPENDENTLY of the
+# due-row filter: a row sitting in retry backoff (next_attempt_after in the
+# future) is invisible to the due sweep, and without this pass it would
+# silently outlive its own age ceiling. Past
+# OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS (default 86400, one day) the row is
+# DELETED unshown with a loud LOCAL-NOTIFY-EXPIRED line naming the id and its
+# age: the operator has long since seen the durable Discord copy, so a day-old
+# banner is pure noise. There is deliberately NO dead_letter_local table: the
+# local payload merely duplicates content the durable webhook channel already
+# carries, nothing would ever consume such a table (the no-dead-state rule),
+# and the loud log line IS the forensic record. And NO attempts cap: at one
+# attempt per scheduled tick, age is the natural bound, an attempts knob would
+# be a second knob doing the same job. A row with a zero occurrence time (a
+# clock glitch at capture) has an unknowable age and is never expired blind.
+# The age arithmetic and the over-age selection live in ONE SQL statement, so
+# the decision is race-free and the exported fields (a hex-derived id and an
+# integer age) are separator-safe. Never returns nonzero (set -e-safe).
+_osquery_expire_over_age_local_notifications() {
+  local max_age="${OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS:-86400}"
+  [[ $max_age =~ ^[0-9]+$ ]] || max_age=86400
+  local rows notification_id age
+  rows="$({
+    printf '.separator "\\t"\n'
+    printf "SELECT notification_id, (CAST(strftime('%%s','now') AS INTEGER) - occurrence_ts)
+  FROM pending_local_notifications
+  WHERE occurrence_ts > 0
+    AND (CAST(strftime('%%s','now') AS INTEGER) - occurrence_ts) > %s;\n" "$max_age"
+  } | _osquery_alerts_db_exec)" || return 0
+  [[ -n $rows ]] || return 0
+  while IFS=$'\t' read -r notification_id age; do
+    [[ -n $notification_id ]] || continue
+    if _osquery_delete_local_notification_row "$notification_id"; then
+      _osquery_log "LOCAL-NOTIFY-EXPIRED notification too old to matter, deleted unshown: notification_id=$notification_id age=${age}s (max ${max_age}s)"
+    else
+      _osquery_log "LOCAL-NOTIFY-EXPIRE-FAILED over-age row could not be deleted: notification_id=$notification_id age=${age}s (row retained)"
+    fi
+  done <<<"$rows"
+  return 0
+}
+
+# Re-attempt ONE stored local notification: decode the hex fields, banner via
+# the confirmed-delete path WITH the occurrence time as the subtitle, and count
+# a fast failure (same base + randomized-delay schedule as the alert queue).
+# Age-out happens BEFORE this in the sweep's independent expiry pass, so every
+# row reaching here is young enough to show.
 #
-# The two staleness behaviors live here. HONEST TIMESTAMPS: a banner shown
-# minutes or hours late must not read as breaking news, so the retry renders
-# "occurred <UTC ISO 8601>" into the banner (first-attempt banners are fresh
-# and stay unmarked). AGE-OUT: past OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS
-# (default 86400, one day) the row is DELETED with a loud LOCAL-NOTIFY-EXPIRED
-# line naming the id and its age, no banner attempt: the operator has long
-# since seen the durable Discord copy, so a day-old banner is pure noise.
-# There is deliberately NO dead_letter_local table: the local payload merely
-# duplicates content the durable webhook channel already carries, nothing would
-# ever consume such a table (the no-dead-state rule), and the loud log line IS
-# the forensic record. And NO attempts cap: at one attempt per scheduled tick,
-# age is the natural bound, an attempts knob would be a second knob doing the
-# same job. A row with a zero/invalid occurrence time (a clock glitch at
-# capture) cannot have its age known, so it is retried, never expired blind,
-# and gets no made-up timestamp subtitle.
+# HONEST TIMESTAMPS: a banner shown minutes or hours late must not read as
+# breaking news, so the retry renders "occurred <UTC ISO 8601>" into the banner
+# (first-attempt banners are fresh and stay unmarked). An unrenderable
+# occurrence time gets no subtitle, never a made-up one.
 #
 # The local channel is the FALLBACK, so its failures are LOG LINES ONLY: never
 # a webhook CRIT, never a dead-letter tally entry, alerting the broken channel
 # through itself is noise. Always returns 0 (set -e-safe, skip-and-continue).
 _redeliver_pending_local_notification() { # <notification_id> <occurrence_ts> <title_hex> <message_hex> <sound_hex>
   local notification_id="$1" occurrence_ts="$2" title message sound
-  local max_age="${OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS:-86400}"
-  [[ $max_age =~ ^[0-9]+$ ]] || max_age=86400
-  local now age
-  now="$(date -u +%s)"
-  [[ $now =~ ^[0-9]+$ ]] || now=0
-  if [[ $occurrence_ts =~ ^[0-9]+$ ]] && ((occurrence_ts > 0 && now > 0)); then
-    age=$((now - occurrence_ts))
-    if ((age > max_age)); then
-      if _osquery_delete_local_notification_row "$notification_id"; then
-        _osquery_log "LOCAL-NOTIFY-EXPIRED notification too old to matter, deleted unshown: notification_id=$notification_id age=${age}s (max ${max_age}s)"
-      else
-        _osquery_log "LOCAL-NOTIFY-EXPIRE-FAILED over-age row could not be deleted: notification_id=$notification_id age=${age}s (row retained)"
-      fi
-      return 0
-    fi
-  fi
   title="$(_osquery_hex_to_text "$3")" || title=""
   message="$(_osquery_hex_to_text "$4")" || message=""
   sound="$(_osquery_hex_to_text "$5")" || sound=""
@@ -942,13 +955,15 @@ _redeliver_pending_local_notification() { # <notification_id> <occurrence_ts> <t
   return 0
 }
 
-# Sweep the stored local notifications: re-banner every DUE row in occurrence
-# order. Runs from the same scheduled drain as the alert queue (one liveness
-# owner, one lock). A missing table (nothing ever captured), a query failure,
-# or an empty queue is a quiet no-op; a failing row never blocks the rows
-# behind it. Never returns nonzero (set -e-safe).
+# Sweep the stored local notifications: first EXPIRE every over-age row
+# (independently of retry backoff, see the expiry pass), then re-banner every
+# DUE row in occurrence order. Runs from the same scheduled drain as the alert
+# queue (one liveness owner, one lock). A missing table (nothing ever
+# captured), a query failure, or an empty queue is a quiet no-op; a failing row
+# never blocks the rows behind it. Never returns nonzero (set -e-safe).
 _drain_pending_local_notifications() {
   _osquery_table_exists pending_local_notifications || return 0
+  _osquery_expire_over_age_local_notifications
   local rows notification_id occurrence_ts title_hex message_hex sound_hex
   rows="$(_osquery_pending_local_notification_rows)" || return 0
   [[ -n $rows ]] || return 0

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -213,6 +213,63 @@ COMMIT;\n" \
   return 0
 }
 
+# Persist one FAILED local notification as a pending_local_notifications row in
+# the SAME database as the alert queue (one store, one lock domain). Follows the
+# alert row's crash-safety rules exactly: the lazy schema bootstrap and THIS
+# insert commit in ONE atomic batch (BEGIN IMMEDIATE ... COMMIT), so no kill
+# window exists where the table was created but the notification vanished; the
+# batch is idempotent (INSERT OR IGNORE on the UNIQUE notification_id), so the
+# locked-database retry in _osquery_alerts_db_exec may replay it safely and a
+# re-store of the same notification stays one row. title, message, and sound
+# are arbitrary operator-facing text, so each is single-quoted with embedded
+# quotes doubled, the same injection-safe escape the alert rows use. Returns
+# nonzero on any persistence failure for the caller to LOG (never to fail on).
+_osquery_store_local_notification_row() { # <occurrence_ts> <notification_id> <title> <message> <sound>
+  local occurrence_timestamp="$1" notification_id="$2" title="$3" message="$4" sound="$5"
+  [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || return 1
+  [[ -n $notification_id ]] || return 1
+  local database_directory created_at
+  database_directory="$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+  mkdir -p "$database_directory" 2>/dev/null || return 1
+  chmod 700 "$database_directory" 2>/dev/null || true
+  created_at="$(date -u +%s)"
+  [[ $created_at =~ ^[0-9]+$ ]] || created_at=0
+  # Escape for a single-quoted SQL literal: every embedded quote is doubled.
+  # The quote lives in a helper variable because spelling it inline inside an
+  # already double-quoted expansion goes wrong in both directions: a \' pattern
+  # keeps its backslash in the replacement, and nested double quotes land as
+  # literal characters (both verified). $single_quote expands cleanly.
+  local single_quote="'"
+  local notification_id_sql="${notification_id//$single_quote/$single_quote$single_quote}"
+  local title_sql="${title//$single_quote/$single_quote$single_quote}"
+  local message_sql="${message//$single_quote/$single_quote$single_quote}"
+  local sound_sql="${sound//$single_quote/$single_quote$single_quote}"
+  if ! printf "BEGIN IMMEDIATE;
+CREATE TABLE IF NOT EXISTS pending_local_notifications (
+  sequence_number    INTEGER PRIMARY KEY AUTOINCREMENT,
+  notification_id    TEXT UNIQUE NOT NULL,
+  occurrence_ts      INTEGER NOT NULL,
+  title              TEXT NOT NULL,
+  message            TEXT NOT NULL,
+  sound              TEXT,
+  attempts           INTEGER NOT NULL DEFAULT 0,
+  next_attempt_after INTEGER NOT NULL DEFAULT 0,
+  created_at         INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO pending_local_notifications
+    (notification_id, occurrence_ts, title, message, sound, attempts, next_attempt_after, created_at)
+  VALUES
+    ('%s', %s, '%s', '%s', '%s', 0, 0, %s);
+COMMIT;\n" \
+    "$notification_id_sql" "$occurrence_timestamp" "$title_sql" "$message_sql" "$sound_sql" "$created_at" |
+    _osquery_alerts_db_exec; then
+    return 1
+  fi
+  [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || return 1
+  chmod 600 "$OSQUERY_UNDELIVERED_ALERTS_DB" 2>/dev/null || true
+  return 0
+}
+
 # Record one FAILED-but-retryable delivery attempt on a pending row: attempts
 # goes up by one and next_attempt_after moves into the future, so the drain
 # leaves the row alone until its wait has passed instead of hammering a failing
@@ -599,6 +656,43 @@ _loud_local() {
   osascript -e "display notification \"$escaped\" with title \"$title\" sound name \"Funk\"" >/dev/null 2>&1
 }
 
+# Fire the loud local CRIT banner DURABLY: show it via _loud_local and, ONLY
+# when the banner failed, persist it as a pending_local_notifications row so a
+# later drain can retry it (a lost CRIT banner otherwise reads as good news).
+# A shown banner touches no storage at all: the success path never bootstraps
+# the table and never creates the database. The optional third argument is a
+# stable identity seed for THIS notification (a caller with occurrence context
+# passes one, so a retried occurrence dedups to one row); absent, the identity
+# derives from title, message, and the capture time. The id is the seed's hash
+# (same shape as the alert request ids), so it is quote-free by construction.
+#
+# ALWAYS returns 0: the banner was either shown or captured for retry, and when
+# even the capture fails (storage broken) that is logged loudly
+# (LOCAL-NOTIFY-STORE-FAILED) but must never abort the caller, every caller is
+# already on its worst-case path when this fires.
+_osquery_notify_local_durable() { # <title> <message> [notification_seed]
+  local title="$1" message="$2" notification_seed="${3-}"
+  if _loud_local "$title" "$message"; then
+    return 0
+  fi
+  local occurrence_timestamp
+  occurrence_timestamp="$(date -u +%s)"
+  [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || occurrence_timestamp=0
+  [[ -n $notification_seed ]] || notification_seed="$title|$message|$occurrence_timestamp"
+  local notification_id
+  if ! notification_id="local-$(printf '%s' "$notification_seed" | _sha256_hex_of_stdin | cut -c1-32)" ||
+    [[ $notification_id == "local-" ]]; then
+    _osquery_log "LOCAL-NOTIFY-STORE-FAILED banner failed and no id could be derived (hasher broken); notification not persisted: $title"
+    return 0
+  fi
+  if _osquery_store_local_notification_row "$occurrence_timestamp" "$notification_id" "$title" "$message" "Funk"; then
+    _osquery_log "LOCAL-NOTIFY-STORED banner failed, persisted for retry: notification_id=$notification_id"
+  else
+    _osquery_log "LOCAL-NOTIFY-STORE-FAILED banner failed AND could not be persisted (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB): $title"
+  fi
+  return 0
+}
+
 # Print the webhook signing key: the environment override when set, otherwise
 # the first line of the notifier's own secret file with any carriage return
 # stripped (so a CRLF file cannot corrupt the key). Prints nothing when no key
@@ -646,11 +740,12 @@ retry_undelivered_alerts() {
   [[ $dead_letter_count =~ ^[0-9]+$ ]] || dead_letter_count=0
   if ((dead_letter_count > 0)); then
     _osquery_log "PIPELINE-DEGRADED $dead_letter_count record(s) dead-lettered this drain pass"
-    # _loud_local now reports a truthful status; this caller cannot act on a
-    # failed banner yet (durable local notifications consume it later), and a
-    # failed banner must never abort the drain, so the status is discarded.
-    _loud_local "osquery alert delivery pipeline degraded" \
-      "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention." || true
+    # Durable banner: shown, or captured for a later retry. No identity seed:
+    # each degraded pass is its own event, so the default derivation (title,
+    # message, capture time) dedups only a same-second duplicate. Always 0,
+    # a failed banner never aborts the drain.
+    _osquery_notify_local_durable "osquery alert delivery pipeline degraded" \
+      "$dead_letter_count undeliverable page(s) dead-lettered; the alert delivery pipeline needs attention."
   fi
   return 0
 }
@@ -778,11 +873,13 @@ send_alert() {
   # stored, and the caller must not advance its cursor past it.
   if ! _store_undelivered_alert "$occurrence_timestamp" "$request_id" "$url" "$body"; then
     _osquery_log "STORE-FAILED write-ahead persist: request_id=$request_id (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB)"
-    # The banner status is discarded here (guarded for errexit callers): this
-    # path is already the worst case, and the nonzero return below is the
-    # caller's real signal that the page was lost.
-    _loud_local "osquery paging FAILED, page LOST" \
-      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB." || true
+    # Durable banner, seeded by this page's request id so a retried occurrence
+    # dedups to one row. The capture will usually fail too on this path (the
+    # same storage is broken), which the wrapper logs loudly; the nonzero
+    # return below stays the caller's real lost-page signal.
+    _osquery_notify_local_durable "osquery paging FAILED, page LOST" \
+      "The page could not be stored locally. Fix $OSQUERY_UNDELIVERED_ALERTS_DB." \
+      "store-failed|$request_id"
     return 1
   fi
 
@@ -793,10 +890,12 @@ send_alert() {
   secret="$(_read_webhook_secret)"
   if [[ -z $secret ]]; then
     _osquery_log "STORED-NOSECRET Discord delivery degraded: request_id=$request_id (no secret in $OSQUERY_WEBHOOK_SECRET_FILE)"
-    # Banner status discarded (guarded for errexit callers): the page is safely
-    # stored, so a failed banner here costs visibility, not the page.
-    _loud_local "osquery Discord paging BROKEN" \
-      "No webhook secret. This page was stored locally and delivers when the secret is restored." || true
+    # Durable banner, seeded by this page's request id so a retried occurrence
+    # dedups to one row. The page itself is safely stored, so a failed banner
+    # costs visibility, not the page, and the capture preserves the visibility.
+    _osquery_notify_local_durable "osquery Discord paging BROKEN" \
+      "No webhook secret. This page was stored locally and delivers when the secret is restored." \
+      "stored-nosecret|$request_id"
     return 0
   fi
 

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -686,33 +686,69 @@ _notify_locally() {
 # already resolved), and one still ALIVE after the window has its banner up,
 # which is success, so it is left running exactly as before.
 _loud_local() {
-  # The optional third argument is the notification sound; empty or absent
-  # falls back to Funk (the historical loud-path sound), so two-argument
-  # callers keep their exact old behavior while the local-notification retry
-  # can replay a stored row's own sound. The optional fourth argument is a
-  # SUBTITLE, used by the drain retry path to render the occurrence time into
-  # a late banner; empty or absent means no subtitle line at all, so every
-  # existing caller's banner is byte-identical. Both notifier channels support
-  # it (alerter --subtitle per its help; osascript display notification's
-  # subtitle clause, verified to parse and post).
-  local title="$1" message="$2" sound="${3:-Funk}" subtitle="${4-}"
+  # Optional third argument: the notification sound (empty or absent falls
+  # back to Funk, the historical loud-path sound). Optional fourth: a SUBTITLE
+  # (the drain retry renders the occurrence time there); empty means no
+  # subtitle line, so two-argument callers' banners are byte-identical. The
+  # empty first argument to the confirm helper means NO durable row is tied to
+  # this banner, so nothing is ever deleted on its behalf.
+  _osquery_show_banner_confirm_delete "" "$1" "$2" "${3-}" "${4-}"
+}
+
+# Show one banner and, when a durable pending_local_notifications row is tied
+# to it (a non-empty notification_id), delete that row ONLY on CONFIRMED
+# success. The DATABASE is the truth about delivery; the return status is
+# ADVISORY (for log wording): 0 means the banner posted or already resolved
+# successfully, nonzero means the notifier is absent or failed fast.
+#
+# Confirmation is per channel. osascript is synchronous: it posts and returns,
+# so its exit 0 confirms and deletes inline. alerter blocks for the banner's
+# whole LIFETIME (verified on 26.5: exit only at resolve, 0 in every resolved
+# case; a failed invocation exits fast and nonzero), so a WATCHER owns the
+# confirm: a backgrounded subshell runs the alerter to completion (the watcher
+# must own the process, a sibling shell cannot wait on another shell's child)
+# and deletes the row only on exit 0. The watcher may outlive the caller;
+# orphaning is fine because alerter's --timeout 60 bounds its life, and WAL,
+# the busy_timeout, and the idempotent delete-by-id make a late delete safe
+# against concurrent sweeps.
+#
+# The caller-facing grace window below decides LOG WORDING ONLY (posted vs
+# failed fast), never persistence. Accepted consequence: AT-LEAST-ONCE banner
+# display. A retained row for a banner that actually showed can re-banner at
+# the next tick only if the watcher died before its delete; a duplicate banner
+# is minor noise, while the silently lost CRIT banner this design eliminates
+# was the real harm. The 60-second alerter ceiling under the 300-second drain
+# tick makes the normal case exactly-once.
+_osquery_show_banner_confirm_delete() { # <notification_id-or-empty> <title> <message> [sound] [subtitle]
+  local notification_id="$1" title="$2" message="$3" sound="${4:-Funk}" subtitle="${5-}"
   if command -v alerter >/dev/null 2>&1; then
     local alerter_arguments=(--timeout 60 --title "$title" --message "$message" --sound "$sound")
     if [[ -n $subtitle ]]; then
       alerter_arguments+=(--subtitle "$subtitle")
     fi
-    alerter "${alerter_arguments[@]}" >/dev/null 2>&1 &
-    local notifier_pid=$!
+    # The watcher: runs the alerter to completion, deletes only on confirmed
+    # success, and exits with the alerter's own status so a fast failure is
+    # visible to the grace-window check below.
+    (
+      alerter_status=0
+      alerter "${alerter_arguments[@]}" >/dev/null 2>&1 || alerter_status=$?
+      if [[ $alerter_status -eq 0 && -n $notification_id ]]; then
+        _osquery_delete_local_notification_row "$notification_id" ||
+          _osquery_log "LOCAL-NOTIFY-DELETE-FAILED shown banner kept its row: notification_id=$notification_id (a later sweep re-banners it)"
+      fi
+      exit "$alerter_status"
+    ) &
+    local watcher_pid=$!
     for _ in 1 2 3 4 5 6; do
-      kill -0 "$notifier_pid" 2>/dev/null || break
+      kill -0 "$watcher_pid" 2>/dev/null || break
       sleep 0.1 2>/dev/null || sleep 1
     done
-    if kill -0 "$notifier_pid" 2>/dev/null; then
+    if kill -0 "$watcher_pid" 2>/dev/null; then
       return 0 # still alive after the window: the banner is up on screen
     fi
-    local notifier_status=0
-    wait "$notifier_pid" 2>/dev/null || notifier_status=$?
-    return "$notifier_status"
+    local watcher_status=0
+    wait "$watcher_pid" 2>/dev/null || watcher_status=$?
+    return "$watcher_status"
   fi
   # osascript posts the notification and returns immediately, so its own exit
   # status IS the outcome; an absent osascript is command-not-found (nonzero).
@@ -724,28 +760,39 @@ _loud_local() {
     osascript_command+=" subtitle \"$escaped_subtitle\""
   fi
   osascript_command+=" sound name \"$sound\""
-  osascript -e "$osascript_command" >/dev/null 2>&1
-}
-
-# Fire the loud local CRIT banner DURABLY: show it via _loud_local and, ONLY
-# when the banner failed, persist it as a pending_local_notifications row so a
-# later drain can retry it (a lost CRIT banner otherwise reads as good news).
-# A shown banner touches no storage at all: the success path never bootstraps
-# the table and never creates the database. The optional third argument is a
-# stable identity seed for THIS notification (a caller with occurrence context
-# passes one, so a retried occurrence dedups to one row); absent, the identity
-# derives from title, message, and the capture time. The id is the seed's hash
-# (same shape as the alert request ids), so it is quote-free by construction.
-#
-# ALWAYS returns 0: the banner was either shown or captured for retry, and when
-# even the capture fails (storage broken) that is logged loudly
-# (LOCAL-NOTIFY-STORE-FAILED) but must never abort the caller, every caller is
-# already on its worst-case path when this fires.
-_osquery_notify_local_durable() { # <title> <message> [notification_seed]
-  local title="$1" message="$2" notification_seed="${3-}"
-  if _loud_local "$title" "$message"; then
+  if osascript -e "$osascript_command" >/dev/null 2>&1; then
+    if [[ -n $notification_id ]]; then
+      _osquery_delete_local_notification_row "$notification_id" ||
+        _osquery_log "LOCAL-NOTIFY-DELETE-FAILED shown banner kept its row: notification_id=$notification_id (a later sweep re-banners it)"
+    fi
     return 0
   fi
+  return 1
+}
+
+# Fire the loud local CRIT banner DURABLY, write-ahead: persist the
+# pending_local_notifications row FIRST (atomic bootstrap + INSERT), THEN
+# attempt the banner, and let CONFIRMED success delete the row (the watcher /
+# inline confirm in _osquery_show_banner_confirm_delete). A failed or
+# unconfirmed banner therefore always has a durable row: a kill at any instant
+# after the persist cannot lose the banner, and an alerter that outlives the
+# grace window and then fails leaves the row untouched because no confirmation
+# ever arrives. The DB is the truth; the banner attempt's return status is
+# advisory log wording only.
+#
+# The optional third argument is a stable identity seed for THIS notification
+# (a caller with occurrence context passes one, so a retried occurrence dedups
+# to one row); absent, the identity derives from title, message, and the
+# capture time. The id is the seed's hash (same shape as the alert request
+# ids), so it is quote-free by construction.
+#
+# ALWAYS returns 0. When the write-ahead persist itself fails (storage broken,
+# the documented unfixable case: send_alert's STORE-FAILED path fires exactly
+# when this same storage is unwritable), the banner still fires best-effort and
+# the loss of durability is logged loudly (LOCAL-NOTIFY-STORE-FAILED), but the
+# caller is never aborted, it is already on its worst-case path.
+_osquery_notify_local_durable() { # <title> <message> [notification_seed]
+  local title="$1" message="$2" notification_seed="${3-}"
   local occurrence_timestamp
   occurrence_timestamp="$(date -u +%s)"
   [[ $occurrence_timestamp =~ ^[0-9]+$ ]] || occurrence_timestamp=0
@@ -753,13 +800,19 @@ _osquery_notify_local_durable() { # <title> <message> [notification_seed]
   local notification_id
   if ! notification_id="local-$(printf '%s' "$notification_seed" | _sha256_hex_of_stdin | cut -c1-32)" ||
     [[ $notification_id == "local-" ]]; then
-    _osquery_log "LOCAL-NOTIFY-STORE-FAILED banner failed and no id could be derived (hasher broken); notification not persisted: $title"
+    _osquery_log "LOCAL-NOTIFY-STORE-FAILED no id could be derived (hasher broken); banner fired without a durable copy: $title"
+    _loud_local "$title" "$message" || true
     return 0
   fi
-  if _osquery_store_local_notification_row "$occurrence_timestamp" "$notification_id" "$title" "$message" "Funk"; then
-    _osquery_log "LOCAL-NOTIFY-STORED banner failed, persisted for retry: notification_id=$notification_id"
+  if ! _osquery_store_local_notification_row "$occurrence_timestamp" "$notification_id" "$title" "$message" "Funk"; then
+    _osquery_log "LOCAL-NOTIFY-STORE-FAILED banner fired without a durable copy (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB): $title"
+    _loud_local "$title" "$message" || true
+    return 0
+  fi
+  if _osquery_show_banner_confirm_delete "$notification_id" "$title" "$message" "Funk" ""; then
+    : # posted (the watcher confirms and deletes) or already confirmed inline
   else
-    _osquery_log "LOCAL-NOTIFY-STORE-FAILED banner failed AND could not be persisted (storage unwritable: $OSQUERY_UNDELIVERED_ALERTS_DB): $title"
+    _osquery_log "LOCAL-NOTIFY-STORED banner failed, row retained for retry: notification_id=$notification_id"
   fi
   return 0
 }
@@ -876,9 +929,11 @@ _redeliver_pending_local_notification() { # <notification_id> <occurrence_ts> <t
   if occurred_iso8601="$(_osquery_epoch_to_iso8601 "$occurrence_ts")" && [[ -n $occurred_iso8601 ]]; then
     occurred_subtitle="occurred $occurred_iso8601"
   fi
-  if _loud_local "$title" "$message" "$sound" "$occurred_subtitle"; then
-    _osquery_delete_local_notification_row "$notification_id" ||
-      _osquery_log "LOCAL-NOTIFY-DELETE-FAILED shown banner kept its row: notification_id=$notification_id (a later sweep re-banners it)"
+  # The row already exists (write-ahead by construction), so the retry hands it
+  # to the confirmed-delete banner: only a CONFIRMED success removes it (the
+  # watcher, or the synchronous fallback inline). An advisory "posted" leaves
+  # the row for the watcher's verdict; only a fast failure books the attempt.
+  if _osquery_show_banner_confirm_delete "$notification_id" "$title" "$message" "$sound" "$occurred_subtitle"; then
     return 0
   fi
   _osquery_record_local_notify_failure "$notification_id" ||

--- a/test/integration/osquery-local-notify-drain.bats
+++ b/test/integration/osquery-local-notify-drain.bats
@@ -28,6 +28,19 @@ local_row_count() {
     'SELECT COUNT(*) FROM pending_local_notifications;' 2>/dev/null || echo 0
 }
 
+# The success-delete is owned by the alerter WATCHER (confirmed-exit semantics),
+# which settles asynchronously, so a delete assertion polls instead of racing.
+wait_for_local_row_count() { # <expected>
+  local expected="$1" attempt count
+  for ((attempt = 0; attempt < 30; attempt++)); do
+    count="$(local_row_count)"
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  printf 'expected %s local row(s) once the watcher settled, still %s\n' "$expected" "$count" >&2
+  return 1
+}
+
 @test "T-LND-redeliver-success: a due local row banners once (text intact) and is deleted" {
   # The title carries a tab and apostrophes and the message an apostrophe, so
   # this also pins the export encoding: arbitrary text must reach the notifier
@@ -41,7 +54,7 @@ local_row_count() {
 
   retry_undelivered_alerts
 
-  [[ "$(local_row_count)" == "0" ]] # delivered -> deleted
+  wait_for_local_row_count 0 # delivered -> confirmed by the watcher -> deleted
   # Exactly one banner attempt, and the stored text reached it intact.
   [[ "$(grep -c . "$ALERTER_LOG")" == "1" ]]
   grep -qF "$tricky_title" "$ALERTER_LOG"
@@ -178,7 +191,7 @@ iso8601_of_epoch() {
 
   retry_undelivered_alerts
 
-  [[ "$(local_row_count)" == "0" ]] # shown -> deleted
+  wait_for_local_row_count 0 # shown -> confirmed by the watcher -> deleted
   # The banner carried the ORIGINAL occurrence time as its subtitle, so the
   # operator reads a late banner as history, not as breaking news.
   grep -qF -- "--subtitle occurred $(iso8601_of_epoch "$occurrence_ts")" "$ALERTER_LOG"
@@ -226,7 +239,7 @@ iso8601_of_epoch() {
   set_alerter_stub_exit 0
   OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS=999999 retry_undelivered_alerts
   grep -qF 'knob title' "$ALERTER_LOG"
-  [[ "$(local_row_count)" == "0" ]] # shown -> deleted
+  wait_for_local_row_count 0 # shown -> confirmed by the watcher -> deleted
   # Re-seed and shrink the ceiling BELOW the row's age: it expires unseen.
   set_alerter_stub_exit 64
   _osquery_notify_local_durable "knob title 2" "knob message 2" "seed-knob-2"
@@ -254,9 +267,38 @@ iso8601_of_epoch() {
   [[ $status -eq 0 ]]
   [[ $output == *DONE* ]]
 
-  [[ "$(local_row_count)" == "0" ]] # ancient expired, fresh shown-and-deleted
+  wait_for_local_row_count 0 # ancient expired, fresh shown-confirmed-deleted
   grep -qF 'fresh behind title' "$ALERTER_LOG" # the row behind the expiry still bannered
   ! grep -qF 'doomed title' "$ALERTER_LOG"     # the expired one never did
   ! grep -qi 'pipeline degraded' "$ALERTER_LOG" # expiry is not a dead-letter; no CRIT
   grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG"
+}
+
+@test "T-LND-late-failure-durable: a redelivered banner that outlives the grace window and then fails keeps its row" {
+  # sol's repro on the retry path: the alerter lives past the ~0.6s grace
+  # window (advisory says posted) and THEN exits nonzero. The old inline
+  # success-delete would have removed the row on the advisory alone; the
+  # watcher-confirmed delete keeps it, because no confirmation ever arrived.
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "late fail title" "late fail message" "seed-latefail"
+  [[ "$(local_row_count)" == "1" ]] # write-ahead: the row exists before any retry
+
+  cat >"$HARNESS_HOME/bin/alerter" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$ALERTER_LOG"
+sleep 0.7
+exit 64
+STUB
+  chmod +x "$HARNESS_HOME/bin/alerter"
+  : >"$ALERTER_LOG"
+
+  retry_undelivered_alerts
+
+  grep -qF 'late fail title' "$ALERTER_LOG" # the retry really attempted the banner
+  sleep 1.2 # let the watcher witness the late nonzero exit
+  if [[ "$(local_row_count)" != "1" ]]; then
+    printf 'expected the row to SURVIVE a banner that failed after the grace window; rows=%s\n' \
+      "$(local_row_count)" >&2
+    return 1
+  fi
 }

--- a/test/integration/osquery-local-notify-drain.bats
+++ b/test/integration/osquery-local-notify-drain.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# The scheduled drainer sweeps pending_local_notifications too (DR-C T3): a
+# CRIT banner that failed and was persisted is re-attempted on the same 300s
+# tick that drains the alert queue, one liveness owner, no second agent. The
+# local sweep runs BEFORE the alert drain: the alert drain's degraded-pipeline
+# CRIT can persist a NEW local row mid-pass, and sweeping local first means
+# that row waits for the next tick instead of being attempted twice in one
+# pass. The local channel is the FALLBACK: its failures are log lines only,
+# never a webhook CRIT and never a dead-letter tally entry. No thresholds and
+# no staleness rendering yet (T4).
+
+setup() {
+  local helpers="$BATS_TEST_DIRNAME/../helpers"
+  # shellcheck source=test/helpers/build-dispatch-harness.sh
+  source "$helpers/build-dispatch-harness.sh"
+  build_dispatch_harness
+}
+teardown() { teardown_dispatch_harness; }
+
+set_alerter_stub_exit() { # <exit-code> -- keep the argv logging, control the outcome
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >>"%s"\nexit %s\n' \
+    "$ALERTER_LOG" "$1" >"$HARNESS_HOME/bin/alerter"
+  chmod +x "$HARNESS_HOME/bin/alerter"
+}
+
+local_row_count() {
+  sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    'SELECT COUNT(*) FROM pending_local_notifications;' 2>/dev/null || echo 0
+}
+
+@test "T-LND-redeliver-success: a due local row banners once (text intact) and is deleted" {
+  # The title carries a tab and apostrophes and the message an apostrophe, so
+  # this also pins the export encoding: arbitrary text must reach the notifier
+  # byte-identical (a naive tab-separated export would garble it).
+  local tricky_title=$'op\'s\tbanner' tricky_message="it's back"
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "$tricky_title" "$tricky_message" "seed-redeliver" # persists (banner fails)
+  [[ "$(local_row_count)" == "1" ]]
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0 # the notifier works again
+
+  retry_undelivered_alerts
+
+  [[ "$(local_row_count)" == "0" ]] # delivered -> deleted
+  # Exactly one banner attempt, and the stored text reached it intact.
+  [[ "$(grep -c . "$ALERTER_LOG")" == "1" ]]
+  grep -qF "$tricky_title" "$ALERTER_LOG"
+  grep -qF "$tricky_message" "$ALERTER_LOG"
+}
+
+@test "T-LND-redeliver-failure: a still-failing local row is retained with attempts+1 and a future next_attempt_after" {
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=3600
+  export OSQUERY_DRAIN_RETRY_RANDOM_SECONDS=0
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "t" "m" "seed-stillfailing"
+  [[ "$(local_row_count)" == "1" ]]
+  local before_drain
+  before_drain="$(date -u +%s)"
+
+  retry_undelivered_alerts
+
+  [[ "$(local_row_count)" == "1" ]] # retained, never lost
+  [[ "$(sqlite3_query 'SELECT attempts FROM pending_local_notifications;')" == "1" ]]
+  local next_attempt_after
+  next_attempt_after="$(sqlite3_query 'SELECT next_attempt_after FROM pending_local_notifications;')"
+  [[ $next_attempt_after -gt $((before_drain + 1800)) ]]
+  grep -q 'LOCAL-NOTIFY-RETRY-FAILED' "$OSQUERY_DELIVERY_LOG" # a log line, not a CRIT
+}
+
+@test "T-LND-not-due: a row whose retry wait has not passed is untouched, no banner attempt" {
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "t" "m" "seed-notdue"
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET next_attempt_after = $(($(date -u +%s) + 3600));"
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+
+  retry_undelivered_alerts
+
+  [[ "$(local_row_count)" == "1" ]]
+  [[ ! -s $ALERTER_LOG ]] # zero attempts on a not-yet-due row
+  [[ "$(sqlite3_query 'SELECT attempts FROM pending_local_notifications;')" == "0" ]]
+}
+
+@test "T-LND-isolation: a failing local row aborts nothing and never feeds the webhook CRIT tally" {
+  # One failing local row + one deliverable alert row in the same pass: the
+  # alert must still deliver, the pass must fire NO degraded-pipeline CRIT
+  # (zero ALERT records dead-lettered; a local failure is not a dead-letter),
+  # and the whole pass survives set -e.
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "t" "m" "seed-isolation"
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-deliverable "$url" "$body_b64"
+  : >"$ALERTER_LOG"
+  : >"$CURL_LOG"
+  set_curl_codes 200
+
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]
+  [[ $output == *DONE* ]]
+
+  grep -qF 'X-Request-ID: osquery-deliverable' "$CURL_LOG" # the alert still delivered
+  assert_pending_alert_count 0
+  [[ "$(local_row_count)" == "1" ]] # the local row is retained for the next tick
+  ! grep -qi 'pipeline degraded' "$ALERTER_LOG" # no CRIT for a local-channel failure
+  grep -q 'LOCAL-NOTIFY-RETRY-FAILED' "$OSQUERY_DELIVERY_LOG"
+}
+
+@test "T-LND-ordering: a local row persisted by THIS pass's degraded CRIT is not attempted until the next tick" {
+  # The alert drain dead-letters a record, fires the pass CRIT, the CRIT banner
+  # FAILS, and the wrapper persists it as a local row mid-pass. The local sweep
+  # already ran (local first), so that fresh row must show zero attempts and
+  # the notifier must have been invoked exactly once (the CRIT attempt itself,
+  # not a same-pass retry of the just-persisted row).
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=1 # the seeded alert row dead-letters pre-POST
+  set_alerter_stub_exit 64
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-doomed "$url" "$body_b64"
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_alerts SET attempts=1 WHERE request_id='osquery-doomed';"
+  : >"$ALERTER_LOG"
+
+  retry_undelivered_alerts
+
+  [[ "$(local_row_count)" == "1" ]] # the failed CRIT was captured...
+  [[ "$(sqlite3_query 'SELECT attempts FROM pending_local_notifications;')" == "0" ]] # ...but NOT retried this pass
+  [[ "$(grep -c . "$ALERTER_LOG")" == "1" ]] # exactly the one CRIT attempt
+}
+
+@test "T-LND-skip-and-continue: the first local row failing does not block the second" {
+  export OSQUERY_DRAIN_RETRY_BASE_SECONDS=3600
+  export OSQUERY_DRAIN_RETRY_RANDOM_SECONDS=0
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "first title" "m1" "seed-first"
+  _osquery_notify_local_durable "second title" "m2" "seed-second"
+  [[ "$(local_row_count)" == "2" ]]
+  # Order the rows deterministically: the first seed strictly older.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = CASE WHEN title='first title' THEN 100 ELSE 200 END;"
+  : >"$ALERTER_LOG"
+
+  retry_undelivered_alerts
+
+  # BOTH rows were attempted (the failing first never starves the second)...
+  grep -qF 'first title' "$ALERTER_LOG"
+  grep -qF 'second title' "$ALERTER_LOG"
+  # ...and both were retained with their bookkeeping counted.
+  [[ "$(local_row_count)" == "2" ]]
+  [[ "$(sqlite3_query 'SELECT COUNT(*) FROM pending_local_notifications WHERE attempts=1;')" == "2" ]]
+}

--- a/test/integration/osquery-local-notify-drain.bats
+++ b/test/integration/osquery-local-notify-drain.bats
@@ -136,9 +136,11 @@ local_row_count() {
   _osquery_notify_local_durable "first title" "m1" "seed-first"
   _osquery_notify_local_durable "second title" "m2" "seed-second"
   [[ "$(local_row_count)" == "2" ]]
-  # Order the rows deterministically: the first seed strictly older.
+  # Order the rows deterministically: the first seed strictly older, but both
+  # RECENT (seconds old), so the age-out behavior added later never expires
+  # them; this pin is about ordering under failure, not staleness.
   sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
-    "UPDATE pending_local_notifications SET occurrence_ts = CASE WHEN title='first title' THEN 100 ELSE 200 END;"
+    "UPDATE pending_local_notifications SET occurrence_ts = CASE WHEN title='first title' THEN $(($(date -u +%s) - 200)) ELSE $(($(date -u +%s) - 100)) END;"
   : >"$ALERTER_LOG"
 
   retry_undelivered_alerts
@@ -149,4 +151,112 @@ local_row_count() {
   # ...and both were retained with their bookkeeping counted.
   [[ "$(local_row_count)" == "2" ]]
   [[ "$(sqlite3_query 'SELECT COUNT(*) FROM pending_local_notifications WHERE attempts=1;')" == "2" ]]
+}
+
+# --- DR-C T4: two staleness behaviors ------------------------------------------
+# Behavior 1: a late-redelivered banner tells the truth about WHEN its event
+# occurred (the occurrence time is rendered into the banner, so a banner shown
+# hours late cannot read as breaking news).
+# Behavior 2: a local notification too old to matter is EXPIRED loudly instead
+# of retried forever (deleted with a forensic log line; the operator has long
+# since seen the durable Discord copy, so a day-old banner is pure noise).
+
+# Render an epoch as the banner subtitle's UTC ISO 8601 form, the same both
+# date flavors: BSD (-r) first, GNU (-d @) as the fallback.
+iso8601_of_epoch() {
+  date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
+@test "T-LND-late-banner-honest-timestamp: a redelivered banner names its occurrence time" {
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "late title" "late message" "seed-late-honest"
+  [[ "$(local_row_count)" == "1" ]]
+  local occurrence_ts
+  occurrence_ts="$(sqlite3_query 'SELECT occurrence_ts FROM pending_local_notifications;')"
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+
+  retry_undelivered_alerts
+
+  [[ "$(local_row_count)" == "0" ]] # shown -> deleted
+  # The banner carried the ORIGINAL occurrence time as its subtitle, so the
+  # operator reads a late banner as history, not as breaking news.
+  grep -qF -- "--subtitle occurred $(iso8601_of_epoch "$occurrence_ts")" "$ALERTER_LOG"
+}
+
+@test "T-LND-fresh-banner-unmarked: a FIRST-ATTEMPT banner carries no staleness subtitle" {
+  # The honest-timestamp marking belongs to the drain retry path ONLY: a fresh
+  # first-attempt banner IS breaking news and must render exactly as before.
+  set_alerter_stub_exit 0
+  : >"$ALERTER_LOG"
+  _osquery_notify_local_durable "fresh title" "fresh message" "seed-fresh"
+  [[ "$(grep -c . "$ALERTER_LOG")" == "1" ]]
+  ! grep -qF -- '--subtitle' "$ALERTER_LOG"
+  ! grep -qF 'occurred' "$ALERTER_LOG"
+}
+
+@test "T-LND-expired-loudly: an over-age row is deleted with a forensic log line, never bannered" {
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "old title" "old message" "seed-expired"
+  local notification_id
+  notification_id="$(sqlite3_query 'SELECT notification_id FROM pending_local_notifications;')"
+  # Age the row past the 1-day default.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = $(($(date -u +%s) - 200000));"
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0 # a working notifier must still NOT be handed the stale banner
+
+  retry_undelivered_alerts
+
+  [[ ! -s $ALERTER_LOG ]]          # zero banner attempts
+  [[ "$(local_row_count)" == "0" ]] # expired -> deleted
+  grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG"       # loud, never silent
+  grep -qF "$notification_id" "$OSQUERY_DELIVERY_LOG"          # names the row
+  grep -qE 'LOCAL-NOTIFY-EXPIRED.*age[=_ ][0-9]+' "$OSQUERY_DELIVERY_LOG" # and its age
+}
+
+@test "T-LND-age-knob: the age ceiling is the operator's knob (small expires, large retries)" {
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "knob title" "knob message" "seed-knob"
+  # Make the row 60 seconds old.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = $(($(date -u +%s) - 60));"
+  # A LARGE ceiling: the 60s-old row is fresh enough and banners.
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+  OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS=999999 retry_undelivered_alerts
+  grep -qF 'knob title' "$ALERTER_LOG"
+  [[ "$(local_row_count)" == "0" ]] # shown -> deleted
+  # Re-seed and shrink the ceiling BELOW the row's age: it expires unseen.
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "knob title 2" "knob message 2" "seed-knob-2"
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = $(($(date -u +%s) - 60));"
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+  OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS=10 retry_undelivered_alerts
+  [[ ! -s $ALERTER_LOG ]]
+  [[ "$(local_row_count)" == "0" ]]
+  grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG"
+}
+
+@test "T-LND-expiry-isolation: expiring a row aborts nothing, fires no CRIT, and later rows still banner" {
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "doomed title" "doomed message" "seed-doomed"
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = 1000;" # ancient
+  _osquery_notify_local_durable "fresh behind title" "fresh behind message" "seed-behind"
+  [[ "$(local_row_count)" == "2" ]]
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+
+  run bash -c "set -euo pipefail; source '$DISPATCH'; retry_undelivered_alerts; echo DONE"
+  [[ $status -eq 0 ]]
+  [[ $output == *DONE* ]]
+
+  [[ "$(local_row_count)" == "0" ]] # ancient expired, fresh shown-and-deleted
+  grep -qF 'fresh behind title' "$ALERTER_LOG" # the row behind the expiry still bannered
+  ! grep -qF 'doomed title' "$ALERTER_LOG"     # the expired one never did
+  ! grep -qi 'pipeline degraded' "$ALERTER_LOG" # expiry is not a dead-letter; no CRIT
+  grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG"
 }

--- a/test/integration/osquery-local-notify-drain.bats
+++ b/test/integration/osquery-local-notify-drain.bats
@@ -274,6 +274,40 @@ iso8601_of_epoch() {
   grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG"
 }
 
+@test "T-LND-expire-in-backoff: an over-age row expires on schedule even while its retry wait has not passed" {
+  # sol's repro: an over-age row whose next_attempt_after is in the FUTURE. A
+  # due-filtered sweep never sees it, so it silently outlives its own age
+  # ceiling. Expiry must run independently of the due filter: the row is
+  # deleted with the loud EXPIRED line in the SAME pass, while a fresh row in
+  # backoff stays untouched.
+  set_alerter_stub_exit 64
+  _osquery_notify_local_durable "buried title" "buried message" "seed-buried"
+  _osquery_notify_local_durable "fresh backoff title" "fresh backoff message" "seed-freshbackoff"
+  [[ "$(local_row_count)" == "2" ]]
+  local now
+  now="$(date -u +%s)"
+  # The buried row: over-age AND in retry backoff (invisible to a due filter).
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = $((now - 86401)), next_attempt_after = $((now + 3600)) WHERE title = 'buried title';"
+  # The fresh row: young, also in backoff; expiry must not touch it.
+  sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "UPDATE pending_local_notifications SET occurrence_ts = $((now - 60)), next_attempt_after = $((now + 3600)) WHERE title = 'fresh backoff title';"
+  : >"$ALERTER_LOG"
+  set_alerter_stub_exit 0
+
+  retry_undelivered_alerts
+
+  if [[ "$(local_row_count)" != "1" ]]; then
+    printf 'expected the over-age buried row to expire in this pass; rows=%s\n' "$(local_row_count)" >&2
+    return 1
+  fi
+  [[ "$(sqlite3_query 'SELECT title FROM pending_local_notifications;')" == "fresh backoff title" ]] ||
+    printf 'expected only the FRESH backoff row to survive\n' >&2
+  [[ "$(sqlite3_query 'SELECT title FROM pending_local_notifications;')" == "fresh backoff title" ]]
+  grep -q 'LOCAL-NOTIFY-EXPIRED' "$OSQUERY_DELIVERY_LOG" # loud in the same pass
+  [[ ! -s $ALERTER_LOG ]] # neither row was bannered (one expired, one in backoff)
+}
+
 @test "T-LND-late-failure-durable: a redelivered banner that outlives the grace window and then fails keeps its row" {
   # sol's repro on the retry path: the alerter lives past the ~0.6s grace
   # window (advisory says posted) and THEN exits nonzero. The old inline

--- a/test/unit/osquery-local-notify-durable.sh
+++ b/test/unit/osquery-local-notify-durable.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 #
-# _osquery_notify_local_durable makes the loud local CRIT channel durable: it
-# fires _loud_local and, ONLY when the banner fails, persists the notification
-# as a pending_local_notifications row in the alert store (same database, same
-# lock domain), so a later drain can retry it. A shown banner persists nothing
-# and must not even bootstrap the table. The persist follows the alert store's
-# crash-safety rules: schema bootstrap and INSERT in one atomic batch,
-# idempotent on notification_id, quote-safe for arbitrary title/message text,
-# and fail-soft (a store failure logs LOCAL-NOTIFY-STORE-FAILED, never aborts
-# the caller).
+# A failed or unconfirmed local banner ALWAYS has a durable row until the
+# notifier confirms it was shown. _osquery_notify_local_durable is WRITE-AHEAD:
+# it persists the pending_local_notifications row FIRST (atomic bootstrap +
+# INSERT, same database and lock domain as the alert queue), then attempts the
+# banner, and the row is deleted only on CONFIRMED success (the alerter watcher
+# sees exit 0; the synchronous osascript fallback confirms inline). The DB is
+# the truth; the caller-facing return status is advisory logging only. This
+# closes two holes the old persist-on-failure design had: a kill between a
+# failed banner and the persist lost the banner entirely, and an alerter that
+# outlived the grace window and THEN failed was treated as delivered.
 #
-# Unit test: stubbed notifier binaries on PATH, throwaway store per pin.
+# Unit test: stubbed notifier binaries on PATH, throwaway store per pin,
+# per-assert expectation messages.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -51,14 +53,29 @@ query() { # <db> <sql>
   sqlite3 -readonly "$1" "$2"
 }
 
-# (a) Failing notifier: exactly ONE row persisted, fields intact.
+row_count() { # <db> -- a missing DB or table reads as zero rows
+  sqlite3 -readonly "$1" 'SELECT COUNT(*) FROM pending_local_notifications;' 2>/dev/null || echo 0
+}
+
+wait_for_row_count() { # <db> <expected> -- the alerter confirm is a WATCHER, so poll
+  local db="$1" expected="$2" attempt count
+  for ((attempt = 0; attempt < 30; attempt++)); do
+    count="$(row_count "$db")"
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  printf 'expected %s row(s) once the watcher settled, still %s\n' "$expected" "$count" >&2
+  return 1
+}
+
+# --- a failing banner leaves exactly one durable row, fields intact -----------
 db="$work/a/store.sqlite3"
 log="$work/a/delivery.log"
 set_alerter_stub 64
 out="$(run_durable "$db" "$log" "banner title" "banner message")" || fail "(a) wrapper aborted its caller"
 [[ $out == *SURVIVED* ]] || fail "(a) caller did not survive"
-[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
-  fail "(a) expected exactly one persisted row"
+[[ "$(row_count "$db")" == "1" ]] ||
+  fail "(a) a failed banner must leave exactly one durable row"
 row="$(query "$db" "SELECT title, message, sound, attempts, next_attempt_after FROM pending_local_notifications;")"
 [[ $row == "banner title|banner message|Funk|0|0" ]] ||
   fail "(a) persisted fields wrong: $row"
@@ -66,40 +83,88 @@ notification_id="$(query "$db" 'SELECT notification_id FROM pending_local_notifi
 [[ -n $notification_id ]] || fail "(a) empty notification_id"
 occurrence_ts="$(query "$db" 'SELECT occurrence_ts FROM pending_local_notifications;')"
 [[ $occurrence_ts =~ ^[0-9]+$ && $occurrence_ts -gt 0 ]] || fail "(a) occurrence_ts not a real timestamp: $occurrence_ts"
-# The schema carries every column the retry drain (T3) will consume.
 columns="$(query "$db" "SELECT group_concat(name, ',') FROM pragma_table_info('pending_local_notifications');")"
 for column in sequence_number notification_id occurrence_ts title message sound attempts next_attempt_after created_at; do
   [[ ",$columns," == *",$column,"* ]] || fail "(a) schema missing column $column (got: $columns)"
 done
 
-# (b) Succeeding notifier: nothing persisted, table NOT bootstrapped, and a
-# never-existing database file stays absent.
+# --- a banner confirmed shown leaves no row behind (alerter watcher) ----------
+# Write-ahead means the row EXISTS during the attempt; the watcher's confirmed
+# exit 0 deletes it. (The old no-bootstrap-on-success property is gone by
+# design: durability beats a pristine success path.)
 db="$work/b/store.sqlite3"
 log="$work/b/delivery.log"
 set_alerter_stub 0
 out="$(run_durable "$db" "$log" "shown title" "shown message")" || fail "(b) wrapper aborted its caller"
-[[ ! -e $db ]] || fail "(b) a SHOWN banner created the store"
+wait_for_row_count "$db" 0 ||
+  fail "(b) a CONFIRMED banner must leave no row once the watcher settles"
 
-# (b2) Succeeding notifier against an EXISTING store: the table is still not
-# bootstrapped (no schema work on the success path).
+# --- the synchronous osascript fallback confirms and deletes inline -----------
 db="$work/b2/store.sqlite3"
-mkdir -p "$work/b2"
-sqlite3 "$db" 'CREATE TABLE unrelated (x);'
-out="$(run_durable "$db" "$work/b2/delivery.log" "shown title" "shown message")" || fail "(b2) wrapper aborted its caller"
-[[ "$(query "$db" "SELECT COUNT(*) FROM sqlite_master WHERE name='pending_local_notifications';")" == "0" ]] ||
-  fail "(b2) the success path bootstrapped the table"
+log="$work/b2/delivery.log"
+rm -f "$work/bin/alerter"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$work/bin/osascript"
+chmod +x "$work/bin/osascript"
+out="$(run_durable "$db" "$log" "fallback title" "fallback message")" || fail "(b2) wrapper aborted its caller"
+[[ "$(row_count "$db")" == "0" ]] ||
+  fail "(b2) the synchronous fallback's exit 0 must delete the row inline, no watcher needed"
+rm -f "$work/bin/osascript"
 
-# (c) The same notification seed persisted twice stays ONE row (idempotent).
+# --- a caller killed mid-banner still leaves a durable row (kill window) ------
+# The banner attempt is held open (the stub sleeps) and the CALLER is SIGKILLed
+# mid-attempt: with write-ahead the row was committed BEFORE the attempt, so
+# the kill cannot lose the banner. The old persist-on-failure design had
+# nothing on disk at this instant.
+db="$work/f/store.sqlite3"
+log="$work/f/delivery.log"
+marker="$work/f/banner-attempt-started"
+mkdir -p "$work/f"
+cat >"$work/bin/alerter" <<STUB
+#!/usr/bin/env bash
+touch '$marker'
+sleep 30
+exit 0
+STUB
+chmod +x "$work/bin/alerter"
+PATH="$stub_path" OSQUERY_UNDELIVERED_ALERTS_DB="$db" OSQUERY_DELIVERY_LOG="$log" \
+  bash -c 'set -euo pipefail; source "$1"; _osquery_notify_local_durable "kill title" "kill message" "seed-kill"' \
+  _ "$DISPATCH" &
+caller_pid=$!
+for _ in $(seq 1 50); do
+  [[ -f $marker ]] && break
+  sleep 0.1
+done
+[[ -f $marker ]] || fail "(f) the banner attempt never started (stub marker missing)"
+kill -KILL "$caller_pid" 2>/dev/null || true
+wait "$caller_pid" 2>/dev/null || true
+[[ "$(row_count "$db")" == "1" ]] ||
+  fail "(f) a caller killed mid-banner must still leave the durable row (write-ahead)"
+
+# --- an alerter that outlives the grace window and THEN fails stays durable ---
+# sol's repro: sleep past the ~0.6s grace window, then exit nonzero. The old
+# design read still-alive as delivered and had persisted nothing; write-ahead
+# plus watcher-confirm keeps the row because no confirmation ever arrived.
+db="$work/g/store.sqlite3"
+log="$work/g/delivery.log"
+printf '#!/usr/bin/env bash\nsleep 0.7\nexit 64\n' >"$work/bin/alerter"
+chmod +x "$work/bin/alerter"
+out="$(run_durable "$db" "$log" "late fail title" "late fail message")" || fail "(g) wrapper aborted its caller"
+[[ "$(row_count "$db")" == "1" ]] ||
+  fail "(g) the row must exist the moment the wrapper returns (write-ahead)"
+sleep 1.2 # let the watcher see the late nonzero exit
+[[ "$(row_count "$db")" == "1" ]] ||
+  fail "(g) a banner that failed after the grace window must keep its durable row"
+
+# --- the same notification seed persisted twice stays ONE row (idempotent) ----
 db="$work/c/store.sqlite3"
 log="$work/c/delivery.log"
 set_alerter_stub 64
 run_durable "$db" "$log" "t" "m" "same-seed" >/dev/null || fail "(c) first persist aborted"
 run_durable "$db" "$log" "t" "m" "same-seed" >/dev/null || fail "(c) second persist aborted"
-[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
-  fail "(c) the same seed stored twice kept more than one row"
+[[ "$(row_count "$db")" == "1" ]] ||
+  fail "(c) the same seed stored twice must keep exactly one row"
 
-# (d) A store failure is fail-soft: unwritable DB parent, the set -e caller
-# survives and the loud LOCAL-NOTIFY-STORE-FAILED line lands in the log.
+# --- a broken store is fail-soft: loud log, caller survives, banner still fires
 mkdir -p "$work/d"
 printf 'a file, not a dir\n' >"$work/d/notadir"
 db="$work/d/notadir/store.sqlite3"
@@ -109,18 +174,18 @@ out="$(run_durable "$db" "$log" "lost title" "lost message")" || fail "(d) a sto
 [[ $out == *SURVIVED* ]] || fail "(d) caller did not survive the store failure"
 grep -q 'LOCAL-NOTIFY-STORE-FAILED' "$log" || fail "(d) no LOCAL-NOTIFY-STORE-FAILED log line"
 
-# (e) Quote safety: apostrophes and SQL-looking text round-trip byte-identical.
+# --- apostrophes and SQL-looking text round-trip byte-identical ---------------
 db="$work/e/store.sqlite3"
 log="$work/e/delivery.log"
 set_alerter_stub 64
 tricky_title="it's broken, isn't it?"
 tricky_message="the operator's page: '); DROP TABLE pending_local_notifications; --"
 run_durable "$db" "$log" "$tricky_title" "$tricky_message" >/dev/null || fail "(e) persist aborted"
-[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
+[[ "$(row_count "$db")" == "1" ]] ||
   fail "(e) quote-carrying notification did not persist as one row"
 [[ "$(query "$db" 'SELECT title FROM pending_local_notifications;')" == "$tricky_title" ]] ||
   fail "(e) title did not round-trip intact"
 [[ "$(query "$db" 'SELECT message FROM pending_local_notifications;')" == "$tricky_message" ]] ||
   fail "(e) message did not round-trip intact"
 
-printf 'osquery-local-notify-durable: OK (persist-on-fail, silent-on-success, idempotent, fail-soft, quote-safe)\n'
+printf 'osquery-local-notify-durable: OK (write-ahead, confirmed-delete, kill-safe, late-fail-safe, idempotent, fail-soft, quote-safe)\n'

--- a/test/unit/osquery-local-notify-durable.sh
+++ b/test/unit/osquery-local-notify-durable.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# _osquery_notify_local_durable makes the loud local CRIT channel durable: it
+# fires _loud_local and, ONLY when the banner fails, persists the notification
+# as a pending_local_notifications row in the alert store (same database, same
+# lock domain), so a later drain can retry it. A shown banner persists nothing
+# and must not even bootstrap the table. The persist follows the alert store's
+# crash-safety rules: schema bootstrap and INSERT in one atomic batch,
+# idempotent on notification_id, quote-safe for arbitrary title/message text,
+# and fail-soft (a store failure logs LOCAL-NOTIFY-STORE-FAILED, never aborts
+# the caller).
+#
+# Unit test: stubbed notifier binaries on PATH, throwaway store per pin.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCH="$REPO_ROOT/dot_local/libexec/osquery/executable_alert-dispatch.sh"
+
+fail() {
+  printf 'osquery-local-notify-durable: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH; cannot exercise the local-notification store\n'
+  exit 0
+}
+[[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+stub_path="$work/bin:/usr/bin:/bin"
+
+set_alerter_stub() { # <exit-code>
+  printf '#!/usr/bin/env bash\nexit %s\n' "$1" >"$work/bin/alerter"
+  chmod +x "$work/bin/alerter"
+}
+
+# run_durable <db-path> <log-path> <args...> -- source the library against the
+# given store in a clean set -e subshell and call the wrapper once.
+run_durable() {
+  local db="$1" log="$2"
+  shift 2
+  PATH="$stub_path" OSQUERY_UNDELIVERED_ALERTS_DB="$db" OSQUERY_DELIVERY_LOG="$log" \
+    bash -c 'set -euo pipefail; source "$1"; shift; _osquery_notify_local_durable "$@"; echo SURVIVED' \
+    _ "$DISPATCH" "$@"
+}
+
+query() { # <db> <sql>
+  sqlite3 -readonly "$1" "$2"
+}
+
+# (a) Failing notifier: exactly ONE row persisted, fields intact.
+db="$work/a/store.sqlite3"
+log="$work/a/delivery.log"
+set_alerter_stub 64
+out="$(run_durable "$db" "$log" "banner title" "banner message")" || fail "(a) wrapper aborted its caller"
+[[ $out == *SURVIVED* ]] || fail "(a) caller did not survive"
+[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
+  fail "(a) expected exactly one persisted row"
+row="$(query "$db" "SELECT title, message, sound, attempts, next_attempt_after FROM pending_local_notifications;")"
+[[ $row == "banner title|banner message|Funk|0|0" ]] ||
+  fail "(a) persisted fields wrong: $row"
+notification_id="$(query "$db" 'SELECT notification_id FROM pending_local_notifications;')"
+[[ -n $notification_id ]] || fail "(a) empty notification_id"
+occurrence_ts="$(query "$db" 'SELECT occurrence_ts FROM pending_local_notifications;')"
+[[ $occurrence_ts =~ ^[0-9]+$ && $occurrence_ts -gt 0 ]] || fail "(a) occurrence_ts not a real timestamp: $occurrence_ts"
+# The schema carries every column the retry drain (T3) will consume.
+columns="$(query "$db" "SELECT group_concat(name, ',') FROM pragma_table_info('pending_local_notifications');")"
+for column in sequence_number notification_id occurrence_ts title message sound attempts next_attempt_after created_at; do
+  [[ ",$columns," == *",$column,"* ]] || fail "(a) schema missing column $column (got: $columns)"
+done
+
+# (b) Succeeding notifier: nothing persisted, table NOT bootstrapped, and a
+# never-existing database file stays absent.
+db="$work/b/store.sqlite3"
+log="$work/b/delivery.log"
+set_alerter_stub 0
+out="$(run_durable "$db" "$log" "shown title" "shown message")" || fail "(b) wrapper aborted its caller"
+[[ ! -e $db ]] || fail "(b) a SHOWN banner created the store"
+
+# (b2) Succeeding notifier against an EXISTING store: the table is still not
+# bootstrapped (no schema work on the success path).
+db="$work/b2/store.sqlite3"
+mkdir -p "$work/b2"
+sqlite3 "$db" 'CREATE TABLE unrelated (x);'
+out="$(run_durable "$db" "$work/b2/delivery.log" "shown title" "shown message")" || fail "(b2) wrapper aborted its caller"
+[[ "$(query "$db" "SELECT COUNT(*) FROM sqlite_master WHERE name='pending_local_notifications';")" == "0" ]] ||
+  fail "(b2) the success path bootstrapped the table"
+
+# (c) The same notification seed persisted twice stays ONE row (idempotent).
+db="$work/c/store.sqlite3"
+log="$work/c/delivery.log"
+set_alerter_stub 64
+run_durable "$db" "$log" "t" "m" "same-seed" >/dev/null || fail "(c) first persist aborted"
+run_durable "$db" "$log" "t" "m" "same-seed" >/dev/null || fail "(c) second persist aborted"
+[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
+  fail "(c) the same seed stored twice kept more than one row"
+
+# (d) A store failure is fail-soft: unwritable DB parent, the set -e caller
+# survives and the loud LOCAL-NOTIFY-STORE-FAILED line lands in the log.
+mkdir -p "$work/d"
+printf 'a file, not a dir\n' >"$work/d/notadir"
+db="$work/d/notadir/store.sqlite3"
+log="$work/d/delivery.log"
+set_alerter_stub 64
+out="$(run_durable "$db" "$log" "lost title" "lost message")" || fail "(d) a store failure aborted the caller"
+[[ $out == *SURVIVED* ]] || fail "(d) caller did not survive the store failure"
+grep -q 'LOCAL-NOTIFY-STORE-FAILED' "$log" || fail "(d) no LOCAL-NOTIFY-STORE-FAILED log line"
+
+# (e) Quote safety: apostrophes and SQL-looking text round-trip byte-identical.
+db="$work/e/store.sqlite3"
+log="$work/e/delivery.log"
+set_alerter_stub 64
+tricky_title="it's broken, isn't it?"
+tricky_message="the operator's page: '); DROP TABLE pending_local_notifications; --"
+run_durable "$db" "$log" "$tricky_title" "$tricky_message" >/dev/null || fail "(e) persist aborted"
+[[ "$(query "$db" 'SELECT COUNT(*) FROM pending_local_notifications;')" == "1" ]] ||
+  fail "(e) quote-carrying notification did not persist as one row"
+[[ "$(query "$db" 'SELECT title FROM pending_local_notifications;')" == "$tricky_title" ]] ||
+  fail "(e) title did not round-trip intact"
+[[ "$(query "$db" 'SELECT message FROM pending_local_notifications;')" == "$tricky_message" ]] ||
+  fail "(e) message did not round-trip intact"
+
+printf 'osquery-local-notify-durable: OK (persist-on-fail, silent-on-success, idempotent, fail-soft, quote-safe)\n'

--- a/test/unit/osquery-loud-local-status.sh
+++ b/test/unit/osquery-loud-local-status.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# _loud_local must report a TRUTHFUL delivery status instead of discarding it:
+# 0 when the notifier was successfully invoked (the banner posted, or resolved
+# cleanly), nonzero when no notifier exists or the invocation failed. Verified
+# alerter (26.5) semantics behind the design: the alerter process lives for the
+# banner's whole lifetime and exits only at resolution (dismiss, click, or
+# timeout, always exit 0), and a FAILED invocation exits fast and nonzero, so a
+# short bounded grace window distinguishes the two without blocking a caller
+# for the banner's 60-second life. This seam is what DR-C T2 builds durable
+# local notifications on; without it a failed CRIT banner is indistinguishable
+# from a shown one.
+#
+# Unit test: stub notifier binaries on PATH, plus one self-contained errexit
+# pin for the drain's one-CRIT caller.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCH="$REPO_ROOT/dot_local/libexec/osquery/executable_alert-dispatch.sh"
+
+fail() {
+  printf 'osquery-loud-local-status: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+
+# The stubs own the notifier surface: every case below manipulates ONLY
+# $work/bin, prepended to a minimal PATH that keeps coreutils reachable.
+stub_path="$work/bin:/usr/bin:/bin"
+
+# run_loud_local <expected-status> <context> -- source the library under the
+# stub PATH in a clean subshell and call _loud_local once.
+run_loud_local() {
+  local expected="$1" context="$2" got=0
+  PATH="$stub_path" bash -c "source '$DISPATCH'; _loud_local 'title' 'message'" || got=$?
+  if [[ $expected == "0" ]]; then
+    [[ $got -eq 0 ]] || fail "$context: expected status 0, got $got"
+  else
+    [[ $got -ne 0 ]] || fail "$context: expected a NONZERO status, got 0"
+  fi
+}
+
+# (a) Notifier present and successful: an alerter stub that exits 0 promptly
+# (a banner that posted and resolved) reports success.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$work/bin/alerter"
+chmod +x "$work/bin/alerter"
+run_loud_local 0 "alerter succeeds"
+
+# (c) Notifier invocation FAILS: an alerter that exits fast and nonzero (the
+# verified failed-invocation shape, e.g. usage error 64) must NOT read as a
+# delivered banner.
+printf '#!/usr/bin/env bash\nexit 64\n' >"$work/bin/alerter"
+chmod +x "$work/bin/alerter"
+run_loud_local 1 "alerter invocation fails"
+
+# (a2) Long-lived alerter = the banner is UP (the process lives for the
+# banner's lifetime). Still-alive after the bounded grace window is success,
+# and _loud_local must return well before the banner's own life ends.
+printf '#!/usr/bin/env bash\nsleep 30\nexit 0\n' >"$work/bin/alerter"
+chmod +x "$work/bin/alerter"
+start_seconds=$SECONDS
+run_loud_local 0 "alerter long-lived (banner up)"
+elapsed=$((SECONDS - start_seconds))
+[[ $elapsed -lt 10 ]] || fail "banner-up path blocked ${elapsed}s; must not wait out the banner"
+
+# (b) No notifier at all: no alerter on PATH and a failing osascript must
+# report nonzero, never a silent fake success.
+rm -f "$work/bin/alerter"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$work/bin/osascript"
+chmod +x "$work/bin/osascript"
+run_loud_local 1 "no alerter, osascript fails"
+
+# (b2) The osascript fallback CAN succeed: it posts and returns immediately,
+# so its own exit status is the outcome.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$work/bin/osascript"
+chmod +x "$work/bin/osascript"
+run_loud_local 0 "osascript fallback succeeds"
+
+# (d) Errexit safety of the existing one-CRIT caller: a drain pass that
+# dead-letters a record fires _loud_local; with a FAILING notifier the drain
+# must complete and exit 0 under set -euo pipefail, never abort mid-sweep.
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'osquery-loud-local-status: OK (a, a2, b, b2, c; d skipped: no sqlite3)\n'
+  exit 0
+}
+rm -f "$work/bin/osascript"
+printf '#!/usr/bin/env bash\nexit 64\n' >"$work/bin/alerter" # notifier always fails
+chmod +x "$work/bin/alerter"
+export OSQUERY_UNDELIVERED_ALERTS_DB="$work/undelivered.sqlite3"
+export OSQUERY_DELIVERY_LOG="$work/delivery.log"
+export OSQUERY_WEBHOOK_SECRET="unit-secret"
+export OSQUERY_DRAIN_MAX_ATTEMPTS=1 # the seeded row dead-letters pre-POST (no curl needed)
+drain_output="$(
+  PATH="$stub_path" bash -c "
+    set -euo pipefail
+    source '$DISPATCH'
+    _osquery_store_alert_row 1000 osquery-errexit-pin \
+      'http://127.0.0.1:8644/webhooks/osquery-priority' \
+      \"\$(printf '{}' | base64)\"
+    sqlite3 \"\$OSQUERY_UNDELIVERED_ALERTS_DB\" \
+      \"UPDATE pending_alerts SET attempts=1 WHERE request_id='osquery-errexit-pin';\"
+    retry_undelivered_alerts
+    echo DRAIN-DONE
+  "
+)" || fail "the drain aborted when _loud_local failed (not errexit-safe)"
+[[ $drain_output == *DRAIN-DONE* ]] || fail "the drain never reached completion past a failing _loud_local"
+
+printf 'osquery-loud-local-status: OK (success, fast-fail, banner-up, absent, fallback, errexit-safe caller)\n'

--- a/test/unit/osquery-store-quote-safety.sh
+++ b/test/unit/osquery-store-quote-safety.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# The alert-row helpers must double embedded single quotes CORRECTLY under
+# EVERY bash the library can run on. Their old escape shape (an unquoted \'
+# pattern inside a double-quoted expansion) is bash-version-dependent,
+# verified both ways: bash 5 removes the backslash and doubles correctly,
+# while bash 3.2 (/bin/bash, the macOS system bash) keeps the backslash and
+# corrupts the SQL. The values are quote-free by construction TODAY (hex
+# request ids, base64 bodies, fixed reasons), and the URL comes from the
+# environment: an apostrophe URL passes every store-time validation
+# (non-empty, no whitespace or control characters) and reaches the INSERT,
+# where under system bash the corrupted SQL failed the store, a FALSE loud
+# rejection of a storable page (verified: rejection, not silent corruption).
+# The fix (quote doubling via a helper variable) behaves identically on both
+# bashes and turns the false rejection into correct storage.
+#
+# Unit test: the round-trips run inside /bin/bash when it exists (the macOS
+# system bash 3.2, the strict case); elsewhere plain bash. A quote-carrying
+# URL, dead-letter reason, and request id all round-trip byte-identical.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCH="$REPO_ROOT/dot_local/libexec/osquery/executable_alert-dispatch.sh"
+
+fail() {
+  printf 'osquery-store-quote-safety: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH; cannot exercise the store helpers\n'
+  exit 0
+}
+[[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
+
+# The strict interpreter: macOS system bash 3.2 when present, else plain bash.
+strict_bash="/bin/bash"
+[[ -x $strict_bash ]] || strict_bash="$(command -v bash)"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+export OSQUERY_UNDELIVERED_ALERTS_DB="$work/store.sqlite3"
+export OSQUERY_DELIVERY_LOG="$work/delivery.log"
+
+query() { sqlite3 -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" "$1"; }
+
+# Drive every store helper inside ONE strict-bash script (source once, run the
+# whole scenario), so the escapes execute under the version being pinned.
+"$strict_bash" -s <<STRICT_SCRIPT || fail "the strict-bash round-trip script failed (see stderr above)"
+set -euo pipefail
+source '$DISPATCH'
+body_b64="\$(printf '%s' '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')"
+
+# (1) An apostrophe URL inside the allowed localhost prefix must STORE.
+_osquery_store_alert_row 1000 osquery-apos-url \
+  "http://127.0.0.1:8644/webhooks/o'brien-priority" "\$body_b64" || {
+  echo "(1) the apostrophe URL was rejected by the store (corrupted SQL)" >&2
+  exit 1
+}
+
+# (2) A dead-letter reason carrying an apostrophe must complete the move.
+_osquery_store_alert_row 2000 osquery-apos-reason \
+  'http://127.0.0.1:8644/webhooks/osquery-priority' "\$body_b64" || {
+  echo "(2) plain store failed" >&2
+  exit 1
+}
+_osquery_dead_letter_alert_row osquery-apos-reason none \
+  "operator's note: gateway refused the page" || {
+  echo "(2) the apostrophe reason failed the dead-letter move" >&2
+  exit 1
+}
+
+# (3) An apostrophe request id must survive bookkeeping and delete-by-id.
+_osquery_store_alert_row 3000 "osquery-o'brien" \
+  'http://127.0.0.1:8644/webhooks/osquery-priority' "\$body_b64" || {
+  echo "(3) store with an apostrophe request id failed" >&2
+  exit 1
+}
+_osquery_record_transient_failure "osquery-o'brien" || {
+  echo "(3) transient bookkeeping failed on the apostrophe id" >&2
+  exit 1
+}
+_osquery_delete_alert_row "osquery-o'brien" || {
+  echo "(3) delete failed on the apostrophe id" >&2
+  exit 1
+}
+STRICT_SCRIPT
+
+# Round-trip assertions on the stored bytes (from THIS shell; reads only).
+apostrophe_url="http://127.0.0.1:8644/webhooks/o'brien-priority"
+stored_url="$(query "SELECT url FROM pending_alerts WHERE request_id='osquery-apos-url';")"
+[[ $stored_url == "$apostrophe_url" ]] ||
+  fail "(1) URL did not round-trip intact: stored '$stored_url'"
+
+# ...and the drain SELECT carries it intact (request id and URL on one row).
+# shellcheck source=/dev/null
+source "$DISPATCH"
+drain_rows="$(_osquery_pending_alert_rows)" || fail "(1) drain SELECT failed"
+printf '%s\n' "$drain_rows" | grep -qF "osquery-apos-url	$apostrophe_url" ||
+  fail "(1) the drain SELECT does not carry the apostrophe URL intact: $drain_rows"
+
+stored_reason="$(query "SELECT reason FROM dead_letter_alerts WHERE request_id='osquery-apos-reason';")"
+[[ $stored_reason == "operator's note: gateway refused the page" ]] ||
+  fail "(2) reason did not round-trip intact: stored '$stored_reason'"
+[[ "$(query 'SELECT COUNT(*) FROM pending_alerts WHERE request_id="osquery-apos-reason";')" == "0" ]] ||
+  fail "(2) the moved row is still pending"
+
+[[ "$(query "SELECT COUNT(*) FROM pending_alerts WHERE request_id='osquery-o''brien';")" == "0" ]] ||
+  fail "(3) the apostrophe-id row was not deleted"
+
+printf 'osquery-store-quote-safety: OK (url, reason, and request id round-trip under %s)\n' "$strict_bash"


### PR DESCRIPTION
## Context

The osquery security pipeline alerts through two channels: CRIT pages go to Discord via a local hermes gateway (made durable by PR #59 and PR #60, which queue and drain undelivered pages in SQLite), and a loud local macOS banner fires for the worst cases, such as a page that could not even be stored. That local banner was fire and forget: if it failed to display, nobody could tell, and the notification was gone.

This PR is slice DR-C of the S9 re-land (the staged re-landing of the osquery delivery-robustness work onto main). It makes the local banner channel durable: a banner is persisted before it is attempted, deleted only when the notifier confirms it was shown, retried by the existing scheduled drainer, marked with its original occurrence time when shown late, and expired loudly once it is too old to matter.

## Summary

- A CRIT banner is persisted before display and deleted only on confirmed showing.
- The scheduled drainer retries stored banners on the same five-minute tick.
- A late-redelivered banner names its original occurrence time in a subtitle.
- Banners older than a day expire loudly instead of retrying forever.
- Local-channel failures are log lines only, never a webhook alert about itself.
- Quote escaping in the alert store now works under every bash version.

Key files:

- `dot_local/libexec/osquery/executable_alert-dispatch.sh`
- `test/integration/osquery-local-notify-drain.bats`
- `test/unit/osquery-local-notify-durable.sh`

## What changed

- `_loud_local` now reports a truthful outcome instead of discarding it. The installed alerter (verified on 26.5) blocks for the banner's whole lifetime and exits 0 at every resolution, while a failed invocation exits fast and nonzero, so a short bounded grace window distinguishes the two without blocking a drain for the 60-second banner life.
- A new `pending_local_notifications` table (same SQLite database and lock domain as the alert queue) holds every unconfirmed banner. The write is WRITE-AHEAD: persist first, attempt second. Confirmation is per channel: a background watcher owns the alerter process and deletes the row only on its confirmed exit 0; the synchronous osascript fallback confirms inline. The accepted consequence is at-least-once display, documented in the code; the 60-second alerter ceiling under the 300-second drain tick makes the normal case exactly-once.
- The existing scheduled drainer sweeps the local queue first (a banner needs no webhook secret, and a row persisted mid-pass by the drain's own degraded-pipeline alert waits for the next tick). Retries reuse the alert queue's backoff and randomized-delay knobs. Row transport hex-encodes title and message in SQL, so tabs, newlines, and quotes survive.
- Staleness policy: the retry path renders "occurred <UTC ISO 8601 (International Organization for Standardization date format)>" as the banner subtitle (both notifier channels verified to support subtitles); rows older than `OSQUERY_LOCAL_NOTIFY_MAX_AGE_SECONDS` (default one day) are deleted unshown with a loud `LOCAL-NOTIFY-EXPIRED` log line, and expiry runs independently of retry backoff so a failing row cannot outlive its ceiling. There is no local dead-letter table: the payload duplicates what Discord already carries, and the log line is the forensic record.
- A latent quoting bug in the alert-row helpers was fixed: their escape shape corrupted SQL under bash 3.2 (the macOS system bash) while working under bash 5, which could falsely reject a storable page whose URL carried an apostrophe. All escapes now use a version-independent quote-doubling form, and a test drives the round-trips under `/bin/bash`.
- 24 new or updated test pins across three files cover truthful outcomes, write-ahead durability (including a mid-banner SIGKILL and a notifier that fails after the grace window), confirmed deletes on both channels, retry bookkeeping, ordering, skip-and-continue, honest timestamps, and both expiry directions.

## Effect of merging

- Merging to main has no live-machine impact. The machine (dresden) applies its dotfiles from `integration/modernization` until the D1 cutover, so the new behavior reaches a running system only when that branch picks these commits up.
- The schema change is additive (one new table, bootstrapped lazily); producer scripts and the `send_alert` contract are unchanged, and no new agents or plists are introduced (the existing drainer owns the sweep).
