### PR TITLE
feat(osquery): land the results alerter as an entry plus six helpers

### DIFF
--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -70,12 +70,16 @@ main() {
   local prev_inode="" prev_offset="" cursor_reset=0
   if [[ -f $STATE ]]; then read -r prev_inode prev_offset <"$STATE" || true; fi
   if ! [[ $prev_inode =~ ^[0-9]+$ && $prev_offset =~ ^[0-9]+$ ]]; then
-    # Reprocess a BOUNDED recent tail (avoids a multi-MB replay; the page cap bounds
-    # the blast radius) and warn LOUDLY below.
+    # Replay the WHOLE current log from byte 0 so a page-worthy finding is never
+    # silently dropped by a lost cursor - a bounded recent tail skipped anything
+    # before it. This is bounded: osquery caps results.log at 10 MB (logger_rotate),
+    # and render_page consolidates the batch into ONE capped page (8 blocks + an
+    # "N more" marker), so a full replay is one page, not a per-finding storm.
+    # Identical repeated resets share the occurrence id inode:0:size, so the store
+    # (request_id UNIQUE) and the Hermes gateway dedup them. Warn LOUDLY below.
     cursor_reset=1
     prev_inode="$inode"
-    local reset_tail="${OSQUERY_RESULTS_RESET_TAIL_BYTES:-262144}"
-    if [[ $size -gt $reset_tail ]]; then prev_offset=$((size - reset_tail)); else prev_offset=0; fi
+    prev_offset=0
   fi
 
   # New inode (rotation/recreation) or a shrink (truncation) -> read from byte 0 so
@@ -88,13 +92,13 @@ main() {
   [[ $size -eq $prev_offset ]] && exit 0
 
   # Warn LOUDLY that the cursor was reset (a real sound -> a page that reaches the
-  # operator, not a muted note). The reprocessed tail surfaces any queued unsafe row
-  # on its own; this is the meta-signal that the alerter's own state was disturbed.
-  # Best-effort (|| true) so it never blocks the batch; the batch page gates the
-  # checkpoint below.
+  # operator, not a muted note). The full replay below re-surfaces every finding in
+  # the current log on its own; this is the meta-signal that the alerter's own state
+  # was disturbed. Best-effort (|| true) so it never blocks the batch; the batch page
+  # gates the checkpoint below.
   if [[ $cursor_reset -eq 1 ]]; then
     send_alert CRIT "🔴 **osquery cursor reset**" \
-      "**The osquery alerter cursor was missing or corrupt - monitoring state was disturbed.**"$'\n'"- Recent results were reprocessed from a bounded tail; a queued batch may have been briefly skipped before this run."$'\n'"- If you did not clear ~/.local/state, something else reset it - **investigate now**." \
+      "**The osquery alerter cursor was missing or corrupt - monitoring state was disturbed.**"$'\n'"- The current log was replayed in full, so findings are re-surfaced below, not lost."$'\n'"- If you did not clear ~/.local/state, something else reset it - **investigate now**." \
       "Sosumi" "cursor-reset:$inode:$size" || true
   fi
 

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -1,328 +1,144 @@
 #!/usr/bin/env bash
 #
-# results-alerter.sh, fired by launchd (WatchPaths) whenever
-# ~/.local/log/osquery/osqueryd.results.log changes. Reads new lines since the
-# last run (byte-offset state file), and surfaces every differential finding
-# from the scheduled packs (intrusion-detection, security-policy-regression,
-# installed-software-drift) AND the file-events query. Each batch becomes a
-# single notification, delivered to both the local notifier and the #osquery
-# Discord channel via alert-dispatch.sh.
+# results-alerter.sh - the osquery alerter ENTRY, fired by launchd (WatchPaths)
+# whenever ~/.local/log/osquery/osqueryd.results.log changes. It reads the new
+# results-log rows since its cursor, runs them through the decomposed pipeline
+# (normalize -> route -> render), delivers a confirmed-CRITICAL batch as one
+# #priority page via alert-dispatch.sh, and advances its cursor ONLY after the
+# batch is durably delivered-or-spooled - so a crash between read and checkpoint
+# re-reads the same rows (at-least-once), never skips them.
 #
-# Supersedes an earlier file-events-only notifier that watched the same log.
+# The pipeline stages are sourced single-responsibility helpers under
+# results-alerter/; this file is the entry that owns the snapshot-to-delivery
+# transaction. ONLY main calls send_alert, the cursor checkpoint (_checkpoint),
+# or exit.
+#
+# No startup drain: the scheduled drainer (drain-undelivered-alerts.sh) owns
+# delivery liveness - it sweeps the write-ahead undelivered-alerts store on its
+# own timer - so the alerter stays single-responsibility (detect and page) and
+# never blocks detection behind a delivery retry. A page that cannot be delivered
+# now is persisted by send_alert's write-ahead store and delivered by that drainer
+# later.
 
 set -euo pipefail
 
 LOG="${OSQUERY_RESULTS_LOG:-$HOME/.local/log/osquery/osqueryd.results.log}"
 STATE="${OSQUERY_RESULTS_OFFSET:-$HOME/.local/state/osquery-results-offset}"
+HELPERS="$HOME/.local/libexec/osquery"
 
 # shellcheck source=/dev/null
-source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+source "$HELPERS/alert-dispatch.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/normalize.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/route.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/allowlist-verdict.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/pipeline-verdict.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/digest-store.sh"
+# shellcheck source=/dev/null
+source "$HELPERS/results-alerter/render-page.sh"
 
-mkdir -p "$(dirname "$STATE")"
-[[ -f $LOG ]] || exit 0
+# _checkpoint <inode> <offset>: atomically write the cursor to the current inode +
+# offset. Called by main ONLY after a batch is durably delivered-or-spooled -
+# never before parsing - so a page that could be neither delivered nor stored
+# leaves the cursor put and the next run retries the same rows.
+_checkpoint() { printf '%s %s\n' "$1" "$2" >"$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"; }
 
-# Portable size + inode (wc -c / ls -i work on macOS and Linux; BSD `stat -f`
-# does not). Inode lets us notice a rotated/recreated log at the same path.
-size="$(wc -c <"$LOG")"
-size=${size//[[:space:]]/}
-# shellcheck disable=SC2012  # $LOG is a fixed, controlled path; ls -i is safe and portable
-inode="$(ls -i "$LOG" | awk '{print $1}')"
+main() {
+  mkdir -p "$(dirname "$STATE")"
+  [[ -f $LOG ]] || exit 0
 
-# State holds "<inode> <offset>". Re-seed silently when it is missing or not in
-# that exact two-integer form (first run, or migrating the old single-int file).
-previous_inode=""
-previous_offset=""
-if [[ -f $STATE ]]; then read -r previous_inode previous_offset <"$STATE" || true; fi
-# Capture-then-validate, not branch-on-read: a state file missing its trailing
-# newline makes `read` return non-zero even though it populated the vars, so
-# keying the re-seed on read's exit status would skip a whole differential batch.
-if ! [[ $previous_inode =~ ^[0-9]+$ && $previous_offset =~ ^[0-9]+$ ]]; then
-  printf '%s %s\n' "$inode" "$size" >"$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"
+  # Portable size + inode (wc -c / ls -i work on macOS and Linux; BSD stat -f does
+  # not). The inode lets us notice a rotated/recreated log at the same path.
+  local size inode
+  size="$(wc -c <"$LOG")"
+  size=${size//[[:space:]]/}
+  # shellcheck disable=SC2012  # $LOG is a fixed, controlled path - ls -i is safe and portable
+  inode="$(ls -i "$LOG" | awk '{print $1}')"
+
+  # The cursor holds "<inode> <offset>". A missing or malformed cursor is an
+  # ALERTING FAILURE, not a silent seek-to-EOF: deleting the cursor must not be a
+  # way to suppress a queued batch. Capture-then-validate (not branch-on-read): a
+  # state file missing its trailing newline makes `read` return non-zero even
+  # though it populated the vars, so keying the re-seed on read's status would skip
+  # a whole batch.
+  local prev_inode="" prev_offset="" cursor_reset=0
+  if [[ -f $STATE ]]; then read -r prev_inode prev_offset <"$STATE" || true; fi
+  if ! [[ $prev_inode =~ ^[0-9]+$ && $prev_offset =~ ^[0-9]+$ ]]; then
+    # Reprocess a BOUNDED recent tail (avoids a multi-MB replay; the page cap bounds
+    # the blast radius) and warn LOUDLY below.
+    cursor_reset=1
+    prev_inode="$inode"
+    local reset_tail="${OSQUERY_RESULTS_RESET_TAIL_BYTES:-262144}"
+    if [[ $size -gt $reset_tail ]]; then prev_offset=$((size - reset_tail)); else prev_offset=0; fi
+  fi
+
+  # New inode (rotation/recreation) or a shrink (truncation) -> read from byte 0 so
+  # nothing is skipped or replayed from the old file.
+  if [[ $inode != "$prev_inode" || $size -lt $prev_offset ]]; then
+    prev_offset=0
+  fi
+
+  # Nothing new since the cursor: exit without touching the cursor.
+  [[ $size -eq $prev_offset ]] && exit 0
+
+  # Warn LOUDLY that the cursor was reset (a real sound -> a page that reaches the
+  # operator, not a muted note). The reprocessed tail surfaces any queued unsafe row
+  # on its own; this is the meta-signal that the alerter's own state was disturbed.
+  # Best-effort (|| true) so it never blocks the batch; the batch page gates the
+  # checkpoint below.
+  if [[ $cursor_reset -eq 1 ]]; then
+    send_alert CRIT "🔴 **osquery cursor reset**" \
+      "**The osquery alerter cursor was missing or corrupt - monitoring state was disturbed.**"$'\n'"- Recent results were reprocessed from a bounded tail; a queued batch may have been briefly skipped before this run."$'\n'"- If you did not clear ~/.local/state, something else reset it - **investigate now**." \
+      "Sosumi" "cursor-reset:$inode:$size" || true
+  fi
+
+  # Read only the new bytes since the cursor. Bound the read to the snapshot window
+  # (head -c) so rows appended after we captured $size are not consumed early and
+  # re-fired next time; || true absorbs head's SIGPIPE. Clamp defensively: an
+  # inode-reusing rotation in the window could otherwise hand head -c a non-positive
+  # count.
+  local span new_lines=""
+  span=$((size - prev_offset))
+  if [[ $span -gt 0 ]]; then
+    new_lines="$(tail -c "+$((prev_offset + 1))" "$LOG" | head -c "$span" || true)"
+  fi
+
+  # The pipeline: normalize the raw rows into findings, route each to page/digest/
+  # log-only (digest and log-only are handled in-stage), render the CRIT
+  # page-candidates into the #priority body. A malformed row yields nothing for that
+  # row (normalize's per-line try/fromjson), so a garbage batch produces an empty
+  # page and never aborts.
+  local render pcount pbody
+  render="$(printf '%s\n' "$new_lines" | normalize_findings | route_findings | render_page)"
+  pcount="$(jq -r '.pcount // 0' <<<"$render" 2>/dev/null || printf '0')"
+  [[ $pcount =~ ^[0-9]+$ ]] || pcount=0
+
+  # Checkpoint ONLY after the batch is durably handled. deliver_ok starts true (a
+  # batch with no page consumed only digest/log-only rows, already handled); a page
+  # that hard-fails to deliver AND spool sets it false, so the cursor stays put and
+  # the next run retries the SAME rows (at-least-once). The occurrence id (inode +
+  # this batch's byte range) makes the page's request_id occurrence-unique yet
+  # stable across a retry of this same batch.
+  local deliver_ok=1
+  if [[ $pcount -gt 0 ]]; then
+    pbody="$(jq -r '.pbody' <<<"$render")"
+    local title="🔴 **CRITICAL**"
+    [[ $pcount -gt 1 ]] && title="🔴 **CRITICAL** · $pcount"
+    if ! send_alert CRIT "$title" "$pbody" "Sosumi" "$inode:$prev_offset:$size"; then
+      deliver_ok=0
+    fi
+  fi
+
+  # Exit 0 even on a delivery hard-failure: the batch was processed and the failure
+  # is already surfaced (send_alert's loud local alert + delivery log). A nonzero
+  # exit would false-trip the uptime watchdog's crash-loop check. The cursor simply
+  # stays put for a retry.
+  [[ $deliver_ok -eq 1 ]] && _checkpoint "$inode" "$size"
   exit 0
-fi
+}
 
-# New inode (rotation/recreation) or a shrink (truncation) → read the current
-# file from byte 0 so nothing is skipped or replayed from the old file.
-if [[ $inode != "$previous_inode" || $size -lt $previous_offset ]]; then
-  previous_offset=0
-fi
-
-[[ $size -eq $previous_offset ]] && exit 0
-
-# Notify on ALL observed activity, tiered by severity so high-threat events
-# stand out from routine ones. Each row is classified:
-#   CRIT (🔴):   a protection turned off (security-policy-regression), a new
-#                 unexpected setuid binary, or ssh-key / sudoers tampering.
-#   NOTICE (🟡): new persistence/auto-start, launchd-dir file changes, or a
-#                 new kernel/system extension.
-#   INFO (🔵):   installed-software drift, listening ports, logins.
-# chezmoi's renameio temp-file churn is excluded. jq emits "<SEV>\t<text>".
-# Bound the read to the snapshot window (head -c) so rows appended after we
-# captured $size aren't consumed early and re-fired next time; `|| true`
-# absorbs head's SIGPIPE. jq -rR + per-line try/fromjson means one malformed
-# line yields nothing for that line instead of aborting the whole batch.
-# $size > $previous_offset is guaranteed by the shrink-reset and equality-exit
-# guards above, but clamp defensively: an inode-reusing rotation in the window
-# since we captured $size could otherwise hand head -c a non-positive count.
-span=$((size - previous_offset))
-new_lines=""
-if [[ $span -gt 0 ]]; then
-  new_lines="$(tail -c "+$((previous_offset + 1))" "$LOG" | head -c "$span" || true)"
-fi
-raw_findings="$(printf '%s\n' "$new_lines" | jq -rR '
-  . as $line | (try ($line | fromjson) catch empty) |
-  # A security-policy row is CRITICAL only when the protection turned OFF, not
-  # on every change. For the boolean states that is an "added" row carrying the
-  # off value; for filevault (the query returns only encrypted volumes) it is a
-  # "removed" row, a volume left the encrypted set. Re-enables, version bumps,
-  # sharing changes, and the paired "removed" old-value rows fall through to
-  # NOTICE. (sharing cannot be direction-classified from a single row, so it is
-  # always NOTICE; the poller covers firewall/Gatekeeper transitions too.)
-  def protection_off:
-    (.name == "pack_security-policy-regression_firewall_state" and .action == "added" and (.columns.global_state // "") == "0")
-    or (.name == "pack_security-policy-regression_gatekeeper_state" and .action == "added" and (.columns.assessments_enabled // "") == "0")
-    or (.name == "pack_security-policy-regression_sip_state" and .action == "added" and (.columns.enabled // "") == "0")
-    or (.name == "pack_security-policy-regression_screenlock_state" and .action == "added" and (.columns.enabled // "") == "0")
-    or (.name == "pack_security-policy-regression_filevault_state" and .action == "removed")
-    or (.action == "currently-off" and (.name | startswith("pack_security-policy-regression_")));
-  def sev:
-    if protection_off
-       or (.name == "pack_intrusion-detection_suid_bin_unexpected")
-       or (.name == "file_events_recent" and ((.columns.category // "") | test("^(ssh|sudoers|sshd_config)$")))
-    then "CRIT"
-    elif (.name | startswith("pack_security-policy-regression_"))
-       or (.name | test("^pack_intrusion-detection_persistence_"))
-       or (.name == "pack_intrusion-detection_kernel_extensions_new")
-       or (.name == "pack_intrusion-detection_system_extensions_new")
-       or (.name == "file_events_recent")
-       or (.name == "es_launchd_writes")
-    then "NOTICE"
-    else "INFO" end;
-  # Snapshot rows (absolute-state floor *_off queries) log under a "snapshot"
-  # array with action "snapshot"; explode each into a synthetic "currently-off"
-  # row so the rest of the pipeline treats it uniformly. Empty snapshot = silent.
-  (if .action == "snapshot"
-   then (.name as $n | .snapshot[]? | {name: $n, action: "currently-off", columns: .})
-   else . end)
-  | select(.name != null and ((.name | startswith("pack_")) or (.name == "file_events_recent") or (.name == "es_launchd_writes")))
-  | select((.columns.target_path // "") | test("/\\.renameio-TempDir") | not)
-  | (.name | sub("^pack_[^_]+_"; "")) as $q
-  | (.action // "changed") as $act
-  # The path the enricher should inspect (a plist, bundle, or binary) per query
-  # type, empty when signing/trust does not apply.
-  | ((if .name == "es_launchd_writes" then (.columns.path // "")
-      elif .name == "file_events_recent" then (.columns.target_path // "")
-      elif (.name | test("_persistence_launchd$")) then (.columns.path // "")
-      elif (.name | test("_persistence_startup_items_crontab$")) then (.columns.path // "")
-      elif (.name | test("_kernel_extensions_new$")) then (.columns.path // "")
-      elif (.name | test("_system_extensions_new$")) then (.columns.bundle_path // .columns.path // "")
-      elif (.name | test("_suid_bin_unexpected$")) then (.columns.path // "")
-      else "" end) | gsub("[\t\n]"; " ")) as $ep
-  # Emit one compact JSON object per finding; the bash side enriches, then renders
-  # it into a #priority block or an #osquery line via the header/field/step maps.
-  | {sev: sev, q: $q, act: $act, cols: (.columns // {}), ep: $ep} | @json
-' 2>/dev/null || true)"
-
-# Advance state before notifying so a slow/failed dispatch never re-fires the
-# same batch on the next WatchPaths trigger. Format: "<inode> <offset>".
-printf '%s %s\n' "$inode" "$size" >"$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"
-
-[[ -z $raw_findings ]] && exit 0
-
-# Enrich CRIT/NOTICE findings with deterministic signing facts (enrich-finding.sh).
-# An UNTRUSTED result promotes NOTICE -> CRIT (louder, never quieter). Fail-open: if the
-# helper is absent or errors, the finding still surfaces, just without a Signing: field.
-# Nothing is ever suppressed here. Each raw line is one compact JSON finding object; we
-# inject .signing and the (possibly promoted) .sev back into it.
-ENRICH_SCRIPT="$HOME/.local/libexec/osquery/enrich-finding.sh"
-
-# Default-deny launch-item allowlist: labels listed here are known-good and are
-# dropped from the quiet #osquery channel (never from #priority, see the
-# CRIT-exempt check in the loop). Load once; fail-open if the file is missing or
-# unreadable (suppress nothing). Strip comments/whitespace/blank lines.
-ALLOWLIST_FILE="${OSQUERY_LAUNCH_ALLOWLIST:-$HOME/.config/osquery/launch-allowlist.txt}"
-allowlist_entries=""
-if [[ -r $ALLOWLIST_FILE ]]; then
-  allowlist_entries="$(sed -e 's/#.*//' -e 's/[[:space:]]//g' "$ALLOWLIST_FILE" | grep -v '^$' || true)"
-fi
-_allowlisted() { [[ -n $allowlist_entries ]] && grep -qxF -- "$1" <<<"$allowlist_entries"; }
-
-enriched=""
-while IFS= read -r finding; do
-  [[ -z $finding ]] && continue
-  # Read the fields we need one-per-line. A tab/space IFS would collapse runs and
-  # shift columns when a middle field is empty (e.g. absent category); line-per-
-  # field preserves empties. Safe because none of these values contains a newline
-  # (enrich_path had newlines stripped upstream; the rest are tokens/labels).
-  {
-    read -r severity
-    read -r enrich_path
-    read -r query_name
-    read -r category
-    read -r label
-  } < <(
-    jq -r '.sev, (.ep // ""), .q, (.cols.category // ""), (.cols.label // .cols.name // "")' <<<"$finding"
-  )
-  signing_facts=""
-  if [[ -n $enrich_path && ($severity == CRIT || $severity == NOTICE) && -x $ENRICH_SCRIPT ]]; then
-    enrich_status=0
-    signing_facts="$("$ENRICH_SCRIPT" "$enrich_path" 2>/dev/null)" || enrich_status=$?
-    [[ $enrich_status -eq 10 && $severity == NOTICE ]] && severity="CRIT"
-  fi
-  # Default-deny allowlist: drop a known-good launch item from #osquery. Checked
-  # AFTER enrichment so a promoted CRIT (an untrusted binary behind an allowlisted
-  # label) is never suppressed. The allowlist only quiets the non-CRIT channel.
-  if [[ $severity != "CRIT" ]]; then
-    allowlist_key=""
-    case "$query_name" in
-      persistence_launchd | persistence_startup_items_crontab) allowlist_key="$label" ;;
-      file_events_recent) [[ $category == "launch_agents" || $category == "launch_daemons" ]] && allowlist_key="$(basename "$enrich_path" .plist)" ;;
-    esac
-    [[ -n $allowlist_key ]] && _allowlisted "$allowlist_key" && continue
-  fi
-  finding="$(jq -c --arg sev "$severity" --arg sig "$signing_facts" \
-    '.sev = $sev | (if $sig == "" then . else .signing = $sig end)' <<<"$finding")"
-  enriched+="$finding"$'\n'
-done <<<"$raw_findings"
-enriched=${enriched%$'\n'}
-
-[[ -z $enriched ]] && exit 0
-
-# Render both channel bodies in one jq pass. #priority gets focused labeled blocks
-# (header + decision-relevant fields + one "→" next step); #osquery gets one compact
-# humanized line per finding. Layout follows the user's ADHD surfacing research: one
-# thing, glanceable, minimal fields, ending in a single action, no raw query jargon.
-render="$(printf '%s\n' "$enriched" | jq -s '
-  # Wrap a value in Discord inline-code backticks. The value is attacker-controlled
-  # (launchd label, path); strip backticks so it cannot break out of the inline-code
-  # span and inject markdown. Display-only, does not affect detection/severity.
-  def code: "`" + (gsub("`"; "") ) + "`";
-  # Plain-English name of a macOS protection query, or null if the finding is not one.
-  def protname:
-    if (.q | test("^firewall")) then "Firewall"
-    elif (.q | test("^gatekeeper")) then "Gatekeeper"
-    elif (.q | test("^sip")) then "System Integrity Protection"
-    elif (.q | test("^filevault")) then "FileVault"
-    elif (.q | test("^screenlock")) then "Screen lock"
-    elif (.q | test("^remote_access_sharing")) then "Sharing"
-    else null end;
-  # Human header for a finding (kernel/system extensions matched before the generic
-  # browser-extension regex so they keep their specific labels).
-  def header:
-    (protname) as $p |
-    if $p != null then (if .sev == "CRIT" then "\($p) turned OFF" else "\($p) changed" end)
-    elif .q == "persistence_launchd" then "New startup item"
-    elif .q == "persistence_launchd_overrides" then "Startup override changed"
-    elif .q == "persistence_startup_items_crontab" then "New startup/cron entry"
-    elif .q == "suid_bin_unexpected" then "New setuid root binary"
-    elif .q == "kernel_extensions_new" then "New kernel extension"
-    elif .q == "system_extensions_new" then "New system extension"
-    elif .q == "listening_ports_non_loopback" then "New network listener"
-    elif .q == "recent_logins" then "Login"
-    elif .q == "installed_apps" then "New app"
-    elif .q == "homebrew_packages" then "New Homebrew package"
-    elif (.q | test("_extensions$|_addons$")) then "New browser extension"
-    elif .q == "file_events_recent" then
-      ((.cols.category // "") as $cat |
-        if $cat == "ssh" then "SSH file changed"
-        elif $cat == "sudoers" then "sudoers changed"
-        elif $cat == "sshd_config" then "sshd_config changed"
-        elif ($cat == "launch_agents" or $cat == "launch_daemons") then "Startup folder changed"
-        else "Watched file changed" end)
-    elif .q == "es_launchd_writes" then "Startup item written by a process"
-    else (.q | gsub("_"; " ")) end;
-  # Best single identifier for a finding.
-  def keyid:
-    .cols as $c |
-    ($c.label // $c.identifier // $c.name // $c.target_path // $c.path // $c.username // "?");
-  # Structured key:value segments for an #osquery single-line entry. Signing rides as
-  # its own segment ("signed: ..." / "UNSIGNED"), not under a redundant "signing:" key.
-  def segs:
-    .cols as $c | (.signing // null) as $sig |
-    (if $sig then [$sig] else [] end) as $sg |
-    if .q == "recent_logins" then ["user: \(($c.username // "?") | code)", "from: \(($c.host // "local") | code)"]
-    elif .q == "listening_ports_non_loopback" then ["process: \(($c.name // "?") | code)", "address: \(("\($c.address // "?"):\($c.port // "?")") | code)"]
-    elif .q == "installed_apps" then ["name: \(($c.name // "?") | code)"] + (if ($c.bundle_short_version // "") != "" then ["version: \(($c.bundle_short_version) | code)"] else [] end)
-    elif .q == "homebrew_packages" then ["name: \(($c.name // "?") | code)", "version: \(($c.version // "?") | code)"]
-    elif (.q | test("_extensions$|_addons$")) then ["name: \(($c.name // "?") | code)", "identifier: \(($c.identifier // "?") | code)"]
-    elif .q == "persistence_launchd" then ["name: \(($c.label // "?") | code)", "program: \(($c.program // "?") | code)"] + $sg
-    elif .q == "persistence_launchd_overrides" then ["label: \(($c.label // "?") | code)", "key: \(($c.key // "?") | code)", "value: \(($c.value // "?") | code)"]
-    elif .q == "persistence_startup_items_crontab" then ["name: \(($c.name // "?") | code)", "command: \(($c.command // "?") | code)"] + $sg
-    elif .q == "system_extensions_new" then ["name: \(($c.identifier // "?") | code)", "team: \(($c.team // "?") | code)"] + $sg
-    elif .q == "kernel_extensions_new" then ["name: \(($c.name // "?") | code)"] + $sg
-    elif .q == "file_events_recent" then ["file: \(($c.target_path // "?") | code)", "action: \((.act) | code)"] + $sg
-    elif .q == "es_launchd_writes" then ["process: \(($c.path // "?") | code)", "wrote: \(($c.filename // $c.dest_filename // "?") | code)"] + $sg
-    elif (protname) != null then ["state: \((.act) | code)"]
-    else ["identifier: \((keyid) | code)"] end;
-  # Decision-relevant "Label: value" lines for a #priority block. Values are wrapped
-  # in Discord inline-code; an untrusted signing verdict is flagged and bolded.
-  def fields:
-    .cols as $c | (.signing // null) as $sig |
-    (if $sig then
-       (if ($sig | test("unsigned|untrusted|ad-hoc|unverified|no authority"; "i"))
-        then ["- **Signing:** ⚠️ **\($sig)**"] else ["- **Signing:** \($sig)"] end)
-     else [] end) as $sg |
-    if .q == "persistence_launchd" then ["- **What:** \(($c.label // "?") | code)", "- **Program:** \(($c.program // "?") | code)"] + $sg
-    elif .q == "persistence_startup_items_crontab" then ["- **What:** \(($c.name // "?") | code)", "- **Command:** \(($c.command // "?") | code)"] + $sg
-    elif .q == "suid_bin_unexpected" then ["- **Path:** \(($c.path // "?") | code)"] + $sg + ["- **Owner:** \(($c.username // "?") | code)"]
-    elif .q == "system_extensions_new" then ["- **Name:** \(($c.identifier // "?") | code)", "- **Team:** \(($c.team // "?") | code)"] + $sg
-    elif .q == "kernel_extensions_new" then ["- **Name:** \(($c.name // "?") | code)", "- **Path:** \(($c.path // "?") | code)"] + $sg
-    elif .q == "file_events_recent" then ["- **File:** \(($c.target_path // "?") | code)", "- **Action:** \(.act)"]
-    elif .q == "es_launchd_writes" then ["- **Process:** \(($c.path // "?") | code)", "- **Wrote:** \(($c.filename // $c.dest_filename // "?") | code)"] + $sg
-    elif (protname) != null then ["- **State:** **OFF**"]
-    else $sg + ["- **What:** \((keyid) | code)"] end;
-  # One or two instructive next-step lines for a #priority (always CRIT) block.
-  def nextstep:
-    (.ep // "") as $ep |
-    if (protname) != null then
-      ["- Did you turn this off? If not, something else did: **investigate now**.", "- Re-enable it in System Settings."]
-    elif (.q == "system_extensions_new" or .q == "kernel_extensions_new") then
-      ["- Did you install this? If not, **remove it**: an extension can intercept traffic or load at boot.", "- Manage at: System Settings → General → Login Items & Extensions"]
-    elif .q == "suid_bin_unexpected" then
-      ["- Did you create this? If not, it lets a program run as **root**, a backdoor.", "- **Inspect:** " + (("codesign -dv \"" + $ep + "\"") | code)]
-    elif .q == "file_events_recent" then
-      ["- Did you change this? If not, someone altered who can log in or run as **root**.", "- **Review:** " + (("sudo cat \"" + $ep + "\"") | code)]
-    elif (.q == "persistence_launchd" or .q == "persistence_startup_items_crontab") then
-      ["- Did you set this up? If not, it **auto-runs at every login**, likely malware.", "- **Inspect:** " + (("cat \"" + $ep + "\"") | code)]
-    elif .q == "es_launchd_writes" then
-      ["- Did you run this? If not, a process is **installing persistence**: investigate it and remove the file.", "- **Inspect the writer:** " + (("codesign -dv \"" + $ep + "\"") | code)]
-    elif ($ep != "") then ["- **Review:** " + ($ep | code)]
-    else [] end;
-  def block:
-    (["**" + header + "**"] + fields + nextstep) | join("\n");
-  def line:
-    "- " + (if .sev == "NOTICE" then "🟡" else "🔵" end) + " **" + header + "**: " + (segs | join(" · "));
-  ([.[] | select(.sev == "CRIT")]) as $crit |
-  ([.[] | select(.sev != "CRIT")] | sort_by(if .sev == "NOTICE" then 0 else 1 end)) as $rest |
-  {
-    pcount: ($crit | length),
-    ocount: ($rest | length),
-    onotice: (any($rest[]; .sev == "NOTICE")),
-    pbody: ($crit | map(block) | join("\n\n")),
-    obody: (($rest[0:12] | map(line) | join("\n"))
-      + (if ($rest | length) > 12 then "\n…\(($rest | length) - 12) more" else "" end))
-  }
-')"
-
-# Dispatch each non-empty channel. #priority carries CRIT only; #osquery NOTICE/INFO.
-priority_count="$(jq -r '.pcount' <<<"$render")"
-osquery_count="$(jq -r '.ocount' <<<"$render")"
-
-if [[ $priority_count -gt 0 ]]; then
-  title="🔴 **CRITICAL**"
-  if [[ $priority_count -gt 1 ]]; then title="🔴 **CRITICAL** · $priority_count"; fi
-  send_alert CRIT "$title" "$(jq -r '.pbody' <<<"$render")" "Sosumi"
-fi
-
-if [[ $osquery_count -gt 0 ]]; then
-  if [[ "$(jq -r '.onotice' <<<"$render")" == "true" ]]; then
-    osquery_severity="NOTICE"
-    osquery_title="🟡 **Notice** · $osquery_count"
-    osquery_sound="Glass"
-  else
-    osquery_severity="INFO"
-    osquery_title="🔵 **Info** · $osquery_count"
-    osquery_sound=""
-  fi
-  send_alert "$osquery_severity" "$osquery_title" "$(jq -r '.obody' <<<"$render")" "$osquery_sound"
-fi
+main "$@"

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -43,23 +43,56 @@ source "$HOME/.local/libexec/osquery/results-alerter/digest-store.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/render-page.sh"
 
+# The single-instance lock file sits beside the cursor it guards, so every alerter
+# invocation contends on one lock no matter what launched it (a WatchPaths burst can
+# fire several). Overridable for tests.
+OSQUERY_RESULTS_LOCK_FILE="${OSQUERY_RESULTS_LOCK_FILE:-${STATE}.lock}"
+
+# _take_single_instance_lock: hold fd 9 open on the lock file and take a nonblocking
+# kernel lock on it (/usr/bin/lockf, the house pattern used by the drainer,
+# hue-pulse, homebrew-weekly-upgrade). Return 0 to proceed, nonzero to skip. The
+# kernel releases the lock on ANY exit (normal or crash), so there is no stale-lock
+# state to clean up. This is MUTUAL EXCLUSION: on a genuine setup error it fails
+# CLOSED (nonzero -> the caller skips), never runs unlocked - two overlapping runs
+# would each read the same cursor+snapshot, double-send the banner, and race the
+# checkpoint. The ONE exception is a host without lockf (any non-darwin box, e.g.
+# Linux CI): there is no kernel lock to take, so the run proceeds unlocked by design.
+_take_single_instance_lock() {
+  local lockf_bin="${OSQUERY_RESULTS_LOCKF_BIN:-/usr/bin/lockf}"
+  [[ -x $lockf_bin ]] || return 0
+  mkdir -p "$(dirname "$OSQUERY_RESULTS_LOCK_FILE")" 2>/dev/null || return 1
+  exec 9>>"$OSQUERY_RESULTS_LOCK_FILE" 2>/dev/null || return 1
+  "$lockf_bin" -s -t 0 9
+}
+
 # _checkpoint <inode> <offset>: atomically write the cursor to the current inode +
 # offset. Called by main ONLY after a batch is durably delivered-or-spooled -
 # never before parsing - so a page that could be neither delivered nor stored
-# leaves the cursor put and the next run retries the same rows.
-_checkpoint() { printf '%s %s\n' "$1" "$2" >"$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"; }
+# leaves the cursor put and the next run retries the same rows. The 9>&- keeps the
+# lock fd out of the mv child (see the fd-hygiene note in main).
+_checkpoint() { printf '%s %s\n' "$1" "$2" >"$STATE.tmp" && mv -f "$STATE.tmp" "$STATE" 9>&-; }
 
 main() {
+  # Take the single-instance lock BEFORE reading the cursor and hold it through
+  # route -> send_alert -> checkpoint, so overlapping WatchPaths invocations
+  # serialize: exactly one run delivers a batch and advances the cursor; a
+  # contended run is a clean no-op. fd HYGIENE: the lock lives on fd 9 (held by
+  # this process); EVERY external command spawned below closes it with 9>&- so a
+  # forked child - especially a backgrounded notifier from send_alert - can never
+  # inherit fd 9 and keep the lock held after this run exits (the latent bug from
+  # the allowlist writer's lock).
+  _take_single_instance_lock || exit 0
+
   mkdir -p "$(dirname "$STATE")"
   [[ -f $LOG ]] || exit 0
 
   # Portable size + inode (wc -c / ls -i work on macOS and Linux; BSD stat -f does
   # not). The inode lets us notice a rotated/recreated log at the same path.
   local size inode
-  size="$(wc -c <"$LOG")"
+  size="$(wc -c <"$LOG" 9>&-)"
   size=${size//[[:space:]]/}
   # shellcheck disable=SC2012  # $LOG is a fixed, controlled path - ls -i is safe and portable
-  inode="$(ls -i "$LOG" | awk '{print $1}')"
+  inode="$({ ls -i "$LOG" | awk '{print $1}'; } 9>&-)"
 
   # The cursor holds "<inode> <offset>". A missing or malformed cursor is an
   # ALERTING FAILURE, not a silent seek-to-EOF: deleting the cursor must not be a
@@ -99,7 +132,7 @@ main() {
   if [[ $cursor_reset -eq 1 ]]; then
     send_alert CRIT "🔴 **osquery cursor reset**" \
       "**The osquery alerter cursor was missing or corrupt - monitoring state was disturbed.**"$'\n'"- The current log was replayed in full, so findings are re-surfaced below, not lost."$'\n'"- If you did not clear ~/.local/state, something else reset it - **investigate now**." \
-      "Sosumi" "cursor-reset:$inode:$size" || true
+      "Sosumi" "cursor-reset:$inode:$size" 9>&- || true
   fi
 
   # Read only the new bytes since the cursor. Bound the read to the snapshot window
@@ -112,8 +145,10 @@ main() {
   span=$((size - prev_offset))
   if [[ $span -gt 0 ]]; then
     snapshot="$(
-      tail -c "+$((prev_offset + 1))" "$LOG" 2>/dev/null | head -c "$span" 2>/dev/null
-      printf x
+      {
+        tail -c "+$((prev_offset + 1))" "$LOG" 2>/dev/null | head -c "$span" 2>/dev/null
+        printf x
+      } 9>&-
     )"
     snapshot="${snapshot%x}"
   fi
@@ -129,7 +164,7 @@ main() {
   local complete_records="" complete_bytes=0
   if [[ $snapshot == *$'\n'* ]]; then
     complete_records="${snapshot%$'\n'*}"$'\n'
-    complete_bytes="$(printf '%s' "$complete_records" | LC_ALL=C wc -c)"
+    complete_bytes="$({ printf '%s' "$complete_records" | LC_ALL=C wc -c; } 9>&-)"
     complete_bytes="${complete_bytes//[[:space:]]/}"
   fi
   local checkpoint_offset=$((prev_offset + complete_bytes))
@@ -140,8 +175,8 @@ main() {
   # row (normalize's per-line try/fromjson), so a garbage batch produces an empty
   # page and never aborts.
   local render pcount pbody
-  render="$(printf '%s' "$complete_records" | normalize_findings | route_findings | render_page)"
-  pcount="$(jq -r '.pcount // 0' <<<"$render" 2>/dev/null || printf '0')"
+  render="$({ printf '%s' "$complete_records" | normalize_findings | route_findings | render_page; } 9>&-)"
+  pcount="$(jq -r '.pcount // 0' 9>&- <<<"$render" 2>/dev/null || printf '0')"
   [[ $pcount =~ ^[0-9]+$ ]] || pcount=0
 
   # Checkpoint ONLY after the batch is durably handled, and only through the last
@@ -153,10 +188,10 @@ main() {
   # request_id occurrence-unique yet stable across a retry of this same batch.
   local deliver_ok=1
   if [[ $pcount -gt 0 ]]; then
-    pbody="$(jq -r '.pbody' <<<"$render")"
+    pbody="$(jq -r '.pbody' 9>&- <<<"$render")"
     local title="🔴 **CRITICAL**"
     [[ $pcount -gt 1 ]] && title="🔴 **CRITICAL** · $pcount"
-    if ! send_alert CRIT "$title" "$pbody" "Sosumi" "$inode:$prev_offset:$checkpoint_offset"; then
+    if ! send_alert CRIT "$title" "$pbody" "Sosumi" "$inode:$prev_offset:$checkpoint_offset" 9>&-; then
       deliver_ok=0
     fi
   fi

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -100,37 +100,59 @@ main() {
 
   # Read only the new bytes since the cursor. Bound the read to the snapshot window
   # (head -c) so rows appended after we captured $size are not consumed early and
-  # re-fired next time; || true absorbs head's SIGPIPE. Clamp defensively: an
-  # inode-reusing rotation in the window could otherwise hand head -c a non-positive
-  # count.
-  local span new_lines=""
+  # re-fired next time. A sentinel byte (x) is appended then stripped: a command
+  # substitution strips trailing newlines, and we must know EXACTLY where the last
+  # complete record ends. The `; printf x` runs after the pipeline regardless of a
+  # head SIGPIPE, so no `|| true` is needed.
+  local span snapshot=""
   span=$((size - prev_offset))
   if [[ $span -gt 0 ]]; then
-    new_lines="$(tail -c "+$((prev_offset + 1))" "$LOG" | head -c "$span" || true)"
+    snapshot="$(
+      tail -c "+$((prev_offset + 1))" "$LOG" 2>/dev/null | head -c "$span" 2>/dev/null
+      printf x
+    )"
+    snapshot="${snapshot%x}"
   fi
 
-  # The pipeline: normalize the raw rows into findings, route each to page/digest/
-  # log-only (digest and log-only are handled in-stage), render the CRIT
+  # Advance only through COMPLETE records. osquery writes a row then its newline; a
+  # torn trailing line (mid-write, no newline yet) must be RETAINED, not skipped, so
+  # the next run re-reads it once complete. complete_records is the snapshot through
+  # its last newline; the trailing bytes after it are a partial line, neither fed to
+  # the pipeline nor checkpointed past. This also stops a complete-JSON-without-a-
+  # newline from being processed early and then double-processed once its newline
+  # lands. complete_bytes is BYTE-exact (LC_ALL=C wc -c) since the cursor is a byte
+  # offset.
+  local complete_records="" complete_bytes=0
+  if [[ $snapshot == *$'\n'* ]]; then
+    complete_records="${snapshot%$'\n'*}"$'\n'
+    complete_bytes="$(printf '%s' "$complete_records" | LC_ALL=C wc -c)"
+    complete_bytes="${complete_bytes//[[:space:]]/}"
+  fi
+  local checkpoint_offset=$((prev_offset + complete_bytes))
+
+  # The pipeline: normalize the complete records into findings, route each to
+  # page/digest/log-only (digest and log-only are handled in-stage), render the CRIT
   # page-candidates into the #priority body. A malformed row yields nothing for that
   # row (normalize's per-line try/fromjson), so a garbage batch produces an empty
   # page and never aborts.
   local render pcount pbody
-  render="$(printf '%s\n' "$new_lines" | normalize_findings | route_findings | render_page)"
+  render="$(printf '%s' "$complete_records" | normalize_findings | route_findings | render_page)"
   pcount="$(jq -r '.pcount // 0' <<<"$render" 2>/dev/null || printf '0')"
   [[ $pcount =~ ^[0-9]+$ ]] || pcount=0
 
-  # Checkpoint ONLY after the batch is durably handled. deliver_ok starts true (a
-  # batch with no page consumed only digest/log-only rows, already handled); a page
-  # that hard-fails to deliver AND spool sets it false, so the cursor stays put and
-  # the next run retries the SAME rows (at-least-once). The occurrence id (inode +
-  # this batch's byte range) makes the page's request_id occurrence-unique yet
-  # stable across a retry of this same batch.
+  # Checkpoint ONLY after the batch is durably handled, and only through the last
+  # COMPLETE record (checkpoint_offset), never past a torn trailing line. deliver_ok
+  # starts true (a batch with no page consumed only digest/log-only rows, already
+  # handled); a page that hard-fails to deliver AND spool sets it false, so the
+  # cursor stays put and the next run retries the SAME rows (at-least-once). The
+  # occurrence id (inode + this batch's complete-record byte range) makes the page's
+  # request_id occurrence-unique yet stable across a retry of this same batch.
   local deliver_ok=1
   if [[ $pcount -gt 0 ]]; then
     pbody="$(jq -r '.pbody' <<<"$render")"
     local title="🔴 **CRITICAL**"
     [[ $pcount -gt 1 ]] && title="🔴 **CRITICAL** · $pcount"
-    if ! send_alert CRIT "$title" "$pbody" "Sosumi" "$inode:$prev_offset:$size"; then
+    if ! send_alert CRIT "$title" "$pbody" "Sosumi" "$inode:$prev_offset:$checkpoint_offset"; then
       deliver_ok=0
     fi
   fi
@@ -139,7 +161,7 @@ main() {
   # is already surfaced (send_alert's loud local alert + delivery log). A nonzero
   # exit would false-trip the uptime watchdog's crash-loop check. The cursor simply
   # stays put for a retry.
-  [[ $deliver_ok -eq 1 ]] && _checkpoint "$inode" "$size"
+  [[ $deliver_ok -eq 1 ]] && _checkpoint "$inode" "$checkpoint_offset"
   exit 0
 }
 

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -24,22 +24,24 @@ set -euo pipefail
 
 LOG="${OSQUERY_RESULTS_LOG:-$HOME/.local/log/osquery/osqueryd.results.log}"
 STATE="${OSQUERY_RESULTS_OFFSET:-$HOME/.local/state/osquery-results-offset}"
-HELPERS="$HOME/.local/libexec/osquery"
 
+# The dispatch library and the six pipeline helpers, from the libexec home (the
+# same deployed path the other consumers source; literal so the relocation guard
+# can assert it).
 # shellcheck source=/dev/null
-source "$HELPERS/alert-dispatch.sh"
+source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/normalize.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/normalize.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/route.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/route.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/allowlist-verdict.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/allowlist-verdict.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/pipeline-verdict.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/digest-store.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/digest-store.sh"
 # shellcheck source=/dev/null
-source "$HELPERS/results-alerter/render-page.sh"
+source "$HOME/.local/libexec/osquery/results-alerter/render-page.sh"
 
 # _checkpoint <inode> <offset>: atomically write the cursor to the current inode +
 # offset. Called by main ONLY after a batch is durably delivered-or-spooled -

--- a/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
@@ -37,14 +37,17 @@ allowlist_verdict() {
   # Pull the FIRST tuple whose label matches, in one pass. `-R` reads each line as
   # a raw string and `fromjson?` parses it, the `?` dropping any line that is not
   # JSON (comments, blanks) instead of aborting - so one jq handles the whole file.
-  # The tuple's path/program/sha256 come back tab-separated (empty for absent).
+  # The tuple's path/program/sha256 come back joined by the ASCII Unit Separator
+  # (0x1F), NOT a tab: a tab is whitespace in IFS, so an empty leading field (a
+  # malformed path-empty tuple) would shift the later fields under `read`. 0x1F is
+  # non-whitespace, so empty fields are preserved, and it cannot occur in a path.
   match=$(jq -rR --arg want "$want_label" \
-    'fromjson? | select(.label == $want) | [.path // "", .program // "", .sha256 // ""] | @tsv' \
+    'fromjson? | select(.label == $want) | [.path // "", .program // "", .sha256 // ""] | join("\u001f")' \
     "$file" 2>/dev/null | head -n1)
   # No line matched the label. (A degraded label-only entry, below, also returns 1,
   # so no-match and cannot-vouch are the same not-allowlisted outcome.)
   [[ -n $match ]] || return 1
-  IFS=$'\t' read -r jpath jprog jhash <<<"$match"
+  IFS=$'\x1f' read -r jpath jprog jhash <<<"$match"
   jpath=$(_allowlist_verdict_expand_home "$jpath")
   jprog=$(_allowlist_verdict_expand_home "$jprog")
   # A degraded label-only entry (no captured identity) cannot vouch for a program.

--- a/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# allowlist-verdict.sh - a sourced helper for results-alerter.sh. Functions only,
+# no main. It answers one question for a user LaunchAgent persistence finding: is
+# this a known-good item (suppress), a reused allowlisted label pointing at a
+# different plist identity (page), or simply not allowlisted?
+#
+# The allowlist is the launchd page-allowlist: OSQUERY_LAUNCHD_ALLOWLIST (the
+# unified env var name, matching the slice-5 writer osquery-allowlist.sh), an
+# NDJSON file of {label, path, program, sha256} tuples, one per line, default
+# ~/.config/osquery/page-launchd-allowlist.txt. Paths/programs are stored
+# home-relative (~/) so the committed seed file stays user-agnostic; the verdict
+# expands ~ to $HOME before comparing to the finding's absolute path/program.
+#
+# The finding supplies (label, path, program). The plist sha256 is NOT an
+# argument and is NOT read from the osquery row or from enrichment: when a stored
+# tuple pins a hash, the verdict re-hashes the ON-DISK plist at the finding's path
+# with shasum at decision time. That binds the allowlist entry to the plist's
+# current bytes, defeating a same-label/same-path/same-program rewrite.
+
+# _allowlist_verdict_expand_home: expand a leading ~/ in a stored value to $HOME/.
+# Namespaced so it does not collide with the other sourced helpers.
+_allowlist_verdict_expand_home() { printf '%s' "${1//\~\//$HOME/}"; }
+
+# allowlist_verdict <label> <path> <program>:
+#   0 = suppress (full tuple match; an empty stored sha256 skips only the hash
+#       dimension, the own-agent seed entries)
+#   2 = reused label -> page (the label is allowlisted but path/program diverges,
+#       or the pinned hash no longer matches the on-disk plist)
+#   1 = not allowlisted (no label match, a degraded label-only entry that cannot
+#       vouch, or a missing/unreadable allowlist file)
+allowlist_verdict() {
+  local want_label="$1" want_path="$2" want_program="$3"
+  local file="${OSQUERY_LAUNCHD_ALLOWLIST:-$HOME/.config/osquery/page-launchd-allowlist.txt}"
+  local match jpath jprog jhash disk_hash
+  [[ -r $file ]] || return 1
+  # Pull the FIRST tuple whose label matches, in one pass. `-R` reads each line as
+  # a raw string and `fromjson?` parses it, the `?` dropping any line that is not
+  # JSON (comments, blanks) instead of aborting - so one jq handles the whole file.
+  # The tuple's path/program/sha256 come back tab-separated (empty for absent).
+  match=$(jq -rR --arg want "$want_label" \
+    'fromjson? | select(.label == $want) | [.path // "", .program // "", .sha256 // ""] | @tsv' \
+    "$file" 2>/dev/null | head -n1)
+  # No line matched the label. (A degraded label-only entry, below, also returns 1,
+  # so no-match and cannot-vouch are the same not-allowlisted outcome.)
+  [[ -n $match ]] || return 1
+  IFS=$'\t' read -r jpath jprog jhash <<<"$match"
+  jpath=$(_allowlist_verdict_expand_home "$jpath")
+  jprog=$(_allowlist_verdict_expand_home "$jprog")
+  # A degraded label-only entry (no captured identity) cannot vouch for a program.
+  # Do NOT suppress on the bare label (that is the R2-1 bug); fail safe as absent.
+  [[ -n $jpath && -n $jprog ]] || return 1
+  # The tuple must match on path AND program; any divergence is a reused label.
+  [[ $want_path == "$jpath" && $want_program == "$jprog" ]] || return 2
+  # When the entry pins the plist hash, the on-disk plist must still match it
+  # (defeats a same-path/same-program plist rewrite). An empty pin skips this
+  # dimension, which is how the own-agent seed entries are stored.
+  if [[ -n $jhash ]]; then
+    disk_hash=$(shasum -a 256 "$want_path" 2>/dev/null | awk '{print $1}')
+    [[ $disk_hash == "$jhash" ]] || return 2
+  fi
+  return 0 # full tuple match -> known-good, suppress
+}

--- a/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
@@ -32,24 +32,24 @@ _allowlist_verdict_expand_home() { printf '%s' "${1//\~\//$HOME/}"; }
 allowlist_verdict() {
   local want_label="$1" want_path="$2" want_program="$3"
   local file="${OSQUERY_LAUNCHD_ALLOWLIST:-$HOME/.config/osquery/page-launchd-allowlist.txt}"
-  local match jpath jprog jhash disk_hash
+  local match_json jpath jprog jhash disk_hash
   [[ -r $file ]] || return 1
-  # Pull the FIRST tuple whose label matches, in one pass. `-R` reads each line as
-  # a raw string and `fromjson?` parses it, the `?` dropping any line that is not
-  # JSON (comments, blanks) instead of aborting - so one jq handles the whole file.
-  # The tuple's path/program/sha256 come back joined by the ASCII Unit Separator
-  # (0x1F), NOT a tab: a tab is whitespace in IFS, so an empty leading field (a
-  # malformed path-empty tuple) would shift the later fields under `read`. 0x1F is
-  # non-whitespace, so empty fields are preserved, and it cannot occur in a path.
-  match=$(jq -rR --arg want "$want_label" \
-    'fromjson? | select(.label == $want) | [.path // "", .program // "", .sha256 // ""] | join("\u001f")' \
+  # Pull the FIRST tuple whose label matches, as a JSON OBJECT, in one pass. `-R`
+  # reads each line as a raw string and `fromjson?` parses it, the `?` dropping any
+  # line that is not JSON (comments, blanks) instead of aborting - so one jq handles
+  # the whole file. The tuple fields are then extracted per-field from that object
+  # (below), never through an in-band delimiter: a value can hold any byte, and
+  # per-field extraction keeps each opaque so a crafted stored value cannot shift
+  # the path/program/sha256 boundaries.
+  match_json=$(jq -Rc --arg want "$want_label" \
+    'fromjson? | select(.label == $want)' \
     "$file" 2>/dev/null | head -n1)
   # No line matched the label. (A degraded label-only entry, below, also returns 1,
   # so no-match and cannot-vouch are the same not-allowlisted outcome.)
-  [[ -n $match ]] || return 1
-  IFS=$'\x1f' read -r jpath jprog jhash <<<"$match"
-  jpath=$(_allowlist_verdict_expand_home "$jpath")
-  jprog=$(_allowlist_verdict_expand_home "$jprog")
+  [[ -n $match_json ]] || return 1
+  jpath=$(_allowlist_verdict_expand_home "$(jq -r '.path // ""' <<<"$match_json")")
+  jprog=$(_allowlist_verdict_expand_home "$(jq -r '.program // ""' <<<"$match_json")")
+  jhash=$(jq -r '.sha256 // ""' <<<"$match_json")
   # A degraded label-only entry (no captured identity) cannot vouch for a program.
   # Do NOT suppress on the bare label (that is the R2-1 bug); fail safe as absent.
   [[ -n $jpath && -n $jprog ]] || return 1

--- a/dot_local/libexec/osquery/results-alerter/digest-store.sh
+++ b/dot_local/libexec/osquery/results-alerter/digest-store.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# digest-store.sh - a sourced helper for results-alerter.sh. Functions only, no
+# main. It owns the digest tier's write side: suspicious-but-ambiguous findings
+# that do not page accumulate here as NDJSON, one line each, for a later daily
+# grouped summary. The read side is a separate slice; this helper only appends.
+#
+# Best-effort by design: failing to record a digest line must never abort
+# detection, so every step is guarded and the function always returns success.
+#
+# Privacy posture (the F5-A lesson - secret digests must not spread to readable
+# files): the line carries only DERIVED triage fields (timestamp, detector,
+# category, identity, action, summary). It never copies the whole columns object,
+# so a raw sha256 or a secret column never reaches the spool. Full filesystem
+# paths ARE stored - the digest is a private single-user triage view where the
+# full path disambiguates (which .env?) - so the spool must not be world-readable:
+# dir 700, file 600, the way the page spool is.
+
+OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
+
+# digest_append <finding-json>: append one NDJSON digest line for the finding.
+digest_append() {
+  local finding="$1"
+  local store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
+  local dir
+  dir="$(dirname "$store")"
+  mkdir -p "$dir" 2>/dev/null || true
+  # Set the dir to 700 BEFORE any file exists, so even the brief window before the
+  # file's own 600 mode is applied is covered by an unreadable parent directory.
+  chmod 700 "$dir" 2>/dev/null || true
+  jq -c --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      timestamp: $timestamp,
+      detector: .q,
+      category: (.cols.category // ""),
+      identity: (if .q == "listening_ports_non_loopback"
+                 then ((.cols.name // .cols.path // "?") + " " + (.cols.address // "?") + ":" + (.cols.port // "?"))
+                 else (.cols.label // .cols.identifier // .cols.target_path // .cols.path // .cols.username // "?") end),
+      action: .act,
+      summary: (.q + " " + ((.cols.label // .cols.identifier // .cols.target_path // .cols.path // .cols.username) // "?"))
+    }' <<<"$finding" >>"$store" 2>/dev/null || true
+  chmod 600 "$store" 2>/dev/null || true
+}

--- a/dot_local/libexec/osquery/results-alerter/normalize.sh
+++ b/dot_local/libexec/osquery/results-alerter/normalize.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# normalize.sh - a sourced helper for results-alerter.sh. Functions only, no
+# main; nothing here delivers, checkpoints, or exits. The entry script sources
+# it and pipes the raw results-log tail through normalize_findings, which is the
+# first stage of the newline-delimited-JSON pipeline.
+#
+# normalize_findings reads raw osquery results-log lines on stdin (one JSON row
+# per line) and writes ONE normalized finding per surviving row to stdout as
+# newline-delimited JSON. The normalized shape this stage guarantees:
+#   {q, act, cols}
+#     q    - the query name with any pack_<pack>_ prefix stripped, so a packed
+#            query and a top-level query reach the routing stage under the same
+#            bare name it matches on.
+#     act  - the row's action, defaulted to "changed" when the row omits it, so
+#            no later stage has to special-case a null action.
+#     cols - the row's columns object (an empty object when absent).
+#
+# Why no snapshot explosion: c69baab made the absolute-state *_off queries
+# DIFFERENTIAL (filevault_off, remote_access_sharing_state, agent_exposure_changed),
+# so an unsafe state now arrives as an ordinary "added" differential row and is
+# logged to results.log, which this alerter reads. There is no longer a snapshot
+# array to fan out, so normalize emits exactly one finding per row; a snapshot-
+# action row is a single finding, carried through unexploded.
+
+# normalize_findings: raw results-log lines on stdin -> normalized finding NDJSON
+# on stdout. jq -rR reads each line as a raw string; the per-line try/fromjson
+# means one malformed line yields nothing for that line instead of aborting the
+# whole batch, and a `2>/dev/null || true` keeps a jq-level hiccup from killing
+# the pipeline (a swallowed batch is caught by the cursor-retry logic in main).
+normalize_findings() {
+  jq -rR '
+    . as $line | (try ($line | fromjson) catch empty)
+    | select(.name != null)
+    # Strip the pack_<pack>_ prefix. [^_]+ matches the pack name (pack names use
+    # hyphens, not underscores) up to the first underscore, so only the pack
+    # segment is removed and the query keeps its own underscores.
+    | (.name | sub("^pack_[^_]+_"; "")) as $q
+    | (.action // "changed") as $act
+    | {q: $q, act: $act, cols: (.columns // {})} | @json
+  ' 2>/dev/null || true
+}

--- a/dot_local/libexec/osquery/results-alerter/normalize.sh
+++ b/dot_local/libexec/osquery/results-alerter/normalize.sh
@@ -30,12 +30,31 @@
 # the pipeline (a swallowed batch is caught by the cursor-retry logic in main).
 normalize_findings() {
   jq -rR '
-    . as $line | (try ($line | fromjson) catch empty)
+    # Known-query allowlist (the security select): the prefix-stripped names of
+    # every scheduled detector the config-base slice ships, EXCEPT heartbeat_canary.
+    # A row whose stripped name is not in this set is dropped before it can become
+    # an alert, so an unknown, renamed, or rogue query name never surfaces. This is
+    # a STRICT allowlist, not a blanket admit of anything under pack_: a made-up
+    # pack_<x> is dropped exactly like an unknown top-level name. heartbeat_canary
+    # is a liveness snapshot that lands only in osqueryd.snapshots.log (which this
+    # alerter does not read); it is excluded defensively so a stray canary row can
+    # never generate noise. Adding a new detector to the config means adding its
+    # name here too (the config and this alerter are co-maintained in one repo).
+    [
+      "new_admin_user", "file_events_recent", "es_launchd_writes",
+      "agent_authfile_changed", "agent_binary_changed", "agent_exposure_changed", "agent_secretfile_changed",
+      "chrome_extensions", "firefox_addons", "homebrew_packages", "installed_apps", "safari_extensions",
+      "kernel_extensions_new", "listening_ports_non_loopback", "persistence_launchd", "persistence_launchd_overrides",
+      "persistence_startup_items_crontab", "recent_logins", "suid_bin_unexpected", "system_extensions_new",
+      "filevault_off", "filevault_state", "firewall_state", "gatekeeper_state", "remote_access_sharing_state", "sip_state"
+    ] as $known
+    | . as $line | (try ($line | fromjson) catch empty)
     | select(.name != null)
     # Strip the pack_<pack>_ prefix. [^_]+ matches the pack name (pack names use
     # hyphens, not underscores) up to the first underscore, so only the pack
     # segment is removed and the query keeps its own underscores.
     | (.name | sub("^pack_[^_]+_"; "")) as $q
+    | select($q | IN($known[]))
     | (.action // "changed") as $act
     | {q: $q, act: $act, cols: (.columns // {})} | @json
   ' 2>/dev/null || true

--- a/dot_local/libexec/osquery/results-alerter/normalize.sh
+++ b/dot_local/libexec/osquery/results-alerter/normalize.sh
@@ -72,6 +72,20 @@ normalize_findings() {
         or $q == "remote_access_sharing_state"
         or $q == "agent_exposure_changed")
     | (.action // "changed") as $act
-    | {q: $q, act: $act, cols: (.columns // {})} | @json
+    # Enrich-path (ep): the exact plist/bundle/binary the enricher must inspect
+    # for signing/trust facts, chosen per query type. Empty when signing does not
+    # apply (e.g. a new admin account has no path to codesign). Matched on the
+    # stripped q, not the full name. system_extensions_new prefers bundle_path and
+    # falls back to path. A path can carry a tab/newline (an FSEvents oddity), so
+    # squash those to spaces - ep is passed to the enricher and rendered downstream.
+    | ((if $q == "es_launchd_writes" then (.columns.path // "")
+        elif $q == "file_events_recent" then (.columns.target_path // "")
+        elif $q == "persistence_launchd" then (.columns.path // "")
+        elif $q == "persistence_startup_items_crontab" then (.columns.path // "")
+        elif $q == "kernel_extensions_new" then (.columns.path // "")
+        elif $q == "system_extensions_new" then (.columns.bundle_path // .columns.path // "")
+        elif $q == "suid_bin_unexpected" then (.columns.path // "")
+        else "" end) | gsub("[\t\n]"; " ")) as $ep
+    | {q: $q, act: $act, cols: (.columns // {}), ep: $ep} | @json
   ' 2>/dev/null || true
 }

--- a/dot_local/libexec/osquery/results-alerter/normalize.sh
+++ b/dot_local/libexec/osquery/results-alerter/normalize.sh
@@ -55,6 +55,22 @@ normalize_findings() {
     # segment is removed and the query keeps its own underscores.
     | (.name | sub("^pack_[^_]+_"; "")) as $q
     | select($q | IN($known[]))
+    # renameio exclusion: chezmoi/renameio writes files via an atomic rename
+    # through a .renameio-TempDir-* scratch dir, so a file_events_recent row whose
+    # target_path is inside one is write churn, not a real change - drop it. Only
+    # file_events_recent carries a target_path, so this is a no-op for other rows.
+    | select((.columns.target_path // "") | test("/\\.renameio-TempDir") | not)
+    # Baseline (counter==0) discard: osquery emits a differential query first full
+    # result set with counter 0 (the seeded baseline). Discard those first-run rows
+    # so pre-existing state does not page on its first observation - EXCEPT the
+    # three absolute-state queries, whose very presence IS an unsafe state (no
+    # volume encrypted / a sharing service enabled / an agent port off-loopback),
+    # so a counter==0 row there is a first-run PAGE that must be kept, not seeded.
+    # An absent counter defaults to 1 (non-baseline), so a row without one is kept.
+    | select((.counter // 1) != 0
+        or $q == "filevault_off"
+        or $q == "remote_access_sharing_state"
+        or $q == "agent_exposure_changed")
     | (.action // "changed") as $act
     | {q: $q, act: $act, cols: (.columns // {})} | @json
   ' 2>/dev/null || true

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# pipeline-verdict.sh - a sourced helper for results-alerter.sh. Functions only,
+# no main. It answers one question for a file change under the watched pipeline
+# directories: is this a tamper to PAGE, a known-good apply to stay SILENT, or an
+# untracked neighbor to log only?
+#
+# The pipeline-integrity manifest is a root-owned, source-derived sha256 list of
+# the alerter's own scripts and plists (shasum format: "<sha256>  <path>"). A
+# change is legitimate only when its EXACT (path, sha256) tuple is in the
+# manifest; a legit chezmoi apply regenerates the manifest in the same apply, so
+# a deployed known-good file matches and stays silent.
+#
+# Fail-open (criterion 6): the manifest slice is LAST in the stack and does not
+# exist yet. With no manifest present, _pipeline_manifest_has_tuple returns
+# not-found, so a tracked change cannot be confirmed legitimate and PAGES. That
+# is the conservative direction - a pipeline-script change is never silently
+# suppressed without a manifest to justify it, and a missing/empty/mismatched
+# hash pages too. Over-paging until the manifest lands is the accepted tradeoff.
+#
+# Return-code contract (from c69baab _pipeline_verdict):
+#   0 = PAGE   (tamper / cannot confirm legit / no manifest / delete)
+#   1 = SILENT (an untracked neighbor, or an exact (path, sha256) manifest match)
+
+PIPELINE_MANIFEST="${OSQUERY_PIPELINE_MANIFEST:-/var/osquery/pipeline-known-good.sha256}"
+
+# _pipeline_manifest_has_tuple <path> <hash>: 0 when the manifest holds a line
+# binding exactly this hash to exactly this path, else 1. Legitimacy is the EXACT
+# (path, sha256) tuple, not the hash alone: binding the hash to ITS path defeats a
+# swap-in-place (a valid hash lifted onto a different tracked path). Hashes are
+# compared case-insensitively (shasum and osquery emit lowercase, but normalize
+# defensively). A missing/unreadable manifest returns 1 - the fail-open hinge.
+_pipeline_manifest_has_tuple() {
+  local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
+  [[ -r $manifest ]] || return 1
+  local want_path="$1" want_hash h p
+  want_hash=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')
+  while read -r h p; do
+    h=$(printf '%s' "$h" | tr '[:upper:]' '[:lower:]')
+    [[ $h == "$want_hash" && $p == "$want_path" ]] && return 0
+  done <"$manifest"
+  return 1
+}
+
+# _pipeline_is_tracked <target>: 0 when the path is pipeline infrastructure. The
+# watches fire for every file in a watched dir, so the tracked set is filtered
+# here: a script under either watched script dir (~/.local/libexec/osquery or
+# ~/.local/bin), or one of our own osquery LaunchAgents by basename. Anything else
+# in a watched dir is a neighbor. Dual-prefix: c69baab only knew the flat
+# ~/.local/bin/osquery-*.sh layout; the scripts now live under libexec/osquery too
+# (with the osquery- prefix dropped), and ~/.local/bin is a root-of-trust dir.
+_pipeline_is_tracked() {
+  local target="$1" base="${1##*/}"
+  case "$target" in
+    "$HOME"/.local/libexec/osquery/* | "$HOME"/.local/bin/*) return 0 ;;
+  esac
+  case "$base" in
+    com.webdavis.osquery-*.plist) return 0 ;;
+  esac
+  return 1
+}
+
+# pipeline_verdict <target> <event_hash> <verb>: 0 = page, 1 = silent.
+pipeline_verdict() {
+  local target="$1" hash_value="$2" verb="$3" disk_hash
+  # Not pipeline infrastructure -> a neighbor in the watched dir, log-only.
+  _pipeline_is_tracked "$target" || return 1
+  # A destructive removal of a tracked file has no bytes to confirm -> always page.
+  [[ $verb == DELETED ]] && return 0
+  # A non-empty EVENT hash (CREATED/UPDATED carry one): validate the exact
+  # (path, hash) tuple directly. No manifest -> not-found -> page (fail-open).
+  if [[ -n $hash_value ]]; then
+    _pipeline_manifest_has_tuple "$target" "$hash_value" && return 1
+    return 0
+  fi
+  # Empty event hash: the live atomic-rename shape (chezmoi writes via rename, and
+  # osquery does not content-hash a rename). Debounce briefly - the rename may
+  # still be settling - then re-hash the on-disk target and check its (path, hash)
+  # tuple. A known-good deployed file matches the same-apply manifest -> silent; a
+  # mismatch, a missing file, or (the current state) no manifest -> page.
+  sleep "${OSQUERY_PIPELINE_REHASH_DELAY:-0.3}"
+  disk_hash=$(shasum -a 256 "$target" 2>/dev/null | awk '{print $1}')
+  [[ -n $disk_hash ]] && _pipeline_manifest_has_tuple "$target" "$disk_hash" && return 1
+  return 0
+}

--- a/dot_local/libexec/osquery/results-alerter/render-page.sh
+++ b/dot_local/libexec/osquery/results-alerter/render-page.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# render-page.sh - a sourced helper for results-alerter.sh. Functions only, no
+# main. It owns the page rendering: render_page reads the enriched findings as
+# NDJSON on stdin, selects the CRIT ones, renders each into a focused #priority
+# block (header + decision-relevant fields + one next-step), and prints the
+# {pcount, pbody} JSON object. Display-only - it never changes detection or tier.
+#
+# Layout follows the ADHD surfacing research: one thing, glanceable, minimal
+# fields, ending in a single action, no raw query jargon.
+#
+# Criterion 7 (basename-only): a secret/auth-file finding
+# (agent_authfile_changed, agent_secretfile_changed) renders the file's BASENAME
+# only - never its full path, and never a sha256/digest. Those detectors reach
+# this renderer only as a page (a page-tier secret change), and the page body
+# fans out to Discord, so it must not disclose the path or the content hash.
+#
+# Caps: every rendered value is backtick-sanitized and capped at 240 chars; the
+# page is capped at 8 blocks (plus an "N more" marker) and then hard-capped at
+# 1900 chars, so an over-length page can never wedge the 2000-char Discord budget.
+
+render_page() {
+  jq -s '
+    # Wrap a value in Discord inline-code backticks. The value is attacker-controlled
+    # (launchd label, path); strip backticks so it cannot break out of the inline-code
+    # span and inject markdown. Display-only. Bound each field to 240 chars with an
+    # explicit omission marker so one giant value cannot alone blow the 2000-char budget.
+    def code:
+      (gsub("`"; "")) as $v
+      | "`" + (if ($v | length) > 240 then ($v[0:240] + "…(truncated)") else $v end) + "`";
+    # Plain-English name of a macOS protection query, or null if the finding is not one.
+    def protname:
+      if (.q | test("^firewall")) then "Firewall"
+      elif (.q | test("^gatekeeper")) then "Gatekeeper"
+      elif (.q | test("^sip")) then "System Integrity Protection"
+      elif (.q | test("^filevault")) then "FileVault"
+      else null end;
+    # Human header for a finding.
+    def header:
+      (protname) as $p |
+      if $p != null then (if .sev == "CRIT" then "\($p) turned OFF" else "\($p) changed" end)
+      elif .q == "persistence_launchd" then "New startup item"
+      elif .q == "persistence_launchd_overrides" then "Startup override changed"
+      elif .q == "persistence_startup_items_crontab" then "New startup/cron entry"
+      elif .q == "suid_bin_unexpected" then "New setuid root binary"
+      elif .q == "new_admin_user" then "New administrator account"
+      elif .q == "agent_exposure_changed" then "Agent port exposed off-loopback"
+      elif .q == "agent_authfile_changed" then "Agent credential changed"
+      elif .q == "agent_secretfile_changed" then "Agent secret file changed"
+      elif .q == "remote_access_sharing_state" then "Remote-access service enabled"
+      elif .q == "kernel_extensions_new" then "New kernel extension"
+      elif .q == "system_extensions_new" then "New system extension"
+      elif .q == "listening_ports_non_loopback" then "New network listener"
+      elif .q == "recent_logins" then "Login"
+      elif .q == "installed_apps" then "New app"
+      elif .q == "homebrew_packages" then "New Homebrew package"
+      elif (.q | test("_extensions$|_addons$")) then "New browser extension"
+      elif .q == "file_events_recent" then
+        ((.cols.category // "") as $cat | ((.cols.target_path // "") | split("/") | last) as $bn |
+          # A tracked pipeline file can arrive under pipeline_integrity OR (for our own
+          # LaunchAgents) launch_agents/launch_daemons, so key the tooling header on the
+          # basename, not only the category.
+          if ($bn | test("^osquery-.*\\.sh$")) or ($bn | test("^com\\.webdavis\\.osquery-.*\\.plist$")) then "Security tooling changed"
+          elif ($cat == "ssh" or $cat == "authorized_keys") then "SSH key file changed"
+          elif $cat == "sudoers" then "sudoers changed"
+          elif $cat == "sshd_config" then "sshd_config changed"
+          elif $cat == "pipeline_integrity" then "Security tooling changed"
+          elif $cat == "allowlist_file" then "Allowlist changed"
+          elif ($cat == "launch_agents" or $cat == "launch_daemons") then "Startup folder changed"
+          else "Watched file changed" end)
+      elif .q == "es_launchd_writes" then "Startup item written by a process"
+      else (.q | gsub("_"; " ")) end;
+    # Best single identifier for a finding.
+    def keyid:
+      .cols as $c |
+      ($c.label // $c.identifier // $c.name // $c.target_path // $c.path // $c.username // "?");
+    # Decision-relevant "Label: value" lines for a #priority block. Values are wrapped
+    # in Discord inline-code; an untrusted signing verdict is flagged and bolded.
+    def fields:
+      # Strip markdown metacharacters from the (attacker-influenceable) signing authority
+      # so a crafted certificate subject cannot inject backticks/emphasis into the body.
+      .cols as $c | ((.signing // null) | if type == "string" then gsub("[`*]"; "") else . end) as $sig |
+      (if $sig then
+         (if ($sig | test("unsigned|untrusted|ad-hoc|unverified|no authority"; "i"))
+          then ["- **Signing:** ⚠️ **\($sig)**"] else ["- **Signing:** \($sig)"] end)
+       else [] end) as $sg |
+      if .q == "persistence_launchd" then ["- **What:** \(($c.label // "?") | code)", "- **Program:** \(($c.program // "?") | code)"] + $sg
+      elif .q == "persistence_startup_items_crontab" then ["- **What:** \(($c.name // "?") | code)", "- **Command:** \(($c.command // "?") | code)"] + $sg
+      elif .q == "suid_bin_unexpected" then ["- **Path:** \(($c.path // "?") | code)"] + $sg + ["- **Owner:** \(($c.username // "?") | code)"]
+      elif .q == "new_admin_user" then ["- **User:** \(($c.username // "?") | code)", "- **UID:** \(($c.uid // "?") | code)"]
+      elif .q == "agent_exposure_changed" then ["- **Process:** \(($c.name // "?") | code)", "- **Address:** \(($c.address // "?") | code)", "- **Port:** \(($c.port // "?") | code)"]
+      # Criterion 7: secret/auth files render the BASENAME only, never the full path,
+      # and never a sha256 (no hash field is rendered for these detectors at all).
+      elif .q == "agent_authfile_changed" then ["- **File:** \((($c.path // "") | split("/") | last) | code)"]
+      elif .q == "agent_secretfile_changed" then ["- **File:** \((($c.path // "") | split("/") | last) | code)"]
+      elif .q == "remote_access_sharing_state" then ["- **Service:** \(($c.service // "?") | code)"]
+      elif .q == "system_extensions_new" then ["- **Name:** \(($c.identifier // "?") | code)", "- **Team:** \(($c.team // "?") | code)"] + $sg
+      elif .q == "kernel_extensions_new" then ["- **Name:** \(($c.name // "?") | code)", "- **Path:** \(($c.path // "?") | code)"] + $sg
+      elif .q == "file_events_recent" then ["- **File:** \(($c.target_path // "?") | code)", "- **Action:** \($c.action // .act)"]
+      elif .q == "es_launchd_writes" then ["- **Process:** \(($c.path // "?") | code)", "- **Wrote:** \(($c.filename // $c.dest_filename // "?") | code)"] + $sg
+      elif (protname) != null then ["- **State:** **OFF**"]
+      else $sg + ["- **What:** \((keyid) | code)"] end;
+    # One or two instructive next-step lines for a #priority (always CRIT) block.
+    def nextstep:
+      (.ep // "") as $ep |
+      if (protname) != null then
+        ["- Did you turn this off? If not, something else did - **investigate now**.", "- Re-enable it in System Settings."]
+      elif (.q == "system_extensions_new" or .q == "kernel_extensions_new") then
+        ["- Did you install this? If not, **remove it** - an extension can intercept traffic or load at boot.", "- Manage at: System Settings → General → Login Items & Extensions"]
+      elif .q == "suid_bin_unexpected" then
+        ["- Did you create this? If not, it lets a program run as **root** - a backdoor.", "- **Inspect:** " + (("codesign -dv \"" + $ep + "\"") | code)]
+      elif .q == "new_admin_user" then
+        ["- Did you create this account? If not, someone gained **admin access** - investigate now.", "- Review accounts: System Settings → Users & Groups"]
+      elif .q == "agent_exposure_changed" then
+        ["- Did you expose this? If not, an agent API is reachable **off-box** - close it now.", "- Re-bind it to 127.0.0.1 or block the port at the firewall."]
+      elif .q == "agent_authfile_changed" then
+        ["- Did you rotate this? If not, an attacker may forge or mute alerts, or hijack remote access - **investigate now**."]
+      elif .q == "agent_secretfile_changed" then
+        ["- Did you rotate this? If not, an attacker may have your alerting or remote-access secret - **investigate now**."]
+      elif .q == "remote_access_sharing_state" then
+        ["- Did you enable this? If not, someone opened a remote-control path into this Mac - **disable it now**.", "- System Settings → General → Sharing"]
+      elif .q == "file_events_recent" then
+        (((.cols.target_path // "") | split("/") | last) as $bn |
+         if ((.cols.category // "") == "pipeline_integrity")
+            or ($bn | test("^osquery-.*\\.sh$")) or ($bn | test("^com\\.webdavis\\.osquery-.*\\.plist$"))
+         then ["- Did you just apply your dotfiles? If not, your **security tooling was modified** - investigate now.", "- **Compare:** " + (("shasum -a 256 \"" + $ep + "\"") | code)]
+         else ["- Did you change this? If not, someone altered who can log in or run as **root**.", "- **Review:** " + (("sudo cat \"" + $ep + "\"") | code)] end)
+      elif (.q == "persistence_launchd" or .q == "persistence_startup_items_crontab") then
+        ["- Did you set this up? If not, it **auto-runs at every login** - likely malware.", "- **Inspect:** " + (("cat \"" + $ep + "\"") | code)]
+      elif .q == "es_launchd_writes" then
+        ["- Did you run this? If not, a process is **installing persistence** - investigate it and remove the file.", "- **Inspect the writer:** " + (("codesign -dv \"" + $ep + "\"") | code)]
+      elif ($ep != "") then ["- **Review:** " + ($ep | code)]
+      else [] end;
+    def block:
+      (["**" + header + "**"] + fields + nextstep) | join("\n");
+    ([.[] | select(.sev == "CRIT")]) as $crit |
+    {
+      pcount: ($crit | length),
+      # Cap the page at eight blocks + a marker so a large simultaneous-CRIT batch cannot
+      # exceed the Discord 2000-char limit and get stuck undelivered in the spool. The
+      # dropped detail still lands in results.log. Mirrors the digest group cap.
+      pbody: (
+        (($crit[0:8] | map(block) | join("\n\n"))
+         + (if ($crit | length) > 8
+            then "\n\n… and \(($crit | length) - 8) more CRITICAL finding(s) - see results.log"
+            else "" end)) as $full
+        # The eight-block cap bounds COUNT, not length - eight blocks with long fields can
+        # still exceed 2000. Apply a FINAL hard length cap; the truncated body is exactly
+        # what is dispatched, so an over-length page can never wedge the spool.
+        | if ($full | length) > 1900
+          then ($full[0:1900] + "\n… (truncated to fit the 2000-char limit - see results.log)")
+          else $full end
+      )
+    }
+  '
+}

--- a/dot_local/libexec/osquery/results-alerter/render-page.sh
+++ b/dot_local/libexec/osquery/results-alerter/render-page.sh
@@ -26,7 +26,12 @@ render_page() {
     # span and inject markdown. Display-only. Bound each field to 240 chars with an
     # explicit omission marker so one giant value cannot alone blow the 2000-char budget.
     def code:
-      (gsub("`"; "")) as $v
+      # Strip backticks (they end the inline-code span) AND squash \r\n\t to spaces:
+      # a newline also breaks out of the inline-code span, so without this an
+      # attacker-controlled column value could inject extra markdown LINES into the
+      # page (e.g. a forged "- **Signing:** signed: Apple"). Every field value passes
+      # through here, so this is the single sanitize chokepoint.
+      (gsub("`"; "") | gsub("[\r\n\t]"; " ")) as $v
       | "`" + (if ($v | length) > 240 then ($v[0:240] + "…(truncated)") else $v end) + "`";
     # Plain-English name of a macOS protection query, or null if the finding is not one.
     def protname:
@@ -79,7 +84,7 @@ render_page() {
     def fields:
       # Strip markdown metacharacters from the (attacker-influenceable) signing authority
       # so a crafted certificate subject cannot inject backticks/emphasis into the body.
-      .cols as $c | ((.signing // null) | if type == "string" then gsub("[`*]"; "") else . end) as $sig |
+      .cols as $c | ((.signing // null) | if type == "string" then (gsub("[`*]"; "") | gsub("[\r\n\t]"; " ")) else . end) as $sig |
       (if $sig then
          (if ($sig | test("unsigned|untrusted|ad-hoc|unverified|no authority"; "i"))
           then ["- **Signing:** ⚠️ **\($sig)**"] else ["- **Signing:** \($sig)"] end)
@@ -96,7 +101,7 @@ render_page() {
       elif .q == "remote_access_sharing_state" then ["- **Service:** \(($c.service // "?") | code)"]
       elif .q == "system_extensions_new" then ["- **Name:** \(($c.identifier // "?") | code)", "- **Team:** \(($c.team // "?") | code)"] + $sg
       elif .q == "kernel_extensions_new" then ["- **Name:** \(($c.name // "?") | code)", "- **Path:** \(($c.path // "?") | code)"] + $sg
-      elif .q == "file_events_recent" then ["- **File:** \(($c.target_path // "?") | code)", "- **Action:** \($c.action // .act)"]
+      elif .q == "file_events_recent" then ["- **File:** \(($c.target_path // "?") | code)", "- **Action:** \(($c.action // .act) | gsub("[\r\n\t]"; " "))"]
       elif .q == "es_launchd_writes" then ["- **Process:** \(($c.path // "?") | code)", "- **Wrote:** \(($c.filename // $c.dest_filename // "?") | code)"] + $sg
       elif (protname) != null then ["- **State:** **OFF**"]
       else $sg + ["- **What:** \((keyid) | code)"] end;

--- a/dot_local/libexec/osquery/results-alerter/render-page.sh
+++ b/dot_local/libexec/osquery/results-alerter/render-page.sh
@@ -108,7 +108,7 @@ render_page() {
       elif (.q == "system_extensions_new" or .q == "kernel_extensions_new") then
         ["- Did you install this? If not, **remove it** - an extension can intercept traffic or load at boot.", "- Manage at: System Settings → General → Login Items & Extensions"]
       elif .q == "suid_bin_unexpected" then
-        ["- Did you create this? If not, it lets a program run as **root** - a backdoor.", "- **Inspect:** " + (("codesign -dv \"" + $ep + "\"") | code)]
+        ["- Did you create this? If not, it lets a program run as **root** - a backdoor.", "- **Inspect:** " + (("codesign -dv -- " + ($ep | @sh)) | code)]
       elif .q == "new_admin_user" then
         ["- Did you create this account? If not, someone gained **admin access** - investigate now.", "- Review accounts: System Settings → Users & Groups"]
       elif .q == "agent_exposure_changed" then
@@ -123,12 +123,12 @@ render_page() {
         (((.cols.target_path // "") | split("/") | last) as $bn |
          if ((.cols.category // "") == "pipeline_integrity")
             or ($bn | test("^osquery-.*\\.sh$")) or ($bn | test("^com\\.webdavis\\.osquery-.*\\.plist$"))
-         then ["- Did you just apply your dotfiles? If not, your **security tooling was modified** - investigate now.", "- **Compare:** " + (("shasum -a 256 \"" + $ep + "\"") | code)]
-         else ["- Did you change this? If not, someone altered who can log in or run as **root**.", "- **Review:** " + (("sudo cat \"" + $ep + "\"") | code)] end)
+         then ["- Did you just apply your dotfiles? If not, your **security tooling was modified** - investigate now.", "- **Compare:** " + (("shasum -a 256 -- " + ($ep | @sh)) | code)]
+         else ["- Did you change this? If not, someone altered who can log in or run as **root**.", "- **Review:** " + (("sudo cat -- " + ($ep | @sh)) | code)] end)
       elif (.q == "persistence_launchd" or .q == "persistence_startup_items_crontab") then
-        ["- Did you set this up? If not, it **auto-runs at every login** - likely malware.", "- **Inspect:** " + (("cat \"" + $ep + "\"") | code)]
+        ["- Did you set this up? If not, it **auto-runs at every login** - likely malware.", "- **Inspect:** " + (("cat -- " + ($ep | @sh)) | code)]
       elif .q == "es_launchd_writes" then
-        ["- Did you run this? If not, a process is **installing persistence** - investigate it and remove the file.", "- **Inspect the writer:** " + (("codesign -dv \"" + $ep + "\"") | code)]
+        ["- Did you run this? If not, a process is **installing persistence** - investigate it and remove the file.", "- **Inspect the writer:** " + (("codesign -dv -- " + ($ep | @sh)) | code)]
       elif ($ep != "") then ["- **Review:** " + ($ep | code)]
       else [] end;
     def block:

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -64,29 +64,33 @@ route_severity() {
 # untrusted signing verdict can never be suppressed by the allowlist (the security
 # invariant: an untrusted program behind an allowlisted label still pages).
 #
+# SECURITY: every attacker-controlled field the gate routes on (path, label,
+# program, target_path, ...) is extracted per-field via jq at its point of use and
+# passed as a SEPARATE argv to the verdict helpers. Bash argv is not
+# delimiter-based, so an embedded separator, newline, or tab in a value stays an
+# opaque argument and can never shift field boundaries to make an unknown plist
+# read as an allowlisted tuple. An in-band delimiter over untrusted fields is
+# never safe.
+#
 # digest_append (digest-store.sh), allowlist_verdict (allowlist-verdict.sh),
 # pipeline_verdict (pipeline-verdict.sh), and the enrich-finding.sh script are
 # expected to be available alongside this helper; the entry script sources all
 # helpers into one process.
 route_findings() {
-  local -a objs=() controls=() sevs=()
+  local -a objs=() sevs=()
   local obj
-  # Read the whole batch (a bounded log-tail, already fully in hand), so the two
-  # jq-heavy steps below run ONCE over the batch instead of per finding.
+  # Read the whole batch (a bounded log-tail, already fully in hand). Iterating by
+  # newline is safe: normalize emits one finding per line via @json, which escapes
+  # any newline WITHIN a value as \n inside the JSON string, so a value's newline
+  # never starts a new record.
   while IFS= read -r obj; do
     [[ -n $obj ]] || continue
     objs+=("$obj")
   done
   [[ ${#objs[@]} -gt 0 ]] || return 0
-  # One jq pass extracts the control fields (q, act, category, file basename, path,
-  # label, program) per finding; one route_severity pass gives the base severity.
-  # Both emit exactly one line per input, in order, so they align with objs by
-  # index. The fields are joined with the ASCII Unit Separator (0x1F), NOT a tab:
-  # a tab is whitespace in IFS, so `read` would collapse the empty category/base
-  # fields and shift the later fields off. 0x1F is non-whitespace, so empty fields
-  # are preserved, and it cannot occur in an osquery path/label/program.
-  mapfile -t controls < <(printf '%s\n' "${objs[@]}" |
-    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // ""), (.cols.target_path // ""), (.cols.sha256 // ""), (.cols.action // ""), (.ep // "")] | join("\u001f")')
+  # Severity is safe to batch: route_severity emits a fixed-vocabulary token
+  # (CRIT/NOTICE/INFO) per finding, in order, never an attacker-controlled value,
+  # so a newline-delimited mapfile cannot be shifted by a crafted column.
   mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
 
   # The signing enricher (enrich-finding.sh): given an inspectable path it emits a
@@ -95,10 +99,12 @@ route_findings() {
   local enrich_script="${OSQUERY_ENRICH_SCRIPT:-$HOME/.local/libexec/osquery/enrich-finding.sh}"
 
   local -a pages=()
-  local i q act category base path label program target hash verb ep sev av signing enrich_status
+  local i q act path label program category target base hash verb ep sev av signing enrich_status
   for i in "${!objs[@]}"; do
     obj=${objs[i]}
-    IFS=$'\x1f' read -r q act category base path label program target hash verb ep <<<"${controls[i]}"
+    q=$(jq -r '.q' <<<"$obj")
+    act=$(jq -r '.act' <<<"$obj")
+    ep=$(jq -r '.ep // ""' <<<"$obj")
     sev=${sevs[i]}
     # Enrichment runs BEFORE the per-detector case (the security invariant): a
     # finding an untrusted signature promotes to CRIT here can NOT then be
@@ -162,6 +168,9 @@ route_findings() {
         ;;
       persistence_launchd)
         [[ $act == added ]] || continue
+        # Each value is extracted per-field and passed as its own argv (below), so a
+        # crafted column cannot impersonate an allowlisted tuple.
+        path=$(jq -r '.cols.path // ""' <<<"$obj")
         case "$path" in
           /System/Library/*) continue ;;   # Apple's own launchd items, log-only
           */LaunchDaemons/*) sev="CRIT" ;; # a root LaunchDaemon runs at boot -> page by path
@@ -173,6 +182,8 @@ route_findings() {
             # reverted #52 (c69baab), which silently digested an unknown agent.
             # allowlist_verdict: 0 = full-tuple match (known-good) -> suppress;
             # 2 = reused label (identity diverges) -> page; 1 = not-found -> page.
+            label=$(jq -r '.cols.label // ""' <<<"$obj")
+            program=$(jq -r '.cols.program // ""' <<<"$obj")
             av=0
             allowlist_verdict "$label" "$path" "$program" || av=$?
             case "$av" in
@@ -188,6 +199,9 @@ route_findings() {
         esac
         ;;
       file_events_recent)
+        category=$(jq -r '.cols.category // ""' <<<"$obj")
+        target=$(jq -r '.cols.target_path // ""' <<<"$obj")
+        base=${target##*/} # basename via bash param expansion (not delimiter-based)
         case "$category" in
           ssh)
             case "$base" in
@@ -206,6 +220,8 @@ route_findings() {
           # digests - page or silent. Until the manifest slice lands, a tracked
           # change fails open to a page (criterion 6).
           pipeline_integrity | launch_agents | launch_daemons)
+            hash=$(jq -r '.cols.sha256 // ""' <<<"$obj")
+            verb=$(jq -r '.cols.action // ""' <<<"$obj")
             if pipeline_verdict "$target" "$hash" "$verb"; then sev="CRIT"; else continue; fi
             ;;
           sudoers)

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -60,13 +60,13 @@ route_severity() {
 # c69baab's gate, overriding the base tier where the detector demands it. The gate
 # is the authority on the final outcome.
 #
-# NOT WIRED YET (see the TODOs inline): the allowlist verdict for a user
-# LaunchAgent (B11), the pipeline verdict for a pipeline file event (B12), and the
-# signing enrichment that can promote a NOTICE to CRIT (B13). Until then a new
-# launchd item and a pipeline file event page unconditionally.
+# NOT WIRED YET (see the TODOs inline): the pipeline verdict for a pipeline file
+# event (B12) and the signing enrichment that can promote a NOTICE to CRIT (B13).
+# Until then a pipeline file event pages unconditionally.
 #
-# digest_append (digest-store.sh) is expected to be sourced alongside this helper;
-# the entry script sources all helpers into one process.
+# digest_append (digest-store.sh) and allowlist_verdict (allowlist-verdict.sh) are
+# expected to be sourced alongside this helper; the entry script sources all
+# helpers into one process.
 route_findings() {
   local -a objs=() controls=() sevs=()
   local obj
@@ -77,18 +77,22 @@ route_findings() {
     objs+=("$obj")
   done
   [[ ${#objs[@]} -gt 0 ]] || return 0
-  # One jq pass extracts the control fields (q, act, category, file basename, path)
-  # per finding, tab-separated; one route_severity pass gives the base severity.
-  # Both emit exactly one line per input, in order, so they align with objs by index.
+  # One jq pass extracts the control fields (q, act, category, file basename, path,
+  # label, program) per finding; one route_severity pass gives the base severity.
+  # Both emit exactly one line per input, in order, so they align with objs by
+  # index. The fields are joined with the ASCII Unit Separator (0x1F), NOT a tab:
+  # a tab is whitespace in IFS, so `read` would collapse the empty category/base
+  # fields and shift the later fields off. 0x1F is non-whitespace, so empty fields
+  # are preserved, and it cannot occur in an osquery path/label/program.
   mapfile -t controls < <(printf '%s\n' "${objs[@]}" |
-    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // "")] | @tsv')
+    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // "")] | join("\u001f")')
   mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
 
   local -a pages=()
-  local i q act category base path sev
+  local i q act category base path label program sev av
   for i in "${!objs[@]}"; do
     obj=${objs[i]}
-    IFS=$'\t' read -r q act category base path <<<"${controls[i]}"
+    IFS=$'\x1f' read -r q act category base path label program <<<"${controls[i]}"
     sev=${sevs[i]}
     case "$q" in
       # Poller-owned protections: the dedicated 60s poller pages a firewall /
@@ -133,11 +137,23 @@ route_findings() {
       persistence_launchd)
         [[ $act == added ]] || continue
         case "$path" in
-          /System/Library/*) continue ;; # Apple's own launchd items, log-only
-          # TODO B11: a user LaunchAgent (the default arm below) should consult
-          # allowlist_verdict - suppress a known-good identity, page a reused label,
-          # digest an unknown one. For now a new launchd item pages unconditionally.
-          *) sev="CRIT" ;;
+          /System/Library/*) continue ;;   # Apple's own launchd items, log-only
+          */LaunchDaemons/*) sev="CRIT" ;; # a root LaunchDaemon runs at boot -> page by path
+          *)
+            # A user LaunchAgent. DEFAULT-DENY (operator ruling 2026-07-22): an
+            # unallowlisted user LaunchAgent PAGES; the operator seeds known-good
+            # agents via the allowlist writer (osquery-allowlist.sh) to suppress
+            # them. This is a deliberate hardening over the digest-unknowns of the
+            # reverted #52 (c69baab), which silently digested an unknown agent.
+            # allowlist_verdict: 0 = full-tuple match (known-good) -> suppress;
+            # 2 = reused label (identity diverges) -> page; 1 = not-found -> page.
+            av=0
+            allowlist_verdict "$label" "$path" "$program" || av=$?
+            case "$av" in
+              0) continue ;;   # known-good identity -> suppressed (log-only)
+              *) sev="CRIT" ;; # reused label OR unknown -> page (default-deny)
+            esac
+            ;;
         esac
         ;;
       file_events_recent)

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -47,3 +47,140 @@ route_severity() {
     sev
   '
 }
+
+# route_findings: the three-outcome gate. Read normalized findings ({q, act, cols,
+# ep}) as NDJSON on stdin and route each to EXACTLY ONE outcome:
+#   PAGE      -> emit the finding (with .sev = "CRIT") as NDJSON on stdout, for
+#                render_page to render into the #priority body.
+#   DIGEST    -> record the finding via digest_append (a spool side effect); emit
+#                nothing.
+#   LOG-ONLY  -> emit nothing and record nothing (the row stays only in results.log).
+#
+# It composes route_severity for the base tier, then a per-detector case mirrors
+# c69baab's gate, overriding the base tier where the detector demands it. The gate
+# is the authority on the final outcome.
+#
+# NOT WIRED YET (see the TODOs inline): the allowlist verdict for a user
+# LaunchAgent (B11), the pipeline verdict for a pipeline file event (B12), and the
+# signing enrichment that can promote a NOTICE to CRIT (B13). Until then a new
+# launchd item and a pipeline file event page unconditionally.
+#
+# digest_append (digest-store.sh) is expected to be sourced alongside this helper;
+# the entry script sources all helpers into one process.
+route_findings() {
+  local -a objs=() controls=() sevs=()
+  local obj
+  # Read the whole batch (a bounded log-tail, already fully in hand), so the two
+  # jq-heavy steps below run ONCE over the batch instead of per finding.
+  while IFS= read -r obj; do
+    [[ -n $obj ]] || continue
+    objs+=("$obj")
+  done
+  [[ ${#objs[@]} -gt 0 ]] || return 0
+  # One jq pass extracts the control fields (q, act, category, file basename, path)
+  # per finding, tab-separated; one route_severity pass gives the base severity.
+  # Both emit exactly one line per input, in order, so they align with objs by index.
+  mapfile -t controls < <(printf '%s\n' "${objs[@]}" |
+    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // "")] | @tsv')
+  mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
+
+  local -a pages=()
+  local i q act category base path sev
+  for i in "${!objs[@]}"; do
+    obj=${objs[i]}
+    IFS=$'\t' read -r q act category base path <<<"${controls[i]}"
+    sev=${sevs[i]}
+    case "$q" in
+      # Poller-owned protections: the dedicated 60s poller pages a firewall /
+      # Gatekeeper / SIP flip, so routing them here too would double-page. Log-only,
+      # overriding route_severity's CRIT for the unsafe transition.
+      firewall_state | gatekeeper_state | sip_state) continue ;;
+      # Wrong-signal or too-noisy-to-surface detectors: log-only.
+      kernel_extensions_new | persistence_startup_items_crontab | es_launchd_writes | agent_binary_changed) continue ;;
+      # Digest tier: suspicious-but-ambiguous, summarized daily, never paged.
+      # agent_authfile_changed is the 3 NON-secret configs (.env, config.toml,
+      # cli-client-id) - routine churn digests, it never pages (the 2 true secrets
+      # are agent_secretfile_changed, a separate paging detector).
+      agent_authfile_changed)
+        digest_append "$obj"
+        continue
+        ;;
+      system_extensions_new)
+        digest_append "$obj"
+        continue
+        ;;
+      listening_ports_non_loopback)
+        [[ $act == added ]] && digest_append "$obj"
+        continue
+        ;;
+      # Page tier, direction-gated to the unsafe transition only.
+      agent_secretfile_changed) sev="CRIT" ;; # a change to one of the 2 secrets pages
+      agent_exposure_changed)
+        # Only the newly-exposed "added" transition pages; a "removed" row is the
+        # port being un-exposed (good news), log-only.
+        [[ $act == added ]] || continue
+        sev="CRIT"
+        ;;
+      remote_access_sharing_state)
+        # An "added" row is a service turning ON (page); "removed" is OFF, log-only.
+        [[ $act == added ]] || continue
+        sev="CRIT"
+        ;;
+      suid_bin_unexpected)
+        # A new setuid-root binary; only the "added" direction. sev is already CRIT.
+        [[ $act == added ]] || continue
+        ;;
+      persistence_launchd)
+        [[ $act == added ]] || continue
+        case "$path" in
+          /System/Library/*) continue ;; # Apple's own launchd items, log-only
+          # TODO B11: a user LaunchAgent (the default arm below) should consult
+          # allowlist_verdict - suppress a known-good identity, page a reused label,
+          # digest an unknown one. For now a new launchd item pages unconditionally.
+          *) sev="CRIT" ;;
+        esac
+        ;;
+      file_events_recent)
+        case "$category" in
+          ssh)
+            case "$base" in
+              authorized_keys | authorized_keys2) sev="CRIT" ;; # remote-auth entry points page
+              *)
+                digest_append "$obj" # other ~/.ssh files (private keys, config) digest
+                continue
+                ;;
+            esac
+            ;;
+          sshd_config) sev="CRIT" ;; # remote-auth policy pages
+          # TODO B12: these categories should consult pipeline_verdict - page a tamper,
+          # stay silent on a known-good apply. For now a pipeline file event pages.
+          pipeline_integrity | launch_agents | launch_daemons) sev="CRIT" ;;
+          sudoers)
+            digest_append "$obj"
+            continue
+            ;;
+          allowlist_file)
+            case "$base" in
+              page-launchd-allowlist.txt)
+                digest_append "$obj" # the page-suppressor edit itself digests
+                continue
+                ;;
+              *) continue ;; # other ~/.config/osquery neighbors, log-only
+            esac
+            ;;
+          *) continue ;;
+        esac
+        ;;
+        # Detectors with no arm (new_admin_user, filevault_off, filevault_state, the
+        # installed-software drift queries, recent_logins, persistence_launchd_overrides)
+        # fall through with the base severity route_severity assigned.
+    esac
+    # TODO B13: signing enrichment (promote a NOTICE to CRIT on an untrusted signing
+    # verdict) goes here, before the page decision.
+    [[ $sev == "CRIT" ]] || continue
+    pages+=("$obj")
+  done
+  # Emit the page-candidates, in input order, with .sev stamped CRIT - one jq pass.
+  [[ ${#pages[@]} -gt 0 ]] && printf '%s\n' "${pages[@]}" | jq -c '.sev = "CRIT"'
+  return 0
+}

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# route.sh - a sourced helper for results-alerter.sh. Functions only, no main;
+# nothing here delivers, checkpoints, or exits. It owns the routing stage: the
+# base severity matrix (route_severity, below) and, in later behaviors, the
+# three-outcome page/digest/log-only gate that composes the leaf verdict helpers.
+#
+# route_severity reads normalized-finding NDJSON on stdin (one {q, act, cols, ep}
+# object per line, as normalize emits) and prints one base severity per finding,
+# in order. It is the pure classifier only; the gate may override this tier for a
+# specific detector (e.g. promote agent_exposure_changed to a page). Adapted from
+# c69baab's sev/protection_off defs, rebased to test the prefix-stripped q rather
+# than the full pack-qualified name (normalize already stripped the pack prefix,
+# so there is no common pack prefix left to test - the security-policy-regression
+# membership is an explicit set of the stripped query names).
+
+route_severity() {
+  jq -r '
+    # protection_off: a security-policy-regression protection observed in its
+    # UNSAFE state. For the boolean states that is an "added" differential row
+    # carrying the off value in its state column; for FileVault it is any
+    # filevault_off "added" row (that query emits a row only when NO APFS volume
+    # is encrypted, so its presence IS the off state - no column check needed).
+    # This is the criterion-2 fix: filevault_off is now a DIFFERENTIAL query, so
+    # the off state arrives as action:added, not the old snapshot "currently-off".
+    def protection_off:
+      (.q == "firewall_state" and .act == "added" and ((.cols.global_state // "") == "0"))
+      or (.q == "gatekeeper_state" and .act == "added" and ((.cols.assessments_enabled // "") == "0"))
+      or (.q == "sip_state" and .act == "added" and ((.cols.enabled // "") == "0"))
+      or (.q == "filevault_off" and .act == "added");
+    # The security-policy-regression pack, by stripped query name. Any such row
+    # that is not protection_off (a re-enable, a version bump, the paired removed
+    # row, FileVault APFS churn) falls through to NOTICE, never silently to INFO.
+    def security_policy_query:
+      .q | IN("filevault_off", "filevault_state", "firewall_state", "gatekeeper_state", "remote_access_sharing_state", "sip_state");
+    def sev:
+      if protection_off or .q == "new_admin_user" or .q == "suid_bin_unexpected"
+      then "CRIT"
+      elif security_policy_query
+        or (.q | startswith("persistence_"))
+        or .q == "kernel_extensions_new"
+        or .q == "system_extensions_new"
+        or .q == "file_events_recent"
+        or .q == "es_launchd_writes"
+      then "NOTICE"
+      else "INFO" end;
+    sev
+  '
+}

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -60,13 +60,12 @@ route_severity() {
 # c69baab's gate, overriding the base tier where the detector demands it. The gate
 # is the authority on the final outcome.
 #
-# NOT WIRED YET (see the TODOs inline): the pipeline verdict for a pipeline file
-# event (B12) and the signing enrichment that can promote a NOTICE to CRIT (B13).
-# Until then a pipeline file event pages unconditionally.
+# NOT WIRED YET (see the TODO inline): the signing enrichment that can promote a
+# NOTICE to CRIT (B13).
 #
-# digest_append (digest-store.sh) and allowlist_verdict (allowlist-verdict.sh) are
-# expected to be sourced alongside this helper; the entry script sources all
-# helpers into one process.
+# digest_append (digest-store.sh), allowlist_verdict (allowlist-verdict.sh), and
+# pipeline_verdict (pipeline-verdict.sh) are expected to be sourced alongside this
+# helper; the entry script sources all helpers into one process.
 route_findings() {
   local -a objs=() controls=() sevs=()
   local obj
@@ -85,14 +84,14 @@ route_findings() {
   # fields and shift the later fields off. 0x1F is non-whitespace, so empty fields
   # are preserved, and it cannot occur in an osquery path/label/program.
   mapfile -t controls < <(printf '%s\n' "${objs[@]}" |
-    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // "")] | join("\u001f")')
+    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // ""), (.cols.target_path // ""), (.cols.sha256 // ""), (.cols.action // "")] | join("\u001f")')
   mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
 
   local -a pages=()
-  local i q act category base path label program sev av
+  local i q act category base path label program target hash verb sev av
   for i in "${!objs[@]}"; do
     obj=${objs[i]}
-    IFS=$'\x1f' read -r q act category base path label program <<<"${controls[i]}"
+    IFS=$'\x1f' read -r q act category base path label program target hash verb <<<"${controls[i]}"
     sev=${sevs[i]}
     case "$q" in
       # Poller-owned protections: the dedicated 60s poller pages a firewall /
@@ -168,9 +167,15 @@ route_findings() {
             esac
             ;;
           sshd_config) sev="CRIT" ;; # remote-auth policy pages
-          # TODO B12: these categories should consult pipeline_verdict - page a tamper,
-          # stay silent on a known-good apply. For now a pipeline file event pages.
-          pipeline_integrity | launch_agents | launch_daemons) sev="CRIT" ;;
+          # The alerter's own scripts/plists (pipeline_integrity) and our own
+          # LaunchAgents (launch_agents/launch_daemons) consult pipeline_verdict:
+          # 0 = page (tamper / cannot confirm / no manifest -> fail-open), 1 = silent
+          # (an untracked neighbor, or an exact (path, sha256) manifest match). Never
+          # digests - page or silent. Until the manifest slice lands, a tracked
+          # change fails open to a page (criterion 6).
+          pipeline_integrity | launch_agents | launch_daemons)
+            if pipeline_verdict "$target" "$hash" "$verb"; then sev="CRIT"; else continue; fi
+            ;;
           sudoers)
             digest_append "$obj"
             continue

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -60,9 +60,12 @@ route_severity() {
 # c69baab's gate, overriding the base tier where the detector demands it. The gate
 # is the authority on the final outcome.
 #
-# Enrichment runs BEFORE the per-detector case so a finding promoted to CRIT by an
-# untrusted signing verdict can never be suppressed by the allowlist (the security
-# invariant: an untrusted program behind an allowlisted label still pages).
+# Enrichment runs BEFORE the per-detector case so its NOTICE->CRIT promotion (on an
+# untrusted signing verdict) is available to the arms. It is HONORED by
+# persistence_launchd (an untrusted program behind an allowlisted label still pages -
+# the security invariant), kernel_extensions_new, and system_extensions_new, and is
+# INTENTIONALLY NOT consulted by the log-only es_launchd_writes /
+# persistence_startup_items_crontab arms (see their comment for why).
 #
 # SECURITY: every attacker-controlled field the gate routes on (path, label,
 # program, target_path, ...) is extracted per-field via jq at its point of use and
@@ -106,14 +109,16 @@ route_findings() {
     act=$(jq -r '.act' <<<"$obj")
     ep=$(jq -r '.ep // ""' <<<"$obj")
     sev=${sevs[i]}
-    # Enrichment runs BEFORE the per-detector case (the security invariant): a
-    # finding an untrusted signature promotes to CRIT here can NOT then be
-    # suppressed by the allowlist below - a promoted CRIT (an untrusted binary
-    # behind an allowlisted label) always pages. For a finding with an inspectable
-    # path and a CRIT/NOTICE base tier, get the signing verdict, attach it as
-    # .signing for render-page, and promote NOTICE -> CRIT (louder, never quieter)
-    # when the verdict is UNTRUSTED (enricher exit 10). Fail-open: an absent or
-    # erroring enricher leaves the finding surfaced, just without a Signing field.
+    # Enrichment runs BEFORE the per-detector case: for a finding with an inspectable
+    # path and a CRIT/NOTICE base tier, get the signing verdict, attach it as .signing
+    # for render-page, and promote NOTICE -> CRIT (louder, never quieter) when the
+    # verdict is UNTRUSTED (enricher exit 10). A promotion here can NOT then be
+    # suppressed by the allowlist below (the security invariant: an untrusted program
+    # behind an allowlisted label still pages). The promotion is HONORED by the
+    # persistence_launchd, kernel_extensions_new, and system_extensions_new arms and
+    # INTENTIONALLY IGNORED by the log-only es_launchd_writes /
+    # persistence_startup_items_crontab arms. Fail-open: an absent or erroring enricher
+    # leaves the finding surfaced, just without a Signing field.
     signing=""
     if [[ -n $ep && ($sev == "CRIT" || $sev == "NOTICE") && -x $enrich_script ]]; then
       enrich_status=0
@@ -130,9 +135,22 @@ route_findings() {
       # cannot occur and the snapshot floor is pure noise. The poller does NOT cover
       # SIP; this is log-only for that reason, not a poller hand-off. (route_severity
       # still classifies a sip_state-off as CRIT; the gate is the authority here.)
+      # FUTURE (operator note 2026-07-22): if SIP is ever turned back on for this
+      # host, flip this arm to page on the off-transition (mirror the filevault_off
+      # tier, which pages an added off-row).
       sip_state) continue ;;
-      # Wrong-signal or too-noisy-to-surface detectors: log-only.
-      kernel_extensions_new | persistence_startup_items_crontab | es_launchd_writes | agent_binary_changed) continue ;;
+      # Log-only REGARDLESS of the enrichment verdict (the kext/sysext promotion
+      # ruling is scoped to those two detectors only). es_launchd_writes is the raw,
+      # noisy Endpoint-Security write event already covered by the persistence_launchd
+      # differential (which pages via allowlist + enrichment), so honoring its
+      # promotion here would double-signal. persistence_startup_items_crontab is a
+      # low-noise legacy vector kept log-only. agent_binary_changed carries no
+      # inspectable path (no enrichment) and is inherently noisy.
+      persistence_startup_items_crontab | es_launchd_writes | agent_binary_changed) continue ;;
+      # A newly-loaded kernel extension: an UNTRUSTED one (enrichment promoted it to
+      # CRIT above) pages; a signed one stays log-only, its base tier. Operator ruling
+      # 2026-07-22. Mirrors the persistence arm's [[ $sev == CRIT ]] honor-the-promotion.
+      kernel_extensions_new) [[ $sev == "CRIT" ]] || continue ;;
       # Digest tier: suspicious-but-ambiguous, summarized daily, never paged.
       # agent_authfile_changed is the 3 NON-secret configs (.env, config.toml,
       # cli-client-id) - routine churn digests, it never pages (the 2 true secrets
@@ -141,9 +159,14 @@ route_findings() {
         digest_append "$obj"
         continue
         ;;
+      # A new system extension is usually an app upgrade re-activating a sysext, so a
+      # SIGNED one digests (its base tier); an UNTRUSTED one (enrichment promoted it
+      # to CRIT above) pages. Operator ruling 2026-07-22.
       system_extensions_new)
-        digest_append "$obj"
-        continue
+        [[ $sev == "CRIT" ]] || {
+          digest_append "$obj"
+          continue
+        }
         ;;
       listening_ports_non_loopback)
         [[ $act == added ]] && digest_append "$obj"

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -116,10 +116,15 @@ route_findings() {
     fi
     [[ -n $signing ]] && obj=$(jq -c --arg sig "$signing" '.signing = $sig' <<<"$obj")
     case "$q" in
-      # Poller-owned protections: the dedicated 60s poller pages a firewall /
-      # Gatekeeper / SIP flip, so routing them here too would double-page. Log-only,
-      # overriding route_severity's CRIT for the unsafe transition.
-      firewall_state | gatekeeper_state | sip_state) continue ;;
+      # Poller-owned: the dedicated 60s poller (firewall-gatekeeper-monitor.sh)
+      # pages a firewall or Gatekeeper flip, so routing them here too would
+      # double-page. Log-only, overriding route_severity's protection_off CRIT.
+      firewall_state | gatekeeper_state) continue ;;
+      # SIP is intentionally off on this developer box, so an on->off transition
+      # cannot occur and the snapshot floor is pure noise. The poller does NOT cover
+      # SIP; this is log-only for that reason, not a poller hand-off. (route_severity
+      # still classifies a sip_state-off as CRIT; the gate is the authority here.)
+      sip_state) continue ;;
       # Wrong-signal or too-noisy-to-surface detectors: log-only.
       kernel_extensions_new | persistence_startup_items_crontab | es_launchd_writes | agent_binary_changed) continue ;;
       # Digest tier: suspicious-but-ambiguous, summarized daily, never paged.

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -60,12 +60,14 @@ route_severity() {
 # c69baab's gate, overriding the base tier where the detector demands it. The gate
 # is the authority on the final outcome.
 #
-# NOT WIRED YET (see the TODO inline): the signing enrichment that can promote a
-# NOTICE to CRIT (B13).
+# Enrichment runs BEFORE the per-detector case so a finding promoted to CRIT by an
+# untrusted signing verdict can never be suppressed by the allowlist (the security
+# invariant: an untrusted program behind an allowlisted label still pages).
 #
-# digest_append (digest-store.sh), allowlist_verdict (allowlist-verdict.sh), and
-# pipeline_verdict (pipeline-verdict.sh) are expected to be sourced alongside this
-# helper; the entry script sources all helpers into one process.
+# digest_append (digest-store.sh), allowlist_verdict (allowlist-verdict.sh),
+# pipeline_verdict (pipeline-verdict.sh), and the enrich-finding.sh script are
+# expected to be available alongside this helper; the entry script sources all
+# helpers into one process.
 route_findings() {
   local -a objs=() controls=() sevs=()
   local obj
@@ -84,15 +86,35 @@ route_findings() {
   # fields and shift the later fields off. 0x1F is non-whitespace, so empty fields
   # are preserved, and it cannot occur in an osquery path/label/program.
   mapfile -t controls < <(printf '%s\n' "${objs[@]}" |
-    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // ""), (.cols.target_path // ""), (.cols.sha256 // ""), (.cols.action // "")] | join("\u001f")')
+    jq -rc '[.q, .act, (.cols.category // ""), ((.cols.target_path // "") | split("/") | last), (.cols.path // ""), (.cols.label // ""), (.cols.program // ""), (.cols.target_path // ""), (.cols.sha256 // ""), (.cols.action // ""), (.ep // "")] | join("\u001f")')
   mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
 
+  # The signing enricher (enrich-finding.sh): given an inspectable path it emits a
+  # trust fact string and exits 10 when the code is UNTRUSTED. Overridable for tests;
+  # absent/non-executable -> enrichment is skipped (fail-open, the finding still surfaces).
+  local enrich_script="${OSQUERY_ENRICH_SCRIPT:-$HOME/.local/libexec/osquery/enrich-finding.sh}"
+
   local -a pages=()
-  local i q act category base path label program target hash verb sev av
+  local i q act category base path label program target hash verb ep sev av signing enrich_status
   for i in "${!objs[@]}"; do
     obj=${objs[i]}
-    IFS=$'\x1f' read -r q act category base path label program target hash verb <<<"${controls[i]}"
+    IFS=$'\x1f' read -r q act category base path label program target hash verb ep <<<"${controls[i]}"
     sev=${sevs[i]}
+    # Enrichment runs BEFORE the per-detector case (the security invariant): a
+    # finding an untrusted signature promotes to CRIT here can NOT then be
+    # suppressed by the allowlist below - a promoted CRIT (an untrusted binary
+    # behind an allowlisted label) always pages. For a finding with an inspectable
+    # path and a CRIT/NOTICE base tier, get the signing verdict, attach it as
+    # .signing for render-page, and promote NOTICE -> CRIT (louder, never quieter)
+    # when the verdict is UNTRUSTED (enricher exit 10). Fail-open: an absent or
+    # erroring enricher leaves the finding surfaced, just without a Signing field.
+    signing=""
+    if [[ -n $ep && ($sev == "CRIT" || $sev == "NOTICE") && -x $enrich_script ]]; then
+      enrich_status=0
+      signing=$("$enrich_script" "$ep" 2>/dev/null) || enrich_status=$?
+      [[ $enrich_status -eq 10 && $sev == "NOTICE" ]] && sev="CRIT"
+    fi
+    [[ -n $signing ]] && obj=$(jq -c --arg sig "$signing" '.signing = $sig' <<<"$obj")
     case "$q" in
       # Poller-owned protections: the dedicated 60s poller pages a firewall /
       # Gatekeeper / SIP flip, so routing them here too would double-page. Log-only,
@@ -149,7 +171,12 @@ route_findings() {
             av=0
             allowlist_verdict "$label" "$path" "$program" || av=$?
             case "$av" in
-              0) continue ;;   # known-good identity -> suppressed (log-only)
+              # Known-good tuple -> suppress, UNLESS enrichment already promoted this
+              # to CRIT on an untrusted program. A promoted CRIT is never suppressed;
+              # the allowlist only quiets a non-CRIT finding. The tuple's plist-hash
+              # dimension catches a tampered PLIST and the signing verdict catches an
+              # untrusted PROGRAM - separate defenses, both able to page.
+              0) [[ $sev == "CRIT" ]] || continue ;;
               *) sev="CRIT" ;; # reused label OR unknown -> page (default-deny)
             esac
             ;;
@@ -196,8 +223,6 @@ route_findings() {
         # installed-software drift queries, recent_logins, persistence_launchd_overrides)
         # fall through with the base severity route_severity assigned.
     esac
-    # TODO B13: signing enrichment (promote a NOTICE to CRIT on an untrusted signing
-    # verdict) goes here, before the page decision.
     [[ $sev == "CRIT" ]] || continue
     pages+=("$obj")
   done

--- a/test/e2e/osquery-alerter-concurrency.bats
+++ b/test/e2e/osquery-alerter-concurrency.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Concurrency: WatchPaths can fire a second alerter invocation while one is still
+# running. Both would read the same cursor+snapshot, both send_alert (two local
+# banners, since the local notification fires before any occurrence-dedup), and
+# both race STATE.tmp. A nonblocking single-instance kernel lock held across the
+# whole run (read -> route -> send_alert -> checkpoint) makes exactly one run
+# deliver the batch; a contended run is a clean no-op (exit 0). The lock fd must
+# not leak to a forked child, or a backgrounded grandchild would wedge it.
+
+setup() {
+  REPO="$BATS_TEST_DIRNAME/../.."
+  ENTRY="$REPO/dot_local/libexec/osquery/executable_results-alerter.sh"
+  HELPER_SRC="$REPO/dot_local/libexec/osquery/results-alerter"
+
+  HOME_DIR="$(mktemp -d)"
+  export HOME="$HOME_DIR"
+  mkdir -p "$HOME/.local/libexec/osquery/results-alerter" "$HOME/.local/state" "$HOME/.local/log/osquery"
+  cp "$HELPER_SRC"/*.sh "$HOME/.local/libexec/osquery/results-alerter/"
+
+  export SEND_ALERT_SPY="$HOME/send_alert.log"
+  : >"$SEND_ALERT_SPY"
+  export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
+  export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
+  : >"$OSQUERY_RESULTS_LOG"
+  ADMIN_ROW='{"name":"new_admin_user","action":"added","columns":{"username":"eve","uid":"501"}}'
+}
+teardown() { rm -rf "$HOME_DIR"; }
+
+log_inode() { ls -i "$OSQUERY_RESULTS_LOG" | awk '{print $1}'; }
+log_size() { wc -c <"$OSQUERY_RESULTS_LOG" | tr -d '[:space:]'; }
+seed_cursor() { printf '%s 0\n' "$(log_inode)" >"$OSQUERY_RESULTS_OFFSET"; }
+cursor_offset() { awk '{print $2}' "$OSQUERY_RESULTS_OFFSET"; }
+call_count() { grep -c '^CALL' "$SEND_ALERT_SPY" 2>/dev/null || true; }
+
+# A send_alert stub that records the call and holds the delivery window open long
+# enough that a second concurrent run overlaps a first one still delivering.
+write_slow_dispatch() {
+  cat >"$HOME/.local/libexec/osquery/alert-dispatch.sh" <<'STUB'
+# shellcheck shell=bash
+send_alert() {
+  printf 'CALL\t%s\n' "$2" >>"$SEND_ALERT_SPY"
+  sleep "${SEND_ALERT_DELAY:-1}"
+  return 0
+}
+STUB
+}
+
+@test "T-CONCURRENT-one-notification: two parallel runs deliver a batch exactly once" {
+  [[ -x /usr/bin/lockf ]] || skip "no /usr/bin/lockf; the single-instance lock is a darwin-only guarantee"
+  write_slow_dispatch
+  seed_cursor
+  printf '%s\n' "$ADMIN_ROW" >>"$OSQUERY_RESULTS_LOG"
+
+  SEND_ALERT_DELAY=1 bash "$ENTRY" &
+  local p1=$!
+  SEND_ALERT_DELAY=1 bash "$ENTRY" &
+  local p2=$!
+  local s1=0 s2=0
+  wait "$p1" || s1=$?
+  wait "$p2" || s2=$?
+
+  [ "$s1" -eq 0 ]                    # both runs exit 0 (the loser is a clean no-op)
+  [ "$s2" -eq 0 ]
+  [ "$(call_count)" -eq 1 ]          # exactly ONE send_alert / ONE banner, no double-send
+  [ "$(cursor_offset)" -eq "$(log_size)" ]  # cursor advanced once
+}
+
+# The lock fd must not leak to a child: a send_alert that spawns a long-lived,
+# DETACHED grandchild must NOT keep the lock held after the run exits, or the next
+# run would be locked out and drop its batch. Exactly the latent bug from the
+# allowlist writer. The grandchild is nohup+disown'd (writing its pid) so it
+# genuinely survives the run's exit; the test then asserts the lock is FREE by
+# acquiring it directly, which fails only if the grandchild inherited the lock fd.
+@test "T-CONCURRENT-fd-hygiene: a detached child never wedges the lock (fd not leaked)" {
+  [[ -x /usr/bin/lockf ]] || skip "no /usr/bin/lockf; the single-instance lock is a darwin-only guarantee"
+  local child_pid_file="$HOME/child.pid"
+  cat >"$HOME/.local/libexec/osquery/alert-dispatch.sh" <<STUB
+# shellcheck shell=bash
+send_alert() {
+  printf 'CALL\t%s\n' "\$2" >>"$SEND_ALERT_SPY"
+  # A detached, long-lived grandchild that survives this run's exit. If it inherited
+  # the lock fd (fd 9), it keeps the kernel lock held after the run is gone.
+  nohup sleep 30 </dev/null >/dev/null 2>&1 &
+  printf '%s\n' "\$!" >"$child_pid_file"
+  disown
+  return 0
+}
+STUB
+  seed_cursor
+  printf '%s\n' "$ADMIN_ROW" >>"$OSQUERY_RESULTS_LOG"
+  run bash "$ENTRY"                  # delivers, spawns the detached grandchild, exits
+  [ "$status" -eq 0 ]
+  [ "$(call_count)" -eq 1 ]
+  local child_pid
+  child_pid="$(cat "$child_pid_file")"
+  kill -0 "$child_pid"               # the grandchild is genuinely still alive
+  # The lock MUST be free now: run 1 released it on exit, and the grandchild did not
+  # inherit fd 9. Acquire it directly; this fails only if the fd leaked.
+  local lock="$OSQUERY_RESULTS_OFFSET.lock" acquired=no
+  if exec 8>>"$lock" && /usr/bin/lockf -s -t 0 8; then acquired=yes; fi
+  exec 8>&-
+  kill "$child_pid" 2>/dev/null || true
+  [ "$acquired" = "yes" ]            # lock free -> the lock fd never leaked to the child
+}

--- a/test/e2e/osquery-alerter-criteria.bats
+++ b/test/e2e/osquery-alerter-criteria.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# The slice-6 acceptance criteria (from the slice-4/5 reviews), driven END-TO-END
+# through the REAL entry script (executable_results-alerter.sh). Each test feeds
+# synthetic results.log rows under a temp HOME with the real pipeline helpers, a
+# recording send_alert spy, a stubbed enricher, and a seeded page-allowlist, then
+# asserts the DELIVERED outcome: a CRIT page (and its body), a digest-spool entry,
+# or nothing. This is the whole-pipeline regression guard - every criterion is
+# also unit-pinned in a helper suite; here it must COMPOSE through the entry.
+
+setup() {
+  REPO="$BATS_TEST_DIRNAME/../.."
+  ENTRY="$REPO/dot_local/libexec/osquery/executable_results-alerter.sh"
+  HELPER_SRC="$REPO/dot_local/libexec/osquery/results-alerter"
+
+  HOME_DIR="$(mktemp -d)"
+  export HOME="$HOME_DIR"
+  mkdir -p "$HOME/.local/libexec/osquery/results-alerter" "$HOME/.local/state" \
+    "$HOME/.local/log/osquery" "$HOME/.config/osquery" "$HOME/Library/LaunchAgents" "$HOME/bin"
+  cp "$HELPER_SRC"/*.sh "$HOME/.local/libexec/osquery/results-alerter/"
+
+  # Recording send_alert spy (records severity, title, and the full detail/pbody).
+  export SEND_ALERT_SPY="$HOME/send_alert.log"
+  : >"$SEND_ALERT_SPY"
+  cat >"$HOME/.local/libexec/osquery/alert-dispatch.sh" <<'STUB'
+# shellcheck shell=bash
+send_alert() {
+  {
+    printf 'CALL\tseverity=%s\ttitle=%s\n' "$1" "$2"
+    printf 'DETAIL-START\n%s\nDETAIL-END\n' "$3"
+  } >>"$SEND_ALERT_SPY"
+  return "${SEND_ALERT_RC:-0}"
+}
+STUB
+
+  # Stubbed enricher: UNTRUSTED (exit 10) when the inspected path contains
+  # UNTRUSTED, else a trusted authority (exit 0).
+  cat >"$HOME/enrich-stub.sh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  *UNTRUSTED*) printf 'UNSIGNED'; exit 10 ;;
+  *) printf 'signed: Apple'; exit 0 ;;
+esac
+STUB
+  chmod +x "$HOME/enrich-stub.sh"
+  export OSQUERY_ENRICH_SCRIPT="$HOME/enrich-stub.sh"
+
+  # Seeded page-allowlist at the NEW default path with two own-agent entries
+  # (empty sha256 -> the hash dimension is skipped). One clean, one whose plist
+  # path carries UNTRUSTED so the enrichment override can be exercised.
+  cat >"$HOME/.config/osquery/page-launchd-allowlist.txt" <<EOF
+{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
+{"label":"com.evil","path":"~/Library/LaunchAgents/com.evilUNTRUSTED.plist","program":"~/bin/evil","sha256":""}
+EOF
+
+  export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
+  export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
+  export OSQUERY_DIGEST_STORE="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
+  : >"$OSQUERY_RESULTS_LOG"
+}
+
+teardown() { rm -rf "$HOME_DIR"; }
+
+log_inode() { ls -i "$OSQUERY_RESULTS_LOG" | awk '{print $1}'; }
+seed_cursor() { printf '%s %s\n' "$(log_inode)" "0" >"$OSQUERY_RESULTS_OFFSET"; }
+append_row() { printf '%s\n' "$1" >>"$OSQUERY_RESULTS_LOG"; }
+run_entry() { run bash "$ENTRY"; [ "$status" -eq 0 ]; }
+
+# feed <row>...: seed a valid cursor, append the rows, run the entry.
+feed() {
+  seed_cursor
+  local row
+  for row in "$@"; do append_row "$row"; done
+  run_entry
+}
+
+assert_crit_page() { grep -q 'severity=CRIT' "$SEND_ALERT_SPY"; }
+assert_no_page() { ! grep -q '^CALL' "$SEND_ALERT_SPY"; }
+pbody_has() { grep -qF -- "$1" "$SEND_ALERT_SPY"; }
+pbody_lacks() { ! grep -qF -- "$1" "$SEND_ALERT_SPY"; }
+digest_has() { grep -qF -- "$1" "$OSQUERY_DIGEST_STORE"; }
+
+# --- Criterion 1: new_admin_user added -> a CRIT page ------------------------
+@test "C1: new_admin_user added fires a CRIT page" {
+  feed '{"name":"new_admin_user","action":"added","columns":{"username":"eve","uid":"501"}}'
+  assert_crit_page
+  pbody_has 'New administrator account'
+}
+
+# --- Criterion 2: differential filevault_off added -> a CRIT page ------------
+@test "C2: differential filevault_off added (not snapshot) fires a CRIT page" {
+  feed '{"name":"pack_security-policy-regression_filevault_off","action":"added","columns":{}}'
+  assert_crit_page
+  pbody_has 'FileVault turned OFF'
+}
+
+# --- Criterion 3: agent detectors route to page/page/digest -----------------
+@test "C3a: agent_exposure_changed added pages" {
+  feed '{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"added","columns":{"name":"nc","address":"0.0.0.0","port":"4444"}}'
+  assert_crit_page
+  pbody_has 'Agent port exposed off-loopback'
+}
+
+@test "C3b: agent_secretfile_changed pages" {
+  feed '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{"path":"/Users/x/.config/relay/webhook-secret","sha256":"cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"}}'
+  assert_crit_page
+  pbody_has 'Agent secret file changed'
+}
+
+@test "C3c: agent_authfile_changed (config.toml) does NOT page, lands in the digest spool" {
+  feed '{"name":"pack_agent-attack-surface_agent_authfile_changed","action":"added","columns":{"path":"/Users/x/.codex/config.toml","sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}'
+  assert_no_page
+  digest_has 'config.toml'
+}
+
+# --- Criterion 4: allowlist end-to-end + enrichment override ----------------
+@test "C4a: a persistence agent fully matching an allowlisted own-agent tuple is suppressed" {
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.good\",\"path\":\"$HOME/Library/LaunchAgents/com.good.plist\",\"program\":\"$HOME/bin/good\"}}"
+  assert_no_page
+}
+
+@test "C4b: the same allowlisted label with a different program pages (reused label)" {
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.good\",\"path\":\"$HOME/Library/LaunchAgents/com.good.plist\",\"program\":\"$HOME/bin/EVIL\"}}"
+  assert_crit_page
+  pbody_has 'New startup item'
+}
+
+@test "C4c: an unknown user LaunchAgent pages (default-deny, operator ruling)" {
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.unknown\",\"path\":\"$HOME/Library/LaunchAgents/com.unknown.plist\",\"program\":\"$HOME/bin/unknown\"}}"
+  assert_crit_page
+  pbody_has 'New startup item'
+}
+
+@test "C4d: an allowlisted-but-untrusted program pages (enrichment beats suppression)" {
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.evil\",\"path\":\"$HOME/Library/LaunchAgents/com.evilUNTRUSTED.plist\",\"program\":\"$HOME/bin/evil\"}}"
+  assert_crit_page
+  pbody_has 'New startup item'
+}
+
+# --- Criterion 5: the allowlist is read from the NEW path, not the old one ---
+@test "C5: the old flat launch-allowlist.txt is NOT consulted (the entry reads the new path/env)" {
+  # Move the SAME allowlist entries to the OLD flat path only; the new path is
+  # empty. A matching agent must PAGE, proving the entry does not read the old path.
+  rm -f "$HOME/.config/osquery/page-launchd-allowlist.txt"
+  cat >"$HOME/.config/osquery/launch-allowlist.txt" <<EOF
+{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
+EOF
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.good\",\"path\":\"$HOME/Library/LaunchAgents/com.good.plist\",\"program\":\"$HOME/bin/good\"}}"
+  assert_crit_page   # not suppressed: the old path is ignored
+}
+
+@test "C5b: the unified OSQUERY_LAUNCHD_ALLOWLIST env var is what the entry reads" {
+  # Point the env var at a custom file (new path empty); a matching agent is
+  # suppressed only if the entry honors the env var.
+  rm -f "$HOME/.config/osquery/page-launchd-allowlist.txt"
+  local custom="$HOME/custom-allowlist.txt"
+  cat >"$custom" <<EOF
+{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
+EOF
+  export OSQUERY_LAUNCHD_ALLOWLIST="$custom"
+  feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.good\",\"path\":\"$HOME/Library/LaunchAgents/com.good.plist\",\"program\":\"$HOME/bin/good\"}}"
+  assert_no_page   # suppressed via the env-var path
+}
+
+# --- Criterion 6: a pipeline_integrity change with no manifest -> page -------
+@test "C6: a pipeline_integrity file change with no manifest pages (fail-open)" {
+  feed "{\"name\":\"file_events_recent\",\"action\":\"added\",\"columns\":{\"category\":\"pipeline_integrity\",\"target_path\":\"$HOME/.local/libexec/osquery/results-alerter/normalize.sh\",\"sha256\":\"abc\",\"action\":\"UPDATED\"}}"
+  assert_crit_page
+  pbody_has 'Security tooling changed'
+}
+
+# --- Criterion 7: basename-only; no full path, no sha256 in the payload ------
+@test "C7: a paged agent_secretfile_changed body shows the basename only, never the path or sha256" {
+  feed '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{"path":"/Users/x/.config/relay/webhook-secret","sha256":"cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"}}'
+  assert_crit_page
+  pbody_has 'webhook-secret'                 # the basename is present
+  pbody_lacks '/Users/x/.config/relay'       # the full path is NOT in the payload
+  pbody_lacks 'cafebabe'                      # the sha256 is NOT in the payload
+}

--- a/test/e2e/osquery-alerter-entry.bats
+++ b/test/e2e/osquery-alerter-entry.bats
@@ -49,6 +49,7 @@ log_size() { wc -c <"$OSQUERY_RESULTS_LOG" | tr -d '[:space:]'; }
 seed_cursor() { printf '%s %s\n' "$(log_inode)" "$1" >"$OSQUERY_RESULTS_OFFSET"; }
 cursor_offset() { awk '{print $2}' "$OSQUERY_RESULTS_OFFSET"; }
 append_row() { printf '%s\n' "$1" >>"$OSQUERY_RESULTS_LOG"; }
+append_partial() { printf '%s' "$1" >>"$OSQUERY_RESULTS_LOG"; } # no trailing newline (torn write)
 crit_page_count() { grep -c 'New administrator account' "$SEND_ALERT_SPY" 2>/dev/null || true; }
 send_alert_calls() { grep -c '^CALL' "$SEND_ALERT_SPY" 2>/dev/null || true; }
 
@@ -128,4 +129,22 @@ run_entry() { run bash "$ENTRY"; }
   [ "$status" -eq 0 ]
   [ "$(crit_page_count)" -eq 0 ]               # nothing paged
   [ "$(cursor_offset)" -eq "$(log_size)" ]     # cursor advanced (no wedge)
+}
+
+# (g) A torn final line (osquery mid-write, no trailing newline) is never lost: the
+#     cursor does not advance past the incomplete record; the completed row pages
+#     exactly once on the next run.
+@test "T-ENTRY-torn: a torn trailing line is retained, then pages once when completed" {
+  seed_cursor 0
+  append_partial "$ADMIN_ROW"                  # a row with NO trailing newline yet
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 0 ]               # not processed while the record is torn
+  [ "$(cursor_offset)" -eq 0 ]                 # cursor NOT advanced past the partial line
+  # osquery finishes the record (writes the newline). The completed row pages once.
+  printf '\n' >>"$OSQUERY_RESULTS_LOG"
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]               # delivered exactly once (no double-send)
+  [ "$(cursor_offset)" -eq "$(log_size)" ]     # cursor now advances past the complete record
 }

--- a/test/e2e/osquery-alerter-entry.bats
+++ b/test/e2e/osquery-alerter-entry.bats
@@ -148,3 +148,35 @@ run_entry() { run bash "$ENTRY"; }
   [ "$(crit_page_count)" -eq 1 ]               # delivered exactly once (no double-send)
   [ "$(cursor_offset)" -eq "$(log_size)" ]     # cursor now advances past the complete record
 }
+
+# (h) A lost/corrupt cursor replays the WHOLE current log, so a page-worthy finding
+#     before the old bounded 256 KiB tail is not silently dropped. osquery caps the
+#     log at 10 MB (logger_rotate), so the full replay is bounded.
+@test "T-ENTRY-reset-lossless: a CRIT before the old 256 KiB tail still pages after a cursor reset" {
+  append_row "$ADMIN_ROW"                       # the early CRIT, at the very start
+  # > 256 KiB of valid, non-paging noise (installed-software drift -> INFO/log-only).
+  seq 1 4000 | awk '{print "{\"name\":\"pack_installed-software-drift_homebrew_packages\",\"action\":\"added\",\"columns\":{\"name\":\"pkg" $1 "\",\"version\":\"1.0\"}}"}' \
+    >>"$OSQUERY_RESULTS_LOG"
+  [ "$(log_size)" -gt 262144 ]                  # the early CRIT is now well before the old tail
+  rm -f "$OSQUERY_RESULTS_OFFSET"               # cursor lost/corrupt
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]               # full replay pages the early CRIT (not dropped)
+}
+
+# (i) A reset never storms per-finding: many simultaneous CRITs on a reset deliver
+#     ONE consolidated, capped page (render_page's 8-block cap), not one page each.
+@test "T-ENTRY-reset-no-storm: a reset with many CRITs delivers ONE capped page" {
+  local i
+  for i in $(seq 1 20); do
+    append_row "{\"name\":\"new_admin_user\",\"action\":\"added\",\"columns\":{\"username\":\"admin$i\",\"uid\":\"$i\"}}"
+  done
+  rm -f "$OSQUERY_RESULTS_OFFSET"
+  run_entry
+  [ "$status" -eq 0 ]
+  # Exactly one batch page (a CRITICAL-titled send_alert), not 20; the cursor-reset
+  # warning is titled separately and does not count.
+  local batch_pages
+  batch_pages=$(grep -c 'title=🔴 \*\*CRITICAL\*\*' "$SEND_ALERT_SPY" 2>/dev/null || true)
+  [ "$batch_pages" -eq 1 ]
+}

--- a/test/e2e/osquery-alerter-entry.bats
+++ b/test/e2e/osquery-alerter-entry.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# The osquery alerter ENTRY (executable_results-alerter.sh) end-to-end: it reads
+# the new results-log rows since its cursor, runs them through the decomposed
+# pipeline (normalize -> route -> render), delivers a CRIT page via send_alert,
+# and advances its cursor ONLY after the batch is durably delivered. This is a
+# whole-script flow, so it runs the real entry as a subprocess under a temp HOME
+# with the real pipeline helpers and a recording send_alert spy (its exit code
+# scriptable, so the checkpoint-after-durable ordering can be exercised).
+
+setup() {
+  REPO="$BATS_TEST_DIRNAME/../.."
+  ENTRY="$REPO/dot_local/libexec/osquery/executable_results-alerter.sh"
+  HELPER_SRC="$REPO/dot_local/libexec/osquery/results-alerter"
+
+  HOME_DIR="$(mktemp -d)"
+  export HOME="$HOME_DIR"
+  mkdir -p "$HOME/.local/libexec/osquery/results-alerter" \
+    "$HOME/.local/state" "$HOME/.local/log/osquery"
+
+  # Mirror a chezmoi apply: the real pipeline helpers at their deployed path.
+  cp "$HELPER_SRC"/*.sh "$HOME/.local/libexec/osquery/results-alerter/"
+
+  # Stub dispatch library: a recording spy send_alert whose exit code is
+  # scriptable via SEND_ALERT_RC (default 0). Records severity, title, detail.
+  export SEND_ALERT_SPY="$HOME/send_alert.log"
+  : >"$SEND_ALERT_SPY"
+  cat >"$HOME/.local/libexec/osquery/alert-dispatch.sh" <<'STUB'
+# shellcheck shell=bash
+send_alert() {
+  {
+    printf 'CALL\tseverity=%s\ttitle=%s\n' "$1" "$2"
+    printf 'DETAIL\t%s\n' "$3"
+  } >>"$SEND_ALERT_SPY"
+  return "${SEND_ALERT_RC:-0}"
+}
+STUB
+
+  export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
+  export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
+  : >"$OSQUERY_RESULTS_LOG"
+
+  ADMIN_ROW='{"name":"new_admin_user","action":"added","columns":{"username":"eve","uid":"501"}}'
+}
+
+teardown() { rm -rf "$HOME_DIR"; }
+
+log_inode() { ls -i "$OSQUERY_RESULTS_LOG" | awk '{print $1}'; }
+log_size() { wc -c <"$OSQUERY_RESULTS_LOG" | tr -d '[:space:]'; }
+seed_cursor() { printf '%s %s\n' "$(log_inode)" "$1" >"$OSQUERY_RESULTS_OFFSET"; }
+cursor_offset() { awk '{print $2}' "$OSQUERY_RESULTS_OFFSET"; }
+append_row() { printf '%s\n' "$1" >>"$OSQUERY_RESULTS_LOG"; }
+crit_page_count() { grep -c 'New administrator account' "$SEND_ALERT_SPY" 2>/dev/null || true; }
+send_alert_calls() { grep -c '^CALL' "$SEND_ALERT_SPY" 2>/dev/null || true; }
+
+run_entry() { run bash "$ENTRY"; }
+
+# (a) A CRIT row drives send_alert with a CRIT page.
+@test "T-ENTRY-crit: a new_admin_user row delivers a CRIT page" {
+  seed_cursor 0            # valid cursor at EOF of the empty log (no cursor-reset)
+  append_row "$ADMIN_ROW"
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]
+  grep -q 'severity=CRIT' "$SEND_ALERT_SPY"
+}
+
+# (b) The cursor advances after a delivered batch; a second run sends nothing new.
+@test "T-ENTRY-advance: the cursor advances and a second run does not double-send" {
+  seed_cursor 0
+  append_row "$ADMIN_ROW"
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(cursor_offset)" -eq "$(log_size)" ]   # advanced to EOF
+  local first_calls
+  first_calls="$(send_alert_calls)"
+  run_entry                                   # no new rows
+  [ "$status" -eq 0 ]
+  [ "$(send_alert_calls)" -eq "$first_calls" ] # no additional send
+}
+
+# (c) Checkpoint-after-durable: if send_alert fails, the cursor does NOT advance,
+#     and the next run re-reads the same row (at-least-once, crash-safe).
+@test "T-ENTRY-durable: a failed delivery keeps the cursor put and the row is re-read" {
+  seed_cursor 0
+  append_row "$ADMIN_ROW"
+  SEND_ALERT_RC=1 run_entry                   # delivery hard-fails
+  [ "$status" -eq 0 ]                          # exit 0 even on delivery failure
+  [ "$(cursor_offset)" -eq 0 ]                 # cursor did NOT advance
+  # The next run, with delivery succeeding, re-reads the SAME row and pages it.
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -ge 1 ]
+  [ "$(cursor_offset)" -eq "$(log_size)" ]     # now advanced
+}
+
+# (d) Log truncation resets the cursor and re-reads from the start. The old
+#     content is several rows so the post-truncate size is clearly smaller than the
+#     seeded offset, which is exactly the shrink the entry detects.
+@test "T-ENTRY-truncate: a truncated log resets the cursor and re-reads" {
+  append_row "$ADMIN_ROW"
+  append_row "$ADMIN_ROW"
+  append_row "$ADMIN_ROW"
+  seed_cursor "$(log_size)"                     # cursor at EOF of the larger old content
+  : >"$OSQUERY_RESULTS_LOG"                     # truncate in place (same inode, size 0)
+  append_row "$ADMIN_ROW"                       # new, smaller content (size < seeded offset)
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]               # re-read from byte 0
+}
+
+# (e) A missing/corrupt cursor fires a loud cursor-reset page (visible, not silent).
+@test "T-ENTRY-cursor-reset: a missing cursor pages a loud cursor-reset warning" {
+  append_row "$ADMIN_ROW"
+  rm -f "$OSQUERY_RESULTS_OFFSET"              # no cursor at all
+  run_entry
+  [ "$status" -eq 0 ]
+  grep -q 'osquery cursor reset' "$SEND_ALERT_SPY"
+  grep -q 'missing or corrupt' "$SEND_ALERT_SPY"
+}
+
+# (f) A malformed batch does not wedge the cursor: garbage rows drop out, no page,
+#     and the cursor still advances past them.
+@test "T-ENTRY-malformed: a garbage batch advances the cursor without paging" {
+  seed_cursor 0
+  append_row 'this is not json at all'
+  append_row '{"name":"heartbeat_canary","action":"snapshot","columns":{}}'  # dropped by the select
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 0 ]               # nothing paged
+  [ "$(cursor_offset)" -eq "$(log_size)" ]     # cursor advanced (no wedge)
+}

--- a/test/e2e/osquery-alerter-hostile-columns.bats
+++ b/test/e2e/osquery-alerter-hostile-columns.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Security: no attacker-controlled column value can be reinterpreted as record
+# structure. The gate must route on the finding's ACTUAL fields, so an embedded
+# separator (0x1F), newline, or tab in a crafted .cols.path/label/program can
+# never shift field boundaries to make an unknown plist read as an allowlisted
+# tuple (which would suppress it). Driven end-to-end through the REAL entry.
+
+setup() {
+  REPO="$BATS_TEST_DIRNAME/../.."
+  ENTRY="$REPO/dot_local/libexec/osquery/executable_results-alerter.sh"
+  HELPER_SRC="$REPO/dot_local/libexec/osquery/results-alerter"
+
+  HOME_DIR="$(mktemp -d)"
+  export HOME="$HOME_DIR"
+  mkdir -p "$HOME/.local/libexec/osquery/results-alerter" "$HOME/.local/state" \
+    "$HOME/.local/log/osquery" "$HOME/.config/osquery" "$HOME/Library/LaunchAgents" "$HOME/bin"
+  cp "$HELPER_SRC"/*.sh "$HOME/.local/libexec/osquery/results-alerter/"
+
+  export SEND_ALERT_SPY="$HOME/send_alert.log"
+  : >"$SEND_ALERT_SPY"
+  cat >"$HOME/.local/libexec/osquery/alert-dispatch.sh" <<'STUB'
+# shellcheck shell=bash
+send_alert() {
+  { printf 'CALL\tseverity=%s\ttitle=%s\n' "$1" "$2"; printf 'DETAIL-START\n%s\nDETAIL-END\n' "$3"; } >>"$SEND_ALERT_SPY"
+  return "${SEND_ALERT_RC:-0}"
+}
+STUB
+  # Trusted enricher (so a promotion never masks a suppression bug: the page must
+  # come from default-deny, not from enrichment).
+  printf '#!/usr/bin/env bash\nprintf %s "signed: Apple"\nexit 0\n' >"$HOME/enrich-stub.sh"
+  chmod +x "$HOME/enrich-stub.sh"
+  export OSQUERY_ENRICH_SCRIPT="$HOME/enrich-stub.sh"
+
+  # An own-agent allowlist entry the attacker will try to impersonate by injection.
+  cat >"$HOME/.config/osquery/page-launchd-allowlist.txt" <<EOF
+{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
+EOF
+
+  export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
+  export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
+  : >"$OSQUERY_RESULTS_LOG"
+}
+teardown() { rm -rf "$HOME_DIR"; }
+
+log_inode() { ls -i "$OSQUERY_RESULTS_LOG" | awk '{print $1}'; }
+seed_cursor() { printf '%s 0\n' "$(log_inode)" >"$OSQUERY_RESULTS_OFFSET"; }
+run_entry() { run bash "$ENTRY"; [ "$status" -eq 0 ]; }
+assert_paged() { grep -q 'severity=CRIT' "$SEND_ALERT_SPY"; }
+
+# HEADLINE: a persistence_launchd finding whose crafted .cols.path embeds a 0x1F
+# tuple (path\x1flabel\x1fprogram) matching the allowlisted own-agent - under an
+# in-band separator this splits so allowlist_verdict reads (com.good, the-good-
+# path, the-good-program) and SUPPRESSES the malicious agent. It must PAGE: the
+# real label is com.attacker (unknown) -> default-deny.
+@test "HOSTILE-0x1F: a 0x1F-injected path cannot impersonate an allowlisted tuple; the finding pages" {
+  seed_cursor
+  local good_path="$HOME/Library/LaunchAgents/com.good.plist" good_prog="$HOME/bin/good"
+  # .cols.path = "<good_path>com.good<good_prog>" (0x1F as  in JSON).
+  printf '{"name":"pack_intrusion-detection_persistence_launchd","action":"added","columns":{"label":"com.attacker","path":"%s\\u001fcom.good\\u001f%s","program":"/attacker/mal"}}\n' \
+    "$good_path" "$good_prog" >>"$OSQUERY_RESULTS_LOG"
+  run_entry
+  assert_paged
+}
+
+# A newline embedded in .cols.label must not truncate or split the record; the
+# unknown agent still pages (default-deny), never silently lost.
+@test "HOSTILE-newline: a newline in a column does not split the record; the finding pages" {
+  seed_cursor
+  printf '{"name":"pack_intrusion-detection_persistence_launchd","action":"added","columns":{"label":"com.attacker\\ncom.good","path":"%s/Library/LaunchAgents/evil.plist","program":"%s/bin/evil"}}\n' \
+    "$HOME" "$HOME" >>"$OSQUERY_RESULTS_LOG"
+  run_entry
+  assert_paged
+}
+
+# A tab embedded in .cols.program must stay an opaque value; the unknown agent pages.
+@test "HOSTILE-tab: a tab in a column stays opaque; the finding pages" {
+  seed_cursor
+  printf '{"name":"pack_intrusion-detection_persistence_launchd","action":"added","columns":{"label":"com.attacker","path":"%s/Library/LaunchAgents/evil.plist","program":"%s/bin/evil\\tcom.good"}}\n' \
+    "$HOME" "$HOME" >>"$OSQUERY_RESULTS_LOG"
+  run_entry
+  assert_paged
+}

--- a/test/integration/osquery-feature-set-location.sh
+++ b/test/integration/osquery-feature-set-location.sh
@@ -58,10 +58,14 @@ for name in firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
     "dot_local/libexec/osquery/executable_${name}.sh"
 done
 
-# results-alerter invokes the enricher from the libexec home.
+# The alerter invokes the enricher from the libexec home. Since the S9
+# decomposition (slice 6) the enricher is invoked by the routing helper (route.sh),
+# not the entry: the gate consults it before the allowlist so a promoted CRIT is
+# never suppressed. Assert the enricher path is referenced there, still under the
+# libexec home.
 # shellcheck disable=SC2016
-assert_contains 'ENRICH_SCRIPT="$HOME/.local/libexec/osquery/enrich-finding.sh"' \
-  "dot_local/libexec/osquery/executable_results-alerter.sh"
+assert_contains '$HOME/.local/libexec/osquery/enrich-finding.sh' \
+  "dot_local/libexec/osquery/results-alerter/route.sh"
 
 if [[ $fail -ne 0 ]]; then
   printf 'osquery-feature-set-location: FAIL\n' >&2

--- a/test/unit/osquery-allowlist-verdict.sh
+++ b/test/unit/osquery-allowlist-verdict.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# allowlist_verdict (results-alerter/allowlist-verdict.sh) decides whether a
+# user LaunchAgent persistence finding is a known-good item to suppress, a
+# reused-label attack to page, or simply not allowlisted. It reads the launchd
+# page-allowlist (OSQUERY_LAUNCHD_ALLOWLIST, the NDJSON tuple file the slice-5
+# writer curates) and matches the finding's identity as a FULL tuple.
+#
+# The identity the finding supplies is (label, path, program); the plist sha256
+# is NOT one of the arguments and is NOT read from the osquery row (the
+# persistence_launchd row carries no sha256 column) nor from enrichment - when a
+# stored tuple PINS a hash, the verdict re-hashes the ON-DISK plist at the
+# finding's path with shasum at decision time and compares. That defeats a
+# same-label/same-path/same-program plist rewrite.
+#
+# Return-code contract (from c69baab _allowlist_verdict):
+#   0 = suppress   - full tuple match (label+path+program, and the on-disk hash
+#                    matches the pin, or the pin is empty so the hash dimension is
+#                    skipped: the own-agent seed entries).
+#   2 = reused-label / page - the label is allowlisted but the identity diverges
+#                    (path/program differs, or the pinned hash no longer matches).
+#                    This is the R2-1 property: a reused allowlisted label pointing
+#                    at a different plist identity is never silently suppressed.
+#   1 = not allowlisted - no label match, a degraded label-only entry that cannot
+#                    vouch, or a missing/empty allowlist file.
+#
+# Unit test: a fixture tuple file + fixture on-disk plists under a temp HOME, so
+# the live re-hash is exercised for real.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+
+fail() {
+  printf 'osquery-allowlist-verdict: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+home="$work/home"
+mkdir -p "$home/Library/LaunchAgents" "$home/bin" "$home/.config/osquery"
+
+# Fixture plists on disk. com.full's stored pin will match this content; com.hashpin's
+# stored pin will deliberately NOT match, to exercise the on-disk re-hash mismatch.
+printf 'FULL PLIST CONTENT\n' >"$home/Library/LaunchAgents/com.full.plist"
+printf 'HASHPIN PLIST CONTENT ON DISK\n' >"$home/Library/LaunchAgents/com.hashpin.plist"
+full_hash="$(shasum -a 256 "$home/Library/LaunchAgents/com.full.plist" | awk '{print $1}')"
+wrong_hash="0000000000000000000000000000000000000000000000000000000000000000"
+
+# The allowlist tuple file. Paths/programs are stored home-relative (~/) exactly
+# as the committed, user-agnostic seed file does; the verdict expands ~ to $HOME.
+# Includes a comment and a blank line to pin robustness, a full pinned entry, a
+# wrong-hash entry, an empty-sha256 own-agent seed entry, and a degraded
+# label-only entry (no path/program).
+allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
+{
+  printf '# curated by osquery-allowlist.sh\n'
+  printf '\n'
+  printf '{"label":"com.full","path":"~/Library/LaunchAgents/com.full.plist","program":"~/bin/full","sha256":"%s"}\n' "$full_hash"
+  printf '{"label":"com.hashpin","path":"~/Library/LaunchAgents/com.hashpin.plist","program":"~/bin/hp","sha256":"%s"}\n' "$wrong_hash"
+  printf '{"label":"com.seed","path":"~/Library/LaunchAgents/com.seed.plist","program":"~/bin/seed","sha256":""}\n'
+  printf '{"label":"com.degraded","path":"","program":"","sha256":""}\n'
+} >"$allowlist"
+
+# Each case: <expected-rc> <TAB> <allowlist-file> <TAB> <label> <TAB> <path>
+# <TAB> <program> <TAB> <behavior label>. Every case runs in ONE sourcing subshell
+# (below) instead of a subshell per case, so the suite stays under the fast unit
+# bar while the live on-disk re-hash is still exercised for real.
+missing="$work/does-not-exist.txt"
+cases=(
+  # (a) full tuple match, on-disk hash matches the pin -> suppress.
+  $'0\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\tfull tuple match (label+path+program+matching on-disk hash) suppresses'
+  # (b) same label, different program -> reused-label page (diverges before the hash check).
+  $'2\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/EVIL"$'\tan allowlisted label with a different program pages (reused label)'
+  # (b2) same label, same program, different path -> reused-label page.
+  $'2\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/EVIL.plist"$'\t'"$home/bin/full"$'\tan allowlisted label with a different path pages (reused label)'
+  # (c) same label/path/program but the on-disk plist no longer matches the pin -> page.
+  $'2\t'"$allowlist"$'\tcom.hashpin\t'"$home/Library/LaunchAgents/com.hashpin.plist"$'\t'"$home/bin/hp"$'\ta pinned-hash entry whose on-disk plist was rewritten pages (hash mismatch)'
+  # (d) unknown label -> not allowlisted.
+  $'1\t'"$allowlist"$'\tcom.unknown\t'"$home/Library/LaunchAgents/com.unknown.plist"$'\t'"$home/bin/unknown"$'\tan unknown label is not allowlisted'
+  # (e) empty-sha256 seed entry -> suppress on label+path+program, skipping the hash dimension
+  #     (the seed plist need not even exist).
+  $'0\t'"$allowlist"$'\tcom.seed\t'"$home/Library/LaunchAgents/com.seed.plist"$'\t'"$home/bin/seed"$'\tan empty-sha256 seed entry suppresses on label+path+program, skipping the hash dimension'
+  # (f) degraded label-only entry (no path/program) cannot vouch -> not allowlisted (fail-safe).
+  $'1\t'"$allowlist"$'\tcom.degraded\t'"$home/Library/LaunchAgents/com.degraded.plist"$'\t'"$home/bin/degraded"$'\ta degraded label-only entry cannot vouch and does not suppress (fail-safe)'
+  # (g) missing allowlist file -> not allowlisted, cleanly, no error.
+  $'1\t'"$missing"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\ta missing allowlist file yields not-allowlisted for everything, no error'
+)
+
+# Split into parallel arrays and feed the (file, label, path, program) tuples
+# through ONE sourcing subshell that prints a return code per line, in order.
+expected=()
+labels=()
+feed=""
+for row in "${cases[@]}"; do
+  IFS=$'\t' read -r rc file label path program label_text <<<"$row"
+  expected+=("$rc")
+  labels+=("$label_text")
+  feed+="$file"$'\t'"$label"$'\t'"$path"$'\t'"$program"$'\n'
+done
+
+got=()
+mapfile -t got < <(
+  printf '%s' "$feed" | HOME="$home" bash -c '
+    source "$1"
+    while IFS="$(printf "\t")" read -r file label path program; do
+      OSQUERY_LAUNCHD_ALLOWLIST="$file"
+      rc=0
+      allowlist_verdict "$label" "$path" "$program" || rc=$?
+      printf "%s\n" "$rc"
+    done
+  ' _ "$HELPER"
+)
+
+[[ ${#got[@]} -eq ${#expected[@]} ]] ||
+  fail "the verdict driver emitted ${#got[@]} results for ${#expected[@]} cases (one per case expected)"
+
+for i in "${!expected[@]}"; do
+  [[ ${got[i]} == "${expected[i]}" ]] ||
+    fail "${labels[i]}: expected return ${expected[i]}, got ${got[i]}"
+done
+
+printf 'osquery-allowlist-verdict: OK (full-tuple suppress, reused-label page on path/program/hash divergence, empty-sha256 seed suppress, unknown/degraded/missing not-allowlisted)\n'

--- a/test/unit/osquery-digest-store.sh
+++ b/test/unit/osquery-digest-store.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# digest_append (results-alerter/digest-store.sh) records a non-paging finding as
+# one NDJSON line in the digest spool, the private local file that accumulates
+# suspicious-but-ambiguous findings between daily digest sends. It is best-effort:
+# a write failure is swallowed so it never aborts the detection path, and the
+# read side (the digest-tier slice) is a later slice - B8 only appends.
+#
+# Privacy posture (F5-A lesson): the line carries only derived triage fields -
+# timestamp, detector, category, identity, action, summary. It NEVER copies the
+# whole columns object, so no raw sha256 and no secret column reaches the spool.
+# Full filesystem paths are stored (this is a single-user private spool, dir 700
+# / file 600), but a secret VALUE or a content hash is not.
+#
+# Unit test: append to a temp spool, then assert the line shape, the accumulation,
+# the 700/600 modes, and the absence of any secret/sha256 leak.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/digest-store.sh"
+
+fail() {
+  printf 'osquery-digest-store: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+store="$work/state/osquery-digest-spool/digest.ndjson"
+dir="$(dirname "$store")"
+
+# perms_of <path> -> octal permission bits. GNU stat -c first (Linux CI), BSD
+# stat -f as the fallback (macOS), per the test-suite's stat-portability guard.
+perms_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+# Three findings appended in ONE sourcing subshell (accumulation): a system
+# extension (identity from .identifier), a listening port (the special-case
+# "name address:port" identity), and an agent authfile change whose columns carry
+# a sha256 AND a secret value that must NOT reach the spool.
+OSQUERY_DIGEST_STORE="$store" bash -c '
+  source "$1"
+  digest_append '\''{"q":"system_extensions_new","act":"added","cols":{"identifier":"com.example.ext","team":"TEAMID"},"ep":""}'\''
+  digest_append '\''{"q":"listening_ports_non_loopback","act":"added","cols":{"name":"nc","address":"0.0.0.0","port":"4444"},"ep":""}'\''
+  digest_append '\''{"q":"agent_authfile_changed","act":"added","cols":{"path":"/Users/x/.codex/config.toml","sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","secret_value":"SUPERSECRETTOKEN"},"ep":""}'\''
+' _ "$HELPER"
+
+# -- accumulation: three appends -> three lines --
+[[ -f $store ]] || fail "the spool file was not created"
+line_count="$(grep -c . "$store" || true)"
+[[ $line_count -eq 3 ]] || fail "expected 3 accumulated NDJSON lines, got $line_count"
+
+# -- private modes: dir 700, file 600 --
+dir_perms="$(perms_of "$dir")"
+file_perms="$(perms_of "$store")"
+[[ $dir_perms == 700 ]] || fail "the spool dir must be 700 (private), got $dir_perms"
+[[ $file_perms == 600 ]] || fail "the spool file must be 600 (private), got $file_perms"
+
+mapfile -t lines <"$store"
+
+# -- line 1: system extension, derived fields --
+l1="${lines[0]}"
+[[ "$(jq -r '.detector' <<<"$l1")" == system_extensions_new ]] || fail "line 1 detector wrong: $l1"
+[[ "$(jq -r '.identity' <<<"$l1")" == com.example.ext ]] || fail "line 1 identity should be the extension identifier: $l1"
+[[ "$(jq -r '.action' <<<"$l1")" == added ]] || fail "line 1 action wrong: $l1"
+[[ "$(jq -r '.summary' <<<"$l1")" == "system_extensions_new com.example.ext" ]] || fail "line 1 summary wrong: $l1"
+[[ "$(jq -r '.timestamp' <<<"$l1")" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail "line 1 timestamp is not ISO 8601 UTC: $l1"
+
+# -- line 2: listening port special-case identity "name address:port" --
+l2="${lines[1]}"
+[[ "$(jq -r '.identity' <<<"$l2")" == "nc 0.0.0.0:4444" ]] || fail "line 2 identity should be 'name address:port': $l2"
+
+# -- line 3: privacy posture. The secret value and the raw sha256 must NOT appear,
+#    and the line must carry no sha256 key. The full path IS allowed. --
+l3="${lines[2]}"
+[[ "$(jq -r '.identity' <<<"$l3")" == "/Users/x/.codex/config.toml" ]] || fail "line 3 identity should be the path: $l3"
+jq -e 'has("sha256")' <<<"$l3" >/dev/null 2>&1 && fail "the digest line must not carry a sha256 field: $l3"
+[[ $l3 != *deadbeef* ]] || fail "a raw sha256 leaked into the digest line: $l3"
+[[ $l3 != *SUPERSECRETTOKEN* ]] || fail "a secret value leaked into the digest line: $l3"
+
+# -- whole-file sweep: no secret/hash anywhere in the spool --
+grep -q 'deadbeef' "$store" && fail "a raw sha256 leaked into the spool file"
+grep -q 'SUPERSECRETTOKEN' "$store" && fail "a secret value leaked into the spool file"
+
+printf 'osquery-digest-store: OK (one NDJSON line per append, accumulation, dir 700 / file 600, listening-port identity, no secret/sha256 leak)\n'

--- a/test/unit/osquery-normalize.sh
+++ b/test/unit/osquery-normalize.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
 #
-# normalize_findings (results-alerter/normalize.sh) turns each raw osquery
-# results-log row into exactly one JSON finding per row. This behavior pins the
-# structural core: the query name is stripped of its pack_<pack>_ prefix so a
-# packed query and a top-level query render under the same bare name the routing
-# stage matches, and a row that omits its action defaults to "changed" so a
-# downstream stage never has to special-case a null.
+# normalize_findings (results-alerter/normalize.sh) is the first stage of the
+# alerter pipeline: it turns the raw osquery results-log tail into normalized
+# finding NDJSON, one {q, act, cols, ep} object per surviving row. This suite
+# pins every admission and shaping rule the stage owns:
 #
-# The snapshot-explosion decision (S9): c69baab made the absolute-state *_off
-# queries DIFFERENTIAL, so their off-state now arrives as an ordinary added row.
-# There is therefore no snapshot array to explode; normalize emits ONE finding
-# per row, and a snapshot-action row is a single finding, never fanned out.
+#   B1 structure  - one finding per row; the query name stripped of its
+#                   pack_<pack>_ prefix; an absent action defaulted to "changed";
+#                   the columns object carried through; a snapshot-action row is a
+#                   single finding (NO explosion, since the *_off queries are now
+#                   differential); a malformed line drops out without aborting.
+#   B2 select     - only recognized detector names are admitted; heartbeat_canary
+#                   and any unknown pack/top-level name are dropped.
+#   B3 filters    - renameio atomic-write churn (a target_path in a
+#                   .renameio-TempDir) is dropped; a counter==0 differential
+#                   baseline row is discarded EXCEPT for the three absolute-state
+#                   queries (filevault_off, remote_access_sharing_state,
+#                   agent_exposure_changed) whose first-run row must page.
+#   B4 ep         - each finding carries the enrich-path the enricher must inspect
+#                   (a plist/bundle/binary), per query type; empty when signing
+#                   does not apply; tabs/newlines squashed to spaces.
 #
-# Unit test: fixture-driven. Feed representative raw lines on stdin, read the
-# normalized NDJSON back, assert the shape. No filesystem, no notifier, no sleeps.
+# Performance: the suite batches its fixtures through ONE normalize pass per
+# behavior group and one summary jq per group (not a jq spawn per row), so it
+# stays inside the fast unit-admission budget. Coverage is unchanged; only the
+# subprocess count is reduced.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -33,255 +44,149 @@ make_sut() {
   bash -c "source '$NORMALIZE'; normalize_findings"
 }
 
-# assert_line_count <expected> <ndjson> <context>: exactly N non-empty findings.
-assert_line_count() {
-  local expected="$1" ndjson="$2" context="$3" got
-  got="$(printf '%s' "$ndjson" | grep -c . || true)"
-  [[ $got -eq $expected ]] ||
-    fail "$context: expected $expected finding(s), got $got -- output was: $ndjson"
+# summarize <jq-per-finding-expr> <ndjson>: reduce the normalized findings to a
+# single deterministic block -- a "count=N" line then one sorted line per finding
+# from the given jq expression. One jq spawn per behavior group; the whole block
+# is compared at once, so every finding's shape is asserted together.
+summarize() {
+  local expr="$1" ndjson="$2"
+  printf '%s' "$ndjson" | jq -s -r "
+    (map($expr) | sort) as \$lines
+    | \"count=\(\$lines | length)\" + (if (\$lines | length) > 0 then \"\n\" + (\$lines | join(\"\n\")) else \"\" end)
+  "
 }
 
-# assert_field <jq-filter> <expected> <ndjson> <context>: the filter applied to
-# the (single-finding) NDJSON yields the expected value.
-assert_field() {
-  local filter="$1" expected="$2" ndjson="$3" context="$4" got
-  got="$(printf '%s' "$ndjson" | jq -r "$filter")"
-  [[ $got == "$expected" ]] ||
-    fail "$context: expected '$expected', got '$got' -- output was: $ndjson"
+# assert_block <expected> <actual> <context>: pure-bash equality, no subprocess.
+assert_block() {
+  local expected="$1" actual="$2" context="$3"
+  [[ $actual == "$expected" ]] || fail "$context
+--- expected ---
+$expected
+--- got ---
+$actual
+----------------"
 }
 
-# A packed row strips its pack_<pack>_ prefix to the bare query name.
-a_pack_row_strips_its_prefix() {
+# --- B1: structural normalization --------------------------------------------
+# One pass over: a packed row (prefix strip + cols passthrough), a hyphenated
+# pack (only the pack segment stripped), a bare top-level row, a row with no
+# action (defaults to "changed"), a snapshot-action row (must stay ONE finding,
+# not fan out its snapshot array), and a malformed line (drops out). The summary
+# key is "q|act|<identity>" where identity is the row's username/path/target_path.
+b1_structural_normalization() {
   local out
-  out="$(printf '%s\n' \
-    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{"path":"/tmp/x"}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "a packed row produces one finding"
-  assert_field '.q' 'suid_bin_unexpected' "$out" "the pack_<pack>_ prefix is stripped"
-  assert_field '.act' 'added' "$out" "the action is carried through"
-  assert_field '.cols.path' '/tmp/x' "$out" "the columns object is carried through"
+  out="$(
+    make_sut <<'EOF'
+{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{"path":"/tmp/x"}}
+{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"added","columns":{}}
+{"name":"new_admin_user","action":"added","columns":{"username":"alice"}}
+{"name":"new_admin_user","columns":{"username":"bob"}}
+{"name":"pack_security-policy-regression_filevault_state","action":"snapshot","snapshot":[{"path":"/a"},{"path":"/b"}]}
+this is not json
+EOF
+  )"
+  local got expected
+  got="$(summarize '.q + "|" + .act + "|" + (.cols.username // .cols.path // .cols.target_path // "")' "$out")"
+  expected='count=5
+agent_exposure_changed|added|
+filevault_state|snapshot|
+new_admin_user|added|alice
+new_admin_user|changed|bob
+suid_bin_unexpected|added|/tmp/x'
+  assert_block "$expected" "$got" \
+    "B1: prefix strip, hyphenated-pack strip, bare top-level, action default, snapshot stays one finding, malformed drops, cols carried through"
 }
 
-# A pack whose name contains hyphens strips only the pack segment, not the query.
-a_hyphenated_pack_row_strips_only_the_pack_segment() {
+# --- B2: known-query select (security allowlist) -----------------------------
+# Only recognized detectors are admitted. heartbeat_canary (the liveness snapshot
+# the alerter defensively drops) and any unknown pack/top-level name fall out.
+b2_known_query_select() {
   local out
-  out="$(printf '%s\n' \
-    '{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"added","columns":{}}' |
-    make_sut)"
-  assert_field '.q' 'agent_exposure_changed' "$out" "only the pack segment is stripped, the query keeps its underscores"
+  out="$(
+    make_sut <<'EOF'
+{"name":"new_admin_user","action":"added","columns":{}}
+{"name":"heartbeat_canary","action":"snapshot","columns":{}}
+{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{}}
+{"name":"pack_foo_bar","action":"added","columns":{}}
+{"name":"pack_security-policy-regression_filevault_off","action":"added","columns":{}}
+{"name":"totally_bogus_query","action":"added","columns":{}}
+EOF
+  )"
+  local got expected
+  got="$(summarize '.q' "$out")"
+  expected='count=3
+agent_secretfile_changed
+filevault_off
+new_admin_user'
+  assert_block "$expected" "$got" \
+    "B2: admit new_admin_user + agent_secretfile_changed + filevault_off; drop heartbeat_canary, pack_foo_bar, and an unknown top-level name"
 }
 
-# A top-level (non-pack) row keeps its bare name unchanged.
-a_top_level_row_keeps_its_bare_name() {
+# --- B3: renameio exclusion + counter==0 baseline discard ---------------------
+# A renameio temp target is dropped; a counter==0 membership baseline (username
+# root) is dropped; counter>0 (eve) and no-counter (mallory) survive; the three
+# absolute-state queries keep their counter==0 first-run row.
+b3_renameio_and_baseline() {
   local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","columns":{"username":"eve"}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "a top-level row produces one finding"
-  assert_field '.q' 'new_admin_user' "$out" "a bare top-level name is left intact"
+  out="$(
+    make_sut <<'EOF'
+{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.config/foo/.renameio-TempDir-abc/bar"}}
+{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.ssh/authorized_keys"}}
+{"name":"new_admin_user","action":"added","counter":0,"columns":{"username":"root"}}
+{"name":"new_admin_user","action":"added","counter":1,"columns":{"username":"eve"}}
+{"name":"new_admin_user","action":"added","columns":{"username":"mallory"}}
+{"name":"pack_security-policy-regression_filevault_off","action":"added","counter":0,"columns":{}}
+{"name":"pack_security-policy-regression_remote_access_sharing_state","action":"added","counter":0,"columns":{}}
+{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"added","counter":0,"columns":{}}
+EOF
+  )"
+  local got expected
+  got="$(summarize '.q + "|" + (.cols.username // .cols.target_path // "")' "$out")"
+  expected='count=6
+agent_exposure_changed|
+file_events_recent|/Users/x/.ssh/authorized_keys
+filevault_off|
+new_admin_user|eve
+new_admin_user|mallory
+remote_access_sharing_state|'
+  assert_block "$expected" "$got" \
+    "B3: renameio temp dropped, real file survives, counter==0 membership (root) dropped, counter>0/no-counter survive, absolute-state counter==0 kept"
 }
 
-# A row that omits its action defaults the action to "changed".
-a_row_without_an_action_defaults_to_changed() {
+# --- B4: enrich-path (ep) per query type --------------------------------------
+# ep is the exact path the enricher inspects, chosen per query: es_launchd_writes
+# -> path; file_events_recent -> target_path; persistence_launchd -> path;
+# system_extensions_new -> bundle_path (falling back to path); suid_bin_unexpected
+# -> path; a query where signing does not apply -> "". Tabs/newlines are squashed
+# to spaces (the es row carries a tab to pin that).
+b4_enrich_path() {
   local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","columns":{}}' |
-    make_sut)"
-  assert_field '.act' 'changed' "$out" "an absent action defaults to changed"
+  out="$(
+    make_sut <<'EOF'
+{"name":"es_launchd_writes","action":"added","columns":{"path":"/usr/bin/foo\tbar"}}
+{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.ssh/authorized_keys"}}
+{"name":"pack_intrusion-detection_persistence_launchd","action":"added","columns":{"path":"/Library/LaunchAgents/com.example.plist","label":"com.example"}}
+{"name":"pack_intrusion-detection_system_extensions_new","action":"added","columns":{"bundle_path":"/Applications/X.app","path":"/ignored"}}
+{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{"path":"/tmp/suid"}}
+{"name":"new_admin_user","action":"added","columns":{"username":"eve"}}
+EOF
+  )"
+  local got expected
+  got="$(summarize '.q + "|" + (.ep // "")' "$out")"
+  expected='count=6
+es_launchd_writes|/usr/bin/foo bar
+file_events_recent|/Users/x/.ssh/authorized_keys
+new_admin_user|
+persistence_launchd|/Library/LaunchAgents/com.example.plist
+suid_bin_unexpected|/tmp/suid
+system_extensions_new|/Applications/X.app'
+  assert_block "$expected" "$got" \
+    "B4: ep per query type (launchd-write path, file-event target_path, persistence path, sysext bundle_path over path, suid path, empty when signing n/a, tab squashed)"
 }
 
-# A snapshot-action row is one finding, never exploded into one-per-snapshot-entry.
-a_snapshot_row_yields_exactly_one_finding() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"pack_security-policy-regression_filevault_state","action":"snapshot","snapshot":[{"path":"/a"},{"path":"/b"}]}' |
-    make_sut)"
-  assert_line_count 1 "$out" "a snapshot row is NOT fanned out into one finding per snapshot entry"
-  assert_field '.act' 'snapshot' "$out" "the snapshot action is carried through as-is"
-}
+b1_structural_normalization
+b2_known_query_select
+b3_renameio_and_baseline
+b4_enrich_path
 
-# Every input row yields its own finding: three rows in, three findings out.
-each_row_yields_its_own_finding() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","columns":{}}' \
-    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{}}' \
-    '{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"removed","columns":{}}' |
-    make_sut)"
-  assert_line_count 3 "$out" "one finding per input row"
-}
-
-# A malformed (non-JSON) line yields no finding for that line and never aborts
-# the batch: the valid rows around it still normalize.
-a_malformed_line_is_skipped_without_aborting_the_batch() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","columns":{}}' \
-    'this is not json' \
-    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{}}' |
-    make_sut)"
-  assert_line_count 2 "$out" "the malformed line drops out, the two valid rows survive"
-}
-
-# --- B2: normalize admits only recognized osquery query names -----------------
-#
-# The select is a security allowlist: a row whose (prefix-stripped) query name is
-# not a known scheduled detector is dropped before it can ever become an alert.
-# The admitted set is every scheduled detector in the rendered config EXCEPT the
-# heartbeat_canary liveness snapshot (which the alerter defensively drops, and
-# which in practice only ever lands in osqueryd.snapshots.log that this alerter
-# does not read). These fixtures name real query rows the config-base slice ships.
-
-# A newly admitted config-base query (agent_secretfile_changed, the two watched
-# secrets) survives normalize with its bare stripped name.
-an_agent_secretfile_row_is_admitted() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "agent_secretfile_changed is a recognized detector and is admitted"
-  assert_field '.q' 'agent_secretfile_changed' "$out" "the admitted row keeps its stripped query name"
-}
-
-# The heartbeat_canary liveness snapshot is defensively excluded: even if a canary
-# row appeared in results.log, it never becomes a finding.
-the_heartbeat_canary_is_dropped() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"heartbeat_canary","action":"snapshot","columns":{}}' |
-    make_sut)"
-  assert_line_count 0 "$out" "heartbeat_canary is the liveness canary and must never surface as a finding"
-}
-
-# A made-up pack query (a name not in the known set) is dropped: the select is a
-# strict allowlist, not a blanket admit of anything under pack_.
-a_made_up_pack_query_is_dropped() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"pack_foo_bar","action":"added","columns":{}}' |
-    make_sut)"
-  assert_line_count 0 "$out" "an unrecognized pack query must not be admitted just because it is packed"
-}
-
-# A made-up top-level query name is dropped.
-a_made_up_top_level_query_is_dropped() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"totally_bogus_query","action":"added","columns":{}}' |
-    make_sut)"
-  assert_line_count 0 "$out" "an unrecognized top-level query must not be admitted"
-}
-
-# A mixed batch: only the admitted rows survive, each still one finding with its
-# stripped name; the two non-admitted rows fall out.
-a_mixed_batch_keeps_only_admitted_rows() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","columns":{}}' \
-    '{"name":"heartbeat_canary","action":"snapshot","columns":{}}' \
-    '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{}}' \
-    '{"name":"pack_foo_bar","action":"added","columns":{}}' \
-    '{"name":"pack_security-policy-regression_filevault_off","action":"added","columns":{}}' |
-    make_sut)"
-  assert_line_count 3 "$out" "only the three recognized detectors survive the select"
-  local names
-  names="$(printf '%s' "$out" | jq -r '.q' | sort | tr '\n' ',')"
-  [[ $names == 'agent_secretfile_changed,filevault_off,new_admin_user,' ]] ||
-    fail "the surviving findings must be exactly the admitted queries -- got: $names"
-}
-
-# --- B3: normalize drops renameio churn and differential baseline rows --------
-#
-# Two admission filters c69baab applied in normalize:
-#  1. renameio exclusion: a row whose columns.target_path is inside osquery's
-#     atomic-write temp dir (the /.renameio-TempDir pattern) is chezmoi/renameio
-#     churn, not a real change, and is dropped. Only file_events_recent carries a
-#     target_path, so the filter is a no-op for the other detectors.
-#  2. baseline (counter==0) discard: osquery emits a differential query's first
-#     full result set with counter 0 (the seeded baseline). Those first-run rows
-#     are discarded so pre-existing state does not page on first observation -
-#     EXCEPT for the three absolute-state queries (filevault_off,
-#     remote_access_sharing_state, agent_exposure_changed) whose very presence is
-#     an unsafe state, so a counter==0 row there is a first-run PAGE, kept.
-
-# A renameio temp-file target is dropped; its non-temp sibling survives.
-a_renameio_temp_target_is_dropped() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.config/foo/.renameio-TempDir-abc/bar"}}' |
-    make_sut)"
-  assert_line_count 0 "$out" "a renameio atomic-write temp target is churn and must be dropped"
-}
-a_non_temp_target_survives_alongside_the_temp_one() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.config/foo/.renameio-TempDir-abc/bar"}}' \
-    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.ssh/authorized_keys"}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "the real (non-temp) sibling survives while the temp row drops"
-  assert_field '.cols.target_path' '/Users/x/.ssh/authorized_keys' "$out" "the surviving row is the real file, not the temp one"
-}
-
-# A counter==0 baseline row of a membership query is dropped (first-run seeding).
-a_baseline_counter_zero_row_is_dropped() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","counter":0,"columns":{"username":"root"}}' |
-    make_sut)"
-  assert_line_count 0 "$out" "a counter==0 first-run baseline row of a membership query must not page"
-}
-
-# A subsequent (counter>0) row of the same membership query survives.
-a_counter_positive_row_survives() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","counter":1,"columns":{"username":"eve"}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "a post-baseline (counter>0) row is a genuine new observation and survives"
-}
-
-# A row with no counter field at all is treated as non-baseline and survives.
-a_row_without_a_counter_survives() {
-  local out
-  out="$(printf '%s\n' \
-    '{"name":"new_admin_user","action":"added","columns":{"username":"eve"}}' |
-    make_sut)"
-  assert_line_count 1 "$out" "an absent counter defaults to non-baseline (kept), never silently dropped"
-}
-
-# The three absolute-state queries KEEP their counter==0 row: a first-run unsafe
-# state (FileVault off / a sharing service enabled / an agent port off-loopback)
-# must page, not seed silently.
-an_absolute_state_counter_zero_row_is_kept() {
-  local out q
-  for q in \
-    'pack_security-policy-regression_filevault_off' \
-    'pack_security-policy-regression_remote_access_sharing_state' \
-    'pack_agent-attack-surface_agent_exposure_changed'; do
-    out="$(printf '%s\n' \
-      "{\"name\":\"$q\",\"action\":\"added\",\"counter\":0,\"columns\":{}}" |
-      make_sut)"
-    assert_line_count 1 "$out" "an absolute-state query ($q) must PAGE on its first-run counter==0 row, not seed"
-  done
-}
-
-a_pack_row_strips_its_prefix
-a_hyphenated_pack_row_strips_only_the_pack_segment
-a_top_level_row_keeps_its_bare_name
-a_row_without_an_action_defaults_to_changed
-a_snapshot_row_yields_exactly_one_finding
-each_row_yields_its_own_finding
-a_malformed_line_is_skipped_without_aborting_the_batch
-an_agent_secretfile_row_is_admitted
-the_heartbeat_canary_is_dropped
-a_made_up_pack_query_is_dropped
-a_made_up_top_level_query_is_dropped
-a_mixed_batch_keeps_only_admitted_rows
-a_renameio_temp_target_is_dropped
-a_non_temp_target_survives_alongside_the_temp_one
-a_baseline_counter_zero_row_is_dropped
-a_counter_positive_row_survives
-a_row_without_a_counter_survives
-an_absolute_state_counter_zero_row_is_kept
-
-printf 'osquery-normalize: OK (B1 prefix strip/action default/one-per-row/malformed-skip; B2 known-query select; B3 renameio-drop + counter==0 baseline discard except the three absolute-state queries)\n'
+printf 'osquery-normalize: OK (B1 structure; B2 known-query select; B3 renameio + counter==0 baseline; B4 enrich-path)\n'

--- a/test/unit/osquery-normalize.sh
+++ b/test/unit/osquery-normalize.sh
@@ -190,6 +190,81 @@ a_mixed_batch_keeps_only_admitted_rows() {
     fail "the surviving findings must be exactly the admitted queries -- got: $names"
 }
 
+# --- B3: normalize drops renameio churn and differential baseline rows --------
+#
+# Two admission filters c69baab applied in normalize:
+#  1. renameio exclusion: a row whose columns.target_path is inside osquery's
+#     atomic-write temp dir (the /.renameio-TempDir pattern) is chezmoi/renameio
+#     churn, not a real change, and is dropped. Only file_events_recent carries a
+#     target_path, so the filter is a no-op for the other detectors.
+#  2. baseline (counter==0) discard: osquery emits a differential query's first
+#     full result set with counter 0 (the seeded baseline). Those first-run rows
+#     are discarded so pre-existing state does not page on first observation -
+#     EXCEPT for the three absolute-state queries (filevault_off,
+#     remote_access_sharing_state, agent_exposure_changed) whose very presence is
+#     an unsafe state, so a counter==0 row there is a first-run PAGE, kept.
+
+# A renameio temp-file target is dropped; its non-temp sibling survives.
+a_renameio_temp_target_is_dropped() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.config/foo/.renameio-TempDir-abc/bar"}}' |
+    make_sut)"
+  assert_line_count 0 "$out" "a renameio atomic-write temp target is churn and must be dropped"
+}
+a_non_temp_target_survives_alongside_the_temp_one() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.config/foo/.renameio-TempDir-abc/bar"}}' \
+    '{"name":"file_events_recent","action":"added","columns":{"target_path":"/Users/x/.ssh/authorized_keys"}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "the real (non-temp) sibling survives while the temp row drops"
+  assert_field '.cols.target_path' '/Users/x/.ssh/authorized_keys' "$out" "the surviving row is the real file, not the temp one"
+}
+
+# A counter==0 baseline row of a membership query is dropped (first-run seeding).
+a_baseline_counter_zero_row_is_dropped() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","counter":0,"columns":{"username":"root"}}' |
+    make_sut)"
+  assert_line_count 0 "$out" "a counter==0 first-run baseline row of a membership query must not page"
+}
+
+# A subsequent (counter>0) row of the same membership query survives.
+a_counter_positive_row_survives() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","counter":1,"columns":{"username":"eve"}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "a post-baseline (counter>0) row is a genuine new observation and survives"
+}
+
+# A row with no counter field at all is treated as non-baseline and survives.
+a_row_without_a_counter_survives() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","columns":{"username":"eve"}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "an absent counter defaults to non-baseline (kept), never silently dropped"
+}
+
+# The three absolute-state queries KEEP their counter==0 row: a first-run unsafe
+# state (FileVault off / a sharing service enabled / an agent port off-loopback)
+# must page, not seed silently.
+an_absolute_state_counter_zero_row_is_kept() {
+  local out q
+  for q in \
+    'pack_security-policy-regression_filevault_off' \
+    'pack_security-policy-regression_remote_access_sharing_state' \
+    'pack_agent-attack-surface_agent_exposure_changed'; do
+    out="$(printf '%s\n' \
+      "{\"name\":\"$q\",\"action\":\"added\",\"counter\":0,\"columns\":{}}" |
+      make_sut)"
+    assert_line_count 1 "$out" "an absolute-state query ($q) must PAGE on its first-run counter==0 row, not seed"
+  done
+}
+
 a_pack_row_strips_its_prefix
 a_hyphenated_pack_row_strips_only_the_pack_segment
 a_top_level_row_keeps_its_bare_name
@@ -202,5 +277,11 @@ the_heartbeat_canary_is_dropped
 a_made_up_pack_query_is_dropped
 a_made_up_top_level_query_is_dropped
 a_mixed_batch_keeps_only_admitted_rows
+a_renameio_temp_target_is_dropped
+a_non_temp_target_survives_alongside_the_temp_one
+a_baseline_counter_zero_row_is_dropped
+a_counter_positive_row_survives
+a_row_without_a_counter_survives
+an_absolute_state_counter_zero_row_is_kept
 
-printf 'osquery-normalize: OK (B1 prefix strip/action default/one-per-row/malformed-skip; B2 known-query select admits detectors, drops heartbeat_canary and unknown pack/top-level names)\n'
+printf 'osquery-normalize: OK (B1 prefix strip/action default/one-per-row/malformed-skip; B2 known-query select; B3 renameio-drop + counter==0 baseline discard except the three absolute-state queries)\n'

--- a/test/unit/osquery-normalize.sh
+++ b/test/unit/osquery-normalize.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# normalize_findings (results-alerter/normalize.sh) turns each raw osquery
+# results-log row into exactly one JSON finding per row. This behavior pins the
+# structural core: the query name is stripped of its pack_<pack>_ prefix so a
+# packed query and a top-level query render under the same bare name the routing
+# stage matches, and a row that omits its action defaults to "changed" so a
+# downstream stage never has to special-case a null.
+#
+# The snapshot-explosion decision (S9): c69baab made the absolute-state *_off
+# queries DIFFERENTIAL, so their off-state now arrives as an ordinary added row.
+# There is therefore no snapshot array to explode; normalize emits ONE finding
+# per row, and a snapshot-action row is a single finding, never fanned out.
+#
+# Unit test: fixture-driven. Feed representative raw lines on stdin, read the
+# normalized NDJSON back, assert the shape. No filesystem, no notifier, no sleeps.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NORMALIZE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/normalize.sh"
+
+fail() {
+  printf 'osquery-normalize: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $NORMALIZE ]] || fail "missing helper: $NORMALIZE"
+
+# make_sut: run normalize_findings over the raw lines passed on stdin and print
+# the normalized NDJSON to stdout. A fresh subshell per call keeps the helper's
+# sourcing side-effect-free and the test order-independent.
+make_sut() {
+  bash -c "source '$NORMALIZE'; normalize_findings"
+}
+
+# assert_line_count <expected> <ndjson> <context>: exactly N non-empty findings.
+assert_line_count() {
+  local expected="$1" ndjson="$2" context="$3" got
+  got="$(printf '%s' "$ndjson" | grep -c . || true)"
+  [[ $got -eq $expected ]] ||
+    fail "$context: expected $expected finding(s), got $got -- output was: $ndjson"
+}
+
+# assert_field <jq-filter> <expected> <ndjson> <context>: the filter applied to
+# the (single-finding) NDJSON yields the expected value.
+assert_field() {
+  local filter="$1" expected="$2" ndjson="$3" context="$4" got
+  got="$(printf '%s' "$ndjson" | jq -r "$filter")"
+  [[ $got == "$expected" ]] ||
+    fail "$context: expected '$expected', got '$got' -- output was: $ndjson"
+}
+
+# A packed row strips its pack_<pack>_ prefix to the bare query name.
+a_pack_row_strips_its_prefix() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{"path":"/tmp/x"}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "a packed row produces one finding"
+  assert_field '.q' 'suid_bin_unexpected' "$out" "the pack_<pack>_ prefix is stripped"
+  assert_field '.act' 'added' "$out" "the action is carried through"
+  assert_field '.cols.path' '/tmp/x' "$out" "the columns object is carried through"
+}
+
+# A pack whose name contains hyphens strips only the pack segment, not the query.
+a_hyphenated_pack_row_strips_only_the_pack_segment() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"added","columns":{}}' |
+    make_sut)"
+  assert_field '.q' 'agent_exposure_changed' "$out" "only the pack segment is stripped, the query keeps its underscores"
+}
+
+# A top-level (non-pack) row keeps its bare name unchanged.
+a_top_level_row_keeps_its_bare_name() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","columns":{"username":"eve"}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "a top-level row produces one finding"
+  assert_field '.q' 'new_admin_user' "$out" "a bare top-level name is left intact"
+}
+
+# A row that omits its action defaults the action to "changed".
+a_row_without_an_action_defaults_to_changed() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","columns":{}}' |
+    make_sut)"
+  assert_field '.act' 'changed' "$out" "an absent action defaults to changed"
+}
+
+# A snapshot-action row is one finding, never exploded into one-per-snapshot-entry.
+a_snapshot_row_yields_exactly_one_finding() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"pack_security-policy-regression_filevault_state","action":"snapshot","snapshot":[{"path":"/a"},{"path":"/b"}]}' |
+    make_sut)"
+  assert_line_count 1 "$out" "a snapshot row is NOT fanned out into one finding per snapshot entry"
+  assert_field '.act' 'snapshot' "$out" "the snapshot action is carried through as-is"
+}
+
+# Every input row yields its own finding: three rows in, three findings out.
+each_row_yields_its_own_finding() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","columns":{}}' \
+    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{}}' \
+    '{"name":"pack_agent-attack-surface_agent_exposure_changed","action":"removed","columns":{}}' |
+    make_sut)"
+  assert_line_count 3 "$out" "one finding per input row"
+}
+
+# A malformed (non-JSON) line yields no finding for that line and never aborts
+# the batch: the valid rows around it still normalize.
+a_malformed_line_is_skipped_without_aborting_the_batch() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","columns":{}}' \
+    'this is not json' \
+    '{"name":"pack_intrusion-detection_suid_bin_unexpected","action":"added","columns":{}}' |
+    make_sut)"
+  assert_line_count 2 "$out" "the malformed line drops out, the two valid rows survive"
+}
+
+a_pack_row_strips_its_prefix
+a_hyphenated_pack_row_strips_only_the_pack_segment
+a_top_level_row_keeps_its_bare_name
+a_row_without_an_action_defaults_to_changed
+a_snapshot_row_yields_exactly_one_finding
+each_row_yields_its_own_finding
+a_malformed_line_is_skipped_without_aborting_the_batch
+
+printf 'osquery-normalize: OK (prefix strip, hyphenated pack, bare top-level, action default, no snapshot explosion, one-per-row, malformed-skip)\n'

--- a/test/unit/osquery-normalize.sh
+++ b/test/unit/osquery-normalize.sh
@@ -123,6 +123,73 @@ a_malformed_line_is_skipped_without_aborting_the_batch() {
   assert_line_count 2 "$out" "the malformed line drops out, the two valid rows survive"
 }
 
+# --- B2: normalize admits only recognized osquery query names -----------------
+#
+# The select is a security allowlist: a row whose (prefix-stripped) query name is
+# not a known scheduled detector is dropped before it can ever become an alert.
+# The admitted set is every scheduled detector in the rendered config EXCEPT the
+# heartbeat_canary liveness snapshot (which the alerter defensively drops, and
+# which in practice only ever lands in osqueryd.snapshots.log that this alerter
+# does not read). These fixtures name real query rows the config-base slice ships.
+
+# A newly admitted config-base query (agent_secretfile_changed, the two watched
+# secrets) survives normalize with its bare stripped name.
+an_agent_secretfile_row_is_admitted() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{}}' |
+    make_sut)"
+  assert_line_count 1 "$out" "agent_secretfile_changed is a recognized detector and is admitted"
+  assert_field '.q' 'agent_secretfile_changed' "$out" "the admitted row keeps its stripped query name"
+}
+
+# The heartbeat_canary liveness snapshot is defensively excluded: even if a canary
+# row appeared in results.log, it never becomes a finding.
+the_heartbeat_canary_is_dropped() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"heartbeat_canary","action":"snapshot","columns":{}}' |
+    make_sut)"
+  assert_line_count 0 "$out" "heartbeat_canary is the liveness canary and must never surface as a finding"
+}
+
+# A made-up pack query (a name not in the known set) is dropped: the select is a
+# strict allowlist, not a blanket admit of anything under pack_.
+a_made_up_pack_query_is_dropped() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"pack_foo_bar","action":"added","columns":{}}' |
+    make_sut)"
+  assert_line_count 0 "$out" "an unrecognized pack query must not be admitted just because it is packed"
+}
+
+# A made-up top-level query name is dropped.
+a_made_up_top_level_query_is_dropped() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"totally_bogus_query","action":"added","columns":{}}' |
+    make_sut)"
+  assert_line_count 0 "$out" "an unrecognized top-level query must not be admitted"
+}
+
+# A mixed batch: only the admitted rows survive, each still one finding with its
+# stripped name; the two non-admitted rows fall out.
+a_mixed_batch_keeps_only_admitted_rows() {
+  local out
+  out="$(printf '%s\n' \
+    '{"name":"new_admin_user","action":"added","columns":{}}' \
+    '{"name":"heartbeat_canary","action":"snapshot","columns":{}}' \
+    '{"name":"pack_agent-attack-surface_agent_secretfile_changed","action":"added","columns":{}}' \
+    '{"name":"pack_foo_bar","action":"added","columns":{}}' \
+    '{"name":"pack_security-policy-regression_filevault_off","action":"added","columns":{}}' |
+    make_sut)"
+  assert_line_count 3 "$out" "only the three recognized detectors survive the select"
+  local names
+  names="$(printf '%s' "$out" | jq -r '.q' | sort | tr '\n' ',')"
+  [[ $names == 'agent_secretfile_changed,filevault_off,new_admin_user,' ]] ||
+    fail "the surviving findings must be exactly the admitted queries -- got: $names"
+}
+
 a_pack_row_strips_its_prefix
 a_hyphenated_pack_row_strips_only_the_pack_segment
 a_top_level_row_keeps_its_bare_name
@@ -130,5 +197,10 @@ a_row_without_an_action_defaults_to_changed
 a_snapshot_row_yields_exactly_one_finding
 each_row_yields_its_own_finding
 a_malformed_line_is_skipped_without_aborting_the_batch
+an_agent_secretfile_row_is_admitted
+the_heartbeat_canary_is_dropped
+a_made_up_pack_query_is_dropped
+a_made_up_top_level_query_is_dropped
+a_mixed_batch_keeps_only_admitted_rows
 
-printf 'osquery-normalize: OK (prefix strip, hyphenated pack, bare top-level, action default, no snapshot explosion, one-per-row, malformed-skip)\n'
+printf 'osquery-normalize: OK (B1 prefix strip/action default/one-per-row/malformed-skip; B2 known-query select admits detectors, drops heartbeat_canary and unknown pack/top-level names)\n'

--- a/test/unit/osquery-pipeline-verdict.sh
+++ b/test/unit/osquery-pipeline-verdict.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# pipeline_verdict (results-alerter/pipeline-verdict.sh) decides whether a file
+# change under the watched pipeline directories is a tamper to PAGE, a known-good
+# apply to stay SILENT, or an untracked neighbor to log only. It checks the
+# change against the pipeline-integrity manifest, a root-owned sha256 list of the
+# alerter's own scripts/plists.
+#
+# Return-code contract (from c69baab _pipeline_verdict), inverted vs the
+# allowlist verdict on purpose:
+#   0 = PAGE   - a tracked file changed and we cannot confirm it legitimate
+#                (tamper, a delete, an empty/mismatched hash, or NO manifest).
+#   1 = SILENT - an untracked neighbor in a watched dir, OR a tracked change whose
+#                exact (path, sha256) tuple is present in the manifest.
+#
+# Criterion 6, the headline this behavior pins: the integrity manifest slice is
+# LAST in the stack and does not exist yet, so with NO manifest present a change
+# to a tracked pipeline file PAGES. That is the conservative fail-open direction -
+# a pipeline-script change is never silently suppressed without a manifest to
+# justify it.
+#
+# Dual tuple-prefix: the tracked pipeline scripts now live under BOTH
+# ~/.local/libexec/osquery/ (the relocated alerter scripts, osquery- prefix
+# dropped) and ~/.local/bin/ (root-of-trust operator tools); our own LaunchAgents
+# are matched by the com.webdavis.osquery-*.plist basename. c69baab only knew
+# ~/.local/bin/osquery-*.sh; the identification is rebased onto the new layout.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
+fail() {
+  printf 'osquery-pipeline-verdict: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+mkdir -p "$home/.local/libexec/osquery/results-alerter" "$home/.local/bin" "$home/Library/LaunchAgents"
+
+# An on-disk tracked file for the atomic-rename (empty-hash) rehash path.
+libexec_script="$home/.local/libexec/osquery/results-alerter.sh"
+bin_script="$home/.local/bin/relay.sh"
+printf 'echo libexec\n' >"$libexec_script"
+printf 'echo bin\n' >"$bin_script"
+
+# Synthetic manifest hashes (the non-empty-hash path compares the EVENT hash to
+# the manifest, no disk read, so these need not match any real file).
+hash_libexec="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+hash_bin="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+hash_wrong="0000000000000000000000000000000000000000000000000000000000000000"
+
+# A stubbed manifest binding each hash to ITS path (shasum format: "<hash>  <path>").
+manifest="$work/pipeline-known-good.sha256"
+{
+  printf '%s  %s\n' "$hash_libexec" "$libexec_script"
+  printf '%s  %s\n' "$hash_bin" "$bin_script"
+} >"$manifest"
+absent_manifest="$work/no-such-manifest.sha256"
+
+# Each case: <expected-rc> TAB <manifest> TAB <target> TAB <hash> TAB <verb> TAB <label>.
+# An empty manifest field means "no manifest" (points at a nonexistent path).
+cases=(
+  # -- Fail-open headline: NO manifest, a tracked change under either prefix PAGES --
+  $'0\t'"$absent_manifest"$'\t'"$libexec_script"$'\t'"$hash_libexec"$'\tUPDATED\ttracked libexec script, no manifest -> PAGE (fail-open, criterion 6)'
+  $'0\t'"$absent_manifest"$'\t'"$bin_script"$'\t'"$hash_bin"$'\tUPDATED\ttracked ~/.local/bin script, no manifest -> PAGE (fail-open, second prefix)'
+  # -- An untracked neighbor in a watched dir is SILENT --
+  $'1\t'"$absent_manifest"$'\t'"$home/Library/LaunchAgents/com.apple.something.plist"$'\t'"$hash_libexec"$'\tUPDATED\tan untracked neighbor plist -> SILENT (not pipeline infrastructure)'
+  # -- Our own osquery LaunchAgent (basename branch), no manifest -> PAGE --
+  $'0\t'"$absent_manifest"$'\t'"$home/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist"$'\t'"$hash_libexec"$'\tUPDATED\tour own osquery LaunchAgent, no manifest -> PAGE'
+  # -- A DELETE of a tracked file always PAGES, even with a manifest present --
+  $'0\t'"$manifest"$'\t'"$libexec_script"$'\t\tDELETED\ta delete of a tracked file -> PAGE (destructive, manifest cannot vouch)'
+  # -- Empty event hash (atomic-rename shape): debounce, rehash disk; no manifest -> PAGE --
+  $'0\t'"$absent_manifest"$'\t'"$libexec_script"$'\t\tMOVED_TO\tatomic-rename empty-hash event, no manifest -> PAGE after rehash'
+  # -- Manifest present: exact (path, hash) tuple known-good -> SILENT --
+  $'1\t'"$manifest"$'\t'"$libexec_script"$'\t'"$hash_libexec"$'\tUPDATED\ttracked change whose exact (path,hash) tuple is in the manifest -> SILENT'
+  # -- Manifest present: hash mismatch on a tracked path -> PAGE (tamper) --
+  $'0\t'"$manifest"$'\t'"$libexec_script"$'\t'"$hash_wrong"$'\tUPDATED\ta tracked path with a hash absent from the manifest -> PAGE (tamper)'
+  # -- Manifest present: a valid hash lifted onto a DIFFERENT tracked path -> PAGE --
+  $'0\t'"$manifest"$'\t'"$libexec_script"$'\t'"$hash_bin"$'\tUPDATED\tswap-in-place (a real hash bound to another path) -> PAGE (tuple binding)'
+)
+
+expected=()
+labels=()
+feed=""
+for row in "${cases[@]}"; do
+  IFS=$'\t' read -r rc manifest_path target hash verb label_text <<<"$row"
+  expected+=("$rc")
+  labels+=("$label_text")
+  feed+="$manifest_path"$'\t'"$target"$'\t'"$hash"$'\t'"$verb"$'\n'
+done
+
+# One sourcing subshell drives every case; OSQUERY_PIPELINE_REHASH_DELAY=0 keeps
+# the atomic-rename debounce from adding real wall time to the unit test.
+got=()
+mapfile -t got < <(
+  printf '%s' "$feed" | HOME="$home" OSQUERY_PIPELINE_REHASH_DELAY=0 bash -c '
+    source "$1"
+    while IFS="$(printf "\t")" read -r manifest target hash verb; do
+      OSQUERY_PIPELINE_MANIFEST="$manifest"
+      rc=0
+      pipeline_verdict "$target" "$hash" "$verb" || rc=$?
+      printf "%s\n" "$rc"
+    done
+  ' _ "$HELPER"
+)
+
+[[ ${#got[@]} -eq ${#expected[@]} ]] ||
+  fail "the verdict driver emitted ${#got[@]} results for ${#expected[@]} cases (one per case expected)"
+
+for i in "${!expected[@]}"; do
+  [[ ${got[i]} == "${expected[i]}" ]] ||
+    fail "${labels[i]}: expected return ${expected[i]}, got ${got[i]}"
+done
+
+printf 'osquery-pipeline-verdict: OK (fail-open PAGE without a manifest under both prefixes; neighbor SILENT; delete PAGES; manifest tuple match SILENT, mismatch/swap-in-place PAGE)\n'

--- a/test/unit/osquery-render-command-injection.sh
+++ b/test/unit/osquery-render-command-injection.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# render_page builds remediation next-step commands (codesign -dv <path>,
+# cat <path>, sudo cat <path>, shasum -a 256 <path>) from the attacker-controlled
+# finding path. A path must NEVER be interpolated into a command as raw text: a
+# crafted path like /tmp/x"; touch /tmp/PROOF; # would, if the operator copies the
+# suggested command, break out of the quotes and run the injected clause. Every
+# rendered command operand that is a path must be a SINGLE safe shell token
+# (jq @sh single-quoting, plus -- before the operand).
+#
+# Unit test (hostile render): for each command-building arm, render a finding whose
+# ep carries a shell-injection payload, extract the emitted command, and EXECUTE it
+# under stub tools (codesign/cat/shasum record their argv; touch drops a PROOF
+# marker if the injection runs). Assert the injected clause never executes and the
+# tool receives the whole path as one argument. bash -n alone does NOT catch this
+# (the injected form is valid bash), so the proof is actual execution.
+#
+# This test deals in LITERAL shell-injection payloads and stub-script bodies, so
+# `$(...)` / `$@` inside single quotes is deliberate (they must NOT expand here).
+# shellcheck disable=SC2016
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/render-page.sh"
+
+fail() {
+  printf 'osquery-render-command-injection: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+# Stub tools: codesign/cat/shasum record every argv line; sudo drops itself and
+# execs the rest; touch drops a PROOF marker so an injected `touch` is detectable.
+for t in codesign cat shasum; do
+  printf '#!/usr/bin/env bash\nfor a in "$@"; do printf "%%s\\n" "$a" >>"%s/argv"; done\nexit 0\n' "$work" >"$work/bin/$t"
+done
+printf '#!/usr/bin/env bash\nexec "$@"\n' >"$work/bin/sudo"
+printf '#!/usr/bin/env bash\n: >"%s/PROOF"\n' "$work" >"$work/bin/touch"
+chmod +x "$work/bin/"*
+
+# render_command <finding-json>: render the finding and print the emitted next-step
+# command (the text inside the backticks on the Inspect/Review/Compare line).
+render_command() {
+  local finding="$1" pbody
+  pbody="$(printf '%s\n' "$finding" | bash -c "source '$HELPER'; render_page" | jq -r '.pbody')"
+  printf '%s\n' "$pbody" | grep -E '\*\*(Inspect|Review|Compare)' | sed -n 's/.*`\(.*\)`.*/\1/p' | head -1
+}
+
+# assert_safe <label> <finding> <payload-substring>: the emitted command runs the
+# tool with the FULL path (payload intact) as one argument and never injects.
+assert_safe() {
+  local label="$1" finding="$2" needle="$3" cmd
+  cmd="$(render_command "$finding")"
+  [[ -n $cmd ]] || fail "$label: no next-step command was rendered"
+  : >"$work/argv"
+  rm -f "$work/PROOF"
+  PATH="$work/bin:/usr/bin:/bin" bash -c "$cmd" >/dev/null 2>&1 || true
+  [[ ! -f "$work/PROOF" ]] || fail "$label: COMMAND INJECTION - the crafted path executed 'touch'. command: $cmd"
+  grep -qF -- "$needle" "$work/argv" ||
+    fail "$label: the tool did not receive the whole path as one argument (argv: $(tr '\n' '|' <"$work/argv")). command: $cmd"
+}
+
+PAYLOAD='/tmp/x"; touch /tmp/PROOF; #'
+SUBST_PAYLOAD='/tmp/$(touch /tmp/PROOF)'
+
+# f <q> <ep> <extra-cols-json>: build a CRIT finding with jq (correct escaping).
+f() { jq -cn --arg q "$1" --arg ep "$2" --argjson cols "$3" '{q:$q,act:"added",sev:"CRIT",cols:($cols + {}),ep:$ep}'; }
+
+# suid_bin_unexpected -> codesign -dv <path>
+assert_safe "suid (codesign) quote-injection" \
+  "$(f suid_bin_unexpected "$PAYLOAD" "$(jq -cn --arg p "$PAYLOAD" '{path:$p,username:"root"}')")" \
+  'touch /tmp/PROOF; #'
+
+# suid with a command-substitution payload
+assert_safe "suid (codesign) command-substitution" \
+  "$(f suid_bin_unexpected "$SUBST_PAYLOAD" "$(jq -cn --arg p "$SUBST_PAYLOAD" '{path:$p,username:"root"}')")" \
+  '$(touch /tmp/PROOF)'
+
+# persistence_launchd -> cat <path>
+assert_safe "persistence (cat) quote-injection" \
+  "$(f persistence_launchd "$PAYLOAD" '{"label":"com.x","program":"/bin/sh"}')" \
+  'touch /tmp/PROOF; #'
+
+# file_events pipeline_integrity -> shasum -a 256 <path>
+assert_safe "file_events pipeline (shasum) quote-injection" \
+  "$(f file_events_recent "$PAYLOAD" '{"category":"pipeline_integrity","target_path":"/x/osquery-alerter.sh"}')" \
+  'touch /tmp/PROOF; #'
+
+# file_events non-pipeline (ssh) -> sudo cat <path>
+assert_safe "file_events ssh (sudo cat) quote-injection" \
+  "$(f file_events_recent "$PAYLOAD" '{"category":"ssh","target_path":"/x/authorized_keys"}')" \
+  'touch /tmp/PROOF; #'
+
+# es_launchd_writes -> codesign -dv <path>
+assert_safe "es_launchd_writes (codesign) quote-injection" \
+  "$(f es_launchd_writes "$PAYLOAD" '{"path":"/proc/x"}')" \
+  'touch /tmp/PROOF; #'
+
+printf 'osquery-render-command-injection: OK (codesign/cat/sudo-cat/shasum next-steps shell-escape the path; quote and command-substitution payloads never execute)\n'

--- a/test/unit/osquery-render-newline-injection.sh
+++ b/test/unit/osquery-render-newline-injection.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# render_page wraps attacker-controlled column values in Discord inline-code
+# backticks (the `code` def) to neutralize markdown. A backtick ends the span and
+# is stripped, but a NEWLINE also breaks out of an inline-code span - so an
+# attacker who embeds \n (or \r) in any rendered column (.cols.label / program /
+# path / username / target_path) can inject arbitrary markdown LINES into the CRIT
+# page that fans out to Discord. The headline forgery: a persistence label of
+# "com.attacker.evil\n- **Signing:** signed: Apple (Developer ID)" would render a
+# FORGED signing-provenance line for an actually-unsigned agent.
+#
+# Every rendered field value must appear as ONE line / one inline-code token, so
+# `code` (the single chokepoint) must squash \r\n\t to spaces, and any field that
+# does not pass through `code` must apply the same sanitize.
+#
+# Unit test: for each attacker-controlled field, render a finding whose value
+# embeds a newline (and separately a carriage return) crafted to forge a Signing
+# line, and assert (a) NO line of the page body starts with the forged
+# "- **Signing:**", and (b) the injected text stays on the SAME line as the value
+# (the newline was squashed).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/render-page.sh"
+
+fail() {
+  printf 'osquery-render-newline-injection: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+
+render_pbody() { printf '%s\n' "$1" | bash -c "source '$HELPER'; render_page" | jq -r '.pbody'; }
+
+# assert_no_line_injection <label> <finding> <marker-substring>: the marker (a
+# unique token planted next to the forged Signing text) and the forged Signing text
+# must share one line, and no line may START with the forged "- **Signing:**".
+assert_no_line_injection() {
+  local label="$1" finding="$2" marker="$3" pbody value_line
+  pbody="$(render_pbody "$finding")"
+  # The finding carries NO real .signing, so ANY line starting with "- **Signing:**"
+  # is the injected forgery.
+  if grep -qE '^- \*\*Signing:\*\*' <<<"$pbody"; then
+    fail "$label: a FORGED '- **Signing:**' line was injected into the page body:
+$pbody"
+  fi
+  # The marker and the injected 'signed: Apple' must be on the same line (the newline
+  # was squashed to a space, keeping the value one inline-code token).
+  value_line="$(grep -F "$marker" <<<"$pbody" || true)"
+  [[ -n $value_line ]] || fail "$label: the field value ($marker) is missing from the body:
+$pbody"
+  grep -qF 'signed: Apple' <<<"$value_line" ||
+    fail "$label: the embedded newline was not squashed - the value split across lines:
+$pbody"
+}
+
+# The injection payload: <marker><newline>- **Signing:** signed: Apple (Developer ID)
+NL_INJECT=$'ZZmarkerZZ\n- **Signing:** signed: Apple (Developer ID)'
+CR_INJECT=$'ZZmarkerZZ\r- **Signing:** signed: Apple (Developer ID)'
+
+# persistence_launchd label -> "What" field
+assert_no_line_injection "persistence label (newline)" \
+  "$(jq -cn --arg v "$NL_INJECT" '{q:"persistence_launchd",act:"added",sev:"CRIT",cols:{label:$v,program:"/bin/sh"},ep:""}')" \
+  'ZZmarkerZZ'
+
+# persistence_launchd program -> "Program" field
+assert_no_line_injection "persistence program (newline)" \
+  "$(jq -cn --arg v "$NL_INJECT" '{q:"persistence_launchd",act:"added",sev:"CRIT",cols:{label:"com.x",program:$v},ep:""}')" \
+  'ZZmarkerZZ'
+
+# suid_bin_unexpected path -> "Path" field
+assert_no_line_injection "suid path (newline)" \
+  "$(jq -cn --arg v "$NL_INJECT" '{q:"suid_bin_unexpected",act:"added",sev:"CRIT",cols:{path:$v,username:"root"},ep:""}')" \
+  'ZZmarkerZZ'
+
+# new_admin_user username -> "User" field
+assert_no_line_injection "new_admin_user username (newline)" \
+  "$(jq -cn --arg v "$NL_INJECT" '{q:"new_admin_user",act:"added",sev:"CRIT",cols:{username:$v,uid:"501"},ep:""}')" \
+  'ZZmarkerZZ'
+
+# file_events_recent target_path -> "File" field
+assert_no_line_injection "file_events target_path (newline)" \
+  "$(jq -cn --arg v "$NL_INJECT" '{q:"file_events_recent",act:"added",sev:"CRIT",cols:{category:"ssh",target_path:$v},ep:""}')" \
+  'ZZmarkerZZ'
+
+# carriage-return variant (label)
+assert_no_line_injection "persistence label (carriage return)" \
+  "$(jq -cn --arg v "$CR_INJECT" '{q:"persistence_launchd",act:"added",sev:"CRIT",cols:{label:$v,program:"/bin/sh"},ep:""}')" \
+  'ZZmarkerZZ'
+
+printf 'osquery-render-newline-injection: OK (label/program/path/username/target_path with embedded \\n or \\r stay one line; no forged Signing line injected)\n'

--- a/test/unit/osquery-render-page.sh
+++ b/test/unit/osquery-render-page.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# render_page (results-alerter/render-page.sh) builds the #priority page body from
+# the enriched findings: it selects the CRIT ones and renders each into a focused
+# block (header + decision-relevant fields + a next-step), returning
+# {pcount, pbody}. It is display-only - it never changes detection or severity.
+#
+# Criterion 7 (basename-only), pinned hard here: a secret/auth-file finding
+# (agent_authfile_changed, agent_secretfile_changed) shows ONLY the file's
+# basename in the payload, never its full path and never a sha256/digest. The
+# digest spool may keep full paths privately (B8), but the notification body -
+# which fans out to Discord - must not.
+#
+# Caps preserved from c69baab: each rendered value is backtick-sanitized and
+# capped at 240 chars; the page is capped at 8 blocks (plus an "N more" marker)
+# and then hard-capped at 1900 chars, so an over-long page can never wedge the
+# 2000-char Discord budget.
+#
+# Unit test: fixture CRIT findings in, assert the body shape, the basename-only
+# privacy, and every cap.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/render-page.sh"
+
+fail() {
+  printf 'osquery-render-page: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $HELPER ]] || fail "missing helper: $HELPER"
+
+# render_page reads enriched-finding NDJSON on stdin and prints the {pcount, pbody}
+# JSON object. A fresh subshell keeps the sourcing side-effect-free.
+render_page_run() { bash -c "source '$HELPER'; render_page"; }
+
+# --- normal CRIT block + basename-only privacy for secret/auth findings --------
+normal_block_and_basename_privacy() {
+  local out pbody pcount
+  out="$(
+    render_page_run <<'EOF'
+{"q":"new_admin_user","act":"added","sev":"CRIT","cols":{"username":"eve","uid":"501"},"ep":""}
+{"q":"agent_secretfile_changed","act":"added","sev":"CRIT","cols":{"path":"/Users/x/.config/relay/webhook-secret","sha256":"cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"},"ep":""}
+{"q":"agent_authfile_changed","act":"added","sev":"CRIT","cols":{"path":"/Users/x/.codex/config.toml","sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},"ep":""}
+EOF
+  )"
+  pcount="$(jq -r '.pcount' <<<"$out")"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+
+  [[ $pcount -eq 3 ]] || fail "expected pcount 3, got $pcount"
+
+  # A normal CRIT finding renders header + fields + next-step.
+  [[ $pbody == *"New administrator account"* ]] || fail "normal finding: missing header -- $pbody"
+  [[ $pbody == *"**User:**"* && $pbody == *"eve"* ]] || fail "normal finding: missing user field -- $pbody"
+  [[ $pbody == *"admin access"* ]] || fail "normal finding: missing next-step -- $pbody"
+
+  # Criterion 7: the secret file shows by BASENAME only. The basename is present;
+  # the full path and the sha256 are ABSENT from the page body.
+  [[ $pbody == *"webhook-secret"* ]] || fail "secret finding: basename missing -- $pbody"
+  [[ $pbody != *"/Users/x/.config/relay"* ]] || fail "criterion 7 VIOLATED: secret full path leaked into pbody -- $pbody"
+  [[ $pbody != *"cafebabe"* ]] || fail "criterion 7 VIOLATED: secret sha256 leaked into pbody -- $pbody"
+
+  # Same for the auth-file finding.
+  [[ $pbody == *"config.toml"* ]] || fail "auth finding: basename missing -- $pbody"
+  [[ $pbody != *"/Users/x/.codex/config.toml"* ]] || fail "criterion 7 VIOLATED: auth full path leaked into pbody -- $pbody"
+  [[ $pbody != *"deadbeef"* ]] || fail "criterion 7 VIOLATED: auth sha256 leaked into pbody -- $pbody"
+}
+
+# --- 240-char field cap --------------------------------------------------------
+field_cap_truncates_an_over_long_value() {
+  local long out pbody
+  long="$(printf 'a%.0s' {1..300})"
+  out="$(printf '{"q":"new_admin_user","act":"added","sev":"CRIT","cols":{"username":"%s","uid":"1"},"ep":""}\n' "$long" | render_page_run)"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+  [[ $pbody == *"(truncated)"* ]] || fail "field cap: expected a (truncated) marker -- $pbody"
+  [[ $pbody != *"$long"* ]] || fail "field cap: the full 300-char value was not truncated -- $pbody"
+}
+
+# --- 8-block cap ---------------------------------------------------------------
+block_cap_limits_to_eight_blocks() {
+  local findings=() i out pcount pbody
+  for i in $(seq 1 10); do
+    findings+=("{\"q\":\"new_admin_user\",\"act\":\"added\",\"sev\":\"CRIT\",\"cols\":{\"username\":\"user$i\",\"uid\":\"$i\"},\"ep\":\"\"}")
+  done
+  out="$(printf '%s\n' "${findings[@]}" | render_page_run)"
+  pcount="$(jq -r '.pcount' <<<"$out")"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+  [[ $pcount -eq 10 ]] || fail "block cap: pcount should count ALL crit findings (10), got $pcount"
+  [[ $pbody == *"and 2 more CRITICAL finding(s)"* ]] || fail "block cap: expected an 'and 2 more' marker -- $pbody"
+  # Exactly 8 rendered header blocks (the 9th and 10th are summarized by the marker).
+  local headers
+  headers="$(grep -c 'New administrator account' <<<"$pbody" || true)"
+  [[ $headers -eq 8 ]] || fail "block cap: expected 8 rendered blocks, got $headers"
+}
+
+# --- 1900-char page cap --------------------------------------------------------
+page_cap_hard_limits_length() {
+  local wide findings=() i out body_len pbody
+  wide="$(printf 'b%.0s' {1..240})"
+  for i in $(seq 1 8); do
+    findings+=("{\"q\":\"new_admin_user\",\"act\":\"added\",\"sev\":\"CRIT\",\"cols\":{\"username\":\"$wide$i\",\"uid\":\"$i\"},\"ep\":\"\"}")
+  done
+  out="$(printf '%s\n' "${findings[@]}" | render_page_run)"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+  body_len="$(jq -r '.pbody | length' <<<"$out")"
+  [[ $pbody == *"truncated to fit the 2000-char limit"* ]] || fail "page cap: expected the 1900-char final cap marker -- length=$body_len"
+  [[ $body_len -lt 2000 ]] || fail "page cap: pbody must be under 2000 chars, got $body_len"
+}
+
+normal_block_and_basename_privacy
+field_cap_truncates_an_over_long_value
+block_cap_limits_to_eight_blocks
+page_cap_hard_limits_length
+
+printf 'osquery-render-page: OK (CRIT block header/fields/nextstep; basename-only secret+auth files with no path/sha256; 240-char field cap; 8-block cap; 1900-char page cap)\n'

--- a/test/unit/osquery-route-enrichment.sh
+++ b/test/unit/osquery-route-enrichment.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# The route gate's signing enrichment (B13). For a finding with an inspectable
+# path and a CRIT/NOTICE base tier, the gate calls the enricher on the path,
+# attaches its .signing fact for render-page, and promotes NOTICE -> CRIT when the
+# signing verdict is UNTRUSTED (enricher exit 10).
+#
+# THE headline invariant: enrichment runs BEFORE the allowlist suppression, so an
+# untrusted program behind a FULLY allowlisted launchd label still PAGES - a
+# promoted CRIT is never suppressed by the allowlist. The tuple's plist-hash
+# dimension catches a tampered plist; the signing verdict catches an untrusted
+# program the plist launches; both are separate defenses and both must page.
+#
+# Unit test: a stubbed enricher (untrusted when the path contains UNTRUSTED, else
+# trusted), a fixture allowlist with a full-tuple match, findings under a temp HOME.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+
+fail() {
+  printf 'osquery-route-enrichment: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+[[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+spy="$work/digest-spy.ndjson"
+mkdir -p "$home/Library/LaunchAgents" "$home/bin" "$home/.config/osquery"
+
+# The stub enricher: UNTRUSTED (exit 10) when the inspected path contains
+# UNTRUSTED, else a trusted authority (exit 0). Deterministic, no real codesign.
+enricher="$work/enrich-stub.sh"
+cat >"$enricher" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  *UNTRUSTED*) printf 'UNSIGNED'; exit 10 ;;
+  *) printf 'signed: Apple'; exit 0 ;;
+esac
+STUB
+chmod +x "$enricher"
+
+# Two allowlisted known-good agents (full-tuple match). One's plist path carries
+# UNTRUSTED (its program's signature is bad); the other is clean.
+mk_plist() {
+  printf 'PLIST %s\n' "$1" >"$1"
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+untrusted_plist="$home/Library/LaunchAgents/com.evilUNTRUSTED.plist"
+trusted_plist="$home/Library/LaunchAgents/com.good.plist"
+untrusted_hash="$(mk_plist "$untrusted_plist")"
+trusted_hash="$(mk_plist "$trusted_plist")"
+
+allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
+{
+  printf '{"label":"com.evil","path":"~/Library/LaunchAgents/com.evilUNTRUSTED.plist","program":"~/bin/evil","sha256":"%s"}\n' "$untrusted_hash"
+  printf '{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":"%s"}\n' "$trusted_hash"
+} >"$allowlist"
+
+findings=(
+  # HEADLINE: fully allowlisted (label+path+program+hash all match) BUT the program
+  # is untrusted (ep path has UNTRUSTED) -> enrichment promotes NOTICE->CRIT ->
+  # PAGES, beating the allowlist suppression. tag A.
+  "{\"q\":\"persistence_launchd\",\"act\":\"added\",\"cols\":{\"label\":\"com.evil\",\"path\":\"$untrusted_plist\",\"program\":\"$home/bin/evil\",\"tag\":\"TAGA\"},\"ep\":\"$untrusted_plist\"}"
+  # Fully allowlisted AND trusted -> stays NOTICE -> SUPPRESSED (not paged). tag B.
+  "{\"q\":\"persistence_launchd\",\"act\":\"added\",\"cols\":{\"label\":\"com.good\",\"path\":\"$trusted_plist\",\"program\":\"$home/bin/good\",\"tag\":\"TAGB\"},\"ep\":\"$trusted_plist\"}"
+  # suid_bin_unexpected (base CRIT already) with an untrusted binary -> PAGES and
+  # carries .signing (enrichment attaches the fact even when no promotion is needed). tag C.
+  '{"q":"suid_bin_unexpected","act":"added","cols":{"path":"/tmp/suidUNTRUSTED","username":"root","tag":"TAGC"},"ep":"/tmp/suidUNTRUSTED"}'
+  # suid with a trusted binary -> PAGES and carries the trusted authority in .signing. tag D.
+  '{"q":"suid_bin_unexpected","act":"added","cols":{"path":"/tmp/suidOK","username":"root","tag":"TAGD"},"ep":"/tmp/suidOK"}'
+)
+
+page_out="$(printf '%s\n' "${findings[@]}" |
+  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" OSQUERY_ENRICH_SCRIPT="$enricher" DIGEST_SPY="$spy" bash -c '
+    source "$1"
+    source "$2"
+    digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+    route_findings
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
+
+# signing_of <tag> -> the .signing value of the paged finding with that tag ("" if absent).
+signing_of() { jq -rs --arg t "$1" 'map(select(.cols.tag == $t)) | (.[0].signing // "")' <<<"$page_out"; }
+in_page() { grep -qF "$1" <<<"$page_out"; }
+
+# HEADLINE: allowlisted + untrusted -> PAGES (promoted CRIT beats allowlist).
+in_page TAGA || fail "HEADLINE: an untrusted program behind a fully allowlisted label MUST page (promoted CRIT beats suppression)"
+[[ "$(signing_of TAGA)" == "UNSIGNED" ]] || fail "the promoted finding must carry .signing=UNSIGNED for render, got '$(signing_of TAGA)'"
+
+# allowlisted + trusted -> suppressed.
+in_page TAGB && fail "an allowlisted AND trusted agent must be SUPPRESSED (stays NOTICE), but it paged"
+
+# suid untrusted -> pages with .signing (already CRIT, no promotion needed).
+in_page TAGC || fail "a CRIT suid finding must still page"
+[[ "$(signing_of TAGC)" == "UNSIGNED" ]] || fail "the CRIT finding must carry the untrusted .signing, got '$(signing_of TAGC)'"
+
+# suid trusted -> pages with the trusted authority attached.
+in_page TAGD || fail "a CRIT suid finding must page regardless of signature"
+[[ "$(signing_of TAGD)" == "signed: Apple" ]] || fail "a trusted CRIT finding must carry .signing='signed: Apple', got '$(signing_of TAGD)'"
+
+# The suppressed (trusted allowlisted) finding is log-only, not digested.
+[[ ! -s $spy ]] || fail "the suppressed finding is log-only, not digested; spy got: $(cat "$spy")"
+
+printf 'osquery-route-enrichment: OK (untrusted-behind-allowlisted PAGES [promoted CRIT beats suppression]; trusted allowlisted suppressed; .signing attached on CRIT findings, untrusted and trusted)\n'

--- a/test/unit/osquery-route-gate.sh
+++ b/test/unit/osquery-route-gate.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# route_findings (results-alerter/route.sh) is the three-outcome gate: it consumes
+# normalized findings ({q, act, cols, ep}), computes each one's base severity via
+# route_severity, and routes it to EXACTLY ONE outcome:
+#   PAGE      -> the finding is emitted (with .sev="CRIT") as NDJSON on stdout, to
+#                be rendered by render_page.
+#   DIGEST    -> the finding is recorded via digest_append (a spool side effect);
+#                nothing is emitted.
+#   LOG-ONLY  -> nothing is emitted and nothing is spooled.
+#
+# The tier per detector mirrors c69baab's gate case. This behavior (B10) wires the
+# CORE routing only: the allowlist verdict (a user LaunchAgent), the pipeline
+# verdict (a pipeline file event), and the signing enrichment are NOT wired yet -
+# a launchd add and a pipeline file event page unconditionally for now (TODO
+# B11/B12/B13).
+#
+# Unit test: fixture normalized findings, each tagged with a unique token, run
+# through ONE gate pass. A token in stdout => paged; in the spool => digested; in
+# neither => log-only.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+
+fail() {
+  printf 'osquery-route-gate: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+spool="$work/digest-spy.ndjson"
+
+# digest_append is a collaborator of the gate, pinned in its own suite
+# (osquery-digest-store.sh). Here we double it with a recording spy so this test
+# exercises the gate's ROUTING (did the finding go to digest?), not the helper's
+# private-spool internals, and stays fast. The spy records the raw finding, so
+# every finding's unique TAGnn token surfaces in whichever channel it was routed to.
+#
+# Each finding carries a unique TAGnn token in a natural field. For a paged
+# finding the whole object is on stdout; for a digested finding the raw object is
+# in the spy file.
+findings=(
+  # -- PAGE --
+  '{"q":"new_admin_user","act":"added","cols":{"username":"adminTAG01","uid":"501"},"ep":""}'
+  '{"q":"filevault_off","act":"added","cols":{"note":"TAG02"},"ep":""}'
+  '{"q":"agent_secretfile_changed","act":"added","cols":{"path":"/Users/x/.config/relay/webhook-secretTAG03"},"ep":""}'
+  '{"q":"agent_exposure_changed","act":"added","cols":{"name":"ncTAG04","address":"0.0.0.0","port":"4444"},"ep":""}'
+  '{"q":"suid_bin_unexpected","act":"added","cols":{"path":"/tmp/suidTAG05"},"ep":"/tmp/suidTAG05"}'
+  '{"q":"persistence_launchd","act":"added","cols":{"path":"/Users/x/Library/LaunchAgents/com.TAG06.plist","label":"com.TAG06","program":"/Users/x/bin/tag06"},"ep":"/Users/x/Library/LaunchAgents/com.TAG06.plist"}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"sshd_config","target_path":"/etc/ssh/sshd_configTAG07"},"ep":"/etc/ssh/sshd_configTAG07"}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"ssh","target_path":"/Users/x/.ssh/authorized_keys","note":"TAG08"},"ep":"/Users/x/.ssh/authorized_keys"}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"pipeline_integrity","target_path":"/Users/x/.local/libexec/osquery/results-alerterTAG09.sh","sha256":"abc","action":"UPDATED"},"ep":"/Users/x/.local/libexec/osquery/results-alerterTAG09.sh"}'
+  # -- DIGEST --
+  '{"q":"agent_authfile_changed","act":"added","cols":{"path":"/Users/x/.codex/config.tomlTAG10"},"ep":""}'
+  '{"q":"system_extensions_new","act":"added","cols":{"identifier":"com.ext.TAG11"},"ep":""}'
+  '{"q":"listening_ports_non_loopback","act":"added","cols":{"name":"procTAG12","address":"0.0.0.0","port":"9999"},"ep":""}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"ssh","target_path":"/Users/x/.ssh/id_rsaTAG13"},"ep":"/Users/x/.ssh/id_rsaTAG13"}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"sudoers","target_path":"/etc/sudoersTAG14"},"ep":"/etc/sudoersTAG14"}'
+  '{"q":"file_events_recent","act":"added","cols":{"category":"allowlist_file","target_path":"/Users/x/.config/osquery-TAG15/page-launchd-allowlist.txt"},"ep":""}'
+  # -- LOG-ONLY --
+  '{"q":"agent_exposure_changed","act":"removed","cols":{"name":"ncTAG16","address":"0.0.0.0","port":"4444"},"ep":""}'
+  '{"q":"firewall_state","act":"added","cols":{"global_state":"0","note":"TAG17"},"ep":""}'
+  '{"q":"homebrew_packages","act":"added","cols":{"name":"pkgTAG18"},"ep":""}'
+  '{"q":"kernel_extensions_new","act":"added","cols":{"name":"kextTAG19"},"ep":""}'
+  '{"q":"filevault_off","act":"removed","cols":{"note":"TAG20"},"ep":""}'
+)
+
+# One gate pass. The spy records every digested finding to the spool file.
+page_out="$(printf '%s\n' "${findings[@]}" |
+  DIGEST_SPY="$spool" bash -c '
+    source "$1"
+    digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+    route_findings
+  ' _ "$ROUTE")"
+
+# classify <token> <page|digest|logonly>: assert where the token surfaced.
+classify() {
+  local token="$1" want="$2" in_page=no in_spool=no
+  grep -qF "$token" <<<"$page_out" && in_page=yes
+  [[ -f $spool ]] && grep -qF "$token" "$spool" && in_spool=yes
+  case "$want" in
+    page) [[ $in_page == yes && $in_spool == no ]] || fail "$token expected PAGE, got page=$in_page digest=$in_spool" ;;
+    digest) [[ $in_spool == yes && $in_page == no ]] || fail "$token expected DIGEST, got page=$in_page digest=$in_spool" ;;
+    logonly) [[ $in_page == no && $in_spool == no ]] || fail "$token expected LOG-ONLY, got page=$in_page digest=$in_spool" ;;
+  esac
+}
+
+# -- PAGE --
+classify TAG01 page # new_admin_user (criterion 1)
+classify TAG02 page # filevault_off added (criterion 2)
+classify TAG03 page # agent_secretfile_changed (criterion 3: the 2 secrets)
+classify TAG04 page # agent_exposure_changed added (criterion 3: off-loopback)
+classify TAG05 page # suid_bin_unexpected added
+classify TAG06 page # persistence_launchd added (unconditional now; TODO B11 allowlist)
+classify TAG07 page # file_events sshd_config
+classify TAG08 page # file_events ssh authorized_keys
+classify TAG09 page # file_events pipeline_integrity (unconditional now; TODO B12 pipeline)
+
+# -- DIGEST --
+classify TAG10 digest # agent_authfile_changed (criterion 3: the 3 non-secret configs)
+classify TAG11 digest # system_extensions_new
+classify TAG12 digest # listening_ports_non_loopback added
+classify TAG13 digest # file_events ssh (a non-authorized_keys file)
+classify TAG14 digest # file_events sudoers
+classify TAG15 digest # file_events allowlist_file (the page-allowlist edit itself)
+
+# -- LOG-ONLY --
+classify TAG16 logonly # agent_exposure_changed removed (the exposure being fixed)
+classify TAG17 logonly # firewall_state (poller-owned; routing here would double-page)
+classify TAG18 logonly # homebrew_packages (INFO drift)
+classify TAG19 logonly # kernel_extensions_new (wrong signal)
+classify TAG20 logonly # filevault_off removed (encryption restored)
+
+# -- Contract: every paged line is exactly one CRIT finding; counts add up. --
+page_count="$(grep -c . <<<"$page_out" || true)"
+[[ $page_count -eq 9 ]] || fail "expected 9 page-candidates, got $page_count"
+[[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$page_out")" == true ]] ||
+  fail "every page-candidate must carry .sev == CRIT"
+digest_count="$(grep -c . "$spool" 2>/dev/null || true)"
+[[ $digest_count -eq 6 ]] || fail "expected 6 digested findings, got $digest_count"
+
+printf 'osquery-route-gate: OK (9 page-candidates all CRIT, 6 digested, 5 log-only; criteria 1-3 tiers pinned; poller-owned + drift are log-only)\n'

--- a/test/unit/osquery-route-gate.sh
+++ b/test/unit/osquery-route-gate.sh
@@ -9,11 +9,11 @@
 #                nothing is emitted.
 #   LOG-ONLY  -> nothing is emitted and nothing is spooled.
 #
-# The tier per detector mirrors c69baab's gate case. This behavior (B10) wires the
-# CORE routing only: the allowlist verdict (a user LaunchAgent), the pipeline
-# verdict (a pipeline file event), and the signing enrichment are NOT wired yet -
-# a launchd add and a pipeline file event page unconditionally for now (TODO
-# B11/B12/B13).
+# The tier per detector mirrors c69baab's gate case. This suite pins the tier
+# TABLE; the fine-grained allowlist (B11) and pipeline (B12) verdict outcomes have
+# their own suites. Here the verdicts are consulted with no allowlist/manifest, so
+# a user LaunchAgent (not-found -> default-deny) and a tracked pipeline file event
+# (fail-open, no manifest) both page.
 #
 # Unit test: fixture normalized findings, each tagged with a unique token, run
 # through ONE gate pass. A token in stdout => paged; in the spool => digested; in
@@ -29,8 +29,11 @@ fail() {
   exit 1
 }
 
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
 [[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
 [[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+[[ -f $PIPELINE_HELPER ]] || fail "missing helper: $PIPELINE_HELPER"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -71,17 +74,21 @@ findings=(
   '{"q":"filevault_off","act":"removed","cols":{"note":"TAG20"},"ep":""}'
 )
 
-# One gate pass. The spy records every digested finding to the spool file.
-# allowlist_verdict is sourced (the persistence arm consults it); with the
-# allowlist file pointed at a nonexistent path, the user-agent finding (TAG06) is
-# not-found -> pages under default-deny.
+# One gate pass. The spy records every digested finding to the spool file. The
+# allowlist and pipeline verdicts are sourced (the persistence and pipeline arms
+# consult them). HOME is pinned to /Users/x (the fixtures' home prefix) so the
+# TAG09 pipeline path resolves as tracked; with the allowlist and manifest both
+# pointed at nonexistent paths, TAG06 (user agent, not-found) and TAG09 (tracked,
+# no manifest) both page.
 page_out="$(printf '%s\n' "${findings[@]}" |
-  DIGEST_SPY="$spool" OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" bash -c '
+  HOME="/Users/x" DIGEST_SPY="$spool" OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" \
+    OSQUERY_PIPELINE_MANIFEST="$work/no-manifest.sha256" bash -c '
     source "$1"
     source "$2"
+    source "$3"
     digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
     route_findings
-  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER" "$PIPELINE_HELPER")"
 
 # classify <token> <page|digest|logonly>: assert where the token surfaced.
 classify() {

--- a/test/unit/osquery-route-gate.sh
+++ b/test/unit/osquery-route-gate.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
 
 fail() {
   printf 'osquery-route-gate: FAIL -- %s\n' "$*" >&2
@@ -29,6 +30,7 @@ fail() {
 }
 
 [[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+[[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -70,12 +72,16 @@ findings=(
 )
 
 # One gate pass. The spy records every digested finding to the spool file.
+# allowlist_verdict is sourced (the persistence arm consults it); with the
+# allowlist file pointed at a nonexistent path, the user-agent finding (TAG06) is
+# not-found -> pages under default-deny.
 page_out="$(printf '%s\n' "${findings[@]}" |
-  DIGEST_SPY="$spool" bash -c '
+  DIGEST_SPY="$spool" OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" bash -c '
     source "$1"
+    source "$2"
     digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
     route_findings
-  ' _ "$ROUTE")"
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
 
 # classify <token> <page|digest|logonly>: assert where the token surfaced.
 classify() {

--- a/test/unit/osquery-route-kext-sysext.sh
+++ b/test/unit/osquery-route-kext-sysext.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Operator ruling 2026-07-22: a newly-loaded UNTRUSTED kernel or system extension
+# pages; a signed one stays at its base tier. Enrichment already promotes a NOTICE
+# finding with an inspectable path to CRIT on an untrusted signing verdict; the
+# kernel_extensions_new and system_extensions_new gate arms must HONOR that
+# promotion instead of discarding it.
+#
+#   kernel_extensions_new: untrusted (promoted CRIT) -> PAGE; signed -> log-only.
+#   system_extensions_new: untrusted (promoted CRIT) -> PAGE; signed -> digest.
+#
+# Regression guards (scope is kext/sysext ONLY): es_launchd_writes and
+# persistence_startup_items_crontab stay log-only REGARDLESS of the promotion.
+#
+# Unit test: stubbed enricher (untrusted when the path contains UNTRUSTED), findings
+# tagged so a token in stdout = paged, in the digest spy = digested, in neither =
+# log-only.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+
+fail() {
+  printf 'osquery-route-kext-sysext: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+spy="$work/digest-spy.ndjson"
+
+enricher="$work/enrich-stub.sh"
+cat >"$enricher" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  *UNTRUSTED*) printf 'UNSIGNED'; exit 10 ;;
+  *) printf 'signed: Apple'; exit 0 ;;
+esac
+STUB
+chmod +x "$enricher"
+
+# Each finding carries a unique TAG in a natural field; ep drives the enricher.
+findings=(
+  # kernel_extensions_new: untrusted -> PAGE, trusted -> log-only
+  '{"q":"kernel_extensions_new","act":"added","cols":{"name":"com.evilTAG_KEXT_U","path":"/x/UNTRUSTED.kext"},"ep":"/x/UNTRUSTED.kext"}'
+  '{"q":"kernel_extensions_new","act":"added","cols":{"name":"com.goodTAG_KEXT_T","path":"/x/good.kext"},"ep":"/x/good.kext"}'
+  # system_extensions_new: untrusted -> PAGE, trusted -> DIGEST
+  '{"q":"system_extensions_new","act":"added","cols":{"identifier":"com.evilTAG_SYSEXT_U","bundle_path":"/x/UNTRUSTED.app"},"ep":"/x/UNTRUSTED.app"}'
+  '{"q":"system_extensions_new","act":"added","cols":{"identifier":"com.goodTAG_SYSEXT_T","bundle_path":"/x/good.app"},"ep":"/x/good.app"}'
+  # regression guards: still log-only even when the enricher would promote them
+  '{"q":"es_launchd_writes","act":"added","cols":{"path":"/x/UNTRUSTED_esTAG_ES_U"},"ep":"/x/UNTRUSTED_esTAG_ES_U"}'
+  '{"q":"persistence_startup_items_crontab","act":"added","cols":{"path":"/x/UNTRUSTED_cronTAG_CRON_U"},"ep":"/x/UNTRUSTED_cronTAG_CRON_U"}'
+)
+
+page_out="$(printf '%s\n' "${findings[@]}" |
+  OSQUERY_ENRICH_SCRIPT="$enricher" DIGEST_SPY="$spy" bash -c '
+    source "$1"
+    digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+    route_findings
+  ' _ "$ROUTE")"
+
+classify() {
+  local token="$1" want="$2" in_page=no in_spool=no
+  grep -qF "$token" <<<"$page_out" && in_page=yes
+  [[ -f $spy ]] && grep -qF "$token" "$spy" && in_spool=yes
+  case "$want" in
+    page) [[ $in_page == yes && $in_spool == no ]] || fail "$token expected PAGE, got page=$in_page digest=$in_spool" ;;
+    digest) [[ $in_spool == yes && $in_page == no ]] || fail "$token expected DIGEST, got page=$in_page digest=$in_spool" ;;
+    logonly) [[ $in_page == no && $in_spool == no ]] || fail "$token expected LOG-ONLY, got page=$in_page digest=$in_spool" ;;
+  esac
+}
+
+classify TAG_KEXT_U page     # untrusted kernel extension pages (operator ruling)
+classify TAG_KEXT_T logonly  # signed kernel extension stays at base tier (log-only)
+classify TAG_SYSEXT_U page   # untrusted system extension pages
+classify TAG_SYSEXT_T digest # signed system extension stays at base tier (digest)
+classify TAG_ES_U logonly    # es_launchd_writes stays log-only despite the promotion
+classify TAG_CRON_U logonly  # persistence_startup_items_crontab stays log-only despite the promotion
+
+# The paged findings are emitted as CRIT.
+[[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$page_out")" == true ]] ||
+  fail "every paged kext/sysext finding must carry .sev == CRIT"
+
+printf 'osquery-route-kext-sysext: OK (untrusted kext/sysext page; signed kext log-only, signed sysext digest; es_launchd_writes + crontab stay log-only despite the promotion)\n'

--- a/test/unit/osquery-route-persistence-allowlist.sh
+++ b/test/unit/osquery-route-persistence-allowlist.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# The route gate's persistence_launchd arm, wired to allowlist_verdict
+# (B11). This pins the DEFAULT-DENY security property (operator ruling
+# 2026-07-22): a new user LaunchAgent PAGES unless it exactly matches an
+# allowlisted known-good tuple. This is a deliberate hardening over the reverted
+# #52 (c69baab), which DIGESTED unknown user LaunchAgents.
+#
+# Verdict -> outcome:
+#   0 (full-tuple match, known-good) -> SUPPRESS (not paged; log-only).
+#   2 (reused allowlisted label, identity diverges) -> PAGE.
+#   1 (unknown, not allowlisted) -> PAGE (the default-deny change from c69baab).
+#   /System/Library/* -> skipped (not paged); */LaunchDaemons/* -> PAGE by path.
+#
+# Unit test: a fixture allowlist tuple file + fixture on-disk plists under a temp
+# HOME (so the pinned-hash dimension is exercised for real), the gate driven with
+# allowlist_verdict sourced. Classification is by a unique TAGnn in each finding's
+# columns (the paged finding is emitted whole on stdout; a suppressed one is not,
+# and none of these should digest).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+
+fail() {
+  printf 'osquery-route-persistence-allowlist: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+[[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+spy="$work/digest-spy.ndjson"
+mkdir -p "$home/Library/LaunchAgents" "$home/bin" "$home/.config/osquery"
+
+# The known-good agent's on-disk plist, hashed into the allowlist tuple.
+printf 'KNOWN GOOD PLIST\n' >"$home/Library/LaunchAgents/com.known.plist"
+known_hash="$(shasum -a 256 "$home/Library/LaunchAgents/com.known.plist" | awk '{print $1}')"
+
+# The allowlist tuple file: one known-good agent, stored home-relative (~/).
+allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
+printf '{"label":"com.known","path":"~/Library/LaunchAgents/com.known.plist","program":"~/bin/known","sha256":"%s"}\n' \
+  "$known_hash" >"$allowlist"
+
+# Fixture persistence_launchd findings. Each carries a unique tag in .cols.tag,
+# which allowlist_verdict ignores (it reads only label/path/program).
+findings=(
+  # full-tuple match -> SUPPRESS (not paged)
+  "{\"q\":\"persistence_launchd\",\"act\":\"added\",\"cols\":{\"label\":\"com.known\",\"path\":\"$home/Library/LaunchAgents/com.known.plist\",\"program\":\"$home/bin/known\",\"tag\":\"TAG01\"},\"ep\":\"\"}"
+  # same label, different program -> reused label -> PAGE
+  "{\"q\":\"persistence_launchd\",\"act\":\"added\",\"cols\":{\"label\":\"com.known\",\"path\":\"$home/Library/LaunchAgents/com.known.plist\",\"program\":\"$home/bin/EVIL\",\"tag\":\"TAG02\"},\"ep\":\"\"}"
+  # unknown label -> PAGE (default-deny)
+  "{\"q\":\"persistence_launchd\",\"act\":\"added\",\"cols\":{\"label\":\"com.unknown\",\"path\":\"$home/Library/LaunchAgents/com.unknown.plist\",\"program\":\"$home/bin/unknown\",\"tag\":\"TAG03\"},\"ep\":\"\"}"
+  # a LaunchDaemon path -> PAGE by path (allowlist not consulted)
+  '{"q":"persistence_launchd","act":"added","cols":{"label":"com.daemon","path":"/Library/LaunchDaemons/com.daemon.plist","program":"/usr/bin/daemon","tag":"TAG04"},"ep":""}'
+  # an Apple /System path -> skipped (not paged)
+  '{"q":"persistence_launchd","act":"added","cols":{"label":"com.apple.x","path":"/System/Library/LaunchAgents/com.apple.x.plist","program":"/usr/bin/x","tag":"TAG05"},"ep":""}'
+)
+
+page_out="$(printf '%s\n' "${findings[@]}" |
+  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" DIGEST_SPY="$spy" bash -c '
+    source "$1"
+    source "$2"
+    digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+    route_findings
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
+
+in_page() { grep -qF "$1" <<<"$page_out"; }
+
+# full-tuple match -> suppressed
+in_page TAG01 && fail "TAG01 (full-tuple match) must be SUPPRESSED, but it paged"
+# reused label -> page
+in_page TAG02 || fail "TAG02 (reused label, different program) must PAGE"
+# unknown -> page (default-deny)
+in_page TAG03 || fail "TAG03 (unknown user LaunchAgent) must PAGE under default-deny (operator ruling)"
+# LaunchDaemon -> page by path
+in_page TAG04 || fail "TAG04 (LaunchDaemon path) must PAGE by path"
+# /System -> skipped
+in_page TAG05 && fail "TAG05 (/System Apple agent) must be skipped, but it paged"
+
+# Under default-deny nothing here digests (the digest-unknowns path is gone).
+[[ ! -s $spy ]] || fail "no persistence_launchd finding should digest under default-deny; spy got: $(cat "$spy")"
+
+# Every paged line is a CRIT finding.
+[[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$page_out")" == true ]] ||
+  fail "every paged persistence finding must carry .sev == CRIT"
+
+printf 'osquery-route-persistence-allowlist: OK (full-tuple suppress; reused-label page; UNKNOWN pages [default-deny]; LaunchDaemon pages by path; /System skipped; none digest)\n'

--- a/test/unit/osquery-route-pipeline.sh
+++ b/test/unit/osquery-route-pipeline.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# The route gate's file_events pipeline arm, wired to pipeline_verdict (B12). A
+# pipeline_integrity / launch_agents / launch_daemons file event consults the
+# verdict instead of paging unconditionally:
+#   pipeline_verdict 0 (page: tamper / cannot confirm / no manifest) -> sev=CRIT
+#   pipeline_verdict 1 (silent: untracked neighbor, or an exact manifest match) -> continue
+#
+# The manifest slice (15) does not exist yet, so a tracked change fails open to a
+# PAGE (criterion 6). This test pins both halves: the fail-open page (no manifest)
+# AND that the verdict is genuinely consulted - an untracked neighbor stays silent,
+# and a stubbed exact (path, sha256) manifest match suppresses the page.
+#
+# Unit test: fixture file_events findings under a temp HOME (so the tracked-path
+# prefixes resolve), two gate passes (no manifest, then a stubbed manifest).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+
+fail() {
+  printf 'osquery-route-pipeline: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+for h in "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER"; do
+  [[ -f $h ]] || fail "missing helper: $h"
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+spy="$work/digest-spy.ndjson"
+mkdir -p "$home/.local/libexec/osquery" "$home/.local/bin" "$home/Library/LaunchAgents"
+absent_manifest="$work/no-manifest.sha256"
+
+# A file event: q=file_events_recent, cols.category the watch category, target_path
+# the file, sha256 the event hash, action the FSEvents verb.
+fe() { # <category> <target_path> <sha256> <verb>
+  printf '{"q":"file_events_recent","act":"added","cols":{"category":"%s","target_path":"%s","sha256":"%s","action":"%s"},"ep":""}\n' \
+    "$1" "$2" "$3" "$4"
+}
+
+# run_gate <manifest> <finding...> -> page NDJSON on stdout (digests go to the spy).
+run_gate() {
+  local manifest="$1"
+  shift
+  printf '%s\n' "$@" |
+    HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" OSQUERY_PIPELINE_REHASH_DELAY=0 \
+      OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" DIGEST_SPY="$spy" bash -c '
+        source "$1"
+        source "$2"
+        source "$3"
+        digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+        route_findings
+      ' _ "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER"
+}
+
+# ---- Pass A: NO manifest. Tracked changes fail open to a page; an untracked
+#      neighbor is silent (proving the verdict is consulted, not page-always). ----
+page_a="$(run_gate "$absent_manifest" \
+  "$(fe pipeline_integrity "$home/.local/libexec/osquery/results-alerterTAG01.sh" abc UPDATED)" \
+  "$(fe pipeline_integrity "$home/.local/bin/relayTAG02.sh" abc UPDATED)" \
+  "$(fe launch_agents "$home/Library/LaunchAgents/com.webdavis.osquery-uptimeTAG03.plist" abc UPDATED)" \
+  "$(fe launch_agents "$home/Library/LaunchAgents/com.apple.somethingTAG04.plist" abc UPDATED)")"
+
+in_a() { grep -qF "$1" <<<"$page_a"; }
+in_a TAG01 || fail "a ~/.local/libexec/osquery script change must PAGE (fail-open, no manifest)"
+in_a TAG02 || fail "a ~/.local/bin script change must PAGE (fail-open, second prefix)"
+in_a TAG03 || fail "our own osquery LaunchAgent change must PAGE (fail-open)"
+in_a TAG04 && fail "an untracked neighbor plist must be SILENT (the verdict is consulted, not page-always)"
+
+# ---- Pass B: a stubbed manifest with an exact (path, sha256) match. That event
+#      is confirmed known-good and stays silent; a DELETE still pages. ----
+known_target="$home/.local/libexec/osquery/knownTAG05.sh"
+known_hash="1111111111111111111111111111111111111111111111111111111111111111"
+manifest="$work/pipeline-known-good.sha256"
+printf '%s  %s\n' "$known_hash" "$known_target" >"$manifest"
+
+page_b="$(run_gate "$manifest" \
+  "$(fe pipeline_integrity "$known_target" "$known_hash" UPDATED)" \
+  "$(fe pipeline_integrity "$home/.local/libexec/osquery/results-alerterTAG06.sh" "" DELETED)")"
+
+in_b() { grep -qF "$1" <<<"$page_b"; }
+in_b TAG05 && fail "an exact (path, sha256) manifest match must be SILENT (the verdict consults the manifest)"
+in_b TAG06 || fail "a DELETE of a tracked pipeline file must PAGE even with a manifest present"
+
+# The pipeline arm never digests; the spy must be empty.
+[[ ! -s $spy ]] || fail "a pipeline file event must never digest; spy got: $(cat "$spy")"
+
+# Every paged line is a CRIT finding.
+for out in "$page_a" "$page_b"; do
+  [[ -z $out ]] && continue
+  [[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$out")" == true ]] ||
+    fail "every paged pipeline finding must carry .sev == CRIT"
+done
+
+printf 'osquery-route-pipeline: OK (fail-open PAGE under both prefixes + own plist; neighbor SILENT; manifest exact match SILENT; delete PAGES; none digest)\n'

--- a/test/unit/osquery-route-severity.sh
+++ b/test/unit/osquery-route-severity.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# route_severity (results-alerter/route.sh) is the pure base-severity classifier
+# of the routing stage: given one normalized finding ({q, act, cols, ep}) it
+# prints CRIT, NOTICE, or INFO. It is the severity MATRIX only; the three-outcome
+# page/digest/log-only gate that can override this base tier lands in a later
+# behavior. Adapted from c69baab's sev/protection_off, rebased to test the
+# prefix-stripped q rather than the full pack-qualified .name.
+#
+#   CRIT   - a protection turned OFF (protection_off), a new admin account, or a
+#            new unexpected setuid-root binary.
+#   NOTICE - any other security-policy-regression query, a persistence_* query,
+#            a new kernel/system extension, a watched file event, or an
+#            Endpoint-Security launchd write.
+#   INFO   - everything else (installed-software drift, listening ports, logins,
+#            and the agent_* queries whose real tier the gate assigns later).
+#
+# protection_off is the criterion-2 fix: filevault_off now arrives as a
+# DIFFERENTIAL action:added row (not the old snapshot "currently-off" form), so a
+# filevault_off finding is CRIT purely on q=="filevault_off" and act=="added";
+# firewall/gatekeeper/sip page only when their state column holds the unsafe "0".
+#
+# Unit test: fixture-driven and streamed. One route_severity pass over an ordered
+# batch of findings, then assert each finding's sev against its expected tier.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+
+fail() {
+  printf 'osquery-route-severity: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+
+# route_severity reads normalized-finding NDJSON on stdin and prints one severity
+# per finding, in order. A fresh subshell keeps the sourcing side-effect-free.
+route_severity_stream() {
+  bash -c "source '$ROUTE'; route_severity"
+}
+
+# Each row: <expected-sev> <TAB> <finding-json> <TAB> <behavior label>. The
+# findings run through ONE route_severity pass; outputs are matched positionally.
+cases=(
+  # -- CRIT: protection_off (differential added) --
+  $'CRIT\t{"q":"filevault_off","act":"added","cols":{},"ep":""}\tfilevault_off differential added -> CRIT (criterion 2, no snapshot form)'
+  $'CRIT\t{"q":"firewall_state","act":"added","cols":{"global_state":"0"},"ep":""}\tfirewall_state added with global_state 0 (firewall OFF) -> CRIT'
+  $'CRIT\t{"q":"gatekeeper_state","act":"added","cols":{"assessments_enabled":"0"},"ep":""}\tgatekeeper_state added with assessments_enabled 0 (Gatekeeper OFF) -> CRIT'
+  $'CRIT\t{"q":"sip_state","act":"added","cols":{"enabled":"0"},"ep":""}\tsip_state added with enabled 0 (SIP OFF) -> CRIT'
+  # -- CRIT: new admin + new setuid binary --
+  $'CRIT\t{"q":"new_admin_user","act":"added","cols":{"username":"eve"},"ep":""}\tnew_admin_user -> CRIT (criterion 1, pages)'
+  $'CRIT\t{"q":"suid_bin_unexpected","act":"added","cols":{"path":"/tmp/x"},"ep":"/tmp/x"}\tsuid_bin_unexpected -> CRIT'
+  # -- NOT protection_off: safe/other-direction security-policy rows fall to NOTICE --
+  $'NOTICE\t{"q":"firewall_state","act":"added","cols":{"global_state":"1"},"ep":""}\tfirewall_state added with global_state 1 (re-enabled) -> NOTICE, not CRIT'
+  $'NOTICE\t{"q":"filevault_off","act":"removed","cols":{},"ep":""}\tfilevault_off removed (encryption restored) -> NOTICE, not CRIT'
+  $'NOTICE\t{"q":"filevault_state","act":"removed","cols":{},"ep":""}\tfilevault_state removed (APFS churn, issue #18) -> NOTICE, never CRIT'
+  $'NOTICE\t{"q":"remote_access_sharing_state","act":"added","cols":{},"ep":""}\tremote_access_sharing_state -> NOTICE at the matrix (gate decides page later)'
+  # -- NOTICE tier --
+  $'NOTICE\t{"q":"persistence_launchd","act":"added","cols":{},"ep":""}\tpersistence_launchd -> NOTICE'
+  $'NOTICE\t{"q":"persistence_startup_items_crontab","act":"added","cols":{},"ep":""}\tpersistence_startup_items_crontab -> NOTICE'
+  $'NOTICE\t{"q":"kernel_extensions_new","act":"added","cols":{},"ep":""}\tkernel_extensions_new -> NOTICE'
+  $'NOTICE\t{"q":"system_extensions_new","act":"added","cols":{},"ep":""}\tsystem_extensions_new -> NOTICE'
+  $'NOTICE\t{"q":"file_events_recent","act":"added","cols":{},"ep":""}\tfile_events_recent -> NOTICE'
+  $'NOTICE\t{"q":"es_launchd_writes","act":"added","cols":{},"ep":""}\tes_launchd_writes -> NOTICE'
+  # -- INFO default: installed-software drift, ports, logins, and the agent_* queries --
+  $'INFO\t{"q":"homebrew_packages","act":"added","cols":{},"ep":""}\thomebrew_packages drift -> INFO'
+  $'INFO\t{"q":"installed_apps","act":"added","cols":{},"ep":""}\tinstalled_apps drift -> INFO'
+  $'INFO\t{"q":"listening_ports_non_loopback","act":"added","cols":{},"ep":""}\tlistening_ports_non_loopback -> INFO'
+  $'INFO\t{"q":"recent_logins","act":"added","cols":{},"ep":""}\trecent_logins -> INFO'
+  $'INFO\t{"q":"agent_exposure_changed","act":"added","cols":{},"ep":""}\tagent_exposure_changed -> INFO at the matrix (gate promotes to page later)'
+)
+
+# Split the cases into parallel arrays, run one route_severity pass, compare.
+expected=()
+findings=()
+labels=()
+for row in "${cases[@]}"; do
+  IFS=$'\t' read -r sev finding label <<<"$row"
+  expected+=("$sev")
+  findings+=("$finding")
+  labels+=("$label")
+done
+
+got=()
+mapfile -t got < <(printf '%s\n' "${findings[@]}" | route_severity_stream)
+
+[[ ${#got[@]} -eq ${#expected[@]} ]] ||
+  fail "route_severity emitted ${#got[@]} severities for ${#expected[@]} findings (one per finding expected)"
+
+for i in "${!expected[@]}"; do
+  [[ ${got[i]} == "${expected[i]}" ]] ||
+    fail "${labels[i]}: expected ${expected[i]}, got ${got[i]}"
+done
+
+printf 'osquery-route-severity: OK (protection_off CRIT on differential added; new_admin_user + suid CRIT; NOTICE tier; INFO default; safe/other-direction rows are not CRIT)\n'


### PR DESCRIPTION
## Context

This repository is a chezmoi-managed dotfiles tree. One thing it deploys is an osquery
security-monitoring setup: osquery watches the machine for suspicious changes and writes them to a
differential results log, and a shell component called the results alerter reads that log and sends a
notification (a "page") whenever a security-relevant event appears, such as a new administrator account, FileVault being switched off, or an unrecognized background launch agent.

This branch lands the results alerter as a small entry script plus six single-responsibility helper
scripts, replacing an earlier single-file version. Splitting it apart makes each decision (what counts as
a finding, how severe it is, whether it should page) independently testable, and it surfaced several
security gaps this branch also closes. Every helper is covered by unit tests, and the end-to-end behavior
is pinned by scenario tests.

## Summary

- Lands the results alerter as an entry script plus six focused helpers, fully test-covered.
- An unrecognized user launch agent now pages by default; only a full allowlist match stays quiet.
- An untrusted kernel or system extension now pages instead of being logged silently.
- The launch-agent allowlist matches the full identity tuple and re-checks the on-disk program signature.
- The read cursor advances only after a page is durably stored, so a crash re-reads rather than dropping findings.
- Closes three ways a hostile log column could tamper with a page: field-separator, shell-command, and newline injection.

Key files:

- `dot_local/libexec/osquery/executable_results-alerter.sh` (entry)
- `dot_local/libexec/osquery/results-alerter/` (the six helpers: normalize, route, allowlist-verdict, pipeline-verdict, digest-store, render-page)

## What changed

The old alerter was one ~328-line script. It is now a 146-line entry that sources six helpers, each with
one job: normalize turns each raw log row into a single finding, route assigns severity and decides page
vs digest vs log-only, allowlist-verdict and pipeline-verdict answer the two suppression questions,
digest-store records non-paging findings privately, and render-page builds the notification body.

Alongside the split, several behaviors changed on purpose:

- Default-deny for launch agents. An unknown user launch agent pages; a match is required to stay quiet,
  and the match must cover the whole identity (label, path, program) and the program's current signature,
  not just the label.
- Untrusted kernel and system extensions page. An unsigned or untrusted extension is promoted to a page
  rather than filed silently.
- Durable cursor. The byte offset into the log advances only after the page is stored, so an interrupted
  run replays instead of skipping a finding.
- Hostile-input hardening. A finding's column values are treated as untrusted throughout: they cannot
  forge an allowlist entry, inject a shell command into a rendered remediation step, or forge extra lines
  in the notification body. Secret and credential file findings render by basename only, never the full
  path or hash.

## Effect of merging

Merging changes source files only. It does not apply anything to a live machine: the alerter reaches a
machine when chezmoi apply runs there. The operator's laptop applies from the integration branch, so this
merge has no live-machine impact until the planned cutover. Until then it is source state only, and CI is
the backstop that re-runs the full lint and test suite headless.
