### PR TITLE
feat(osquery): re-land the gui/501 security-posture poller

### DIFF
--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -56,25 +56,41 @@ cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
 
+# page_gap_once <marker_path> <title> <body> -- the shared page-once-via-marker
+# discipline for both the monitoring-gap and the persistence-gap paths: the same
+# notify-before-persist contract page_crit_and_persist gives the transition and
+# first-observation paths, in ONE place so the two markers cannot diverge. If the
+# marker is absent, send_alert FIRST and write the marker ONLY on success (best
+# effort: a marker in an unwritable dir cannot be written, so the page may
+# re-fire); return 0 when paged or already marked, nonzero when send_alert could
+# not store the page (so a persisting condition re-pages). The per-path bodies,
+# recovery-clear placement, and caller exit code stay OUTSIDE this helper.
+page_gap_once() {
+  local marker="$1" title="$2" body="$3"
+  if [[ -f $marker ]]; then
+    return 0
+  fi
+  if send_alert CRIT "$title" "$body" "Sosumi"; then
+    : >"$marker" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
 # R2-9 monitoring gap. Any scalar missing or out of its exact domain (firewall
 # 0/1/2, Gatekeeper 0/1, screenlock 0/1) means the security state is UNKNOWN, not
 # safe; an empty or failed read leaves all three empty and lands here too. Do NOT
 # persist it (it would poison the baseline) and do NOT compare it (it would
-# fabricate a transition): the last good baseline is preserved. Page ONCE per gap.
-# With no marker, notify FIRST (reusing the notify-before-persist durability) and
-# write the marker only on send_alert success; if send_alert cannot store the
-# page (it still fires a last-resort local banner), leave no marker, log, and exit
-# nonzero so a PERSISTING gap re-pages next tick. An existing marker suppresses
-# re-paging. (Values are bracketed, [] for empty, to keep the page apostrophe-free
+# fabricate a transition): the last good baseline is preserved. Page ONCE per gap
+# (page_gap_once); if send_alert cannot store the page (it still fires a
+# last-resort local banner), log and exit nonzero so a PERSISTING gap re-pages
+# next tick. (Values are bracketed, [] for empty, to keep the page apostrophe-free
 # for the alerting stack.)
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
-  if [[ ! -f $GAP ]]; then
-    gap_body="**Security-posture monitoring gap**"$'\n'"- The posture query returned an unreadable value (firewall=[$cur_fw] gatekeeper=[$cur_gk] screenlock=[$cur_sl]): the firewall / Gatekeeper / screen-lock state is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query by hand, then re-check."
-    if ! send_alert CRIT "🔴 **CRITICAL**" "$gap_body" "Sosumi"; then
-      printf 'firewall-gatekeeper-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
-      exit 1
-    fi
-    : >"$GAP"
+  gap_body="**Security-posture monitoring gap**"$'\n'"- The posture query returned an unreadable value (firewall=[$cur_fw] gatekeeper=[$cur_gk] screenlock=[$cur_sl]): the firewall / Gatekeeper / screen-lock state is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query by hand, then re-check."
+  if ! page_gap_once "$GAP" "🔴 **CRITICAL**" "$gap_body"; then
+    printf 'firewall-gatekeeper-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
+    exit 1
   fi
   exit 0
 fi
@@ -129,12 +145,8 @@ persist_baseline() {
     rm -f "$PERSIST_GAP" 2>/dev/null || true
     return 0
   fi
-  if [[ ! -f $PERSIST_GAP ]]; then
-    degraded_body="**Security-posture monitor degraded**"$'\n'"- The posture monitor could not persist its baseline: it cannot advance state, so a stale baseline could mask the next real change and blind the monitor."$'\n'"- Check the state directory free space and permissions. **Check now.**"
-    if send_alert CRIT "🔴 **CRITICAL**" "$degraded_body" "Sosumi"; then
-      : >"$PERSIST_GAP" 2>/dev/null || true
-    fi
-  fi
+  degraded_body="**Security-posture monitor degraded**"$'\n'"- The posture monitor could not persist its baseline: it cannot advance state, so a stale baseline could mask the next real change and blind the monitor."$'\n'"- Check the state directory free space and permissions. **Check now.**"
+  page_gap_once "$PERSIST_GAP" "🔴 **CRITICAL**" "$degraded_body" || true
   exit 1
 }
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -29,12 +29,27 @@ trap 'rm -f "$STATE.tmp"' EXIT
 
 # Read the current posture in a single combined query (one osqueryi startup per
 # tick, not one per protection). screenlock is folded in per R2-3.
-posture=$("$OSQUERYI" --json "
+#
+# Bound the query so a WEDGED osqueryi (a hung table never closes its stdout)
+# becomes a monitoring gap, not silent blindness. Without a deadline, `|| true`
+# handles an osqueryi EXIT but not a HANG, launchd skips ticks while the process
+# lives, and the uptime-watchdog cannot catch it (its probe queries a different
+# table that answers while a posture table hangs). gtimeout preferred, timeout
+# fallback (the codebase convention); if neither is on PATH, degrade to an
+# unbounded read (no worse than before; the darwin fleet has one). The bound is
+# well under the 60s tick and env-overridable. On timeout osqueryi is killed, its
+# stdout closes, and the read collapses to empty, which the gap gate below pages.
+posture_query=("$OSQUERYI" --json "
   SELECT
     (SELECT global_state FROM alf) AS firewall,
     (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper,
     (SELECT enabled FROM screenlock) AS screenlock
-" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
+")
+posture_timeout_bin="$(command -v gtimeout || command -v timeout || true)"
+if [[ -n $posture_timeout_bin ]]; then
+  posture_query=("$posture_timeout_bin" "${OSQUERY_POSTURE_TIMEOUT:-20}" "${posture_query[@]}")
+fi
+posture=$("${posture_query[@]}" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
 
 cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -69,9 +69,10 @@ if [[ -f $STATE ]]; then
 fi
 
 # Persist the current posture owner-only (0600) so a later run can trust its own
-# baseline. Written via a private temp file plus an atomic rename, and BEFORE any
-# notification, so a slow alerter cannot double-notify off a half-written state.
-# send_alert is itself write-ahead durable, so persisting first drops no page.
+# baseline. Written via a private temp file plus an atomic rename. Ordering for an
+# OFF transition is notify-before-persist (see below): the baseline advances ONLY
+# after send_alert durably enqueues the page. In steady state (no transition) it
+# just refreshes the baseline.
 write_state() {
   (
     umask 077
@@ -79,12 +80,11 @@ write_state() {
   ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
-write_state
-
 # No trustworthy prior baseline (first run, or a lost/planted/corrupt state file):
 # seed the baseline silently. Paging a protection that is ALREADY off at first
 # sight is a later behavior.
 if [[ $prev_valid -eq 0 ]]; then
+  write_state
   exit 0
 fi
 
@@ -127,12 +127,27 @@ if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
   crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
 fi
 
-# No OFF transition: silent.
-[[ ${#crit_blocks[@]} -eq 0 ]] && exit 0
+# No OFF transition (steady state or a re-enable): refresh the baseline, silent.
+if [[ ${#crit_blocks[@]} -eq 0 ]]; then
+  write_state
+  exit 0
+fi
 
-# One page for the tick, even when several protections turned off together.
+# An OFF transition: NOTIFY BEFORE PERSIST. send_alert is write-ahead durable, so
+# durably enqueue the page FIRST, then advance the baseline only once it is safely
+# queued. If send_alert fails (could not persist the page), leave the baseline on
+# its prior value and exit nonzero so the next tick re-detects and retries; do not
+# swallow the failure. A crash in the narrow window after the page is queued but
+# before the baseline advances re-pages next tick (at-least-once), never loses the
+# page. One page for the tick, even when several protections turned off together.
 body=$(printf '%s\n\n' "${crit_blocks[@]}")
 body=${body%$'\n\n'}
 title="🔴 **CRITICAL**"
 if [[ ${#crit_blocks[@]} -gt 1 ]]; then title="🔴 **CRITICAL** · ${#crit_blocks[@]}"; fi
-send_alert CRIT "$title" "$body" "Sosumi" || true
+
+if ! send_alert CRIT "$title" "$body" "Sosumi"; then
+  printf 'firewall-gatekeeper-monitor: send_alert could not queue the CRIT page; baseline not advanced, retrying next tick\n' >&2
+  exit 1
+fi
+
+write_state

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -15,7 +15,8 @@
 set -euo pipefail
 
 STATE="${OSQUERY_POSTURE_STATE:-$HOME/.local/state/osquery-posture-state.json}"
-GAP="$STATE.gap" # page-once marker for a monitoring gap (R2-9)
+GAP="$STATE.gap"                 # page-once marker for a monitoring gap (R2-9)
+PERSIST_GAP="$STATE.persist-gap" # page-once marker for a baseline-persist failure
 OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
 
 # shellcheck source=/dev/null
@@ -61,10 +62,11 @@ cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
 # persist it (it would poison the baseline) and do NOT compare it (it would
 # fabricate a transition): the last good baseline is preserved. Page ONCE per gap.
 # With no marker, notify FIRST (reusing the notify-before-persist durability) and
-# write the marker only on send_alert success; if send_alert fails, leave no
-# marker, log, and exit nonzero so the next tick retries (at-least-once). An
-# existing marker suppresses re-paging. (Values are bracketed, [] for empty, to
-# keep the page apostrophe-free for the alerting stack.)
+# write the marker only on send_alert success; if send_alert cannot store the
+# page (it still fires a last-resort local banner), leave no marker, log, and exit
+# nonzero so a PERSISTING gap re-pages next tick. An existing marker suppresses
+# re-paging. (Values are bracketed, [] for empty, to keep the page apostrophe-free
+# for the alerting stack.)
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
   if [[ ! -f $GAP ]]; then
     gap_body="**Security-posture monitoring gap**"$'\n'"- The posture query returned an unreadable value (firewall=[$cur_fw] gatekeeper=[$cur_gk] screenlock=[$cur_sl]): the firewall / Gatekeeper / screen-lock state is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query by hand, then re-check."
@@ -113,12 +115,38 @@ write_state() {
   ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
-# Emit one CRIT page built from the given blocks, then seed or advance the
-# baseline. Notify-before-persist: send_alert is write-ahead durable, so page
-# FIRST and write_state only on success; on a send_alert failure leave the
-# baseline as-is, log, and exit nonzero so the next tick re-detects and retries
-# (at-least-once). Shared by the first-observation and transition paths so both
-# obey one durability contract.
+# Persist the baseline, and make a persistence FAILURE loud rather than silent. If
+# write_state fails the monitor is degraded: it cannot advance its baseline, so a
+# stale baseline could silently mask the next real change (a stale prev=OFF reads
+# the next real OFF as steady-off, silent, permanently). Page a degraded-monitor
+# gap ONCE via its own marker, then exit nonzero so launchd retries and the stale
+# baseline is never silently trusted. On success clear the marker (recovery). The
+# marker lives in the state dir, so if that dir is itself unwritable the marker
+# cannot be written and the degraded page may re-fire, acceptable for a serious
+# ongoing fault (loud beats silently trusting a stale baseline).
+persist_baseline() {
+  if write_state; then
+    rm -f "$PERSIST_GAP" 2>/dev/null || true
+    return 0
+  fi
+  if [[ ! -f $PERSIST_GAP ]]; then
+    degraded_body="**Security-posture monitor degraded**"$'\n'"- The posture monitor could not persist its baseline: it cannot advance state, so a stale baseline could mask the next real change and blind the monitor."$'\n'"- Check the state directory free space and permissions. **Check now.**"
+    if send_alert CRIT "🔴 **CRITICAL**" "$degraded_body" "Sosumi"; then
+      : >"$PERSIST_GAP" 2>/dev/null || true
+    fi
+  fi
+  exit 1
+}
+
+# Emit one CRIT page built from the given blocks, then advance the baseline.
+# Notify-before-persist: send_alert is write-ahead durable (it stores the page
+# before any network attempt and, if it cannot even store, fires a last-resort
+# local banner), so a page is never silently dropped. The baseline advances only
+# after send_alert succeeds; on a send_alert store-failure the baseline is left
+# as-is and the poller exits nonzero, so a PERSISTING condition re-pages next tick
+# and recovers its durable/remote copy (a transient that clears before the retry
+# was still surfaced locally by the banner). Shared by the first-observation and
+# transition paths so both obey one durability contract.
 page_crit_and_persist() {
   local body title
   body=$(printf '%s\n\n' "$@")
@@ -129,7 +157,7 @@ page_crit_and_persist() {
     printf 'firewall-gatekeeper-monitor: send_alert could not queue the CRIT page; baseline not advanced, retrying next tick\n' >&2
     exit 1
   fi
-  write_state
+  persist_baseline
 }
 
 # No trustworthy prior baseline (first run, or a lost/deleted/planted/corrupt
@@ -153,7 +181,7 @@ if [[ $prev_valid -eq 0 ]]; then
     first_obs_blocks+=("**Screen lock is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the screen-lock password requirement is already off, anyone at the machine has access. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
   fi
   if [[ ${#first_obs_blocks[@]} -eq 0 ]]; then
-    write_state # healthy first observation: seed the baseline silently
+    persist_baseline # healthy first observation: seed the baseline silently
     exit 0
   fi
   page_crit_and_persist "${first_obs_blocks[@]}"
@@ -201,7 +229,7 @@ fi
 
 # No OFF transition (steady state or a re-enable): refresh the baseline, silent.
 if [[ ${#crit_blocks[@]} -eq 0 ]]; then
-  write_state
+  persist_baseline
   exit 0
 fi
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -98,11 +98,50 @@ write_state() {
   ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
-# No trustworthy prior baseline (first run, or a lost/planted/corrupt state file):
-# seed the baseline silently. Paging a protection that is ALREADY off at first
-# sight is a later behavior.
-if [[ $prev_valid -eq 0 ]]; then
+# Emit one CRIT page built from the given blocks, then seed or advance the
+# baseline. Notify-before-persist: send_alert is write-ahead durable, so page
+# FIRST and write_state only on success; on a send_alert failure leave the
+# baseline as-is, log, and exit nonzero so the next tick re-detects and retries
+# (at-least-once). Shared by the first-observation and transition paths so both
+# obey one durability contract.
+page_crit_and_persist() {
+  local body title
+  body=$(printf '%s\n\n' "$@")
+  body=${body%$'\n\n'}
+  title="🔴 **CRITICAL**"
+  if [[ $# -gt 1 ]]; then title="🔴 **CRITICAL** · $#"; fi
+  if ! send_alert CRIT "$title" "$body" "Sosumi"; then
+    printf 'firewall-gatekeeper-monitor: send_alert could not queue the CRIT page; baseline not advanced, retrying next tick\n' >&2
+    exit 1
+  fi
   write_state
+}
+
+# No trustworthy prior baseline (first run, or a lost/deleted/planted/corrupt
+# state file). DIVERGENCE from c69baab's silent first-run seed (F4, banked from
+# the slice-6 alerter review): the alerter log-onlys firewall/Gatekeeper
+# off-events and relies on THIS poller to page them, so a protection ALREADY off
+# with no prior baseline would otherwise be silently accepted and go unpaged
+# forever. Page each already-off protection as a first-observation exposure
+# (screenlock too: it is poller-only, and an already-off lock is a real exposure),
+# with the same notify-before-persist durability. If all three are ON, seed
+# silently.
+if [[ $prev_valid -eq 0 ]]; then
+  first_obs_blocks=()
+  if [[ $cur_fw == "0" ]]; then
+    first_obs_blocks+=("**Firewall is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the firewall is already off, a pre-existing exposure. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
+  fi
+  if [[ $cur_gk == "0" ]]; then
+    first_obs_blocks+=("**Gatekeeper is OFF (first observation)**"$'\n'"- **Now:** **DISABLED**"$'\n'"- The monitor has no prior baseline and Gatekeeper is already disabled, a pre-existing exposure. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security")
+  fi
+  if [[ $cur_sl == "0" ]]; then
+    first_obs_blocks+=("**Screen lock is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the screen-lock password requirement is already off, anyone at the machine has access. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
+  fi
+  if [[ ${#first_obs_blocks[@]} -eq 0 ]]; then
+    write_state # healthy first observation: seed the baseline silently
+    exit 0
+  fi
+  page_crit_and_persist "${first_obs_blocks[@]}"
   exit 0
 fi
 
@@ -151,21 +190,6 @@ if [[ ${#crit_blocks[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# An OFF transition: NOTIFY BEFORE PERSIST. send_alert is write-ahead durable, so
-# durably enqueue the page FIRST, then advance the baseline only once it is safely
-# queued. If send_alert fails (could not persist the page), leave the baseline on
-# its prior value and exit nonzero so the next tick re-detects and retries; do not
-# swallow the failure. A crash in the narrow window after the page is queued but
-# before the baseline advances re-pages next tick (at-least-once), never loses the
-# page. One page for the tick, even when several protections turned off together.
-body=$(printf '%s\n\n' "${crit_blocks[@]}")
-body=${body%$'\n\n'}
-title="🔴 **CRITICAL**"
-if [[ ${#crit_blocks[@]} -gt 1 ]]; then title="🔴 **CRITICAL** · ${#crit_blocks[@]}"; fi
-
-if ! send_alert CRIT "$title" "$body" "Sosumi"; then
-  printf 'firewall-gatekeeper-monitor: send_alert could not queue the CRIT page; baseline not advanced, retrying next tick\n' >&2
-  exit 1
-fi
-
-write_state
+# An OFF transition: page (notify-before-persist), then advance the baseline. One
+# page for the tick, even when several protections turned off together.
+page_crit_and_persist "${crit_blocks[@]}"

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 STATE="${OSQUERY_POSTURE_STATE:-$HOME/.local/state/osquery-posture-state.json}"
+GAP="$STATE.gap" # page-once marker for a monitoring gap (R2-9)
 OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
 
 # shellcheck source=/dev/null
@@ -35,29 +36,35 @@ posture=$("$OSQUERYI" --json "
     (SELECT enabled FROM screenlock) AS screenlock
 " 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
 
-# A failed or empty read (osqueryi missing, the daemon not up on a fresh boot, or
-# the tables transiently unavailable) leaves posture empty or null. Do NOT persist
-# that over a good baseline: a blank baseline would blind or misfeed the next
-# run's comparison. Exit and let the next tick retry, preserving the last good
-# baseline. Paging on an unreadable posture (the monitoring-gap marker) is a
-# later behavior.
-if [[ -z $posture || $posture == "null" ]]; then
-  exit 0
-fi
-
 cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
 
-# Validate every scalar against its exact domain (firewall 0/1/2, Gatekeeper 0/1,
-# screenlock 0/1). A partial or out-of-domain reading is a monitoring gap: the
-# security state is UNKNOWN, not safe. Treat it as a failed read: do NOT persist it
-# (it would poison the baseline) and do NOT compare it (it would fabricate a
-# transition). Preserve the last good baseline and exit. PAGING this gap is a later
-# behavior (B3).
+# R2-9 monitoring gap. Any scalar missing or out of its exact domain (firewall
+# 0/1/2, Gatekeeper 0/1, screenlock 0/1) means the security state is UNKNOWN, not
+# safe; an empty or failed read leaves all three empty and lands here too. Do NOT
+# persist it (it would poison the baseline) and do NOT compare it (it would
+# fabricate a transition): the last good baseline is preserved. Page ONCE per gap.
+# With no marker, notify FIRST (reusing the notify-before-persist durability) and
+# write the marker only on send_alert success; if send_alert fails, leave no
+# marker, log, and exit nonzero so the next tick retries (at-least-once). An
+# existing marker suppresses re-paging. (Values are bracketed, [] for empty, to
+# keep the page apostrophe-free for the alerting stack.)
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
+  if [[ ! -f $GAP ]]; then
+    gap_body="**Security-posture monitoring gap**"$'\n'"- The posture query returned an unreadable value (firewall=[$cur_fw] gatekeeper=[$cur_gk] screenlock=[$cur_sl]): the firewall / Gatekeeper / screen-lock state is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query by hand, then re-check."
+    if ! send_alert CRIT "🔴 **CRITICAL**" "$gap_body" "Sosumi"; then
+      printf 'firewall-gatekeeper-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
+      exit 1
+    fi
+    : >"$GAP"
+  fi
   exit 0
 fi
+
+# A valid read cleared the gap (recovery): drop the marker so a future gap pages
+# again. Done before the normal transition/persist logic.
+rm -f "$GAP" 2>/dev/null || true
 
 # Validate any existing baseline BEFORE trusting it (and before write_state
 # overwrites it): it must be owner-only (mode 600) AND parse to three in-domain

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -49,10 +49,21 @@ cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
 
+# Validate every scalar against its exact domain (firewall 0/1/2, Gatekeeper 0/1,
+# screenlock 0/1). A partial or out-of-domain reading is a monitoring gap: the
+# security state is UNKNOWN, not safe. Treat it as a failed read: do NOT persist it
+# (it would poison the baseline) and do NOT compare it (it would fabricate a
+# transition). Preserve the last good baseline and exit. PAGING this gap is a later
+# behavior (B3).
+if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
+  exit 0
+fi
+
 # Validate any existing baseline BEFORE trusting it (and before write_state
-# overwrites it): it must be owner-only (mode 600) AND parse to three integer
-# states. A group/world-readable or corrupt baseline is not trustworthy (it could
-# be planted to mask a disabled protection), so it is treated as no prior
+# overwrites it): it must be owner-only (mode 600) AND parse to three in-domain
+# scalars (same domains as above). A group/world-readable, corrupt, or
+# out-of-domain baseline is not trustworthy (it could be planted to mask a
+# disabled protection, or fabricate a transition), so it is treated as no prior
 # baseline. GNU-first stat, BSD fallback.
 prev_valid=0
 prev_fw=""
@@ -63,7 +74,7 @@ if [[ -f $STATE ]]; then
   prev_fw=$(jq -r '.firewall // empty' <"$STATE" 2>/dev/null || echo "")
   prev_gk=$(jq -r '.gatekeeper // empty' <"$STATE" 2>/dev/null || echo "")
   prev_sl=$(jq -r '.screenlock // empty' <"$STATE" 2>/dev/null || echo "")
-  if [[ $st_mode == "600" && $prev_fw =~ ^[0-9]+$ && $prev_gk =~ ^[0-9]+$ && $prev_sl =~ ^[0-9]+$ ]]; then
+  if [[ $st_mode == "600" && $prev_fw =~ ^[012]$ && $prev_gk =~ ^[01]$ && $prev_sl =~ ^[01]$ ]]; then
     prev_valid=1
   fi
 fi

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -2,8 +2,9 @@
 #
 # firewall-gatekeeper-monitor.sh, polled every 60s by a launchd StartInterval
 # agent. The security-posture monitor: it reads the live firewall (alf),
-# Gatekeeper, AND screen-lock state via osqueryi in the gui/501 user session and
-# persists it as an owner-only baseline that a later run compares against.
+# Gatekeeper, AND screen-lock state via osqueryi in the gui/501 user session,
+# compares against the previous run's baseline, and pages CRIT only on a
+# protection turning OFF. Silent in steady state.
 #
 # R2-3: screen-lock-off detection lives HERE, not in the root-daemon pack. The
 # screenlock osquery table is scoped to the logged-in user, so the ROOT osqueryd
@@ -44,9 +45,33 @@ if [[ -z $posture || $posture == "null" ]]; then
   exit 0
 fi
 
+cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
+cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")
+cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
+
+# Validate any existing baseline BEFORE trusting it (and before write_state
+# overwrites it): it must be owner-only (mode 600) AND parse to three integer
+# states. A group/world-readable or corrupt baseline is not trustworthy (it could
+# be planted to mask a disabled protection), so it is treated as no prior
+# baseline. GNU-first stat, BSD fallback.
+prev_valid=0
+prev_fw=""
+prev_gk=""
+prev_sl=""
+if [[ -f $STATE ]]; then
+  st_mode=$(stat -c '%a' "$STATE" 2>/dev/null || stat -f '%Lp' "$STATE" 2>/dev/null || echo "")
+  prev_fw=$(jq -r '.firewall // empty' <"$STATE" 2>/dev/null || echo "")
+  prev_gk=$(jq -r '.gatekeeper // empty' <"$STATE" 2>/dev/null || echo "")
+  prev_sl=$(jq -r '.screenlock // empty' <"$STATE" 2>/dev/null || echo "")
+  if [[ $st_mode == "600" && $prev_fw =~ ^[0-9]+$ && $prev_gk =~ ^[0-9]+$ && $prev_sl =~ ^[0-9]+$ ]]; then
+    prev_valid=1
+  fi
+fi
+
 # Persist the current posture owner-only (0600) so a later run can trust its own
 # baseline. Written via a private temp file plus an atomic rename, and BEFORE any
 # notification, so a slow alerter cannot double-notify off a half-written state.
+# send_alert is itself write-ahead durable, so persisting first drops no page.
 write_state() {
   (
     umask 077
@@ -55,3 +80,59 @@ write_state() {
 }
 
 write_state
+
+# No trustworthy prior baseline (first run, or a lost/planted/corrupt state file):
+# seed the baseline silently. Paging a protection that is ALREADY off at first
+# sight is a later behavior.
+if [[ $prev_valid -eq 0 ]]; then
+  exit 0
+fi
+
+# Human-readable state text for the Was: line of each transition block.
+fw_to_text() {
+  case "$1" in
+    0) echo "OFF" ;;
+    1) echo "on (allow signed)" ;;
+    2) echo "on (block all)" ;;
+    *) echo "?($1)" ;;
+  esac
+}
+gk_to_text() {
+  case "$1" in
+    0) echo "DISABLED" ;;
+    1) echo "enabled" ;;
+    *) echo "?($1)" ;;
+  esac
+}
+sl_to_text() {
+  case "$1" in
+    0) echo "OFF" ;;
+    1) echo "on" ;;
+    *) echo "?($1)" ;;
+  esac
+}
+
+# A trusted baseline exists: page CRIT only on a protection turning OFF. A
+# re-enable (OFF -> ON) is good news, not actionable, and there is no notice
+# channel, so it is silent. Each block mirrors the results-alerter protection-off
+# shape: bold header, Was/Now state, then a decision-first next step.
+crit_blocks=()
+if [[ $cur_fw != "$prev_fw" && $cur_fw == "0" ]]; then
+  crit_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(fw_to_text "$prev_fw")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
+fi
+if [[ $cur_gk != "$prev_gk" && $cur_gk == "0" ]]; then
+  crit_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gk_to_text "$prev_gk")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security")
+fi
+if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
+  crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
+fi
+
+# No OFF transition: silent.
+[[ ${#crit_blocks[@]} -eq 0 ]] && exit 0
+
+# One page for the tick, even when several protections turned off together.
+body=$(printf '%s\n\n' "${crit_blocks[@]}")
+body=${body%$'\n\n'}
+title="🔴 **CRITICAL**"
+if [[ ${#crit_blocks[@]} -gt 1 ]]; then title="🔴 **CRITICAL** · ${#crit_blocks[@]}"; fi
+send_alert CRIT "$title" "$body" "Sosumi" || true

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 #
 # firewall-gatekeeper-monitor.sh, polled every 60s by a launchd StartInterval
-# agent. Queries the live firewall (alf) and gatekeeper state via osqueryi,
-# compares against the previous run, and fires alerter only on transitions.
-# Silent in steady state.
+# agent. The security-posture monitor: it reads the live firewall (alf),
+# Gatekeeper, AND screen-lock state via osqueryi in the gui/501 user session and
+# persists it as an owner-only baseline that a later run compares against.
+#
+# R2-3: screen-lock-off detection lives HERE, not in the root-daemon pack. The
+# screenlock osquery table is scoped to the logged-in user, so the ROOT osqueryd
+# daemon (no user session) never returns a screenlock row (the pack's screenlock
+# queries were dead). This poller runs as a gui/501 user LaunchAgent whose
+# osqueryi DOES have the user session, so it is the correct place to read it.
 
 set -euo pipefail
 
@@ -15,88 +21,23 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 
 mkdir -p "$(dirname "$STATE")"
 
-# Read current posture in a single combined query so we get one osqueryi
-# startup per tick instead of two.
-posture="$("$OSQUERYI" --json "
+# Read the current posture in a single combined query (one osqueryi startup per
+# tick, not one per protection). screenlock is folded in per R2-3.
+posture=$("$OSQUERYI" --json "
   SELECT
     (SELECT global_state FROM alf) AS firewall,
-    (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper
-" 2>/dev/null | jq -c '.[0]')"
+    (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper,
+    (SELECT enabled FROM screenlock) AS screenlock
+" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
 
-if [[ -z $posture || $posture == "null" ]]; then
-  # osqueryi failed (daemon not up yet on fresh boot, or alf/gatekeeper
-  # tables transiently unavailable). Exit silently; next tick will retry.
-  exit 0
-fi
-
-current_firewall="$(jq -r '.firewall' <<<"$posture")"
-current_gatekeeper="$(jq -r '.gatekeeper' <<<"$posture")"
-
-# First run: write state and exit. No notification: we don't know what the
-# previous state was, so we can't claim a transition.
-if [[ ! -f $STATE ]]; then
-  printf '%s\n' "$posture" >"$STATE"
-  exit 0
-fi
-
-previous_firewall="$(jq -r '.firewall' <"$STATE")"
-previous_gatekeeper="$(jq -r '.gatekeeper' <"$STATE")"
-
-# Update state file BEFORE notification so a slow alerter can't cause duplicate
-# notifications on the next tick.
-printf '%s\n' "$posture" >"$STATE"
-
-# Build human-readable messages for each transition.
-firewall_state_text() {
-  case "$1" in
-    0) echo "OFF" ;;
-    1) echo "on (allow signed)" ;;
-    2) echo "on (block all)" ;;
-    *) echo "?($1)" ;;
-  esac
-}
-gatekeeper_state_text() {
-  case "$1" in
-    0) echo "DISABLED" ;;
-    1) echo "enabled" ;;
-    *) echo "?($1)" ;;
-  esac
+# Persist the current posture owner-only (0600) so a later run can trust its own
+# baseline. Written via a private temp file plus an atomic rename, and BEFORE any
+# notification, so a slow alerter cannot double-notify off a half-written state.
+write_state() {
+  (
+    umask 077
+    printf '%s\n' "$posture" >"$STATE.tmp"
+  ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
-# A protection turning OFF is CRITICAL → a focused #priority block; a re-enable is
-# a NOTICE → a compact #osquery line. The block mirrors osquery-results-alerter's
-# protection-off shape: bold header, Was/Now state, then a decision-first next step
-# ("Did you turn this off? …") ahead of the re-enable line.
-critical_blocks=()
-notice_lines=()
-
-if [[ $current_firewall != "$previous_firewall" ]]; then
-  if [[ $current_firewall == "0" ]]; then
-    critical_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(firewall_state_text "$previous_firewall")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did: **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
-  else
-    notice_lines+=("🟡 **Firewall**: from: $(firewall_state_text "$previous_firewall"), to: $(firewall_state_text "$current_firewall")")
-  fi
-fi
-if [[ $current_gatekeeper != "$previous_gatekeeper" ]]; then
-  if [[ $current_gatekeeper == "0" ]]; then
-    critical_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gatekeeper_state_text "$previous_gatekeeper")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did: **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security")
-  else
-    notice_lines+=("🟡 **Gatekeeper**: from: $(gatekeeper_state_text "$previous_gatekeeper"), to: $(gatekeeper_state_text "$current_gatekeeper")")
-  fi
-fi
-
-# No transitions. Silent.
-[[ ${#critical_blocks[@]} -eq 0 && ${#notice_lines[@]} -eq 0 ]] && exit 0
-
-if [[ ${#critical_blocks[@]} -gt 0 ]]; then
-  body="$(printf '%s\n\n' "${critical_blocks[@]}")"
-  body=${body%$'\n\n'}
-  title="🔴 **CRITICAL**"
-  if [[ ${#critical_blocks[@]} -gt 1 ]]; then title="🔴 **CRITICAL** · ${#critical_blocks[@]}"; fi
-  send_alert CRIT "$title" "$body" "Sosumi"
-fi
-if [[ ${#notice_lines[@]} -gt 0 ]]; then
-  body="$(printf '%s\n' "${notice_lines[@]}")"
-  body=${body%$'\n'}
-  send_alert NOTICE "🟡 **Notice** · ${#notice_lines[@]}" "$body" "Glass"
-fi
+write_state

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -21,6 +21,10 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 
 mkdir -p "$(dirname "$STATE")"
 
+# Never leave a partial temp baseline behind, on any exit path (a mid-write
+# failure, or the empty-read guard below).
+trap 'rm -f "$STATE.tmp"' EXIT
+
 # Read the current posture in a single combined query (one osqueryi startup per
 # tick, not one per protection). screenlock is folded in per R2-3.
 posture=$("$OSQUERYI" --json "
@@ -29,6 +33,16 @@ posture=$("$OSQUERYI" --json "
     (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper,
     (SELECT enabled FROM screenlock) AS screenlock
 " 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
+
+# A failed or empty read (osqueryi missing, the daemon not up on a fresh boot, or
+# the tables transiently unavailable) leaves posture empty or null. Do NOT persist
+# that over a good baseline: a blank baseline would blind or misfeed the next
+# run's comparison. Exit and let the next tick retry, preserving the last good
+# baseline. Paging on an unreadable posture (the monitoring-gap marker) is a
+# later behavior.
+if [[ -z $posture || $posture == "null" ]]; then
+  exit 0
+fi
 
 # Persist the current posture owner-only (0600) so a later run can trust its own
 # baseline. Written via a private temp file plus an atomic rename, and BEFORE any

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -72,15 +72,24 @@ SHIM
   # never delivers; it records each call's argv and whether the baseline already
   # existed at call time, so a test can prove persist happens before any page.
   export POLLER_SEND_ALERT_LOG="$POLLER_HOME/send-alert.log"
+  export POLLER_SEND_ALERT_SEVERITY="$POLLER_HOME/send-alert-severity.log"
   export POLLER_SEND_ALERT_STATE_WITNESS="$POLLER_HOME/send-alert-state-witness.log"
+  export POLLER_SEND_ALERT_STATE_AT_CALL="$POLLER_HOME/send-alert-state-at-call.log"
   : >"$POLLER_SEND_ALERT_LOG"
+  : >"$POLLER_SEND_ALERT_SEVERITY"
   : >"$POLLER_SEND_ALERT_STATE_WITNESS"
+  : >"$POLLER_SEND_ALERT_STATE_AT_CALL"
   cat >"$POLLER_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
 # shellcheck shell=bash
 send_alert() {
+  # Severity (arg 1) on its own line: one line per call, so a test counts pages.
+  printf '%s\n' "${1:-}" >>"$POLLER_SEND_ALERT_SEVERITY"
+  # Full argv (severity, title, body, sound) for body/naming assertions.
   printf '%s\n' "$*" >>"$POLLER_SEND_ALERT_LOG"
   if [[ -f ${OSQUERY_POSTURE_STATE:-/nonexistent} ]]; then
     printf 'state-present\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
+    # The baseline as it stood when the page fired: proves write_state ran first.
+    cat "$OSQUERY_POSTURE_STATE" >>"$POLLER_SEND_ALERT_STATE_AT_CALL"
   else
     printf 'state-absent\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
   fi
@@ -192,6 +201,66 @@ assert_baseline_unchanged() {
     printf 'expected the baseline byte-for-byte preserved.\nsnapshot:\n%s\nnow:\n%s\n' \
       "$(cat "$POLLER_HOME/baseline.snapshot" 2>/dev/null || echo '(no snapshot)')" \
       "$(cat "$OSQUERY_POSTURE_STATE" 2>/dev/null || echo '(missing)')" >&2
+    return 1
+  fi
+}
+
+# assert_page_count <n> -- send_alert was called exactly <n> times (one severity
+# line per call; the body may span many lines, so the severity log is the count).
+assert_page_count() {
+  local count
+  count=$(wc -l <"$POLLER_SEND_ALERT_SEVERITY")
+  count=${count//[[:space:]]/}
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s page(s), got %s; send_alert log:\n%s\n' \
+      "$1" "$count" "$(cat "$POLLER_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_severity_is <severity> -- a page fired and every page carried
+# <severity> (only a CRIT reaches the #priority webhook, so the severity arg is
+# the security-relevant one, not just the title text).
+assert_page_severity_is() {
+  if [[ ! -s $POLLER_SEND_ALERT_SEVERITY ]]; then
+    printf 'expected a %s page, but send_alert was never called\n' "$1" >&2
+    return 1
+  fi
+  if grep -qvxF "$1" "$POLLER_SEND_ALERT_SEVERITY"; then
+    printf 'expected every page at severity %s, got:\n%s\n' \
+      "$1" "$(cat "$POLLER_SEND_ALERT_SEVERITY")" >&2
+    return 1
+  fi
+}
+
+# assert_page_body_has <substring> -- some page's argv contained <substring> (the
+# body names which protection turned off, or its prior state text).
+assert_page_body_has() {
+  if ! grep -qF -- "$1" "$POLLER_SEND_ALERT_LOG"; then
+    printf 'expected a page naming %s; send_alert log:\n%s\n' \
+      "$1" "$(cat "$POLLER_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_body_lacks <substring> -- no page mentioned <substring> (a steady
+# protection is never named in an unrelated transition's page).
+assert_page_body_lacks() {
+  if grep -qF -- "$1" "$POLLER_SEND_ALERT_LOG"; then
+    printf 'expected NO page mentioning %s; send_alert log:\n%s\n' \
+      "$1" "$(cat "$POLLER_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_saw_baseline <compact-json> -- at the moment send_alert fired, the
+# persisted baseline already held <compact-json>, proving write_state ran before
+# the page (the ordering that lets a slow alerter never double-page off a stale
+# baseline).
+assert_page_saw_baseline() {
+  if ! grep -qF -- "$1" "$POLLER_SEND_ALERT_STATE_AT_CALL"; then
+    printf 'expected the baseline at page time to be %s; saw:\n%s\n' \
+      "$1" "$(cat "$POLLER_SEND_ALERT_STATE_AT_CALL" 2>/dev/null || echo '(none)')" >&2
     return 1
   fi
 }

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Test harness (makeSUT) for the security-posture poller
+# (dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh).
+#
+# The poller runs as a gui/501 user LaunchAgent every 60s: it reads the live
+# firewall (alf), Gatekeeper, and screen-lock posture through osqueryi and
+# persists it as an owner-only baseline. This harness stands the poller up in
+# isolation and records what it does through two recording spies:
+#
+#   - a programmable, recording osqueryi stub: it appends the SQL it was handed
+#     to $POLLER_OSQUERYI_QUERY and a marker per call to $POLLER_OSQUERYI_CALLS,
+#     then prints $POLLER_OSQUERYI_JSON, so a test sets a known posture and can
+#     prove BOTH what the poller asked for and what it read, with no real
+#     osquery/launchd dependency; and
+#   - a recording send_alert spy, installed as a stand-in dispatch library at the
+#     new libexec path the poller sources ($HOME/.local/libexec/osquery/
+#     alert-dispatch.sh). It never delivers; it records each call's argv and
+#     whether the baseline already existed at the moment of the call, so a test
+#     can prove the poller stays silent AND that any page fires only AFTER the
+#     baseline is written.
+#
+# A fresh temp HOME keeps every run off the operator's real ~/.local/state and
+# ~/.local/libexec. Sourced by the poller suite; no main.
+
+POLLER_TOOL="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh"
+
+# set_posture <json-array> -- the JSON array of row objects the osqueryi stub
+# returns. osquery --json emits an array and the poller reads .[0]; scalars are
+# strings, matching osquery's JSON output for these integer columns.
+set_posture() {
+  export POLLER_OSQUERYI_JSON="$1"
+}
+
+setup_poller_harness() {
+  export POLLER_HOME
+  POLLER_HOME="$(mktemp -d)"
+  # Ownership marker set only after our own mktemp, so teardown removes this
+  # path and never a pre-set or inherited POLLER_HOME.
+  _POLLER_HARNESS_OWNED_DIR="$POLLER_HOME"
+
+  mkdir -p "$POLLER_HOME/bin" \
+    "$POLLER_HOME/.local/libexec/osquery" \
+    "$POLLER_HOME/.local/state"
+
+  # The env-overridable baseline path, under the sandbox HOME.
+  export OSQUERY_POSTURE_STATE="$POLLER_HOME/.local/state/osquery-posture-state.json"
+
+  # Recording osqueryi stub: log the query and a per-call marker, then print the
+  # programmed posture. It ignores the SQL for its OUTPUT (the test drives the
+  # posture directly) but RECORDS it so a test can assert the read shape.
+  export POLLER_OSQUERYI_QUERY="$POLLER_HOME/osqueryi-query.log"
+  export POLLER_OSQUERYI_CALLS="$POLLER_HOME/osqueryi-calls.log"
+  : >"$POLLER_OSQUERYI_QUERY"
+  : >"$POLLER_OSQUERYI_CALLS"
+  cat >"$POLLER_HOME/bin/osqueryi" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$POLLER_OSQUERYI_QUERY"
+printf 'call\n' >>"$POLLER_OSQUERYI_CALLS"
+printf '%s\n' "${POLLER_OSQUERYI_JSON:-[]}"
+SHIM
+  chmod +x "$POLLER_HOME/bin/osqueryi"
+  export POLLER_OSQUERYI="$POLLER_HOME/bin/osqueryi"
+
+  # Recording send_alert spy at the NEW dispatch path the poller sources. It
+  # never delivers; it records each call's argv and whether the baseline already
+  # existed at call time, so a test can prove persist happens before any page.
+  export POLLER_SEND_ALERT_LOG="$POLLER_HOME/send-alert.log"
+  export POLLER_SEND_ALERT_STATE_WITNESS="$POLLER_HOME/send-alert-state-witness.log"
+  : >"$POLLER_SEND_ALERT_LOG"
+  : >"$POLLER_SEND_ALERT_STATE_WITNESS"
+  cat >"$POLLER_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
+# shellcheck shell=bash
+send_alert() {
+  printf '%s\n' "$*" >>"$POLLER_SEND_ALERT_LOG"
+  if [[ -f ${OSQUERY_POSTURE_STATE:-/nonexistent} ]]; then
+    printf 'state-present\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
+  else
+    printf 'state-absent\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
+  fi
+}
+SHIM
+
+  # Default posture: all protections ON (healthy). A test overrides via
+  # set_posture before running the poller.
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+}
+
+teardown_poller_harness() {
+  [[ -n ${_POLLER_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_POLLER_HARNESS_OWNED_DIR"
+  unset _POLLER_HARNESS_OWNED_DIR
+}
+
+# run_poller [args...] -- run the poller under the harness env. HOME is the temp
+# home so the sourced dispatch spy and the default state path resolve inside the
+# sandbox; OSQUERYI points at the recording stub.
+run_poller() {
+  HOME="$POLLER_HOME" \
+    OSQUERYI="$POLLER_OSQUERYI" \
+    OSQUERY_POSTURE_STATE="$OSQUERY_POSTURE_STATE" \
+    bash "$POLLER_TOOL" "$@"
+}
+
+# assert_mode <octal> <path> -- the path carries the expected permission bits.
+# GNU stat first (the nix shell), BSD stat as the fallback (the portable order).
+assert_mode() {
+  local mode
+  mode=$(stat -c '%a' "$2" 2>/dev/null || stat -f '%Lp' "$2" 2>/dev/null)
+  if [[ $mode != "$1" ]]; then
+    printf 'expected mode %s on %s, got %s\n' "$1" "$2" "$mode" >&2
+    return 1
+  fi
+}
+
+# assert_osqueryi_call_count <n> -- the poller invoked osqueryi exactly <n>
+# times (one combined query per tick, not one per protection).
+assert_osqueryi_call_count() {
+  local count
+  count=$(wc -l <"$POLLER_OSQUERYI_CALLS") # one marker line per invocation
+  count=${count//[[:space:]]/}
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s osqueryi call(s), got %s\n' "$1" "$count" >&2
+    return 1
+  fi
+}
+
+# assert_query_reads <substring> -- the recorded osqueryi query contains
+# <substring> (a table/column the combined read must ask for).
+assert_query_reads() {
+  if ! grep -qF -- "$1" "$POLLER_OSQUERYI_QUERY"; then
+    printf 'expected the osqueryi query to read %s; query was:\n%s\n' \
+      "$1" "$(cat "$POLLER_OSQUERYI_QUERY")" >&2
+    return 1
+  fi
+}
+
+# assert_baseline_scalar <key> <value> -- the persisted baseline's <key> equals
+# <value> (a JSON scalar, string-typed as osquery emits).
+assert_baseline_scalar() {
+  local got
+  got=$(jq -r --arg k "$1" '.[$k] // empty' "$OSQUERY_POSTURE_STATE" 2>/dev/null || echo "")
+  if [[ $got != "$2" ]]; then
+    printf 'expected baseline .%s == %s, got %q; baseline:\n%s\n' \
+      "$1" "$2" "$got" "$(cat "$OSQUERY_POSTURE_STATE" 2>/dev/null || echo '(no file)')" >&2
+    return 1
+  fi
+}
+
+# assert_no_page -- the poller did not call send_alert at all (silent).
+assert_no_page() {
+  if [[ -s $POLLER_SEND_ALERT_LOG ]]; then
+    printf 'expected NO page, but send_alert was called:\n%s\n' \
+      "$(cat "$POLLER_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_persist_before_notify -- no send_alert call ever saw a missing baseline,
+# so every notification (if any) fired only AFTER the baseline was written.
+assert_persist_before_notify() {
+  if grep -qF 'state-absent' "$POLLER_SEND_ALERT_STATE_WITNESS" 2>/dev/null; then
+    printf 'expected the baseline to exist before any notification, but a send_alert call saw it missing\n' >&2
+    return 1
+  fi
+}

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -56,6 +56,13 @@ setup_poller_harness() {
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$POLLER_OSQUERYI_QUERY"
 printf 'call\n' >>"$POLLER_OSQUERYI_CALLS"
+# POLLER_OSQUERYI_SLEEP models a wedged or slow query. exec into sleep so this is
+# a SINGLE process (no child holding stdout open): a timeout kill then closes the
+# pipe at the bound. It never emits, so a bounded poller reads empty and gaps;
+# an unbounded poller blocks until the sleep ends.
+if [[ -n ${POLLER_OSQUERYI_SLEEP:-} ]]; then
+  exec sleep "$POLLER_OSQUERYI_SLEEP"
+fi
 # POLLER_OSQUERYI_EXIT models a hard osqueryi failure: a non-zero value means no
 # stdout and that exit status (a missing binary, or the daemon not up on a fresh
 # boot). Zero, the default, prints the programmed posture.

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -76,15 +76,13 @@ SHIM
   export POLLER_OSQUERYI="$POLLER_HOME/bin/osqueryi"
 
   # Recording send_alert spy at the NEW dispatch path the poller sources. It
-  # never delivers; it records each call's argv and whether the baseline already
-  # existed at call time, so a test can prove persist happens before any page.
+  # never delivers; it records each call's argv and the baseline as it stood at
+  # call time, so a test can prove the ordering (notify-before-persist).
   export POLLER_SEND_ALERT_LOG="$POLLER_HOME/send-alert.log"
   export POLLER_SEND_ALERT_SEVERITY="$POLLER_HOME/send-alert-severity.log"
-  export POLLER_SEND_ALERT_STATE_WITNESS="$POLLER_HOME/send-alert-state-witness.log"
   export POLLER_SEND_ALERT_STATE_AT_CALL="$POLLER_HOME/send-alert-state-at-call.log"
   : >"$POLLER_SEND_ALERT_LOG"
   : >"$POLLER_SEND_ALERT_SEVERITY"
-  : >"$POLLER_SEND_ALERT_STATE_WITNESS"
   : >"$POLLER_SEND_ALERT_STATE_AT_CALL"
   cat >"$POLLER_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
 # shellcheck shell=bash
@@ -93,13 +91,10 @@ send_alert() {
   printf '%s\n' "${1:-}" >>"$POLLER_SEND_ALERT_SEVERITY"
   # Full argv (severity, title, body, sound) for body/naming assertions.
   printf '%s\n' "$*" >>"$POLLER_SEND_ALERT_LOG"
+  # The baseline as it stood when the page fired, so a test can prove the ordering
+  # (notify-before-persist: the baseline still holds the PRIOR value).
   if [[ -f ${OSQUERY_POSTURE_STATE:-/nonexistent} ]]; then
-    printf 'state-present\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
-    # The baseline as it stood when the page fired, so a test can prove the
-    # ordering (notify-before-persist: the baseline still holds the PRIOR value).
     cat "$OSQUERY_POSTURE_STATE" >>"$POLLER_SEND_ALERT_STATE_AT_CALL"
-  else
-    printf 'state-absent\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
   fi
   # POLLER_SEND_ALERT_EXIT models a dispatch that could NOT durably queue the
   # page (nonzero). Default 0 (queued): the poller then advances the baseline.
@@ -178,15 +173,6 @@ assert_no_page() {
   if [[ -s $POLLER_SEND_ALERT_LOG ]]; then
     printf 'expected NO page, but send_alert was called:\n%s\n' \
       "$(cat "$POLLER_SEND_ALERT_LOG")" >&2
-    return 1
-  fi
-}
-
-# assert_persist_before_notify -- no send_alert call ever saw a missing baseline,
-# so every notification (if any) fired only AFTER the baseline was written.
-assert_persist_before_notify() {
-  if grep -qF 'state-absent' "$POLLER_SEND_ALERT_STATE_WITNESS" 2>/dev/null; then
-    printf 'expected the baseline to exist before any notification, but a send_alert call saw it missing\n' >&2
     return 1
   fi
 }

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -56,6 +56,13 @@ setup_poller_harness() {
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$POLLER_OSQUERYI_QUERY"
 printf 'call\n' >>"$POLLER_OSQUERYI_CALLS"
+# POLLER_OSQUERYI_EXIT models a hard osqueryi failure: a non-zero value means no
+# stdout and that exit status (a missing binary, or the daemon not up on a fresh
+# boot). Zero, the default, prints the programmed posture.
+exit_code="${POLLER_OSQUERYI_EXIT:-0}"
+if [[ $exit_code -ne 0 ]]; then
+  exit "$exit_code"
+fi
 printf '%s\n' "${POLLER_OSQUERYI_JSON:-[]}"
 SHIM
   chmod +x "$POLLER_HOME/bin/osqueryi"
@@ -160,6 +167,31 @@ assert_no_page() {
 assert_persist_before_notify() {
   if grep -qF 'state-absent' "$POLLER_SEND_ALERT_STATE_WITNESS" 2>/dev/null; then
     printf 'expected the baseline to exist before any notification, but a send_alert call saw it missing\n' >&2
+    return 1
+  fi
+}
+
+# seed_baseline <compact-json-object> -- write a known-good posture baseline at
+# 0600, so a sad-path test can prove a failed or empty read leaves it untouched.
+seed_baseline() {
+  mkdir -p "$(dirname "$OSQUERY_POSTURE_STATE")"
+  printf '%s\n' "$1" >"$OSQUERY_POSTURE_STATE"
+  chmod 600 "$OSQUERY_POSTURE_STATE"
+}
+
+# snapshot_baseline -- copy the current baseline aside so assert_baseline_unchanged
+# can compare byte-for-byte after a run.
+snapshot_baseline() {
+  cp "$OSQUERY_POSTURE_STATE" "$POLLER_HOME/baseline.snapshot"
+}
+
+# assert_baseline_unchanged -- the baseline is byte-for-byte identical to the last
+# snapshot (a failed or empty read must neither clobber nor blank it).
+assert_baseline_unchanged() {
+  if ! cmp -s "$POLLER_HOME/baseline.snapshot" "$OSQUERY_POSTURE_STATE"; then
+    printf 'expected the baseline byte-for-byte preserved.\nsnapshot:\n%s\nnow:\n%s\n' \
+      "$(cat "$POLLER_HOME/baseline.snapshot" 2>/dev/null || echo '(no snapshot)')" \
+      "$(cat "$OSQUERY_POSTURE_STATE" 2>/dev/null || echo '(missing)')" >&2
     return 1
   fi
 }

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -88,11 +88,15 @@ send_alert() {
   printf '%s\n' "$*" >>"$POLLER_SEND_ALERT_LOG"
   if [[ -f ${OSQUERY_POSTURE_STATE:-/nonexistent} ]]; then
     printf 'state-present\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
-    # The baseline as it stood when the page fired: proves write_state ran first.
+    # The baseline as it stood when the page fired, so a test can prove the
+    # ordering (notify-before-persist: the baseline still holds the PRIOR value).
     cat "$OSQUERY_POSTURE_STATE" >>"$POLLER_SEND_ALERT_STATE_AT_CALL"
   else
     printf 'state-absent\n' >>"$POLLER_SEND_ALERT_STATE_WITNESS"
   fi
+  # POLLER_SEND_ALERT_EXIT models a dispatch that could NOT durably queue the
+  # page (nonzero). Default 0 (queued): the poller then advances the baseline.
+  return "${POLLER_SEND_ALERT_EXIT:-0}"
 }
 SHIM
 

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -285,3 +285,13 @@ assert_no_gap_marker() {
     return 1
   fi
 }
+
+# assert_no_baseline -- no baseline file exists (a first-observation page whose
+# send_alert failed must not have seeded one).
+assert_no_baseline() {
+  if [[ -f $OSQUERY_POSTURE_STATE ]]; then
+    printf 'expected NO baseline file, but %s exists with:\n%s\n' \
+      "$OSQUERY_POSTURE_STATE" "$(cat "$OSQUERY_POSTURE_STATE")" >&2
+    return 1
+  fi
+}

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -268,3 +268,20 @@ assert_page_saw_baseline() {
     return 1
   fi
 }
+
+# assert_gap_marker -- the page-once monitoring-gap marker (STATE.gap) exists.
+assert_gap_marker() {
+  if [[ ! -f $OSQUERY_POSTURE_STATE.gap ]]; then
+    printf 'expected the gap marker %s.gap to exist, but it does not\n' "$OSQUERY_POSTURE_STATE" >&2
+    return 1
+  fi
+}
+
+# assert_no_gap_marker -- the monitoring-gap marker does not exist (never paged,
+# or cleared on recovery).
+assert_no_gap_marker() {
+  if [[ -f $OSQUERY_POSTURE_STATE.gap ]]; then
+    printf 'expected NO gap marker, but %s.gap exists\n' "$OSQUERY_POSTURE_STATE" >&2
+    return 1
+  fi
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -254,3 +254,51 @@ teardown() { teardown_poller_harness; }
 
   assert_no_page # a protection turning back ON is not actionable and has no notice channel
 }
+
+# --- strict scalar validation: a partial/out-of-domain value is a failed read ----
+# Each scalar must be in its exact domain (firewall 0/1/2, gatekeeper 0/1,
+# screenlock 0/1). Applied to the current read (do not poison the baseline) and to
+# the prior-baseline trust check (do not fabricate a transition).
+
+@test "T-POLL-partial-read-preserves-baseline: a partial posture (missing a field) preserves the baseline, and does not poison the next comparison" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+
+  # Tick 1: the screenlock field is absent. That is a monitoring gap, not a
+  # posture: it must NOT persist (which would poison the baseline) and must NOT page.
+  set_posture '[{"firewall":"1","gatekeeper":"1"}]'
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on a partial read, got $status: $output"
+    false
+  }
+  assert_baseline_unchanged
+  assert_no_page
+
+  # Tick 2: a healthy read with screenlock now OFF. Because tick 1 did not poison
+  # the baseline, the prior is still the good all-ON, so screenlock 1->0 pages.
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"0"}]'
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on tick 2, got $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Screen lock turned OFF'
+}
+
+@test "T-POLL-out-of-domain-prior-not-trusted: an out-of-domain prior baseline value is distrusted, so no false transition pages" {
+  # A prior firewall of "00" is not a valid domain value. Trusting it via a string
+  # compare against a current "0" would read "00" != "0" and fabricate a CRIT.
+  seed_baseline '{"firewall":"00","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # the untrusted prior is treated as no-prior: seed silently, no false CRIT
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -266,12 +266,12 @@ teardown() { teardown_poller_harness; }
 # screenlock 0/1). Applied to the current read (do not poison the baseline) and to
 # the prior-baseline trust check (do not fabricate a transition).
 
-@test "T-POLL-partial-read-preserves-baseline: a partial posture (missing a field) preserves the baseline, and does not poison the next comparison" {
+@test "T-POLL-partial-read-preserves-baseline: a partial posture preserves the baseline (a gap page, not a poisoned baseline), and recovery still detects a real transition" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline
 
-  # Tick 1: the screenlock field is absent. That is a monitoring gap, not a
-  # posture: it must NOT persist (which would poison the baseline) and must NOT page.
+  # Tick 1: the screenlock field is absent, a monitoring gap. It pages the gap but
+  # must NOT persist the partial (which would poison the baseline).
   set_posture '[{"firewall":"1","gatekeeper":"1"}]'
   run run_poller
   [[ $status -eq 0 ]] || {
@@ -279,7 +279,7 @@ teardown() { teardown_poller_harness; }
     false
   }
   assert_baseline_unchanged
-  assert_no_page
+  assert_page_body_has 'monitoring gap'
 
   # Tick 2: a healthy read with screenlock now OFF. Because tick 1 did not poison
   # the baseline, the prior is still the good all-ON, so screenlock 1->0 pages.
@@ -289,9 +289,7 @@ teardown() { teardown_poller_harness; }
     echo "expected the poller to exit 0 on tick 2, got $status: $output"
     false
   }
-  assert_page_count 1
-  assert_page_severity_is CRIT
-  assert_page_body_has 'Screen lock turned OFF'
+  assert_page_body_has 'Screen lock turned OFF' # a real transition after recovery: proof of no poisoning
 }
 
 @test "T-POLL-out-of-domain-prior-not-trusted: an out-of-domain prior baseline value is distrusted, so no false transition pages" {
@@ -307,6 +305,92 @@ teardown() { teardown_poller_harness; }
   }
 
   assert_no_page # the untrusted prior is treated as no-prior: seed silently, no false CRIT
+}
+
+# --- B3: a monitoring gap pages once as CRIT and clears on recovery --------------
+# The failed-read path (empty/failed read, or any scalar out of domain) now PAGES
+# once, via a STATE.gap marker, reusing notify-before-persist: page first, write
+# the marker only on success. Recovery (a valid read) clears the marker.
+
+@test "T-POLL-gap-pages-once: a gap read with no marker pages exactly one CRIT naming the gap, writes the marker, and preserves the baseline" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]' # firewall out of domain
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 after paging the gap, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_gap_marker         # the page-once marker now exists
+  assert_baseline_unchanged # a gap never persists the bad posture
+}
+
+@test "T-POLL-gap-no-respam: a second consecutive gap tick does not re-page (one page per gap)" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller # tick 1: pages and writes the marker
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  run run_poller # tick 2: the marker suppresses a re-page
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+
+  assert_page_count 1 # still exactly one page across both gap ticks
+}
+
+@test "T-POLL-gap-page-failure-no-marker: a gap whose send_alert fails writes no marker, exits nonzero, and re-pages next tick" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_SEND_ALERT_EXIT=1 # dispatch cannot queue the gap page
+
+  run run_poller
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the gap page could not be queued, got $status: $output"
+    false
+  }
+  assert_no_gap_marker # no marker on failure, so the next tick retries
+  assert_page_count 1  # it attempted the page
+
+  export POLLER_SEND_ALERT_EXIT=0
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "retry status $status: $output"
+    false
+  }
+  assert_page_count 2 # re-detected the still-unmarked gap and re-paged (at-least-once)
+  assert_gap_marker
+}
+
+@test "T-POLL-gap-recovery-clears-marker: a valid read after a gap clears the marker, so a later gap pages again" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+
+  set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]'
+  run run_poller # gap 1: pages and writes the marker
+  assert_page_count 1
+  assert_gap_marker
+
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  run run_poller # recovery: a valid read clears the marker, steady state (no page)
+  [[ $status -eq 0 ]] || {
+    echo "recovery status $status: $output"
+    false
+  }
+  assert_no_gap_marker
+
+  set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]'
+  run run_poller # gap 2: the marker was cleared, so it pages again
+  assert_page_count 2 # the second gap is not suppressed by a stale marker
+  assert_gap_marker
 }
 
 # --- change-detection and re-enable coverage ------------------------------------

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -194,6 +194,8 @@ teardown() { teardown_poller_harness; }
   assert_page_body_has 'Gatekeeper turned OFF'
   assert_page_body_lacks 'Firewall'
   assert_page_body_lacks 'Screen lock'
+  # Notify-before-persist: at page time the on-disk baseline still holds the prior all-ON.
+  assert_page_saw_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
 }
 
 @test "T-POLL-screenlock-off-pages: screen-lock 1->0 pages one CRIT naming the screen lock" {
@@ -211,6 +213,8 @@ teardown() { teardown_poller_harness; }
   assert_page_body_has 'Screen lock turned OFF'
   assert_page_body_lacks 'Firewall'
   assert_page_body_lacks 'Gatekeeper'
+  # Notify-before-persist: at page time the on-disk baseline still holds the prior all-ON.
+  assert_page_saw_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
 }
 
 @test "T-POLL-multi-off-one-page: two protections turning off in one tick page a single CRIT naming both" {
@@ -227,6 +231,8 @@ teardown() { teardown_poller_harness; }
   assert_page_severity_is CRIT
   assert_page_body_has 'Firewall turned OFF'
   assert_page_body_has 'Gatekeeper turned OFF'
+  # Notify-before-persist: at page time the on-disk baseline still holds the prior all-ON.
+  assert_page_saw_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
 }
 
 @test "T-POLL-steady-silent: an all-ON posture unchanged from a valid baseline pages nothing" {
@@ -301,4 +307,47 @@ teardown() { teardown_poller_harness; }
   }
 
   assert_no_page # the untrusted prior is treated as no-prior: seed silently, no false CRIT
+}
+
+# --- change-detection and re-enable coverage ------------------------------------
+
+@test "T-POLL-steady-off-silent: a protection already OFF and unchanged pages nothing" {
+  # firewall is OFF in the baseline AND in the current read: no transition, so no
+  # page. A bare "cur == 0" check without change-detection would page every tick.
+  seed_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page
+}
+
+@test "T-POLL-gatekeeper-reenable-silent: a Gatekeeper re-enable (0->1) pages nothing" {
+  seed_baseline '{"firewall":"1","gatekeeper":"0","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # a protection turning back ON is not actionable
+}
+
+@test "T-POLL-screenlock-reenable-silent: a screen-lock re-enable (0->1) pages nothing" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"0"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # a protection turning back ON is not actionable
 }

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -77,3 +77,36 @@ teardown() { teardown_poller_harness; }
   assert_no_page               # read+persist only: no transition paging in B1
   assert_persist_before_notify # any future page fires only AFTER the baseline is written
 }
+
+@test "T-POLL-read-failure-preserves-baseline: a hard osqueryi failure exits 0 and leaves the good baseline byte-for-byte intact at 0600" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  export POLLER_OSQUERYI_EXIT=1 # osqueryi hard-fails: no output, non-zero exit
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on a failed read (retry next tick), got $status: $output"
+    false
+  }
+
+  # A blind read must never overwrite a good baseline: it would blind or misfeed
+  # the next run's comparison.
+  assert_baseline_unchanged
+  assert_mode 600 "$OSQUERY_POSTURE_STATE"
+}
+
+@test "T-POLL-empty-read-preserves-baseline: an empty osqueryi result exits 0 and leaves the good baseline byte-for-byte intact at 0600" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture '[]' # osqueryi succeeds but returns no row
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on an empty read, got $status: $output"
+    false
+  }
+
+  # An empty read must not blank the baseline to a 1-byte file.
+  assert_baseline_unchanged
+  assert_mode 600 "$OSQUERY_POSTURE_STATE"
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -110,3 +110,119 @@ teardown() { teardown_poller_harness; }
   assert_baseline_unchanged
   assert_mode 600 "$OSQUERY_POSTURE_STATE"
 }
+
+# --- B2: a protection turning OFF pages CRIT; steady state is silent -------------
+# With a valid prior baseline, compare per protection and page on an OFF
+# transition. Re-enable (OFF -> ON) is silent, matching c69baab.
+
+@test "T-POLL-firewall-off-pages: firewall 1->0 pages one CRIT naming the firewall, after the new baseline is persisted" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT # only a CRIT reaches the #priority webhook
+  assert_page_body_has 'Firewall turned OFF'
+  assert_page_body_lacks 'Gatekeeper' # only the protection that changed is named
+  assert_page_body_lacks 'Screen lock'
+  # Ordering: the new baseline (firewall 0) was already persisted when the page fired.
+  assert_page_saw_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
+  assert_persist_before_notify
+}
+
+@test "T-POLL-firewall-blockall-off-pages: firewall 2->0 (block-all to off) pages CRIT naming the firewall" {
+  seed_baseline '{"firewall":"2","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Firewall turned OFF'
+  assert_page_body_has 'on (block all)' # the Was: text comes from fw_to_text(2)
+}
+
+@test "T-POLL-gatekeeper-off-pages: gatekeeper 1->0 pages one CRIT naming Gatekeeper" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"0","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Gatekeeper turned OFF'
+  assert_page_body_lacks 'Firewall'
+  assert_page_body_lacks 'Screen lock'
+}
+
+@test "T-POLL-screenlock-off-pages: screen-lock 1->0 pages one CRIT naming the screen lock" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"0"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Screen lock turned OFF'
+  assert_page_body_lacks 'Firewall'
+  assert_page_body_lacks 'Gatekeeper'
+}
+
+@test "T-POLL-multi-off-one-page: two protections turning off in one tick page a single CRIT naming both" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"0","gatekeeper":"0","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_page_count 1 # one page for the tick, not one per protection
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Firewall turned OFF'
+  assert_page_body_has 'Gatekeeper turned OFF'
+}
+
+@test "T-POLL-steady-silent: an all-ON posture unchanged from a valid baseline pages nothing" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # steady state is silent even with a valid prior baseline
+}
+
+@test "T-POLL-reenable-silent: a re-enable (firewall 0->1) pages nothing, matching c69baab" {
+  seed_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # a protection turning back ON is not actionable and has no notice channel
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -555,3 +555,26 @@ teardown() { teardown_poller_harness; }
   assert_gap_marker         # the bounded read collapses to empty -> the gap gate
   assert_baseline_unchanged # a wedged read is a gap: it never persists
 }
+
+# --- a persistence failure is loud, never a silently-trusted stale baseline ------
+
+@test "T-POLL-persist-failure-pages-degraded: a baseline-write failure pages a degraded-monitor gap instead of silently trusting a stale baseline" {
+  seed_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
+
+  # Firewall re-enabled (0->1): a SILENT re-enable path that must persist the new
+  # baseline. Make the state dir unwritable so write_state fails on this tick.
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  chmod 500 "$(dirname "$OSQUERY_POSTURE_STATE")"
+  run run_poller
+  chmod 700 "$(dirname "$OSQUERY_POSTURE_STATE")" # restore before asserting / teardown
+
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the baseline could not be persisted, got $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'degraded' # loud degraded-monitor page, not a silent abort
+  # Without this, the failed write leaves the stale prior=0 baseline, which would
+  # silently mask a later real OFF as steady-off (0 vs stale 0).
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -534,3 +534,24 @@ teardown() { teardown_poller_harness; }
   }
   assert_page_count 1 # still one page: a first observation seeds and does not re-page every tick
 }
+
+# --- bounded posture query: a wedged osqueryi becomes a gap, not silent blindness -
+
+@test "T-POLL-osqueryi-hang-pages-gap: a posture query that outlasts the bound is killed and pages a monitoring gap" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  export OSQUERY_POSTURE_TIMEOUT=1 # bound the query at 1s
+  export POLLER_OSQUERYI_SLEEP=30  # osqueryi wedges far past the bound
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected exit 0 after the bounded query gapped, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_gap_marker         # the bounded read collapses to empty -> the gap gate
+  assert_baseline_unchanged # a wedged read is a gap: it never persists
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -115,7 +115,7 @@ teardown() { teardown_poller_harness; }
 # With a valid prior baseline, compare per protection and page on an OFF
 # transition. Re-enable (OFF -> ON) is silent, matching c69baab.
 
-@test "T-POLL-firewall-off-pages: firewall 1->0 pages one CRIT naming the firewall, after the new baseline is persisted" {
+@test "T-POLL-firewall-off-pages: firewall 1->0 pages one CRIT naming the firewall, queued BEFORE the baseline advances" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
 
@@ -130,9 +130,37 @@ teardown() { teardown_poller_harness; }
   assert_page_body_has 'Firewall turned OFF'
   assert_page_body_lacks 'Gatekeeper' # only the protection that changed is named
   assert_page_body_lacks 'Screen lock'
-  # Ordering: the new baseline (firewall 0) was already persisted when the page fired.
-  assert_page_saw_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
-  assert_persist_before_notify
+  # Ordering (notify-before-persist): at page time the baseline still holds the
+  # PRIOR value, so a crash before the advance re-detects and re-pages next tick.
+  assert_page_saw_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  # Once the page is durably queued, the baseline advances to the observed OFF value.
+  assert_baseline_scalar firewall 0
+}
+
+@test "T-POLL-page-failure-keeps-baseline: a send_alert failure does not advance the baseline, so the next tick re-detects and re-pages" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  export POLLER_SEND_ALERT_EXIT=1 # dispatch cannot durably queue the page
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -ne 0 ]] || {
+    echo "expected the poller to surface the send_alert failure (nonzero), got $status: $output"
+    false
+  }
+  assert_page_count 1        # it DID attempt the page
+  assert_baseline_unchanged  # but the baseline did NOT advance to the OFF value
+
+  # Next tick: dispatch now succeeds. The still-ON baseline re-detects the OFF
+  # transition and re-pages (at-least-once), then advances. Nothing was lost.
+  export POLLER_SEND_ALERT_EXIT=0
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the retry to exit 0, got $status: $output"
+    false
+  }
+  assert_page_count 2 # re-detected and re-paged, never silently lost
+  assert_baseline_scalar firewall 0
 }
 
 @test "T-POLL-firewall-blockall-off-pages: firewall 2->0 (block-all to off) pages CRIT naming the firewall" {

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# The security-posture poller (executable_firewall-gatekeeper-monitor.sh) runs as a
+# gui/501 user LaunchAgent every 60s. B1 scope: it reads the firewall, Gatekeeper,
+# and screen-lock posture in ONE osqueryi query and persists it as an owner-only
+# (0600) baseline, written before any notification. No transition paging yet (B2),
+# no monitoring-gap logic yet (B3).
+#
+# R2-3: screen-lock lives HERE, not in the root-daemon pack. The screenlock osquery
+# table is scoped to the logged-in user, so only this user-session poller can read
+# it (the root daemon never returns a screenlock row).
+
+load ../fixtures/osquery-poller-lib
+
+setup() { setup_poller_harness; }
+teardown() { teardown_poller_harness; }
+
+@test "T-POLL-read-combined: one osqueryi query reads firewall, Gatekeeper, AND screen-lock together" {
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on a healthy read, got $status: $output"
+    false
+  }
+
+  assert_osqueryi_call_count 1             # one combined query per tick, not one per protection
+  assert_query_reads 'global_state'        # the firewall column (alf)
+  assert_query_reads 'assessments_enabled' # the Gatekeeper column
+  assert_query_reads 'screenlock'          # R2-3: the screen-lock read is IN the combined query
+}
+
+@test "T-POLL-persist-0600: the poller persists the posture as an owner-only (0600) baseline with no temp left behind" {
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  [[ -f $OSQUERY_POSTURE_STATE ]] || {
+    echo "expected the baseline file at $OSQUERY_POSTURE_STATE, but it is missing"
+    false
+  }
+  # Owner-only: a group/world-readable baseline could be planted to mask a
+  # disabled protection, so the write must land at 0600.
+  assert_mode 600 "$OSQUERY_POSTURE_STATE"
+  [[ ! -e $OSQUERY_POSTURE_STATE.tmp ]] || {
+    echo "expected the write_state temp file to be gone, but $OSQUERY_POSTURE_STATE.tmp remains"
+    false
+  }
+}
+
+@test "T-POLL-persist-scalars: the baseline carries the exact firewall, Gatekeeper, and screen-lock scalars it read" {
+  set_posture '[{"firewall":"2","gatekeeper":"1","screenlock":"0"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0, got $status: $output"
+    false
+  }
+
+  assert_baseline_scalar firewall 2   # alf global_state 2 = block-all
+  assert_baseline_scalar gatekeeper 1
+  assert_baseline_scalar screenlock 0
+}
+
+@test "T-POLL-silent-first-run: a healthy first run persists the baseline and pages nothing, notifying only after the baseline exists" {
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected the poller to exit 0 on a healthy first run, got $status: $output"
+    false
+  }
+
+  assert_no_page               # read+persist only: no transition paging in B1
+  assert_persist_before_notify # any future page fires only AFTER the baseline is written
+}

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -231,6 +231,7 @@ teardown() { teardown_poller_harness; }
   assert_page_severity_is CRIT
   assert_page_body_has 'Firewall turned OFF'
   assert_page_body_has 'Gatekeeper turned OFF'
+  assert_page_body_has '· 2' # the count title marks two protections in one page
   # Notify-before-persist: at page time the on-disk baseline still holds the prior all-ON.
   assert_page_saw_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
 }
@@ -477,6 +478,7 @@ teardown() { teardown_poller_harness; }
   assert_page_severity_is CRIT
   assert_page_body_has 'Firewall is OFF (first observation)'
   assert_page_body_has 'Gatekeeper is OFF (first observation)'
+  assert_page_body_has '· 2' # the count title marks two protections in one page
 }
 
 @test "T-POLL-first-obs-screenlock-off-pages: first run with the screen lock already OFF pages naming the screen lock" {
@@ -513,4 +515,22 @@ teardown() { teardown_poller_harness; }
   }
   assert_page_count 2               # re-detected the still-unbaselined exposure and re-paged
   assert_baseline_scalar firewall 0 # now seeded
+}
+
+@test "T-POLL-first-obs-continuity: an already-off first observation pages once and seeds, then an identical next tick is silent" {
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller # first observation: pages the already-off firewall and seeds the baseline
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+
+  run run_poller # identical next tick: the seeded prior is now trusted, firewall steady off, silent
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1 # still one page: a first observation seeds and does not re-page every tick
 }

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -292,9 +292,11 @@ teardown() { teardown_poller_harness; }
   assert_page_body_has 'Screen lock turned OFF' # a real transition after recovery: proof of no poisoning
 }
 
-@test "T-POLL-out-of-domain-prior-not-trusted: an out-of-domain prior baseline value is distrusted, so no false transition pages" {
+@test "T-POLL-out-of-domain-prior-not-trusted: an out-of-domain prior is distrusted, so it never fabricates a transition (a first-observation page instead)" {
   # A prior firewall of "00" is not a valid domain value. Trusting it via a string
-  # compare against a current "0" would read "00" != "0" and fabricate a CRIT.
+  # compare against a current "0" would read "00" != "0" and fabricate a "turned
+  # OFF" transition. It is distrusted, so there is no trusted prior: this is a
+  # first observation with the firewall already off, not a fabricated transition.
   seed_baseline '{"firewall":"00","gatekeeper":"1","screenlock":"1"}'
   set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
 
@@ -304,7 +306,8 @@ teardown() { teardown_poller_harness; }
     false
   }
 
-  assert_no_page # the untrusted prior is treated as no-prior: seed silently, no false CRIT
+  assert_page_body_lacks 'turned OFF'                       # no fabricated transition
+  assert_page_body_has 'Firewall is OFF (first observation)' # correct: no trusted prior, already off
 }
 
 # --- B3: a monitoring gap pages once as CRIT and clears on recovery --------------
@@ -434,4 +437,80 @@ teardown() { teardown_poller_harness; }
   }
 
   assert_no_page # a protection turning back ON is not actionable
+}
+
+# --- B4: an already-OFF protection at first observation (no prior) PAGES ---------
+# DIVERGENCE from c69baab (F4, banked from the slice-6 alerter review): with no
+# trusted prior baseline, a protection already off is a first-observation exposure
+# that must page (the alerter log-onlys these and relies on the poller), not be
+# silently baselined. No seed_baseline in these tests: the state file is absent.
+
+@test "T-POLL-first-obs-firewall-off-pages: first run (no prior) with the firewall already OFF pages one CRIT, then seeds the baseline" {
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected exit 0 after paging the first-observation exposure, got $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Firewall is OFF (first observation)'
+  assert_page_body_lacks 'turned OFF' # a first observation, not a transition
+  # The baseline is seeded (only after the page succeeds), so the next tick is quiet.
+  assert_baseline_scalar firewall 0
+  assert_baseline_scalar gatekeeper 1
+  assert_baseline_scalar screenlock 1
+}
+
+@test "T-POLL-first-obs-multi-off-pages: first run with two protections already OFF pages a single CRIT naming both" {
+  set_posture '[{"firewall":"0","gatekeeper":"0","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1 # one page for the first observation, not one per protection
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Firewall is OFF (first observation)'
+  assert_page_body_has 'Gatekeeper is OFF (first observation)'
+}
+
+@test "T-POLL-first-obs-screenlock-off-pages: first run with the screen lock already OFF pages naming the screen lock" {
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"0"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Screen lock is OFF (first observation)'
+}
+
+@test "T-POLL-first-obs-page-failure-no-seed: a first-observation page whose send_alert fails seeds no baseline, exits nonzero, and re-pages next tick" {
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_SEND_ALERT_EXIT=1 # dispatch cannot queue the first-observation page
+
+  run run_poller
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the first-observation page could not be queued, got $status: $output"
+    false
+  }
+  assert_no_baseline  # no baseline seeded on failure, so the exposure is re-detected
+  assert_page_count 1 # it attempted the page
+
+  export POLLER_SEND_ALERT_EXIT=0
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "retry status $status: $output"
+    false
+  }
+  assert_page_count 2               # re-detected the still-unbaselined exposure and re-paged
+  assert_baseline_scalar firewall 0 # now seeded
 }

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 # The security-posture poller (executable_firewall-gatekeeper-monitor.sh) runs as a
-# gui/501 user LaunchAgent every 60s. B1 scope: it reads the firewall, Gatekeeper,
-# and screen-lock posture in ONE osqueryi query and persists it as an owner-only
-# (0600) baseline, written before any notification. No transition paging yet (B2),
-# no monitoring-gap logic yet (B3).
+# gui/501 user LaunchAgent every 60s. It reads the firewall, Gatekeeper, and
+# screen-lock posture in ONE bounded osqueryi query, treats any unreadable or
+# partial read as a monitoring gap (pages once, never poisons the baseline), and
+# pages CRIT on a protection turning off or an already-off protection at first
+# observation (no trusted prior); it is silent in steady state and on re-enables.
+# Every page precedes the state advance (notify-before-persist), and a persistence
+# failure is itself a loud degraded-monitor gap.
 #
 # R2-3: screen-lock lives HERE, not in the root-daemon pack. The screenlock osquery
 # table is scoped to the logged-in user, so only this user-session poller can read
@@ -65,7 +68,7 @@ teardown() { teardown_poller_harness; }
   assert_baseline_scalar screenlock 0
 }
 
-@test "T-POLL-silent-first-run: a healthy first run persists the baseline and pages nothing, notifying only after the baseline exists" {
+@test "T-POLL-silent-first-run: a healthy first run seeds the baseline and pages nothing" {
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 
   run run_poller
@@ -74,11 +77,10 @@ teardown() { teardown_poller_harness; }
     false
   }
 
-  assert_no_page               # read+persist only: no transition paging in B1
-  assert_persist_before_notify # any future page fires only AFTER the baseline is written
+  assert_no_page # all protections ON with no prior baseline: seed silently
 }
 
-@test "T-POLL-read-failure-preserves-baseline: a hard osqueryi failure exits 0 and leaves the good baseline byte-for-byte intact at 0600" {
+@test "T-POLL-read-failure-preserves-baseline: a hard osqueryi failure pages the monitoring gap and leaves the good baseline intact at 0600" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline
   export POLLER_OSQUERYI_EXIT=1 # osqueryi hard-fails: no output, non-zero exit
@@ -89,13 +91,17 @@ teardown() { teardown_poller_harness; }
     false
   }
 
-  # A blind read must never overwrite a good baseline: it would blind or misfeed
-  # the next run's comparison.
+  # A hard-failed read is a gap: page ONCE (a silent-skip of it would blind the
+  # monitor) and never overwrite the good baseline.
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_gap_marker
   assert_baseline_unchanged
   assert_mode 600 "$OSQUERY_POSTURE_STATE"
 }
 
-@test "T-POLL-empty-read-preserves-baseline: an empty osqueryi result exits 0 and leaves the good baseline byte-for-byte intact at 0600" {
+@test "T-POLL-empty-read-preserves-baseline: an empty osqueryi result pages the monitoring gap and leaves the good baseline intact at 0600" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline
   set_posture '[]' # osqueryi succeeds but returns no row
@@ -106,7 +112,12 @@ teardown() { teardown_poller_harness; }
     false
   }
 
-  # An empty read must not blank the baseline to a 1-byte file.
+  # An empty read is a gap: page ONCE (a silent-skip of it would blind the monitor)
+  # and never blank the baseline to a 1-byte file.
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_gap_marker
   assert_baseline_unchanged
   assert_mode 600 "$OSQUERY_POSTURE_STATE"
 }
@@ -577,4 +588,22 @@ teardown() { teardown_poller_harness; }
   assert_page_body_has 'degraded' # loud degraded-monitor page, not a silent abort
   # Without this, the failed write leaves the stale prior=0 baseline, which would
   # silently mask a later real OFF as steady-off (0 vs stale 0).
+}
+
+@test "T-POLL-mode-644-prior-distrusted: a group/world-readable (0644) prior baseline is distrusted, so an already-off first observation pages" {
+  seed_baseline '{"firewall":"0","gatekeeper":"1","screenlock":"1"}'
+  chmod 644 "$OSQUERY_POSTURE_STATE" # not owner-only: could be planted to mask a disabled protection
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  # 0644 fails the mode-600 trust check, so there is no trusted prior: this is a
+  # first observation with the firewall already off. If the mode check were
+  # dropped, the 0644 prior would be trusted and firewall 0-vs-0 would read as a
+  # silent steady-off.
+  assert_page_body_has 'Firewall is OFF (first observation)'
 }

--- a/test/unit/osquery-firewall-gatekeeper-monitor-launchagent.sh
+++ b/test/unit/osquery-firewall-gatekeeper-monitor-launchagent.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# The scheduled security-posture poller LaunchAgent:
+# com.webdavis.osquery-firewall-gatekeeper-monitor must run the deployed poller
+# every 60 seconds AND at load time. RunAtLoad is true on purpose: on load the
+# poller establishes the baseline and, via the first-observation floor, surfaces
+# an already-off protection immediately instead of waiting a full interval. It is
+# a gui/<uid> USER agent, not a system daemon: the screenlock osquery table is
+# scoped to the logged-in user, so the poller needs the user session to read it.
+# Its loader chezmoiscript must be wired exactly like the sibling osquery agents
+# (darwin gate, plist-hash onchange trigger, bootout + bootstrap with the retry
+# loop).
+#
+# Unit test: render the plist and loader templates with the host chezmoi and
+# assert their content. No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-firewall-gatekeeper-monitor-launchagent.sh.tmpl"
+
+fail() {
+  printf 'osquery-firewall-gatekeeper-monitor-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+
+# Render both templates exactly as at apply time. --source pins the render to
+# THIS checkout (hermetic), mirroring the sibling launchagent tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key>
+# with the value element on the FOLLOWING line, so match the key then its next
+# line (same helper shape as the sibling launchagent tests).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, schedule, program path, logs -------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-firewall-gatekeeper-monitor</string>'
+assert_plist_kv StartInterval '<integer>60</integer>'
+# RunAtLoad true: on load the poller establishes the baseline and surfaces an
+# already-off protection immediately (the first-observation floor), not a full
+# interval later. Matches c69baab and the uptime-watchdog sibling.
+assert_plist_kv RunAtLoad '<true/>'
+
+# ProgramArguments runs the DEPLOYED poller from the libexec home (the
+# executable_ source prefix is dropped in the target).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/firewall-gatekeeper-monitor.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/firewall-gatekeeper-monitor.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/firewall-gatekeeper-monitor.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/firewall-gatekeeper-monitor.log</string>"
+
+# --- the loader: darwin gate, onchange trigger, gui user target, bootout+bootstrap retry ----
+
+# The loader re-runs when the plist CONTENT changes: the plist-hash include line
+# is the onchange trigger, and it must name the poller's own plist template.
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the poller plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+
+# The rendered loader targets the poller's label and plist as a gui/<uid> USER
+# agent (NOT a system daemon: the screenlock table needs the user session), and
+# keeps the sibling bootout-then-bootstrap shape with the retry loop. The needles
+# below are literal loader lines; $HOME and $(id -u) must NOT expand here (same
+# rule as the feature-set-location test's source-line needles).
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist"' ||
+  fail "rendered loader does not point at the poller plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-firewall-gatekeeper-monitor"' ||
+  fail "rendered loader does not target the poller label as a gui/<uid> user agent"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-firewall-gatekeeper-monitor-launchagent: OK (label + 60s interval + RunAtLoad true; gui/<uid> user agent; deployed libexec program; loader gated, hashed, bootout+bootstrap with retry)\n'


### PR DESCRIPTION
## Context

This is part of the S9 re-land: the osquery security-monitoring feature-set is being re-landed on `main`
slice by slice after an earlier bulk revert. This slice re-lands the user-level security-posture poller.

The poller is a gui/501 user LaunchAgent that reads the live firewall (alf), Gatekeeper, and screen-lock
state through osqueryi every 60 seconds and pages when a protection turns off. It runs in the user session
on purpose: the `screenlock` osquery table is scoped to the logged-in user, so the root osqueryd daemon
never sees it. The root-daemon alerter only logs firewall and Gatekeeper off-events and leaves the actual
protection-off paging to this poller.

## Summary

- Re-lands the gui/501 firewall/Gatekeeper/screen-lock posture poller.
- Pages a CRIT when a protection turns off, and when a protection is already off at first observation (no trusted prior baseline).
- Treats an unreadable, partial, or wedged read as a monitoring gap that pages once and never poisons the baseline.
- Pages a degraded-monitor CRIT when the baseline cannot be persisted, rather than silently trusting a stale one.
- Emits every page before it advances the baseline (notify-before-persist, at-least-once durability).
- Bounds the posture query with a timeout, so a hung osqueryi becomes a gap page, not silent blindness.

Key files:
- `dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh`
- `Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist.tmpl` and its `run_onchange` loader (pre-existing, verified by a render test)
- `test/integration/osquery-poller.bats`, `test/fixtures/osquery-poller-lib.bash`, `test/unit/osquery-firewall-gatekeeper-monitor-launchagent.sh`

## What the poller does

- One combined osqueryi query reads all three protections per tick, bounded by a timeout so a wedged query cannot black-hole the monitor.
- A trusted prior baseline (owner-only 0600, three in-domain scalars) drives transition detection: a protection turning off pages CRIT; steady state and re-enables are silent.
- With no trusted prior, an already-off protection pages a first-observation exposure; an all-on first run seeds silently.
- The baseline is persisted owner-only through a temp file plus atomic rename, and only after a page is durably queued.

## How it was tested

- 31 integration pins driven by a stubbed osqueryi and a recording send_alert spy, plus one LaunchAgent render unit test. The full lint and test suite is green.

## Effect of merging

- Adds the poller script, its LaunchAgent plist and loader, and the tests to `main`. There is no live-machine impact on merge: the agent loads and the poller begins paging only once the operator runs `chezmoi apply` and the osquery alerting stack goes live at the D1 cutover. Until then it is inert source in the repo.
