### PR TITLE
test: stub alerter in update-skills roster-failclosed

### DIFF
--- a/test/integration/update-skills-roster-failclosed.sh
+++ b/test/integration/update-skills-roster-failclosed.sh
@@ -80,6 +80,17 @@ for s in "${skills[@]}"; do
 done
 EOF
 chmod +x "$stub/npx"
+# alerter stub: the broken-roster cases below reach update-skills' loud-alert
+# path, which shells the real `alerter --timeout 30`. Stub it so a dev machine
+# with Homebrew alerter installed does not fire a real 30-second macOS
+# notification per case (blocking the suite; the continuous-integration runner
+# has no alerter, so this stayed hidden there). No case asserts the alert, so a
+# no-op suffices; asserting siblings record $ALERTER_LOG.
+cat >"$stub/alerter" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$stub/alerter"
 export PATH="$stub:$PATH"
 
 run_full() { UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" 2>&1; }


### PR DESCRIPTION
## Context

`update-skills.sh` is this repo's weekly skills updater; when it refuses a broken run it fires a loud local `alerter` notification. Its `roster-failclosed` integration test exercised that alert path but never stubbed `alerter`, so on a developer machine with the Homebrew `alerter` installed each broken-roster case fired a real 30-second macOS notification, blocking `just test` for about 151 seconds and spamming the operator. Continuous integration never caught it because the runner has no `alerter`, so the notification was skipped there.

## Summary

- Stub `alerter` in the `roster-failclosed` test so no real notification fires.
- Unblocks local `just test`: this test drops from about 151 seconds to about 1 second.

## Effect of merging

Developer-experience only. No runtime behavior changes, and production `update-skills.sh` is untouched.
