### PR TITLE
feat(osquery): S9 config base (schedule queries, packs, file-integrity watches)

### DIFF
--- a/.chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl
@@ -38,6 +38,9 @@ PACK_POLICY
 install_root /var/osquery/packs/installed-software-drift.conf <<'PACK_DRIFT'
 {{ includeTemplate "osquery/packs/installed-software-drift.conf" . }}
 PACK_DRIFT
+install_root /var/osquery/packs/agent-attack-surface.conf <<'PACK_AGENT'
+{{ includeTemplate "osquery/packs/agent-attack-surface.conf" . }}
+PACK_AGENT
 
 # CLI flags (event flags are CLI-only and ignored if set only in the config's
 # "options" block). --config_path now points at the root-owned copy;

--- a/.chezmoitemplates/osquery/osquery.conf
+++ b/.chezmoitemplates/osquery/osquery.conf
@@ -40,6 +40,13 @@
     "ssh": [
       "{{ .chezmoi.homeDir }}/.ssh/%%"
     ],
+    "allowlist_file": [
+      "{{ .chezmoi.homeDir }}/.config/osquery/%%"
+    ],
+    "pipeline_integrity": [
+      "{{ .chezmoi.homeDir }}/.local/libexec/osquery/%%",
+      "{{ .chezmoi.homeDir }}/.local/bin/%%"
+    ],
     "launch_agents": [
       "{{ .chezmoi.homeDir }}/Library/LaunchAgents/%%",
       "/Library/LaunchAgents/%%"
@@ -57,8 +64,12 @@
     ]
   },
   "file_paths_hashes": {
-    "ssh": [
-      "{{ .chezmoi.homeDir }}/.ssh/%%"
+    "pipeline_integrity": [
+      "{{ .chezmoi.homeDir }}/.local/libexec/osquery/%%",
+      "{{ .chezmoi.homeDir }}/.local/bin/%%"
+    ],
+    "launch_agents": [
+      "{{ .chezmoi.homeDir }}/Library/LaunchAgents/%%"
     ],
     "sudoers": [
       "/etc/sudoers",

--- a/.chezmoitemplates/osquery/osquery.conf
+++ b/.chezmoitemplates/osquery/osquery.conf
@@ -15,6 +15,19 @@
       "query": "SELECT path, filename, dest_filename, pid, parent, event_type, time FROM es_process_file_events WHERE filename LIKE '%/LaunchAgents/%' OR filename LIKE '%/LaunchDaemons/%' OR dest_filename LIKE '%/LaunchAgents/%' OR dest_filename LIKE '%/LaunchDaemons/%';",
       "interval": 10,
       "removed": false
+    },
+    "new_admin_user": {
+      "query": "SELECT u.username, u.uid FROM users u JOIN user_groups ug ON u.uid = ug.uid WHERE ug.gid = 80;",
+      "interval": 3600,
+      "removed": false,
+      "platform": "darwin",
+      "description": "Members of the local admin group (gid 80). A new differential row is a newly created administrator account (privilege escalation) and pages. The baseline (root plus the operator) seeds silently via the counter==0 discard, so no page on first run. removed:false so deleting an admin does not page. Top-level (not a pack) on purpose: the alerter gate matches the bare name new_admin_user, whereas a pack entry would render as pack_<pack>_new_admin_user and never match."
+    },
+    "heartbeat_canary": {
+      "query": "SELECT unix_time FROM time;",
+      "interval": 600,
+      "snapshot": true,
+      "description": "Daemon-liveness canary. A snapshot query the ROOT osqueryd runs every 600s, so it writes one row to osqueryd.snapshots.log each interval proving the daemon is alive and actively running its schedule (not merely that a one-shot osqueryi still works while osqueryd is wedged). Snapshot (not differential) on purpose: snapshot rows land in osqueryd.snapshots.log, which the alerter does not read, so the canary never generates alert noise. The heartbeat checker script that reads this row arrives in a later slice."
     }
   },
   "packs": {

--- a/.chezmoitemplates/osquery/osquery.conf
+++ b/.chezmoitemplates/osquery/osquery.conf
@@ -20,7 +20,8 @@
   "packs": {
     "intrusion-detection": "/var/osquery/packs/intrusion-detection.conf",
     "security-policy-regression": "/var/osquery/packs/security-policy-regression.conf",
-    "installed-software-drift": "/var/osquery/packs/installed-software-drift.conf"
+    "installed-software-drift": "/var/osquery/packs/installed-software-drift.conf",
+    "agent-attack-surface": "/var/osquery/packs/agent-attack-surface.conf"
   },
   "file_paths": {
     "ssh": [

--- a/.chezmoitemplates/osquery/packs/agent-attack-surface.conf
+++ b/.chezmoitemplates/osquery/packs/agent-attack-surface.conf
@@ -7,10 +7,16 @@
       "description": "An agent control-plane / MCP / data service bound off-loopback. Pattern-based, NOT a fixed port list (MCP servers multiply and their ports drift): any MCP server (cmdline ~ mcp: qmd 8181, workspace-mcp 8000-8004, future ones), the hermes gateway (8644), the paseo daemon (6767), or postgres (5432). These belong on 127.0.0.1; off-loopback exposes the operator's remote-access / data surface off-box. Pages. Excludes ONLY real loopback (127.0.0.0/8, ::1) and the port-0 placeholder (the Paseo.app GUI socket that false-paged on every GUI relaunch); the %/Paseo% path clause was dropped for the same reason (the real paseo daemon is covered by the 6767 port clause). IPv6 link-local (fe80::) is NOT excluded, it is reachable by any host on the same link (RFC 4291), so an agent bound to a link-local address is a real off-box exposure; the family column carries the address scope in the rendered alert."
     },
     "agent_authfile_changed": {
-      "query": "SELECT path, sha256 FROM hash WHERE path IN ('{{ .chezmoi.homeDir }}/.config/osquery/webhook-secret', '{{ .chezmoi.homeDir }}/.paseo/daemon-keypair.json', '{{ .chezmoi.homeDir }}/.paseo/cli-client-id', '{{ .chezmoi.homeDir }}/.hermes/.env', '{{ .chezmoi.homeDir }}/.codex/config.toml');",
+      "query": "SELECT path, sha256 FROM hash WHERE path IN ('{{ .chezmoi.homeDir }}/.paseo/cli-client-id', '{{ .chezmoi.homeDir }}/.hermes/.env', '{{ .chezmoi.homeDir }}/.codex/config.toml');",
       "interval": 600,
       "platform": "darwin",
-      "description": "A content change to an agent auth/credential file. webhook-secret + daemon-keypair.json page (forge/mute alerts, hijack access); .env, config.toml, and cli-client-id digest. The alerter renders the basename only; the sha256 never reaches the payload."
+      "description": "A content change to a NON-secret agent config file (.env, config.toml, cli-client-id). All three digest. Content-hashed on purpose: these are configuration, not key material, so their sha256 in results.log discloses nothing. The two true secrets are watched by agent_secretfile_changed via metadata instead, never through the hash table. The alerter renders the basename only; the sha256 never reaches the payload."
+    },
+    "agent_secretfile_changed": {
+      "query": "SELECT path, size, mtime, ctime, inode FROM file WHERE path IN ('{{ .chezmoi.homeDir }}/.config/osquery/webhook-secret', '{{ .chezmoi.homeDir }}/.paseo/daemon-keypair.json');",
+      "interval": 600,
+      "platform": "darwin",
+      "description": "A rewrite of a true agent secret file: webhook-secret (forge or mute alerts) and daemon-keypair.json (hijack agent access). Pages. Watched via file-table METADATA (size, mtime, ctime, inode), NOT a content hash: results.log is group-readable, and a secret's digest must never be written there. inode catches atomic-rename replacement, size and mtime catch in-place edits, and ctime catches an edit whose mtime was restored afterward (utimes cannot rewind ctime). Accepted limit: a deliberate forgery that preserves size and both timestamps (clock manipulation or raw device writes) is not detected."
     },
     "agent_binary_changed": {
       "query": "SELECT f.path, f.size, f.inode, f.mtime, s.cdhash, s.team_identifier, s.signed FROM file f LEFT JOIN signature s ON f.path = s.path AND s.arch = '' WHERE f.path IN ('/opt/homebrew/bin/codex', '/opt/homebrew/bin/paseo');",

--- a/.chezmoitemplates/osquery/packs/agent-attack-surface.conf
+++ b/.chezmoitemplates/osquery/packs/agent-attack-surface.conf
@@ -1,0 +1,22 @@
+{
+  "queries": {
+    "agent_exposure_changed": {
+      "query": "SELECT lp.address, lp.port, lp.protocol, lp.family, p.name, p.path FROM listening_ports lp JOIN processes p ON lp.pid = p.pid WHERE lp.port != 0 AND lp.address NOT IN ('127.0.0.1', '::1') AND lp.address NOT LIKE '127.%' AND (p.cmdline LIKE '%mcp%' OR lp.port IN (5432, 6767, 8644) OR p.path LIKE '%hermes%');",
+      "interval": 600,
+      "platform": "darwin",
+      "description": "An agent control-plane / MCP / data service bound off-loopback. Pattern-based, NOT a fixed port list (MCP servers multiply and their ports drift): any MCP server (cmdline ~ mcp: qmd 8181, workspace-mcp 8000-8004, future ones), the hermes gateway (8644), the paseo daemon (6767), or postgres (5432). These belong on 127.0.0.1; off-loopback exposes the operator's remote-access / data surface off-box. Pages. Excludes ONLY real loopback (127.0.0.0/8, ::1) and the port-0 placeholder (the Paseo.app GUI socket that false-paged on every GUI relaunch); the %/Paseo% path clause was dropped for the same reason (the real paseo daemon is covered by the 6767 port clause). IPv6 link-local (fe80::) is NOT excluded, it is reachable by any host on the same link (RFC 4291), so an agent bound to a link-local address is a real off-box exposure; the family column carries the address scope in the rendered alert."
+    },
+    "agent_authfile_changed": {
+      "query": "SELECT path, sha256 FROM hash WHERE path IN ('{{ .chezmoi.homeDir }}/.config/osquery/webhook-secret', '{{ .chezmoi.homeDir }}/.paseo/daemon-keypair.json', '{{ .chezmoi.homeDir }}/.paseo/cli-client-id', '{{ .chezmoi.homeDir }}/.hermes/.env', '{{ .chezmoi.homeDir }}/.codex/config.toml');",
+      "interval": 600,
+      "platform": "darwin",
+      "description": "A content change to an agent auth/credential file. webhook-secret + daemon-keypair.json page (forge/mute alerts, hijack access); .env, config.toml, and cli-client-id digest. The alerter renders the basename only; the sha256 never reaches the payload."
+    },
+    "agent_binary_changed": {
+      "query": "SELECT f.path, f.size, f.inode, f.mtime, s.cdhash, s.team_identifier, s.signed FROM file f LEFT JOIN signature s ON f.path = s.path AND s.arch = '' WHERE f.path IN ('/opt/homebrew/bin/codex', '/opt/homebrew/bin/paseo');",
+      "interval": 3600,
+      "platform": "darwin",
+      "description": "An agent CLI binary change. LOG-ONLY (recorded in results.log for forensics, never delivered): a hash cannot tell a legit frequent self-update from a swap, and the honest limits below make a page unwarranted. HONEST COVERAGE (R2-12): this does NOT detect CONTENT changes for these binaries. codex is a ~260 MB Mach-O that exceeds osquery read_max, so its sha256 is ALWAYS empty (verified live); a re-signed content swap is invisible to the hash table. What IS detected: the signature columns (signed / cdhash / team_identifier, LEFT JOINed at arch=''). codex is signed (verified live: Developer ID Application, OpenAI OpCo team 2DC432GLL2, codesign --verify rc=0), so a cdhash change or a signed-to-unsigned transition IS a real unsafe signal for it, recorded here for forensics. paseo is UNSIGNED (verified live: signed=0, codesign --verify rc=1), so it has NO cdhash signal and its ONLY signal is the coarse (size, inode, mtime) tuple, which an in-place edit can preserve; a content change to an oversized-or-unsigned binary can go undetected. claude is excluded (also over read_max, and not an attack-surface CLI here). The robust fix (an external-hashing user poller that shasum's the resolved binary out-of-band, sidestepping read_max) is tracked as follow-up task #23; until then this tier stays log-only and makes no false promise of content-change detection."
+    }
+  }
+}

--- a/.chezmoitemplates/osquery/packs/intrusion-detection.conf
+++ b/.chezmoitemplates/osquery/packs/intrusion-detection.conf
@@ -19,10 +19,10 @@
       "description": "New legacy StartupItem or crontab entry, low-noise persistence vectors on modern macOS."
     },
     "listening_ports_non_loopback": {
-      "query": "SELECT lp.address, lp.port, lp.protocol, lp.family, p.name, p.path, p.pid, p.uid, p.cmdline FROM listening_ports lp JOIN processes p ON lp.pid = p.pid WHERE lp.port != 0 AND lp.address NOT IN ('127.0.0.1', '::1') AND lp.address NOT LIKE '127.%' AND lp.address NOT LIKE 'fe80:%';",
+      "query": "SELECT lp.address, lp.port, lp.protocol, lp.family, p.name, p.path, p.pid, p.uid, p.cmdline FROM listening_ports lp JOIN processes p ON lp.pid = p.pid WHERE lp.port != 0 AND lp.address NOT IN ('127.0.0.1', '::1') AND lp.address NOT LIKE '127.%';",
       "interval": 300,
       "platform": "darwin",
-      "description": "New externally-reachable network listener with owning-process attribution, classic backdoor/C2 signal."
+      "description": "New externally-reachable network listener with owning-process attribution, classic backdoor/C2 signal. Excludes ONLY real loopback (127.0.0.0/8, ::1) and the port-0 placeholder; IPv6 link-local (fe80::) is reachable by any host on the same link (RFC 4291), not loopback, so it stays included and the family column carries the address scope."
     },
     "kernel_extensions_new": {
       "query": "SELECT name, version, path, size, linked_against FROM kernel_extensions;",

--- a/.chezmoitemplates/osquery/packs/security-policy-regression.conf
+++ b/.chezmoitemplates/osquery/packs/security-policy-regression.conf
@@ -22,47 +22,19 @@
       "query": "SELECT name, filevault_status, encryption_status, encrypted FROM disk_encryption WHERE type = 'APFS Encryption' AND filevault_status = 'on';",
       "interval": 21600,
       "platform": "darwin",
-      "description": "FileVault-encrypted volumes (verified to report correctly on Apple Silicon). Rows present = FileVault on; the rows disappearing = regression signal."
-    },
-    "screenlock_state": {
-      "query": "SELECT enabled, grace_period FROM screenlock;",
-      "interval": 3600,
-      "platform": "darwin",
-      "description": "Screen-lock password requirement. enabled flipping to 0, or a growing grace_period, weakens lock-screen protection."
+      "description": "FileVault-encrypted APFS volumes (informational only). Rows present = FileVault on. A row DISAPPEARING is NOT a regression signal: APFS volume identity churn drops a row while the data volume stays encrypted. Genuine FileVault-off is detected by filevault_off, not this query; a removed row here is log-only."
     },
     "remote_access_sharing_state": {
-      "query": "SELECT remote_login, remote_management, screen_sharing, remote_apple_events, file_sharing, internet_sharing FROM sharing_preferences;",
+      "query": "SELECT 'screen_sharing' AS service FROM sharing_preferences WHERE screen_sharing = 1 UNION ALL SELECT 'remote_management' FROM sharing_preferences WHERE remote_management = 1 UNION ALL SELECT 'remote_apple_events' FROM sharing_preferences WHERE remote_apple_events = 1 UNION ALL SELECT 'internet_sharing' FROM sharing_preferences WHERE internet_sharing = 1;",
       "interval": 3600,
       "platform": "darwin",
-      "description": "Remote-access/sharing services that should stay off on a hardened host. Any flipping to 1 is the regression signal. (remote_login/SSH and file_sharing are currently ON on this host.)"
-    },
-    "firewall_off": {
-      "query": "SELECT global_state FROM alf WHERE global_state = 0;",
-      "interval": 86400,
-      "snapshot": true,
-      "platform": "darwin",
-      "description": "Absolute-state floor (snapshot): a row here means the firewall is OFF right now. Differential queries seed silently and miss a protection already off at baseline; this catches that. Empty (silent) when on."
-    },
-    "gatekeeper_off": {
-      "query": "SELECT assessments_enabled FROM gatekeeper WHERE assessments_enabled = 0;",
-      "interval": 86400,
-      "snapshot": true,
-      "platform": "darwin",
-      "description": "Absolute-state floor (snapshot): a row here means Gatekeeper is OFF right now. Empty (silent) when on."
-    },
-    "screenlock_off": {
-      "query": "SELECT enabled FROM screenlock WHERE enabled = 0;",
-      "interval": 86400,
-      "snapshot": true,
-      "platform": "darwin",
-      "description": "Absolute-state floor (snapshot): a row here means screen-lock is OFF right now. Empty (silent) when on."
+      "description": "ON-transition detector. Emits one row per currently-ENABLED high-risk service, so a new differential row = that service just turned on (a remote-control path opened) -> page. Excludes remote_login (SSH) and file_sharing: both are intentionally ON on dresden (the operator's own access). The counter==0 baseline discards anything already on at first run; all four watched services are currently OFF."
     },
     "filevault_off": {
       "query": "SELECT 'filevault' AS protection WHERE NOT EXISTS (SELECT 1 FROM disk_encryption WHERE type = 'APFS Encryption' AND filevault_status = 'on');",
-      "interval": 86400,
-      "snapshot": true,
+      "interval": 3600,
       "platform": "darwin",
-      "description": "Absolute-state floor (snapshot): a row here means NO APFS volume is FileVault-encrypted, i.e. FileVault is OFF right now. Empty (silent) when on."
+      "description": "FileVault off-detector. Returns one constant row only when NO APFS volume is FileVault-encrypted (FileVault OFF), empty otherwise. Differential (NOT snapshot) on purpose: snapshot results are written to osqueryd.snapshots.log, which the alerter does not read, so as a snapshot this never paged. As a differential query the off-row is logged 'added' to osqueryd.results.log when FileVault goes off, exactly like firewall_state. The row is constant, so APFS volume identity churn cannot trigger it; it fires only on genuine FileVault-off. (Screen-lock-off detection was removed from this pack: the screenlock table is scoped to the logged-in user, so the ROOT osqueryd daemon never returns a screenlock row and both screenlock queries were dead; a user-level poller re-lands that detection in its own slice.)"
     }
   }
 }

--- a/test/integration/osquery-config-agent-pack.sh
+++ b/test/integration/osquery-config-agent-pack.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# The agent attack surface is watched: the rendered config ships the
+# agent-attack-surface pack and the root setup installs it. Three queries make
+# up the pack: an off-loopback exposure watch over the agent control-plane
+# ports and patterns (paging), a hash watch over the agent auth/credential
+# files, and an honest log-only signature watch over the agent CLI binaries.
+# Render-driven: chezmoi renders the templates exactly as at apply time and jq
+# asserts the shipped JSON, so a template regression fails here before it
+# silently stops the root daemon from loading its config.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not found (run inside the nix dev shell)\n'
+  exit 0
+fi
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+render() { HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$1"; }
+
+fails=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+PACK_TEMPLATE=".chezmoitemplates/osquery/packs/agent-attack-surface.conf"
+CONF_TEMPLATE=".chezmoitemplates/osquery/osquery.conf"
+SETUP_SCRIPT=".chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl"
+
+# --- (a) osquery.conf ships the pack in its packs map -------------------------
+conf_json="$(render "$CONF_TEMPLATE")" || fail "osquery.conf failed to render"
+pack_path="$(jq -r '.packs["agent-attack-surface"] // empty' <<<"$conf_json")"
+[[ $pack_path == "/var/osquery/packs/agent-attack-surface.conf" ]] ||
+  fail "osquery.conf packs map must point agent-attack-surface at /var/osquery/packs/agent-attack-surface.conf (got '${pack_path:-absent}')"
+
+# --- (b) the pack renders to valid JSON with the three queries ----------------
+if [[ ! -f $PACK_TEMPLATE ]]; then
+  fail "missing pack template: $PACK_TEMPLATE"
+else
+  pack_json="$(render "$PACK_TEMPLATE")" || fail "pack template failed to render"
+  jq empty <<<"$pack_json" 2>/dev/null || fail "rendered pack is not valid JSON"
+
+  # No em-dash anywhere in the shipped pack (descriptions included).
+  if grep -q $'\xe2\x80\x94' <<<"$pack_json"; then
+    fail "the rendered pack contains an em-dash"
+  fi
+
+  # query_field <name> <jq-path> -- print one field of one pack query.
+  query_field() {
+    jq -r --arg q "$1" ".queries[\$q]$2 // empty" <<<"$pack_json"
+  }
+
+  # agent_exposure_changed: the off-loopback agent exposure watch (pages).
+  exposure_query="$(query_field agent_exposure_changed .query)"
+  [[ -n $exposure_query ]] || fail "agent_exposure_changed: query missing"
+  [[ "$(query_field agent_exposure_changed .interval)" == "600" ]] ||
+    fail "agent_exposure_changed: expected interval 600"
+  [[ "$(query_field agent_exposure_changed .platform)" == "darwin" ]] ||
+    fail "agent_exposure_changed: expected platform darwin"
+  # Excludes ONLY real loopback (127.0.0.0/8 and ::1) and the port-0
+  # placeholder; link-local (fe80) must NOT be excluded (it is off-box
+  # reachable, the FX9 lesson).
+  grep -qF "lp.address NOT IN ('127.0.0.1', '::1')" <<<"$exposure_query" ||
+    fail "agent_exposure_changed: lost the exact-loopback exclusion"
+  grep -qF "NOT LIKE '127.%'" <<<"$exposure_query" ||
+    fail "agent_exposure_changed: lost the 127.0.0.0/8 exclusion"
+  grep -qF "lp.port != 0" <<<"$exposure_query" ||
+    fail "agent_exposure_changed: lost the port-0 placeholder exclusion"
+  grep -qiE "fe80" <<<"$exposure_query" &&
+    fail "agent_exposure_changed: must not exclude link-local (fe80)"
+  # The pattern clauses: MCP by cmdline, hermes by path, and the fixed
+  # control-plane/data ports.
+  grep -qF "cmdline LIKE '%mcp%'" <<<"$exposure_query" ||
+    fail "agent_exposure_changed: lost the MCP cmdline pattern"
+  grep -qF "path LIKE '%hermes%'" <<<"$exposure_query" ||
+    fail "agent_exposure_changed: lost the hermes path pattern"
+  for port in 5432 6767 8644; do
+    grep -qE "(\(|, )$port(,|\))" <<<"$exposure_query" ||
+      fail "agent_exposure_changed: lost port $port from the port clause"
+  done
+
+  # agent_authfile_changed: the auth/credential file hash watch.
+  authfile_query="$(query_field agent_authfile_changed .query)"
+  [[ -n $authfile_query ]] || fail "agent_authfile_changed: query missing"
+  [[ "$(query_field agent_authfile_changed .interval)" == "600" ]] ||
+    fail "agent_authfile_changed: expected interval 600"
+  for watched_suffix in \
+    "/.config/osquery/webhook-secret" \
+    "/.paseo/daemon-keypair.json" \
+    "/.paseo/cli-client-id" \
+    "/.hermes/.env" \
+    "/.codex/config.toml"; do
+    grep -qF "$watched_suffix" <<<"$authfile_query" ||
+      fail "agent_authfile_changed: not watching $watched_suffix"
+  done
+
+  # agent_binary_changed: the honest log-only binary watch (signature columns
+  # are the real signal; the description carries the honest-coverage limits).
+  binary_query="$(query_field agent_binary_changed .query)"
+  [[ -n $binary_query ]] || fail "agent_binary_changed: query missing"
+  [[ "$(query_field agent_binary_changed .interval)" == "3600" ]] ||
+    fail "agent_binary_changed: expected interval 3600"
+  for binary in "/opt/homebrew/bin/codex" "/opt/homebrew/bin/paseo"; do
+    grep -qF "$binary" <<<"$binary_query" ||
+      fail "agent_binary_changed: not watching $binary"
+  done
+  for signature_column in "s.cdhash" "s.team_identifier" "s.signed"; do
+    grep -qF "$signature_column" <<<"$binary_query" ||
+      fail "agent_binary_changed: lost signature column $signature_column"
+  done
+  grep -qF "LEFT JOIN signature" <<<"$binary_query" ||
+    fail "agent_binary_changed: lost the LEFT JOIN on signature"
+fi
+
+# --- (c) the root setup installs the pack -------------------------------------
+grep -qF "install_root /var/osquery/packs/agent-attack-surface.conf" "$SETUP_SCRIPT" ||
+  fail "setup script has no install_root block for the pack"
+grep -qF 'includeTemplate "osquery/packs/agent-attack-surface.conf"' "$SETUP_SCRIPT" ||
+  fail "setup script does not render the pack via includeTemplate"
+
+if ((fails > 0)); then
+  printf '%d agent-attack-surface config assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'PASS: the agent-attack-surface pack ships (three queries, honest exclusions) and the root setup installs it\n'

--- a/test/integration/osquery-config-agent-pack.sh
+++ b/test/integration/osquery-config-agent-pack.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 #
 # The agent attack surface is watched: the rendered config ships the
-# agent-attack-surface pack and the root setup installs it. Three queries make
+# agent-attack-surface pack and the root setup installs it. Four queries make
 # up the pack: an off-loopback exposure watch over the agent control-plane
-# ports and patterns (paging), a hash watch over the agent auth/credential
-# files, and an honest log-only signature watch over the agent CLI binaries.
+# ports and patterns (paging), a content-hash watch over the three NON-secret
+# agent config files, a metadata-only watch over the two true secret files (no
+# secret digest may ever reach the group-readable results.log), and an honest
+# log-only signature watch over the agent CLI binaries.
 # Render-driven: chezmoi renders the templates exactly as at apply time and jq
 # asserts the shipped JSON, so a template regression fails here before it
 # silently stops the root daemon from loading its config.
@@ -84,20 +86,71 @@ else
       fail "agent_exposure_changed: lost port $port from the port clause"
   done
 
-  # agent_authfile_changed: the auth/credential file hash watch.
+  # agent_authfile_changed: the content-hash watch over the three NON-secret
+  # agent config files. The two true secrets must NOT be here: their sha256
+  # would land in the group-readable results.log.
   authfile_query="$(query_field agent_authfile_changed .query)"
   [[ -n $authfile_query ]] || fail "agent_authfile_changed: query missing"
   [[ "$(query_field agent_authfile_changed .interval)" == "600" ]] ||
     fail "agent_authfile_changed: expected interval 600"
   for watched_suffix in \
-    "/.config/osquery/webhook-secret" \
-    "/.paseo/daemon-keypair.json" \
     "/.paseo/cli-client-id" \
     "/.hermes/.env" \
     "/.codex/config.toml"; do
     grep -qF "$watched_suffix" <<<"$authfile_query" ||
-      fail "agent_authfile_changed: not watching $watched_suffix"
+      fail "agent_authfile_changed: not content-hashing $watched_suffix"
   done
+  for secret_suffix in \
+    "/.config/osquery/webhook-secret" \
+    "/.paseo/daemon-keypair.json"; do
+    grep -qF "$secret_suffix" <<<"$authfile_query" &&
+      fail "agent_authfile_changed: must not content-hash the secret $secret_suffix"
+  done
+
+  # agent_secretfile_changed: the two true secrets, watched by file-table
+  # METADATA only, so no secret digest is ever computed into results.log.
+  secretfile_query="$(query_field agent_secretfile_changed .query)"
+  [[ -n $secretfile_query ]] || fail "agent_secretfile_changed: query missing"
+  [[ "$(query_field agent_secretfile_changed .interval)" == "600" ]] ||
+    fail "agent_secretfile_changed: expected interval 600"
+  [[ "$(query_field agent_secretfile_changed .platform)" == "darwin" ]] ||
+    fail "agent_secretfile_changed: expected platform darwin"
+  for secret_suffix in \
+    "/.config/osquery/webhook-secret" \
+    "/.paseo/daemon-keypair.json"; do
+    grep -qF "$secret_suffix" <<<"$secretfile_query" ||
+      fail "agent_secretfile_changed: not watching the secret $secret_suffix"
+  done
+  grep -qF "FROM file " <<<"$secretfile_query" ||
+    fail "agent_secretfile_changed: must read the file table (metadata), not a hashing table"
+  for metadata_column in size mtime ctime inode; do
+    grep -qE "(SELECT|,) ?[a-z, ]*\b$metadata_column\b" <<<"$secretfile_query" ||
+      fail "agent_secretfile_changed: lost the $metadata_column metadata column"
+  done
+  grep -qi "sha256" <<<"$secretfile_query" &&
+    fail "agent_secretfile_changed: must not select any content digest (sha256)"
+  grep -qiE "FROM hash\b" <<<"$secretfile_query" &&
+    fail "agent_secretfile_changed: must not read the hash table"
+
+  # Config-wide: no query anywhere in the rendered conf or this pack may put a
+  # secret path and a content digest in the same statement. Each query is one
+  # line in jq -r output (SQL strings carry no newlines), so grep-chain counts.
+  for rendered in "$conf_json" "$pack_json"; do
+    leaky_count="$(jq -r '.. | .query? // empty' <<<"$rendered" |
+      grep -E "webhook-secret|daemon-keypair" |
+      grep -ciE "sha256|FROM hash" || true)"
+    [[ ${leaky_count:-0} -eq 0 ]] ||
+      fail "a rendered query pairs a secret path with a content digest ($leaky_count occurrence(s))"
+  done
+
+  # And the FIM leg: ~/.config/osquery is event-watched but must NOT be in
+  # file_paths_hashes, or file_events rows for webhook-secret would carry a
+  # sha256 into results.log through the side door.
+  if jq -e '.file_paths_hashes | has("allowlist_file")' <<<"$conf_json" >/dev/null; then
+    fail "file_paths_hashes must not hash allowlist_file (webhook-secret digest via file_events)"
+  fi
+  jq -r '.file_paths_hashes[][]' <<<"$conf_json" | grep -qF "/.config/osquery" &&
+    fail "file_paths_hashes must not cover ~/.config/osquery (webhook-secret lives there)"
 
   # agent_binary_changed: the honest log-only binary watch (signature columns
   # are the real signal; the description carries the honest-coverage limits).
@@ -127,4 +180,4 @@ if ((fails > 0)); then
   printf '%d agent-attack-surface config assertion(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'PASS: the agent-attack-surface pack ships (three queries, honest exclusions) and the root setup installs it\n'
+printf 'PASS: the agent-attack-surface pack ships (four queries, secrets metadata-only) and the root setup installs it\n'

--- a/test/integration/osquery-config-file-integrity.sh
+++ b/test/integration/osquery-config-file-integrity.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# File-integrity watches cover the alerting pipeline's own homes and the
+# alerter's config directory. The rendered osquery.conf must:
+#
+#   - watch BOTH pipeline homes under one pipeline_integrity category (no
+#     split): ~/.local/libexec/osquery (the pipeline scripts' home) AND
+#     ~/.local/bin (root-of-trust operator tools: relay.sh, hue-pulse.sh,
+#     the weekly upgrade, update-skills all run unattended from there);
+#   - watch the alerter's config directory (~/.config/osquery, where the
+#     page-launchd allowlist lives) as allowlist_file;
+#   - hash pipeline_integrity (both homes) and ~/Library/LaunchAgents, so
+#     pipeline-script and LaunchAgent events carry the sha256 the alerter's
+#     (path, hash) tuple check needs;
+#   - keep the ~/.ssh directory EVENT watch but carry no ssh hashes entry:
+#     the hash maps are consumer-driven (the tuple check) and nothing reads
+#     ssh hashes, while hashing all of ~/.ssh would hash churny files
+#     (known_hosts rewrites on every connection) and private key material
+#     into logs for no consumer.
+#
+# Render-driven: chezmoi renders osquery.conf exactly as at apply time with
+# HOME pointed at a scratch dir, so the assertions also prove the paths come
+# from {{ .chezmoi.homeDir }} and not a hardcoded home.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not found (run inside the nix dev shell)\n'
+  exit 0
+fi
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+render() { HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$1"; }
+
+fails=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+CONF_TEMPLATE=".chezmoitemplates/osquery/osquery.conf"
+
+conf_json="$(render "$CONF_TEMPLATE")" || fail "osquery.conf failed to render"
+jq empty <<<"$conf_json" 2>/dev/null || fail "rendered osquery.conf is not valid JSON"
+
+# No em-dash anywhere in the shipped config.
+if grep -q $'\xe2\x80\x94' <<<"$conf_json"; then
+  fail "the rendered osquery.conf contains an em-dash"
+fi
+
+# has_path <map> <category> <path> -- the category's array contains the path.
+has_path() {
+  jq -e --arg c "$2" --arg p "$3" ".${1}[\$c] // [] | index(\$p) != null" <<<"$conf_json" >/dev/null
+}
+
+# Both pipeline homes, one category, in the EVENT-watch map...
+has_path file_paths pipeline_integrity "$render_home/.local/libexec/osquery/%%" ||
+  fail "file_paths.pipeline_integrity must watch ~/.local/libexec/osquery/%% (the pipeline scripts' home)"
+has_path file_paths pipeline_integrity "$render_home/.local/bin/%%" ||
+  fail "file_paths.pipeline_integrity must watch ~/.local/bin/%% (root-of-trust operator tools)"
+
+# ...and both in the HASH map, so their events carry the sha256 the alerter's
+# (path, hash) tuple check needs.
+has_path file_paths_hashes pipeline_integrity "$render_home/.local/libexec/osquery/%%" ||
+  fail "file_paths_hashes.pipeline_integrity must hash ~/.local/libexec/osquery/%%"
+has_path file_paths_hashes pipeline_integrity "$render_home/.local/bin/%%" ||
+  fail "file_paths_hashes.pipeline_integrity must hash ~/.local/bin/%%"
+
+# The alerter's config directory is event-watched.
+has_path file_paths allowlist_file "$render_home/.config/osquery/%%" ||
+  fail "file_paths.allowlist_file must watch ~/.config/osquery/%% (the page-launchd allowlist's home)"
+
+# User LaunchAgents are hashed (the tuple check's other consumer).
+has_path file_paths_hashes launch_agents "$render_home/Library/LaunchAgents/%%" ||
+  fail "file_paths_hashes.launch_agents must hash ~/Library/LaunchAgents/%%"
+
+# The ~/.ssh EVENT watch stays...
+has_path file_paths ssh "$render_home/.ssh/%%" ||
+  fail "file_paths.ssh must keep the ~/.ssh/%% directory event watch"
+
+# ...but no ssh hashes entry: nothing consumes ssh hashes, and hashing all of
+# ~/.ssh would hash churny known_hosts and private key material for no reader.
+if jq -e '.file_paths_hashes | has("ssh")' <<<"$conf_json" >/dev/null; then
+  fail "file_paths_hashes must not carry an ssh entry (no consumer; churny/private content)"
+fi
+
+if ((fails > 0)); then
+  printf '%d file-integrity watch assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'PASS: file-integrity watches cover both pipeline homes, the alerter config dir, and hash only what the tuple check reads\n'

--- a/test/integration/osquery-config-linklocal.sh
+++ b/test/integration/osquery-config-linklocal.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Off-loopback listener queries treat IPv6 link-local as REAL exposure: only
+# true loopback is excluded. Link-local (fe80::) is reachable by any host on
+# the same link (RFC 4291), not loopback, so a listener bound to a link-local
+# address is a real off-box exposure that must not be filtered out of either
+# watch. Render-driven: each pack renders exactly as at apply time and the
+# query's WHERE clause is asserted to exclude real loopback (127.0.0.0/8, ::1)
+# while never mentioning fe80.
+#
+# Two queries carry the guarantee: intrusion-detection's
+# listening_ports_non_loopback (the S9 fix re-landed here) and
+# agent-attack-surface's agent_exposure_changed (landed already fixed in B1,
+# so its half is a green-at-red regression guard).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not found (run inside the nix dev shell)\n'
+  exit 0
+fi
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+render() { HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$1"; }
+
+fails=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+# check_query <pack-template> <query-name> -- the query excludes only true
+# loopback and never link-local.
+check_query() {
+  local pack="$1" query_name="$2" query
+  query="$(render "$pack" | jq -r --arg q "$query_name" '.queries[$q].query')"
+  [[ -n $query && $query != null ]] || {
+    fail "$query_name: not found in $pack"
+    return
+  }
+  # Link-local must NOT be excluded: it is on-link reachable, a real exposure.
+  grep -qiE "fe80" <<<"$query" && fail "$query_name still excludes link-local (fe80): $query"
+  # ...while the real loopback exclusions must remain.
+  grep -qF "127.%" <<<"$query" || fail "$query_name lost the 127.0.0.0/8 loopback exclusion"
+  grep -qF "::1" <<<"$query" || fail "$query_name lost the ::1 loopback exclusion"
+}
+
+check_query ".chezmoitemplates/osquery/packs/intrusion-detection.conf" listening_ports_non_loopback
+check_query ".chezmoitemplates/osquery/packs/agent-attack-surface.conf" agent_exposure_changed
+
+if ((fails > 0)); then
+  printf '%d link-local query assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'PASS: both off-loopback listener queries include link-local, exclude only real loopback\n'

--- a/test/integration/osquery-config-schedule-canaries.sh
+++ b/test/integration/osquery-config-schedule-canaries.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# A newly created administrator account pages, and the ROOT daemon proves its
+# own liveness on schedule. Two TOP-LEVEL schedule queries in osquery.conf carry
+# the guarantee (top-level, not a pack, on purpose: the alerter gate matches the
+# bare query name, whereas a pack entry renders as pack_<pack>_<name> and would
+# never match):
+#
+#   new_admin_user   -- a new differential row is a newly created admin (gid 80,
+#                       privilege escalation) and pages; the baseline seeds
+#                       silently via the counter==0 discard; removed:false so
+#                       deleting an admin does not page; platform darwin.
+#   heartbeat_canary -- a snapshot query the ROOT osqueryd runs each interval,
+#                       writing one row to osqueryd.snapshots.log so a checker
+#                       (a later slice) can prove the daemon runs its schedule;
+#                       snapshot on purpose so the alerter (which reads only
+#                       results.log) never sees it.
+#
+# Render-driven: chezmoi renders osquery.conf exactly as at apply time and jq
+# asserts the shipped schedule JSON, so a template regression fails here before
+# it silently changes what the root daemon watches.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not found (run inside the nix dev shell)\n'
+  exit 0
+fi
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+render() { HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$1"; }
+
+fails=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+CONF_TEMPLATE=".chezmoitemplates/osquery/osquery.conf"
+
+conf_json="$(render "$CONF_TEMPLATE")" || fail "osquery.conf failed to render"
+jq empty <<<"$conf_json" 2>/dev/null || fail "rendered osquery.conf is not valid JSON"
+
+# No em-dash anywhere in the shipped config (descriptions included).
+if grep -q $'\xe2\x80\x94' <<<"$conf_json"; then
+  fail "the rendered osquery.conf contains an em-dash"
+fi
+
+# sched_field <query-name> <jq-suffix> -- print one field of one schedule entry
+# without `// empty`, so a boolean false comes through instead of collapsing.
+sched_field() {
+  jq -r --arg q "$1" ".schedule[\$q]$2" <<<"$conf_json"
+}
+
+# --- new_admin_user: the privilege-escalation pager (top-level, not a pack) ---
+admin_query="$(sched_field new_admin_user .query)"
+[[ -n $admin_query && $admin_query != null ]] ||
+  fail "new_admin_user: query missing from osquery.conf schedule"
+[[ $admin_query == "SELECT u.username, u.uid FROM users u JOIN user_groups ug ON u.uid = ug.uid WHERE ug.gid = 80;" ]] ||
+  fail "new_admin_user: query semantics changed (got '${admin_query}')"
+[[ "$(sched_field new_admin_user .interval)" == "3600" ]] ||
+  fail "new_admin_user: expected interval 3600"
+[[ "$(sched_field new_admin_user .removed)" == "false" ]] ||
+  fail "new_admin_user: expected removed:false (deleting an admin must not page)"
+[[ "$(sched_field new_admin_user .platform)" == "darwin" ]] ||
+  fail "new_admin_user: expected platform darwin"
+
+# --- heartbeat_canary: the daemon-liveness snapshot ---------------------------
+canary_query="$(sched_field heartbeat_canary .query)"
+[[ -n $canary_query && $canary_query != null ]] ||
+  fail "heartbeat_canary: query missing from osquery.conf schedule"
+[[ $canary_query == "SELECT unix_time FROM time;" ]] ||
+  fail "heartbeat_canary: query semantics changed (got '${canary_query}')"
+[[ "$(sched_field heartbeat_canary .interval)" == "600" ]] ||
+  fail "heartbeat_canary: expected interval 600"
+[[ "$(sched_field heartbeat_canary .snapshot)" == "true" ]] ||
+  fail "heartbeat_canary: expected snapshot:true (so the alerter never sees it)"
+
+if ((fails > 0)); then
+  printf '%d schedule-canary assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'PASS: new_admin_user pages on a new admin (top-level) and heartbeat_canary snapshots daemon liveness\n'

--- a/test/integration/osquery-config-security-policy.sh
+++ b/test/integration/osquery-config-security-policy.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# The security-policy pack detects transitions and genuine regressions, never
+# dead states or identity churn. Render-driven pins over the rendered
+# security-policy-regression pack:
+#
+#   - remote_access_sharing_state is an ON-transition detector: one row per
+#     currently-ENABLED high-risk service via UNION ALL (screen_sharing,
+#     remote_management, remote_apple_events, internet_sharing), so a new
+#     differential row means that service just turned on and pages. It must
+#     NOT mention remote_login or file_sharing (intentionally ON on dresden,
+#     the operator's own access).
+#   - filevault_off is DIFFERENTIAL (no snapshot flag) at interval 3600 with
+#     the constant-row WHERE NOT EXISTS shape: snapshot rows land in
+#     osqueryd.snapshots.log, which the alerter never reads, so as a snapshot
+#     it never paged; the constant row makes it churn-proof.
+#   - the four dead or dead-end queries are gone: screenlock_state and
+#     screenlock_off (the screenlock table is scoped to the logged-in user,
+#     so the ROOT daemon always returned nothing; a user-level poller
+#     re-lands that detection in its own slice) and firewall_off and
+#     gatekeeper_off (snapshot floors the alerter never read; the _state
+#     differentials already cover those transitions).
+#   - filevault_state is honest: a row disappearing is NOT a regression
+#     signal (APFS volume identity churn drops rows while the data stays
+#     encrypted); genuine off is filevault_off's job.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1 && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  printf 'SKIP: chezmoi not found (run inside the nix dev shell)\n'
+  exit 0
+fi
+
+render_home="$(mktemp -d)"
+trap 'rm -rf "$render_home"' EXIT
+render() { HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$1"; }
+
+fails=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+PACK_TEMPLATE=".chezmoitemplates/osquery/packs/security-policy-regression.conf"
+
+pack_json="$(render "$PACK_TEMPLATE")" || fail "pack failed to render"
+jq empty <<<"$pack_json" 2>/dev/null || fail "rendered pack is not valid JSON"
+
+# No em-dash anywhere in the shipped pack (descriptions included).
+if grep -q $'\xe2\x80\x94' <<<"$pack_json"; then
+  fail "the rendered pack contains an em-dash"
+fi
+
+# query_field <name> <jq-suffix> -- print one field of one pack query, without
+# `// empty` so a boolean false survives instead of collapsing.
+query_field() {
+  jq -r --arg q "$1" ".queries[\$q]$2" <<<"$pack_json"
+}
+
+# --- remote_access_sharing_state: the ON-transition detector ------------------
+remote_query="$(query_field remote_access_sharing_state .query)"
+[[ -n $remote_query && $remote_query != null ]] ||
+  fail "remote_access_sharing_state: query missing"
+grep -qF "UNION ALL" <<<"$remote_query" ||
+  fail "remote_access_sharing_state: lost the UNION ALL one-row-per-enabled-service shape"
+for service in screen_sharing remote_management remote_apple_events internet_sharing; do
+  grep -qF "'$service'" <<<"$remote_query" ||
+    fail "remote_access_sharing_state: lost the '$service' service literal"
+  grep -qE "WHERE $service = 1" <<<"$remote_query" ||
+    fail "remote_access_sharing_state: $service is not filtered to currently-ENABLED (= 1)"
+done
+for excluded in remote_login file_sharing; do
+  grep -qF "$excluded" <<<"$remote_query" &&
+    fail "remote_access_sharing_state: must not watch $excluded (intentionally ON on dresden)"
+done
+[[ "$(query_field remote_access_sharing_state .interval)" == "3600" ]] ||
+  fail "remote_access_sharing_state: expected interval 3600"
+
+# --- filevault_off: differential, churn-proof constant row --------------------
+filevault_off_query="$(query_field filevault_off .query)"
+[[ -n $filevault_off_query && $filevault_off_query != null ]] ||
+  fail "filevault_off: query missing"
+if jq -e '.queries.filevault_off | has("snapshot")' <<<"$pack_json" >/dev/null; then
+  fail "filevault_off: must be differential (no snapshot flag; the alerter never reads snapshots.log)"
+fi
+[[ "$(query_field filevault_off .interval)" == "3600" ]] ||
+  fail "filevault_off: expected interval 3600"
+grep -qF "WHERE NOT EXISTS" <<<"$filevault_off_query" ||
+  fail "filevault_off: lost the constant-row WHERE NOT EXISTS shape"
+grep -qF "'filevault' AS protection" <<<"$filevault_off_query" ||
+  fail "filevault_off: lost the constant 'filevault' row (the churn-proofing)"
+
+# --- the four dead/dead-end queries are gone -----------------------------------
+for removed in screenlock_state screenlock_off firewall_off gatekeeper_off; do
+  if jq -e --arg q "$removed" '.queries | has($q)' <<<"$pack_json" >/dev/null; then
+    fail "$removed: dead query must be removed from the pack"
+  fi
+done
+
+# --- filevault_state: honest about identity churn ------------------------------
+filevault_state_desc="$(query_field filevault_state .description)"
+grep -qF "the rows disappearing = regression signal" <<<"$filevault_state_desc" &&
+  fail "filevault_state: description still claims disappearing rows are a regression signal"
+grep -qF "NOT a regression" <<<"$filevault_state_desc" ||
+  fail "filevault_state: description must state a disappearing row is NOT a regression (identity churn)"
+
+if ((fails > 0)); then
+  printf '%d security-policy pack assertion(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'PASS: the security-policy pack pages on ON-transitions and genuine FileVault-off, with the dead queries gone\n'


### PR DESCRIPTION
## Context

This chezmoi dotfiles repo declares the osquery configuration that a root `osqueryd` daemon loads on the operator's Mac. The osquery three-tier alerting work from PR #52 was reverted and is being re-landed in reviewed pieces; this PR is the config foundation: the schedule queries, packs, and file-integrity watches that the alerting scripts (arriving in later PRs) key their query names on.

Every change is render-driven tested: chezmoi renders each template exactly as it would at apply time, and jq assertions pin the shipped JSON (query text, intervals, snapshot/removed/platform flags), so a template regression fails in CI before it can silently change what the root daemon watches.

## Summary

- Ships and root-installs the agent-attack-surface pack (exposure, config-file, secret-file, and binary-signature watches).
- Secret files are watched by metadata only; no secret digest ever reaches the results log.
- Off-loopback listener watches stop excluding IPv6 link-local, a real on-link exposure.
- A newly created admin account (gid 80) pages via a top-level schedule query.
- A snapshot heartbeat canary proves the root daemon runs its schedule.
- File-integrity watches now cover both pipeline homes and the alerter's config directory.
- Security-policy pack rebuilt around transition detection; four dead queries removed.

Key files:
- `.chezmoitemplates/osquery/osquery.conf`
- `.chezmoitemplates/osquery/packs/agent-attack-surface.conf`
- `.chezmoitemplates/osquery/packs/security-policy-regression.conf`
- `.chezmoitemplates/osquery/packs/intrusion-detection.conf`
- `.chezmoiscripts/run_onchange_before_50-setup-osquery.sh.tmpl`
- `test/integration/osquery-config-*.sh` (five render-driven tests)

## What changed

- **Agent attack surface (new pack):** four queries watch the agent control plane. `agent_exposure_changed` pages when an MCP (Model Context Protocol) server, the hermes gateway, the paseo daemon, or postgres binds off-loopback. `agent_authfile_changed` hash-watches the three non-secret agent config files; their sha256 in the results log discloses nothing. `agent_secretfile_changed` watches the two true secret files (webhook secret, daemon keypair) via file metadata (size, mtime, ctime, inode) rather than a content hash, so no secret digest is ever written to the group-readable results log; the accepted trade (a forgery preserving size and both timestamps goes undetected) is recorded in the query description. `agent_binary_changed` is honestly log-only: the description records exactly which signals exist (signature columns) and which do not (content hashes for oversized or unsigned binaries).
- **Link-local fix:** `listening_ports_non_loopback` and `agent_exposure_changed` exclude only real loopback (127.0.0.0/8, ::1). IPv6 link-local (fe80::) is reachable by any host on the same link, so a listener bound there stays visible.
- **Top-level schedule queries:** `new_admin_user` (differential, hourly, removed:false) pages on a new gid-80 member; the baseline seeds silently. `heartbeat_canary` (snapshot, 600s) writes one row per interval to snapshots.log so a later checker can prove the daemon is actively running its schedule. Both sit at the top level rather than in a pack because pack queries get a `pack_` name prefix.
- **File-integrity watches:** a single `pipeline_integrity` category event-watches and hashes both `~/.local/libexec/osquery` (pipeline scripts) and `~/.local/bin` (operator tools that run unattended). `~/.config/osquery` is watched as `allowlist_file`, and `~/Library/LaunchAgents` is hashed. The ssh hashes entry is dropped (nothing consumed ssh hashes, and hashing all of `~/.ssh` would log churny known_hosts and key-material digests); the ssh event watch stays.
- **Security-policy pack:** `remote_access_sharing_state` now emits one row per currently-enabled high-risk sharing service, so a new row means a service just turned on (remote_login and file_sharing are excluded as intentionally on). `filevault_off` becomes a differential with a constant row, immune to APFS volume identity churn, and `filevault_state` is now labeled informational. Four queries that could never fire from the root daemon (both screenlock queries) or duplicated existing coverage (firewall_off, gatekeeper_off) are removed; screenlock detection returns via a user-level poller in a later PR.

## Effect of merging

- No live machine changes. The config lands at `chezmoi apply` time, and main is not applied to any machine until the planned cutover.
- The alerting components that route these query names (paging, digest, suppression) arrive in later PRs; until then the new queries only write to osquery's local result logs.
