### PR TITLE
feat(osquery): daily digest of non-paging findings

### DIFF
--- a/.chezmoidata/osquery.yaml
+++ b/.chezmoidata/osquery.yaml
@@ -1,0 +1,6 @@
+# osquery alerting configuration consumed by templates.
+# digestHour/digestMinute drive the daily digest agent's StartCalendarInterval
+# (local time). 18:00 is an end-of-day glance; empty days stay silent.
+osquery:
+  digestHour: 18
+  digestMinute: 0

--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-digest-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-digest-launchagent.sh.tmpl
@@ -1,0 +1,25 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# run_onchange_after_60-load-osquery-digest-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl" | sha256sum }}
+# schedule: {{ .osquery.digestHour }}:{{ .osquery.digestMinute }} (rendered here so a
+# data-only osquery.yaml change re-fires this loader; the include above hashes the plist
+# template SOURCE, whose digestHour/digestMinute placeholders are literals that do not
+# change when their values do).
+
+set -euo pipefail
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-digest.plist"
+TARGET="gui/$(id -u)/com.webdavis.osquery-digest"
+
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.osquery-digest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>{{ .chezmoi.homeDir }}/.local/libexec/osquery/digest.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>{{ .osquery.digestHour }}</integer>
+    <key>Minute</key>
+    <integer>{{ .osquery.digestMinute }}</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/digest.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/digest.log</string>
+</dict>
+</plist>

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -59,8 +59,9 @@ digest_title() { printf '🗒️ osquery daily digest · %s · %s item(s)' "$(da
 # the body string, never send. Findings group by detector; each group renders a
 # header with its true count, up to DIGEST_MAX_BULLETS_PER_GROUP bullets, then a
 # "+K more" roll-up. At most DIGEST_MAX_GROUPS groups render (the rest collapse to
-# an "and K more" marker), and a hard head -c backstop caps the whole body at
-# DIGEST_MAX_BODY_CHARS, well under Discord's 2000-char limit. Each field is
+# an "and K more" marker), and a codepoint-wise cap inside jq truncates the whole
+# body at DIGEST_MAX_BODY_CHARS with a marker (no `head -c` pipe, so no silent
+# byte-cut and no SIGPIPE), well under Discord's 2000-char limit. Each field is
 # truncated at DIGEST_MAX_FIELD_CHARS so one giant value cannot fill the body cap
 # and crowd every other detector out. The four caps are env-overridable named
 # knobs, not magic numbers, and the group cap keeps a busy day from losing whole
@@ -82,7 +83,8 @@ render_digest_body() {
   jq -rRs \
     --argjson max_bullets "$max_bullets" \
     --argjson max_groups "$max_groups" \
-    --argjson max_field "$max_field" '
+    --argjson max_field "$max_field" \
+    --argjson max_body_chars "$max_body_chars" '
     # The single sanitize chokepoint every attacker-influenceable field passes
     # through before it is wrapped in an inline-code span below: strip backticks (so
     # a crafted value cannot close its wrapping span and escape to live markdown),
@@ -110,14 +112,19 @@ render_digest_body() {
     split("\n")
     | map(select(length > 0) | (try fromjson catch empty))
     | group_by(.detector) as $groups
-    # Cap the NUMBER of groups and mark the overflow, so a busy day cannot drop
-    # whole trailing groups to a silent mid-line head -c cut (the dropped content
-    # still lives in the spool/.last). head -c below is the final hard backstop.
-    | ($groups[0:$max_groups][] | render_group),
-      (if ($groups | length) > $max_groups
-       then "… and \(($groups | length) - $max_groups) more detector group(s) - see results.log"
-       else empty end)
-  ' "$work_file" | head -c "$max_body_chars"
+    # Cap the NUMBER of groups and mark the overflow, so a busy day cannot drop whole
+    # trailing groups to a silent mid-line cut (the dropped content still lives in the
+    # spool/.last). Collect the whole stream into one string, then codepoint-slice it
+    # to $max_body_chars with a marker: the cap lives INSIDE jq (no `| head -c`), so it
+    # truncates honestly (no lost tail markers, no mid-multibyte cut) and there is no
+    # pipe to block on a huge body and take SIGPIPE.
+    | [ ($groups[0:$max_groups][] | render_group),
+        (if ($groups | length) > $max_groups
+         then "… and \(($groups | length) - $max_groups) more detector group(s) - see results.log"
+         else empty end) ]
+    | join("\n")
+    | if length > $max_body_chars then .[0:$max_body_chars] + "\n… (truncated)" else . end
+  ' "$work_file"
 }
 
 main() {

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -42,9 +42,11 @@ restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
 # header with its true count, up to DIGEST_MAX_BULLETS_PER_GROUP bullets, then a
 # "+K more" roll-up. At most DIGEST_MAX_GROUPS groups render (the rest collapse to
 # an "and K more" marker), and a hard head -c backstop caps the whole body at
-# DIGEST_MAX_BODY_CHARS, well under Discord's 2000-char limit. The three caps are
-# env-overridable named knobs, not magic numbers, and the group cap keeps a busy
-# day from losing whole trailing groups to a silent mid-line cut.
+# DIGEST_MAX_BODY_CHARS, well under Discord's 2000-char limit. Each field is
+# truncated at DIGEST_MAX_FIELD_CHARS so one giant value cannot fill the body cap
+# and crowd every other detector out. The four caps are env-overridable named
+# knobs, not magic numbers, and the group cap keeps a busy day from losing whole
+# trailing groups to a silent mid-line cut.
 #
 # Injection safety: .identity and .summary originate from findings with
 # attacker-influenceable columns, so every rendered field flows through sanitize
@@ -56,14 +58,19 @@ render_digest_body() {
   local max_bullets="${DIGEST_MAX_BULLETS_PER_GROUP:-10}"
   local max_groups="${DIGEST_MAX_GROUPS:-12}"
   local max_body_chars="${DIGEST_MAX_BODY_CHARS:-1800}"
+  local max_field="${DIGEST_MAX_FIELD_CHARS:-240}"
   jq -rRs \
     --argjson max_bullets "$max_bullets" \
-    --argjson max_groups "$max_groups" '
+    --argjson max_groups "$max_groups" \
+    --argjson max_field "$max_field" '
     # The single sanitize chokepoint every attacker-influenceable field passes
-    # through: strip backticks (they open an inline-code span) and squash CR,
-    # newline, and tab to a space (a newline would break the value out of its
-    # bullet into a forged line). Values are data, never structure.
-    def sanitize: gsub("`"; "") | gsub("[\r\n\t]"; " ");
+    # through: strip backticks (they open an inline-code span), squash CR, newline,
+    # and tab to a space (a newline would break the value out of its bullet into a
+    # forged line), and truncate at $max_field so one crafted or huge value cannot
+    # fill the body cap and crowd every other detector out. Data, never structure.
+    def sanitize:
+      gsub("`"; "") | gsub("[\r\n\t]"; " ")
+      | if length > $max_field then .[0:$max_field] + "…(truncated)" else . end;
     # One block per detector group: header with the true count, up to $max_bullets
     # bullets, then a "+K more" roll-up for the overflow, then a blank separator.
     def render_group:

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -36,11 +36,53 @@ rotated_work_file() { printf '%s.%s.build' "$1" "$(date -u +%s)"; }
 # user, so a failed build must leave the findings for another run, not lose them.
 restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
 
-# render_digest_body <work_file> - render the grouped, capped digest body from the
-# rotated batch. Implemented in the grouping behavior; defined here as the build
-# step the ERR trap wraps, so a render failure restores the batch instead of
-# losing the day's findings.
-render_digest_body() { :; }
+# render_digest_body <work_file> - build and print the grouped, capped,
+# Discord-safe digest body from the rotated batch. Single responsibility: produce
+# the body string, never send. Findings group by detector; each group renders a
+# header with its true count, up to DIGEST_MAX_BULLETS_PER_GROUP bullets, then a
+# "+K more" roll-up. At most DIGEST_MAX_GROUPS groups render (the rest collapse to
+# an "and K more" marker), and a hard head -c backstop caps the whole body at
+# DIGEST_MAX_BODY_CHARS, well under Discord's 2000-char limit. The three caps are
+# env-overridable named knobs, not magic numbers, and the group cap keeps a busy
+# day from losing whole trailing groups to a silent mid-line cut.
+#
+# Injection safety: .identity and .summary originate from findings with
+# attacker-influenceable columns, so every rendered field flows through sanitize
+# (strip backticks, squash CR/newline/tab to spaces), the same chokepoint the
+# alerter's render-page uses. A crafted newline or backtick therefore stays inert
+# inside its own bullet and can never forge an extra markdown line or block.
+render_digest_body() {
+  local work_file="$1"
+  local max_bullets="${DIGEST_MAX_BULLETS_PER_GROUP:-10}"
+  local max_groups="${DIGEST_MAX_GROUPS:-12}"
+  local max_body_chars="${DIGEST_MAX_BODY_CHARS:-1800}"
+  jq -rRs \
+    --argjson max_bullets "$max_bullets" \
+    --argjson max_groups "$max_groups" '
+    # The single sanitize chokepoint every attacker-influenceable field passes
+    # through: strip backticks (they open an inline-code span) and squash CR,
+    # newline, and tab to a space (a newline would break the value out of its
+    # bullet into a forged line). Values are data, never structure.
+    def sanitize: gsub("`"; "") | gsub("[\r\n\t]"; " ");
+    # One block per detector group: header with the true count, up to $max_bullets
+    # bullets, then a "+K more" roll-up for the overflow, then a blank separator.
+    def render_group:
+      "**\(.[0].detector)** (\(length))",
+      (.[0:$max_bullets][] | "- \(.identity | sanitize) - \(.summary | sanitize)"),
+      (if length > $max_bullets then "… +\(length - $max_bullets) more" else empty end),
+      "";
+    split("\n")
+    | map(select(length > 0) | fromjson)
+    | group_by(.detector) as $groups
+    # Cap the NUMBER of groups and mark the overflow, so a busy day cannot drop
+    # whole trailing groups to a silent mid-line head -c cut (the dropped content
+    # still lives in the spool/.last). head -c below is the final hard backstop.
+    | ($groups[0:$max_groups][] | render_group),
+      (if ($groups | length) > $max_groups
+       then "… and \(($groups | length) - $max_groups) more detector group(s) - see results.log"
+       else empty end)
+  ' "$work_file" | head -c "$max_body_chars"
+}
 
 main() {
   local store work_file

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -67,10 +67,12 @@ digest_title() { printf '🗒️ osquery daily digest · %s · %s item(s)' "$(da
 # trailing groups to a silent mid-line cut.
 #
 # Injection safety: .identity and .summary originate from findings with
-# attacker-influenceable columns, so every rendered field flows through sanitize
-# (strip backticks, squash CR/newline/tab to spaces), the same chokepoint the
-# alerter's render-page uses. A crafted newline or backtick therefore stays inert
-# inside its own bullet and can never forge an extra markdown line or block.
+# attacker-influenceable columns, so every rendered field is WRAPPED in an inline
+# code span and flows through sanitize first (strip backticks so the value cannot
+# close that span, squash CR/newline/tab to spaces, per-field cap), exactly the
+# treatment the alerter's render-page gives these same fields. A crafted newline can
+# never forge an extra markdown line or block, and a crafted mention (@everyone) or
+# link renders as literal inline-code text, never a live Discord mention or link.
 render_digest_body() {
   local work_file="$1"
   local max_bullets="${DIGEST_MAX_BULLETS_PER_GROUP:-10}"
@@ -82,18 +84,22 @@ render_digest_body() {
     --argjson max_groups "$max_groups" \
     --argjson max_field "$max_field" '
     # The single sanitize chokepoint every attacker-influenceable field passes
-    # through: strip backticks (they open an inline-code span), squash CR, newline,
-    # and tab to a space (a newline would break the value out of its bullet into a
-    # forged line), and truncate at $max_field so one crafted or huge value cannot
-    # fill the body cap and crowd every other detector out. Data, never structure.
+    # through before it is wrapped in an inline-code span below: strip backticks (so
+    # a crafted value cannot close its wrapping span and escape to live markdown),
+    # squash CR, newline, and tab to a space (a newline would forge an extra line),
+    # and truncate at $max_field so one crafted or huge value cannot fill the body
+    # cap and crowd every other detector out. Data, never structure.
     def sanitize:
       gsub("`"; "") | gsub("[\r\n\t]"; " ")
       | if length > $max_field then .[0:$max_field] + "…(truncated)" else . end;
     # One block per detector group: header with the true count, up to $max_bullets
     # bullets, then a "+K more" roll-up for the overflow, then a blank separator.
+    # Each attacker-influenceable field is WRAPPED in backticks (an inline-code
+    # span), exactly as the alerter render-page does, so a crafted mention or link
+    # renders as literal inert text, never a live Discord @everyone or clickable link.
     def render_group:
       "**\(.[0].detector)** (\(length))",
-      (.[0:$max_bullets][] | "- \(.identity | sanitize) - \(.summary | sanitize)"),
+      (.[0:$max_bullets][] | "- `\(.identity | sanitize)` - `\(.summary | sanitize)`"),
       (if length > $max_bullets then "… +\(length - $max_bullets) more" else empty end),
       "";
     # Parse per line and DROP a torn or malformed line (try/catch), never

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -23,13 +23,61 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # the write side (results-alerter/digest-store.sh), so reader and writer agree on
 # the file without a shared constant that could drift between them.
 OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
-store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
 
-# Empty-suppression, first gate: an absent or zero-byte store has nothing to
-# summarize, so stay silent. -s is false for both a missing and an empty file.
-[[ -s $store ]] || exit 0
+# rotated_work_file <store> - the unique work-file path this run claims its batch
+# into. Derived from the store path plus a UTC unix timestamp and a .build suffix:
+# unique-per-run so a stale work file from a crashed run is never silently reused,
+# and .build names the in-flight batch for forensics.
+rotated_work_file() { printf '%s.%s.build' "$1" "$(date -u +%s)"; }
 
-# Empty-suppression, second gate: a store holding only whitespace (blank lines
-# left by an interrupted write, say) carries no real records, so stay silent too.
-# grep finds no non-whitespace byte.
-grep -q '[^[:space:]]' "$store" || exit 0
+# restore_batch <work_file> <store> - put the claimed batch back as the live store
+# so the next daily run retries it. This is the ERR trap's action for a build
+# failure BEFORE the send: a silently dropped digest is invisible to this single
+# user, so a failed build must leave the findings for another run, not lose them.
+restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
+
+# render_digest_body <work_file> - render the grouped, capped digest body from the
+# rotated batch. Implemented in the grouping behavior; defined here as the build
+# step the ERR trap wraps, so a render failure restores the batch instead of
+# losing the day's findings.
+render_digest_body() { :; }
+
+main() {
+  local store work_file
+  store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
+
+  # Empty-suppression, first gate: an absent or zero-byte store has nothing to
+  # summarize, so stay silent. -s is false for both a missing and an empty file.
+  [[ -s $store ]] || return 0
+
+  # Atomically claim the batch: move the live store aside so findings the alerter
+  # appends WHILE we build land in a fresh $store for the next run instead of being
+  # consumed (then rotated away) by this one. A failed mv leaves the store
+  # untouched, so nothing is lost; stay silent and let the next run retry.
+  work_file="$(rotated_work_file "$store")"
+  mv -f "$store" "$work_file" 2>/dev/null || return 0
+
+  # From here until the send, any build failure must restore the batch rather than
+  # drop the day's digest. The send itself is fire-and-forget (a lost daily digest
+  # is low-stakes and send_alert is write-ahead durable on its own), so the send
+  # behavior clears this trap; it guards the BUILD only.
+  trap 'restore_batch "$work_file" "$store"' ERR
+
+  # Empty-suppression, second gate, now on the CLAIMED batch: a whitespace-only or
+  # zero-byte batch has no real records, so discard it and stay silent. Reading the
+  # work file (not the live store) both guards the exact batch this run claimed and
+  # clears accumulated blank lines from the live store on every run.
+  grep -q '[^[:space:]]' "$work_file" 2>/dev/null || {
+    rm -f "$work_file"
+    return 0
+  }
+
+  render_digest_body "$work_file"
+}
+
+# Run only when executed, not when sourced: a test sources this file to exercise
+# an individual step (e.g. to force a build failure and assert the ERR-trap
+# restore) without launching the whole flow.
+if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
+  main "$@"
+fi

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -42,6 +42,10 @@ restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
 # persists indefinitely, so keep it 600 (defensive: mv preserves mode, but a store
 # written before the 600 hardening might not have carried it).
 rotate_to_last() {
+  # A failed same-dir rename DELETES the work file (unlike restore_batch's mv || true,
+  # which keeps the batch to retry): a rename failure within one directory implies a
+  # broken filesystem, and the findings also live in results.log, so a lost .last is
+  # low-stakes forensic loss, not a lost digest.
   mv -f "$1" "$2.last" 2>/dev/null || rm -f "$1"
   chmod 600 "$2.last" 2>/dev/null || true
 }
@@ -165,10 +169,11 @@ main() {
   # CRIT selects the #priority route; the EMPTY sound makes it locally silent AND
   # threads tier=muted into the POST so the Hermes adapter suppresses the ping (a
   # digest must never notify like a page). No occurrence id is threaded, so send_alert
-  # derives a per-send-unique request id (distinct days never collide), and the
-  # rotate-to-.last below keeps a re-run from re-sending this batch. || true: a hard
-  # send failure is low-stakes (send_alert already stored the page and alerted
-  # locally), so keep it off set -e's abort path and still rotate to .last.
+  # derives a per-send-unique request id (distinct days never collide); a re-run does
+  # not re-send this batch because the CLAIM at the start already emptied the live
+  # store (the .last rotate below is forensic, not the dedup). || true: a hard send
+  # failure is low-stakes (send_alert already stored the page and alerted locally), so
+  # keep it off set -e's abort path and still rotate to .last.
   send_alert CRIT "$title" "$body" "" || true
 
   # Preserve the built batch as .last for forensics regardless of send outcome.

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -18,11 +18,19 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 
-# The digest spool the alerter's digest_append accumulates into, one NDJSON line
-# per non-paging finding. Same default path and OSQUERY_DIGEST_STORE override as
-# the write side (results-alerter/digest-store.sh), so reader and writer agree on
-# the file without a shared constant that could drift between them.
+# The digest spool the alerter's digest_append accumulates into, one NDJSON line per non-paging
+# finding. This default and the OSQUERY_DIGEST_STORE override MUST match the write side
+# (results-alerter/digest-store.sh): they are two INDEPENDENT literals, so if they ever diverge the
+# reader watches a path nobody writes and the digest is silently empty forever. A parity assertion in
+# test/integration/osquery-feature-set-location.sh keeps the two literals byte-identical.
 OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
+
+# numeric_or <value> <default> - the value if it is a non-negative integer, else the default. A
+# typo'd env cap (DIGEST_MAX_GROUPS=abc) would otherwise reach jq's --argjson as invalid JSON and
+# fail the render, silently killing the daily digest; fall back so a bad env never does that.
+numeric_or() {
+  if [[ $1 =~ ^[0-9]+$ ]]; then printf '%s' "$1"; else printf '%s' "$2"; fi
+}
 
 # rotated_work_file <store> - the work-file path this run claims its batch into. Derived from the
 # store path plus a UTC unix timestamp, the PROCESS ID, and a .build suffix. The pid makes it
@@ -82,10 +90,11 @@ digest_title() { printf '🗒️ osquery daily digest · %s · %s item(s)' "$(da
 # link renders as literal inline-code text, never a live Discord mention or link.
 render_digest_body() {
   local work_file="$1"
-  local max_bullets="${DIGEST_MAX_BULLETS_PER_GROUP:-10}"
-  local max_groups="${DIGEST_MAX_GROUPS:-12}"
-  local max_body_chars="${DIGEST_MAX_BODY_CHARS:-1800}"
-  local max_field="${DIGEST_MAX_FIELD_CHARS:-240}"
+  local max_bullets max_groups max_body_chars max_field
+  max_bullets="$(numeric_or "${DIGEST_MAX_BULLETS_PER_GROUP:-}" 10)"
+  max_groups="$(numeric_or "${DIGEST_MAX_GROUPS:-}" 12)"
+  max_body_chars="$(numeric_or "${DIGEST_MAX_BODY_CHARS:-}" 1800)"
+  max_field="$(numeric_or "${DIGEST_MAX_FIELD_CHARS:-}" 240)"
   jq -rRs \
     --argjson max_bullets "$max_bullets" \
     --argjson max_groups "$max_groups" \

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -78,8 +78,11 @@ render_digest_body() {
       (.[0:$max_bullets][] | "- \(.identity | sanitize) - \(.summary | sanitize)"),
       (if length > $max_bullets then "… +\(length - $max_bullets) more" else empty end),
       "";
+    # Parse per line and DROP a torn or malformed line (try/catch), never
+    # slurp-and-abort: one interrupted digest_append must not fail the whole run
+    # and drop the whole day of findings. Mirrors the resilient results.log reader.
     split("\n")
-    | map(select(length > 0) | fromjson)
+    | map(select(length > 0) | (try fromjson catch empty))
     | group_by(.detector) as $groups
     # Cap the NUMBER of groups and mark the overflow, so a busy day cannot drop
     # whole trailing groups to a silent mid-line head -c cut (the dropped content

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -97,9 +97,11 @@ render_digest_body() {
     # Each attacker-influenceable field is WRAPPED in backticks (an inline-code
     # span), exactly as the alerter render-page does, so a crafted mention or link
     # renders as literal inert text, never a live Discord @everyone or clickable link.
+    # A null, missing, or numeric field is coerced first (via // and tostring), so a
+    # valid-JSON wrong-shape line cannot abort the render with a non-string gsub error.
     def render_group:
-      "**\(.[0].detector)** (\(length))",
-      (.[0:$max_bullets][] | "- `\(.identity | sanitize)` - `\(.summary | sanitize)`"),
+      "**\(.[0].detector // "?" | tostring)** (\(length))",
+      (.[0:$max_bullets][] | "- `\(.identity // "?" | tostring | sanitize)` - `\(.summary // "?" | tostring | sanitize)`"),
       (if length > $max_bullets then "… +\(length - $max_bullets) more" else empty end),
       "";
     # Parse per line and DROP a torn or malformed line (try/catch), never

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# digest.sh - the daily osquery digest builder. Drains the digest spool (NDJSON,
+# written by the alerter's digest_append) into ONE grouped, silent, non-paging
+# message, then rotates the live store aside for forensics. Empty-suppressed: an
+# absent, zero-byte, or whitespace-only store produces no message and no error.
+#
+# Cadence is owned by the daily launchd agent, NOT this script: there is no
+# internal time gate, so a manual invocation builds (or stays silent) exactly the
+# way the scheduled one does. That keeps the "when" in one declarative place (the
+# LaunchAgent's StartCalendarInterval) and makes the builder trivially testable.
+set -euo pipefail
+
+# The shared dispatch library, from the libexec home (the same deployed path the
+# other consumers source; the literal string lets the relocation guard assert it).
+# send_alert is the write-ahead-durable sender the CRIT page path also uses, so
+# the digest inherits that durability without its own delivery machinery.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+
+# The digest spool the alerter's digest_append accumulates into, one NDJSON line
+# per non-paging finding. Same default path and OSQUERY_DIGEST_STORE override as
+# the write side (results-alerter/digest-store.sh), so reader and writer agree on
+# the file without a shared constant that could drift between them.
+OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
+store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
+
+# Empty-suppression, first gate: an absent or zero-byte store has nothing to
+# summarize, so stay silent. -s is false for both a missing and an empty file.
+[[ -s $store ]] || exit 0
+
+# Empty-suppression, second gate: a store holding only whitespace (blank lines
+# left by an interrupted write, say) carries no real records, so stay silent too.
+# grep finds no non-whitespace byte.
+grep -q '[^[:space:]]' "$store" || exit 0

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -30,11 +30,16 @@ OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndj
 # and .build names the in-flight batch for forensics.
 rotated_work_file() { printf '%s.%s.build' "$1" "$(date -u +%s)"; }
 
-# restore_batch <work_file> <store> - put the claimed batch back as the live store
-# so the next daily run retries it. This is the ERR trap's action for a build
-# failure BEFORE the send: a silently dropped digest is invisible to this single
-# user, so a failed build must leave the findings for another run, not lose them.
-restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
+# restore_batch <work_file> <store> - put the claimed batch back as the live store so the next
+# daily run retries it. It APPENDS rather than mv -f overwrites: the alerter can append a new
+# finding to the fresh store DURING the build, and an overwrite would destroy that concurrent
+# append, whereas an append cannot clobber it (order within a grouped digest is irrelevant). The
+# work file is removed only if the append succeeded, so a failed append leaves the batch to retry.
+# This is the ERR trap's action for a build failure before the send AND the hard-send-failure
+# branch: a silently dropped digest is invisible to this single user.
+restore_batch() {
+  if cat -- "$1" >>"$2" 2>/dev/null; then rm -f -- "$1" || true; fi
+}
 
 # rotate_to_last <work_file> <store> - preserve the built batch as $store.last for
 # forensics, regardless of send outcome; the live store is already fresh (rotated at
@@ -175,24 +180,24 @@ main() {
   item_count="$(grep -c . "$work_file" 2>/dev/null)" || item_count=0
   title="$(digest_title "$item_count")"
 
-  # Fire-and-forget from here: CLEAR the pre-send restore trap so a failed send never
-  # restores the batch. send_alert is write-ahead durable on its own (it persists a
-  # pending_alerts row and the scheduled drainer retries it, exactly as the page path),
-  # so restoring would double-store and re-send a duplicate on the next run.
+  # Clear the pre-send restore trap: item_count and title above were the last trap-guarded build
+  # steps, and the send outcome is handled EXPLICITLY below, not by the trap.
   trap - ERR
 
-  # CRIT selects the #priority route; the EMPTY sound makes it locally silent AND
-  # threads tier=muted into the POST so the Hermes adapter suppresses the ping (a
-  # digest must never notify like a page). No occurrence id is threaded, so send_alert
-  # derives a per-send-unique request id (distinct days never collide); a re-run does
-  # not re-send this batch because the CLAIM at the start already emptied the live
-  # store (the .last rotate below is forensic, not the dedup). || true: a hard send
-  # failure is low-stakes (send_alert already stored the page and alerted locally), so
-  # keep it off set -e's abort path and still rotate to .last.
-  send_alert CRIT "$title" "$body" "" || true
-
-  # Preserve the built batch as .last for forensics regardless of send outcome.
-  rotate_to_last "$work_file" "$store"
+  # CRIT selects the #priority route; the EMPTY sound makes it locally silent AND threads tier=muted
+  # into the POST so the Hermes adapter suppresses the ping (a digest must never notify like a page).
+  # No occurrence id is threaded, so send_alert derives a per-send-unique request id (distinct days
+  # never collide); the dedup is the atomic CLAIM at the start (which already emptied the live store),
+  # not this rotate. send_alert returns nonzero ONLY when its write-ahead persist FAILED (the page was
+  # neither delivered nor stored, "the caller must not advance its cursor past it"), so on failure
+  # RESTORE the batch for the next run; restoring cannot double-store because nothing was stored. On
+  # success (any STORED outcome: delivered / stored-nosecret / stored-delivery-pending) durability is
+  # delegated to send_alert's own store + drainer, so rotate the batch to .last for forensics.
+  if send_alert CRIT "$title" "$body" ""; then
+    rotate_to_last "$work_file" "$store"
+  else
+    restore_batch "$work_file" "$store"
+  fi
 }
 
 # Run only when executed, not when sourced: a test sources this file to exercise

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -24,11 +24,12 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # the file without a shared constant that could drift between them.
 OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
 
-# rotated_work_file <store> - the unique work-file path this run claims its batch
-# into. Derived from the store path plus a UTC unix timestamp and a .build suffix:
-# unique-per-run so a stale work file from a crashed run is never silently reused,
-# and .build names the in-flight batch for forensics.
-rotated_work_file() { printf '%s.%s.build' "$1" "$(date -u +%s)"; }
+# rotated_work_file <store> - the work-file path this run claims its batch into. Derived from the
+# store path plus a UTC unix timestamp, the PROCESS ID, and a .build suffix. The pid makes it
+# per-invocation unique: date +%s is only per-second, so two runs in the same second would collide
+# on the timestamp alone and the second claim would clobber the first. .build names the in-flight
+# batch for forensics and for the orphan sweep in main.
+rotated_work_file() { printf '%s.%s.%s.build' "$1" "$(date -u +%s)" "$$"; }
 
 # restore_batch <work_file> <store> - put the claimed batch back as the live store so the next
 # daily run retries it. It APPENDS rather than mv -f overwrites: the alerter can append a new
@@ -133,8 +134,19 @@ render_digest_body() {
 }
 
 main() {
-  local store work_file body item_count title
+  local store work_file body item_count title orphan
   store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
+
+  # Recover orphaned work files first: a run killed by a signal (SIGKILL, power loss, or the SIGTERM
+  # launchd sends gui agents at logout, which is ~18:00-adjacent) between claim and rotate leaves a
+  # .build orphan the ERR trap could not restore (signals do not fire it) and no later run would
+  # consult. Fold each back into the live store before the empty gate. Steady state sweeps nothing: a
+  # normal run leaves no .build (it rotates to .last or restores). nullglob is not set, so guard the
+  # literal-pattern no-match case with -e.
+  for orphan in "$store".*.build; do
+    [[ -e $orphan ]] || continue
+    if cat -- "$orphan" >>"$store" 2>/dev/null; then rm -f -- "$orphan" || true; fi
+  done
 
   # Empty-suppression, first gate: an absent or zero-byte store has nothing to
   # summarize, so stay silent. -s is false for both a missing and an empty file.

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -36,6 +36,20 @@ rotated_work_file() { printf '%s.%s.build' "$1" "$(date -u +%s)"; }
 # user, so a failed build must leave the findings for another run, not lose them.
 restore_batch() { mv -f "$1" "$2" 2>/dev/null || true; }
 
+# rotate_to_last <work_file> <store> - preserve the built batch as $store.last for
+# forensics, regardless of send outcome; the live store is already fresh (rotated at
+# the start), so a re-run is silent. The .last holds full filesystem paths and
+# persists indefinitely, so keep it 600 (defensive: mv preserves mode, but a store
+# written before the 600 hardening might not have carried it).
+rotate_to_last() {
+  mv -f "$1" "$2.last" 2>/dev/null || rm -f "$1"
+  chmod 600 "$2.last" 2>/dev/null || true
+}
+
+# digest_title <item_count> - the one-line digest header: a notebook glyph, the UTC
+# date, and the item count. Sent as the CRIT title of the silent (muted) message.
+digest_title() { printf '🗒️ osquery daily digest · %s · %s item(s)' "$(date -u +%Y-%m-%d)" "$1"; }
+
 # render_digest_body <work_file> - build and print the grouped, capped,
 # Discord-safe digest body from the rotated batch. Single responsibility: produce
 # the body string, never send. Findings group by detector; each group renders a
@@ -95,7 +109,7 @@ render_digest_body() {
 }
 
 main() {
-  local store work_file
+  local store work_file body item_count title
   store="${OSQUERY_DIGEST_STORE:-$OSQUERY_DIGEST_STORE_DEFAULT}"
 
   # Empty-suppression, first gate: an absent or zero-byte store has nothing to
@@ -124,7 +138,41 @@ main() {
     return 0
   }
 
-  render_digest_body "$work_file"
+  # Build the grouped, capped, sanitized body from the claimed batch. Under the ERR
+  # trap: a render failure here restores the batch for the next run (pre-send).
+  body="$(render_digest_body "$work_file")"
+
+  # Empty-body second gate: if every line was torn/dropped the body renders empty
+  # even though Guard 2 (non-whitespace bytes) passed. Do NOT send a misleading silent
+  # "N item(s)" with an empty body; preserve the unrecoverable batch to .last and stay
+  # silent (re-rendering it would only render empty again).
+  if ! printf '%s' "$body" | grep -q '[^[:space:]]'; then
+    rotate_to_last "$work_file" "$store"
+    return 0
+  fi
+
+  # The item count for the title, from a torn-safe line count (grep -c, never a JSON
+  # parse), so a torn line never breaks it. || guards the (here impossible) empty case.
+  item_count="$(grep -c . "$work_file" 2>/dev/null)" || item_count=0
+  title="$(digest_title "$item_count")"
+
+  # Fire-and-forget from here: CLEAR the pre-send restore trap so a failed send never
+  # restores the batch. send_alert is write-ahead durable on its own (it persists a
+  # pending_alerts row and the scheduled drainer retries it, exactly as the page path),
+  # so restoring would double-store and re-send a duplicate on the next run.
+  trap - ERR
+
+  # CRIT selects the #priority route; the EMPTY sound makes it locally silent AND
+  # threads tier=muted into the POST so the Hermes adapter suppresses the ping (a
+  # digest must never notify like a page). No occurrence id is threaded, so send_alert
+  # derives a per-send-unique request id (distinct days never collide), and the
+  # rotate-to-.last below keeps a re-run from re-sending this batch. || true: a hard
+  # send failure is low-stakes (send_alert already stored the page and alerted
+  # locally), so keep it off set -e's abort path and still rotate to .last.
+  send_alert CRIT "$title" "$body" "" || true
+
+  # Preserve the built batch as .last for forensics regardless of send outcome.
+  rotate_to_last "$work_file" "$store"
 }
 
 # Run only when executed, not when sourced: a test sources this file to exercise

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -381,3 +381,22 @@ body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
   # And the forged field marker never becomes its own line.
   assert_no_injected_line "$body"
 }
+
+@test "an oversized field is truncated in the sanitize chokepoint and cannot crowd out other groups" {
+  local giant
+  giant="$(printf 'x%.0s' {1..5000})" # one field far larger than the whole body cap
+  local body
+  body="$(render_body \
+    "$(digest_record aaa_giant id_giant "$giant")" \
+    "$(digest_record zzz_small id_small 'a small summary')")"
+  # The oversized field is truncated in place with the per-field marker (DIGEST_MAX_FIELD_CHARS).
+  assert_body_has "$body" '…(truncated)'
+  # ... so it cannot alone consume the whole body cap: the later detector group still renders.
+  assert_body_has "$body" '**zzz_small** (1)'
+  assert_body_has "$body" '- id_small - a small summary'
+  # And the full oversized value never survives into the body.
+  if grep -qF -- "$giant" <<<"$body"; then
+    printf 'expected the oversized field truncated, but the full value survived\n' >&2
+    return 1
+  fi
+}

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -367,8 +367,8 @@ assert_last_mode_600() {
   assert_body_has "$body" '**persistence_launchd** (2)'
   assert_body_has "$body" '**system_extensions_new** (1)'
   assert_body_has "$body" '**sudoers** (1)'
-  assert_body_has "$body" '- com.foo.agent - persistence_launchd com.foo.agent'
-  assert_body_has "$body" '- io.tailscale - system_extensions_new io.tailscale'
+  assert_body_has "$body" '- `com.foo.agent` - `persistence_launchd com.foo.agent`'
+  assert_body_has "$body" '- `io.tailscale` - `system_extensions_new io.tailscale`'
 }
 
 @test "a detector with more findings than the bullet cap shows N bullets and a +K more roll-up" {
@@ -379,7 +379,7 @@ assert_last_mode_600() {
   local body
   body="$(render_body "${records[@]}")"
   assert_body_has "$body" '**persistence_launchd** (14)' # the header counts the true total
-  assert_line_count "$body" '^- com\.item\.' 10          # DIGEST_MAX_BULLETS_PER_GROUP default
+  assert_line_count "$body" '^- `com\.item\.' 10         # DIGEST_MAX_BULLETS_PER_GROUP default
   assert_body_has "$body" '+4 more'
 }
 
@@ -440,9 +440,20 @@ assert_last_mode_600() {
   local body
   body="$(render_body "$(digest_record persistence_launchd "$evil" 'malicious finding')")"
   # The crafted newline is squashed to a space, so the value stays inert INSIDE one bullet.
-  assert_body_has "$body" '- evil - **Signing:** signed: Apple - malicious finding'
+  assert_body_has "$body" '- `evil - **Signing:** signed: Apple` - `malicious finding`'
   # And the forged field marker never becomes its own line.
   assert_no_injected_line "$body"
+}
+
+@test "an attacker-controlled field renders inside a code span, so a mention or link is inert" {
+  # render-page wraps every attacker-influenceable field in backticks; the digest does the
+  # same, so a crafted mention or link renders as literal inline-code text, not a live
+  # Discord @everyone or a clickable link. (The line/block-forging guard above is separate.)
+  local body
+  body="$(render_body "$(digest_record persistence_launchd '@everyone' '[click](http://evil.example)')")"
+  assert_body_has "$body" '- `@everyone` - `[click](http://evil.example)`' # both fields inside code spans
+  assert_body_has "$body" '`@everyone`'                                     # the mention is inert inline code, not bare
+  assert_body_has "$body" '`[click](http://evil.example)`'                  # the link markdown is inert inline code too
 }
 
 @test "an oversized field is truncated in the sanitize chokepoint and cannot crowd out other groups" {
@@ -456,7 +467,7 @@ assert_last_mode_600() {
   assert_body_has "$body" '…(truncated)'
   # ... so it cannot alone consume the whole body cap: the later detector group still renders.
   assert_body_has "$body" '**zzz_small** (1)'
-  assert_body_has "$body" '- id_small - a small summary'
+  assert_body_has "$body" '- `id_small` - `a small summary`'
   # And the full oversized value never survives into the body.
   if grep -qF -- "$giant" <<<"$body"; then
     printf 'expected the oversized field truncated, but the full value survived\n' >&2
@@ -476,8 +487,8 @@ assert_last_mode_600() {
   local body
   body="$(render_body "${records[@]}")"
   assert_body_has "$body" '**persistence_launchd** (2)' # the two GOOD launchd findings; the torn one skipped
-  assert_body_has "$body" '- com.good.one - persistence_launchd com.good.one'
-  assert_body_has "$body" '- com.good.two - persistence_launchd com.good.two'
+  assert_body_has "$body" '- `com.good.one` - `persistence_launchd com.good.one`'
+  assert_body_has "$body" '- `com.good.two` - `persistence_launchd com.good.two`'
   assert_body_has "$body" '**sudoers** (1)'
   if grep -qF -- 'com.tor' <<<"$body"; then
     printf 'expected the torn line skipped, but its fragment appeared:\n%s\n' "$body" >&2

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -607,6 +607,37 @@ assert_last_mode_600() {
   assert_body_has "$store_content" '/etc/sudoers.d/c' # AND the concurrent append survives
 }
 
+@test "the work-file name includes the pid, so same-second claims from different runs do not collide" {
+  # date +%s is per-second: two invocations in the same second would derive the same work file and
+  # the second mv -f would clobber the first. The name must carry the process id too.
+  local out wf pid
+  out="$(bash -c 'source "$DIGEST_BUILDER"; printf "%s\n%s" "$(rotated_work_file /tmp/store)" "$$"' digest-wf-probe)"
+  wf="$(printf '%s' "$out" | head -1)"
+  pid="$(printf '%s' "$out" | tail -1)"
+  if [[ $wf != *".$pid.build" ]]; then
+    printf 'expected the work file to end with .%s.build (per-process pid), got %s\n' "$pid" "$wf" >&2
+    return 1
+  fi
+}
+
+@test "an orphaned .build from a killed run is swept back into the next digest" {
+  # A run killed by a signal (SIGKILL, power loss, or the SIGTERM launchd sends gui agents at
+  # logout) between claim and rotate leaves a .build orphan the ERR trap could not restore (signals
+  # do not fire it) and no later run would consult. The next run must sweep it back and deliver it.
+  mkdir -p "$(dirname "$OSQUERY_DIGEST_STORE")"
+  printf '%s\n' "$(digest_record persistence_launchd com.orphan.finding 'orphaned')" \
+    >"$OSQUERY_DIGEST_STORE.1700000000.999.build"
+  seed_store "$(digest_record sudoers /etc/sudoers.d/new 'current')"
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected exit 0, got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_sent_once
+  assert_sent_body_has '`com.orphan.finding`' # the orphan finding recovered and sent
+  assert_sent_body_has '`/etc/sudoers.d/new`' # and the current finding too
+}
+
 @test "an all-torn store renders an empty body, so it sends nothing and preserves the batch to .last" {
   # Every line unparseable: Guard 2 (non-whitespace bytes) passes and the raw lines are
   # counted, but the rendered body is empty. The builder must NOT send a misleading

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -30,18 +30,31 @@ setup_digest_harness() {
   _DIGEST_HARNESS_OWNED_DIR="$HARNESS_HOME"
   export HOME="$HARNESS_HOME"
 
-  # The recording spy for send_alert, at the exact libexec path the builder
-  # sources. It appends each call's argv to $SEND_ALERT_LOG, so "no dispatch" is
-  # an empty log and a later behavior can grep the log for the rendered body.
+  # The recording spy for send_alert, at the exact libexec path the builder sources.
+  # It writes one CALL marker per call to $SEND_ALERT_LOG (so a test counts calls and
+  # "no dispatch" is an empty log) plus the severity/title/body/sound of the call, so
+  # a test can assert HOW the builder dispatched without a real send. SEND_ALERT_RC
+  # (default 0) lets a test force a hard send failure to exercise fire-and-forget.
   local dispatch_dir="$HARNESS_HOME/.local/libexec/osquery"
   mkdir -p "$dispatch_dir"
   export SEND_ALERT_LOG="$HARNESS_HOME/send-alert.log"
+  export SEND_ALERT_SEVERITY="$HARNESS_HOME/send-alert.severity"
+  export SEND_ALERT_TITLE="$HARNESS_HOME/send-alert.title"
+  export SEND_ALERT_BODY="$HARNESS_HOME/send-alert.body"
+  export SEND_ALERT_SOUND="$HARNESS_HOME/send-alert.sound"
   : >"$SEND_ALERT_LOG"
   cat >"$dispatch_dir/alert-dispatch.sh" <<'SPY'
 # Recording spy for alert-dispatch.sh: capture each send_alert call so a test can
-# assert whether the builder dispatched, and with what, without a real send.
+# assert whether, and how, the builder dispatched without a real send. One CALL
+# marker per call (for counting) plus the severity/title/body/sound of the call.
+# SEND_ALERT_RC (default 0) lets a test force a hard send failure.
 send_alert() {
-  printf '%s\n' "$*" >>"$SEND_ALERT_LOG"
+  printf 'CALL\n' >>"$SEND_ALERT_LOG"
+  printf '%s' "${1-}" >"$SEND_ALERT_SEVERITY"
+  printf '%s' "${2-}" >"$SEND_ALERT_TITLE"
+  printf '%s' "${3-}" >"$SEND_ALERT_BODY"
+  printf '%s' "${4-}" >"$SEND_ALERT_SOUND"
+  return "${SEND_ALERT_RC:-0}"
 }
 SPY
 
@@ -148,27 +161,6 @@ assert_live_store_freed() {
   fi
 }
 
-# assert_work_file_holds <n> - exactly one .build work file exists and carries
-# the <n> rotated records.
-assert_work_file_holds() {
-  local want="$1"
-  local work_files=("$OSQUERY_DIGEST_STORE".*.build)
-  if [[ ! -e ${work_files[0]} ]]; then
-    printf 'expected one .build work file holding the rotated batch, found none\n' >&2
-    return 1
-  fi
-  if [[ ${#work_files[@]} -ne 1 ]]; then
-    printf 'expected exactly one .build work file, found %s: %s\n' "${#work_files[@]}" "${work_files[*]}" >&2
-    return 1
-  fi
-  local got
-  got="$(count_records "${work_files[0]}")"
-  if [[ $got -ne $want ]]; then
-    printf 'expected the work file to hold %s record(s), got %s\n' "$want" "$got" >&2
-    return 1
-  fi
-}
-
 # assert_build_ran_against_work_file - the build step ran against the CLAIMED
 # batch, proving the rotate happened before the build (not against the live store).
 assert_build_ran_against_work_file() {
@@ -250,6 +242,62 @@ assert_no_injected_line() {
 # body_byte_length <body> - the body length in bytes (the head -c cap's unit).
 body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
 
+# assert_sent_once - exactly one send_alert call was recorded.
+assert_sent_once() {
+  local calls
+  calls="$(grep -c 'CALL' "$SEND_ALERT_LOG" 2>/dev/null || printf '0')"
+  if [[ $calls -ne 1 ]]; then
+    printf 'expected exactly one send_alert call, got %s\n' "$calls" >&2
+    return 1
+  fi
+}
+
+# assert_sent_silent_crit - the recorded send is CRIT (selects the #priority route)
+# with an EMPTY sound (silent/muted -> tier=muted, so Hermes suppresses the ping).
+assert_sent_silent_crit() {
+  local severity sound
+  severity="$(cat "$SEND_ALERT_SEVERITY" 2>/dev/null || true)"
+  sound="$(cat "$SEND_ALERT_SOUND" 2>/dev/null || true)"
+  if [[ $severity != CRIT ]]; then
+    printf 'expected CRIT severity (selects #priority), got %q\n' "$severity" >&2
+    return 1
+  fi
+  if [[ -n $sound ]]; then
+    printf 'expected an EMPTY sound (silent/muted, not a page ping), got %q\n' "$sound" >&2
+    return 1
+  fi
+}
+
+# assert_sent_body_has <fixed-needle> - the recorded send body contains the needle.
+assert_sent_body_has() {
+  local needle="$1"
+  if ! grep -qF -- "$needle" "$SEND_ALERT_BODY" 2>/dev/null; then
+    printf 'expected the sent body to contain %q, body was:\n%s\n' "$needle" "$(cat "$SEND_ALERT_BODY" 2>/dev/null || true)" >&2
+    return 1
+  fi
+}
+
+# assert_batch_in_last <n> - the built batch was preserved as $store.last with <n> records.
+assert_batch_in_last() {
+  local want="$1" got
+  got="$(count_records "$OSQUERY_DIGEST_STORE.last")"
+  if [[ ! -s $OSQUERY_DIGEST_STORE.last || $got -ne $want ]]; then
+    printf 'expected the batch preserved to .last with %s record(s), got %s\n' "$want" "$got" >&2
+    return 1
+  fi
+}
+
+# assert_last_mode_600 - the .last forensic file is mode 600 (it holds full paths).
+# GNU stat first (the nix shell), BSD stat as the fallback (the portable order).
+assert_last_mode_600() {
+  local mode
+  mode=$(stat -c '%a' "$OSQUERY_DIGEST_STORE.last" 2>/dev/null || stat -f '%Lp' "$OSQUERY_DIGEST_STORE.last" 2>/dev/null)
+  if [[ $mode != 600 ]]; then
+    printf 'expected .last mode 600 (holds full paths), got %s\n' "$mode" >&2
+    return 1
+  fi
+}
+
 @test "an absent digest store produces no message and exits 0" {
   given_absent_store
   assert_silent_success
@@ -265,18 +313,22 @@ body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
   assert_silent_success
 }
 
-@test "a store with real records is rotated to a work file, freeing the live store" {
+@test "a store with records sends exactly one silent digest, then rotates the batch to .last" {
   seed_store \
     "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')" \
-    "$(digest_record persistence_launchd com.bar.agent 'persistence_launchd com.bar.agent')"
+    "$(digest_record sudoers /etc/sudoers.d/foo 'sudoers /etc/sudoers.d/foo')"
   run run_digest
   if [[ $status -ne 0 ]]; then
-    printf 'expected exit 0 after the rotate, got %s: %s\n' "$status" "$output" >&2
+    printf 'expected exit 0, got %s: %s\n' "$status" "$output" >&2
     return 1
   fi
-  assert_live_store_freed
-  assert_work_file_holds 2
-  assert_no_send
+  assert_sent_once
+  assert_sent_silent_crit # CRIT route + EMPTY sound => tier=muted (non-paging)
+  assert_sent_body_has '**persistence_launchd** (1)'
+  assert_sent_body_has '**sudoers** (1)'
+  assert_live_store_freed # the live store is fresh for the next run
+  assert_batch_in_last 2  # the built batch is preserved for forensics
+  assert_last_mode_600
 }
 
 @test "a build failure before the send restores the rotated batch to the live store" {
@@ -428,5 +480,42 @@ body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
     printf 'expected the build to survive the torn line (exit 0), got %s: %s\n' "$status" "$output" >&2
     return 1
   fi
+  assert_live_store_freed
+}
+
+@test "a failed send still rotates the batch to .last and never restores it for a re-send" {
+  seed_store "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')"
+  export SEND_ALERT_RC=1 # the spy simulates a HARD send failure
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected fire-and-forget exit 0 despite the failed send, got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_sent_once        # exactly one send ATTEMPT, no restore-and-retry loop
+  assert_batch_in_last 1  # preserved to .last, NOT restored to the live store
+  assert_live_store_freed # durability lives in send_alert's write-ahead store, not a batch restore
+  # A second run finds a fresh (empty) store and is silent: this batch is never re-sent.
+  : >"$SEND_ALERT_LOG"
+  unset SEND_ALERT_RC
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected the second run silent (exit 0), got %s\n' "$status" >&2
+    return 1
+  fi
+  assert_no_send
+}
+
+@test "an all-torn store renders an empty body, so it sends nothing and preserves the batch to .last" {
+  # Every line unparseable: Guard 2 (non-whitespace bytes) passes and the raw lines are
+  # counted, but the rendered body is empty. The builder must NOT send a misleading
+  # silent "N item(s)" with an empty body; it preserves the batch to .last and stays silent.
+  seed_store '{"detector":"persistence_launchd","identity":"x' '{"oops'
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected exit 0, got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_no_send
+  assert_batch_in_last 2  # the unrecoverable batch is preserved for forensics
   assert_live_store_freed
 }

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -12,7 +12,9 @@
 #   B2 atomic rotate + ERR-restore: a store with real records is claimed into a
 #      unique work file (freeing the live store for concurrent appends), and a
 #      build failure BEFORE the send restores the batch so nothing is lost.
-# Grouping, the silent send, and the rotation to .last land in later behaviors.
+#   B3 grouped, capped, injection-safe body: findings group by detector into
+#      capped Discord-safe blocks, and a crafted field cannot inject extra lines.
+# The silent send and the rotation to .last land in later behaviors.
 
 setup() { setup_digest_harness; }
 teardown() { teardown_digest_harness; }
@@ -199,6 +201,55 @@ assert_no_work_file_left() {
   fi
 }
 
+# render_digest_body_on <work_file> - source the builder (its source-guard keeps
+# main from running) and call the build step directly on a fixture work file,
+# printing the rendered body. The unit seam for the body render: B3 has no send
+# yet, so a test reads the body from stdout.
+render_digest_body_on() {
+  bash -c 'source "$DIGEST_BUILDER"; render_digest_body "$1"' digest-render-probe "$1"
+}
+
+# render_body <record>... - build a fixture work file from the given NDJSON
+# records and print the rendered digest body.
+render_body() {
+  local work_file="$HARNESS_HOME/fixture.build"
+  printf '%s\n' "$@" >"$work_file"
+  render_digest_body_on "$work_file"
+}
+
+# assert_body_has <body> <fixed-needle> - the body contains the needle.
+assert_body_has() {
+  local body="$1" needle="$2"
+  if ! grep -qF -- "$needle" <<<"$body"; then
+    printf 'expected the digest body to contain %q, body was:\n%s\n' "$needle" "$body" >&2
+    return 1
+  fi
+}
+
+# assert_line_count <body> <regex> <n> - exactly <n> body lines match the regex.
+assert_line_count() {
+  local body="$1" regex="$2" want="$3" got
+  got="$(grep -cE -- "$regex" <<<"$body" || true)"
+  if [[ $got -ne $want ]]; then
+    printf 'expected %s line(s) matching /%s/, got %s, body was:\n%s\n' "$want" "$regex" "$got" "$body" >&2
+    return 1
+  fi
+}
+
+# assert_no_injected_line <body> - no body line BEGINS with a forged field marker.
+# A sanitized field keeps crafted "- **Signing:**" text inline within its own
+# bullet; only a sanitize regression would push it to the start of a new line.
+assert_no_injected_line() {
+  local body="$1"
+  if grep -qE '^- \*\*Signing:\*\*' <<<"$body"; then
+    printf 'INJECTION: a body line begins with a forged "- **Signing:**" marker:\n%s\n' "$body" >&2
+    return 1
+  fi
+}
+
+# body_byte_length <body> - the body length in bytes (the head -c cap's unit).
+body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
+
 @test "an absent digest store produces no message and exits 0" {
   given_absent_store
   assert_silent_success
@@ -241,4 +292,92 @@ assert_no_work_file_left() {
   assert_live_store_restored 2
   assert_no_work_file_left
   assert_no_send
+}
+
+@test "findings across three detectors render as three grouped blocks with header and count" {
+  local body
+  body="$(render_body \
+    "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')" \
+    "$(digest_record persistence_launchd com.bar.agent 'persistence_launchd com.bar.agent')" \
+    "$(digest_record system_extensions_new io.tailscale 'system_extensions_new io.tailscale')" \
+    "$(digest_record sudoers /etc/sudoers.d/foo 'sudoers /etc/sudoers.d/foo')")"
+  assert_body_has "$body" '**persistence_launchd** (2)'
+  assert_body_has "$body" '**system_extensions_new** (1)'
+  assert_body_has "$body" '**sudoers** (1)'
+  assert_body_has "$body" '- com.foo.agent - persistence_launchd com.foo.agent'
+  assert_body_has "$body" '- io.tailscale - system_extensions_new io.tailscale'
+}
+
+@test "a detector with more findings than the bullet cap shows N bullets and a +K more roll-up" {
+  local records=() i
+  for i in $(seq 1 14); do
+    records+=("$(digest_record persistence_launchd "com.item.$i" "summary $i")")
+  done
+  local body
+  body="$(render_body "${records[@]}")"
+  assert_body_has "$body" '**persistence_launchd** (14)' # the header counts the true total
+  assert_line_count "$body" '^- com\.item\.' 10          # DIGEST_MAX_BULLETS_PER_GROUP default
+  assert_body_has "$body" '+4 more'
+}
+
+@test "more detector groups than the group cap show M blocks and an and-K-more marker" {
+  local records=() i
+  for i in $(seq 1 15); do
+    records+=("$(digest_record "detector_$i" "id_$i" "summary $i")")
+  done
+  local body
+  body="$(render_body "${records[@]}")"
+  assert_line_count "$body" '^\*\*detector_' 12 # DIGEST_MAX_GROUPS default
+  assert_body_has "$body" 'and 3 more detector group(s)'
+}
+
+@test "the body stays under the char cap even with many findings" {
+  local records=() i
+  for i in $(seq 1 150); do
+    records+=("$(printf '{"timestamp":"t","detector":"det_%s","category":"","identity":"identity_number_%s","action":"added","summary":"a summary long enough to add real bytes for finding number %s"}' "$((i % 15))" "$i" "$i")")
+  done
+  # Default cap: the body renders content yet stays well under Discord's 2000.
+  local body bytes
+  body="$(render_body "${records[@]}")"
+  assert_body_has "$body" '**det_'
+  bytes="$(body_byte_length "$body")"
+  if [[ $bytes -gt 1800 ]]; then
+    printf 'expected body <= the 1800 default cap (well under 2000), got %s\n' "$bytes" >&2
+    return 1
+  fi
+  # Overridable: a tighter cap is honored, proving the hard head -c backstop and the knob.
+  export DIGEST_MAX_BODY_CHARS=500
+  body="$(render_body "${records[@]}")"
+  bytes="$(body_byte_length "$body")"
+  if [[ $bytes -gt 500 ]]; then
+    printf 'expected body <= the 500 override cap, got %s\n' "$bytes" >&2
+    return 1
+  fi
+}
+
+@test "the group and bullet caps are env-overridable named constants" {
+  local records=() i
+  for i in $(seq 1 6); do
+    records+=("$(digest_record "det_$i" "id_$i" "summary $i")")
+  done
+  for i in $(seq 1 4); do
+    records+=("$(digest_record det_1 "extra_$i" "extra $i")") # det_1 gets five findings total
+  done
+  export DIGEST_MAX_GROUPS=2 DIGEST_MAX_BULLETS_PER_GROUP=3
+  local body
+  body="$(render_body "${records[@]}")"
+  assert_line_count "$body" '^\*\*det_' 2 # DIGEST_MAX_GROUPS honored
+  assert_body_has "$body" 'and 4 more detector group(s)'
+  assert_body_has "$body" '+2 more' # det_1: 5 findings, 3 bullets + "+2 more" (DIGEST_MAX_BULLETS_PER_GROUP)
+}
+
+@test "a crafted identity cannot inject an extra markdown line into the digest body" {
+  local evil
+  evil=$'evil\n- **Signing:** signed: Apple'
+  local body
+  body="$(render_body "$(digest_record persistence_launchd "$evil" 'malicious finding')")"
+  # The crafted newline is squashed to a space, so the value stays inert INSIDE one bullet.
+  assert_body_has "$body" '- evil - **Signing:** signed: Apple - malicious finding'
+  # And the forged field marker never becomes its own line.
+  assert_no_injected_line "$body"
 }

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -6,9 +6,13 @@
 # send_alert, so a test asserts whether (and how) the builder dispatched without
 # touching the network or the real SQLite store.
 #
-# B1 (this commit): empty-suppression. An absent, zero-byte, or whitespace-only
-# store produces no message and no error. Grouping, rotation, and the send land
-# in later behaviors.
+# Behaviors covered so far:
+#   B1 empty-suppression: an absent, zero-byte, or whitespace-only store produces
+#      no message and no error.
+#   B2 atomic rotate + ERR-restore: a store with real records is claimed into a
+#      unique work file (freeing the live store for concurrent appends), and a
+#      build failure BEFORE the send restores the batch so nothing is lost.
+# Grouping, the silent send, and the rotation to .last land in later behaviors.
 
 setup() { setup_digest_harness; }
 teardown() { teardown_digest_harness; }
@@ -40,10 +44,15 @@ send_alert() {
 SPY
 
   # A temp spool path the builder resolves via OSQUERY_DIGEST_STORE. Left ABSENT
-  # by default so a test opts in to a zero-byte or whitespace-only variant.
+  # by default so a test opts in to a zero-byte, whitespace-only, or seeded store.
   export OSQUERY_DIGEST_STORE="$HARNESS_HOME/.local/state/osquery-digest-spool/digest.ndjson"
 
-  DIGEST_BUILDER="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_digest.sh"
+  # A witness the fault-injection driver writes when the build step runs against
+  # the CLAIMED (rotated) batch: it proves the rotate happened before the build.
+  export DIGEST_BUILD_WITNESS="$HARNESS_HOME/build-witness"
+
+  # Exported so the fault-injection driver (a child bash) can source the builder.
+  export DIGEST_BUILDER="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_digest.sh"
 }
 
 # teardown_digest_harness - remove ONLY a temp dir this harness created. The
@@ -57,6 +66,40 @@ teardown_digest_harness() {
 
 # run_digest - invoke the builder as a child process under the harness env.
 run_digest() { bash "$DIGEST_BUILDER"; }
+
+# run_digest_with_failing_build - drive the builder to a forced PRE-SEND failure.
+# A child bash sources the builder (its source-guard keeps main from auto-running),
+# overrides the build step to fail (after witnessing that the batch was already
+# claimed into the work file), then runs main. Sourcing is why the builder splits
+# main from a source-guard: it is the seam that lets a test fault-inject one step.
+run_digest_with_failing_build() {
+  bash -c '
+    source "$DIGEST_BUILDER"
+    render_digest_body() {
+      local work_file="$1"
+      [[ -f $work_file ]] && printf "claimed\n" >"$DIGEST_BUILD_WITNESS"
+      return 1
+    }
+    main
+  ' digest-build-fault-injector
+}
+
+# digest_record <detector> <identity> <summary> - one NDJSON spool line in the
+# shape digest_append writes (results-alerter/digest-store.sh), so the builder
+# reads records identical to production.
+digest_record() {
+  jq -cn --arg detector "$1" --arg identity "$2" --arg summary "$3" \
+    '{timestamp: "2026-07-18T00:00:00Z", detector: $detector, category: "", identity: $identity, action: "added", summary: $summary}'
+}
+
+# seed_store <record>... - write the given NDJSON records to the live store.
+seed_store() {
+  mkdir -p "$(dirname "$OSQUERY_DIGEST_STORE")"
+  printf '%s\n' "$@" >"$OSQUERY_DIGEST_STORE"
+}
+
+# count_records <file> - number of non-blank lines (records) in a spool file.
+count_records() { grep -c '[^[:space:]]' "$1" 2>/dev/null || printf '0'; }
 
 # given_absent_store - the spool file does not exist (the default, made explicit).
 given_absent_store() { rm -f "$OSQUERY_DIGEST_STORE"; }
@@ -76,7 +119,7 @@ given_whitespace_only_store() {
 # assert_no_send - the recording spy captured no send_alert call.
 assert_no_send() {
   if [[ -s $SEND_ALERT_LOG ]]; then
-    printf 'expected NO dispatch (an empty store is silent), but send_alert was called: %s\n' \
+    printf 'expected NO dispatch, but send_alert was called: %s\n' \
       "$(cat "$SEND_ALERT_LOG")" >&2
     return 1
   fi
@@ -93,6 +136,69 @@ assert_silent_success() {
   assert_no_send
 }
 
+# assert_live_store_freed - the live store was rotated aside, so a concurrent
+# alerter append lands in a fresh file this run will not consume.
+assert_live_store_freed() {
+  if [[ -s $OSQUERY_DIGEST_STORE ]]; then
+    printf 'expected the live store freed (rotated aside), but it still holds: %s\n' \
+      "$(cat "$OSQUERY_DIGEST_STORE")" >&2
+    return 1
+  fi
+}
+
+# assert_work_file_holds <n> - exactly one .build work file exists and carries
+# the <n> rotated records.
+assert_work_file_holds() {
+  local want="$1"
+  local work_files=("$OSQUERY_DIGEST_STORE".*.build)
+  if [[ ! -e ${work_files[0]} ]]; then
+    printf 'expected one .build work file holding the rotated batch, found none\n' >&2
+    return 1
+  fi
+  if [[ ${#work_files[@]} -ne 1 ]]; then
+    printf 'expected exactly one .build work file, found %s: %s\n' "${#work_files[@]}" "${work_files[*]}" >&2
+    return 1
+  fi
+  local got
+  got="$(count_records "${work_files[0]}")"
+  if [[ $got -ne $want ]]; then
+    printf 'expected the work file to hold %s record(s), got %s\n' "$want" "$got" >&2
+    return 1
+  fi
+}
+
+# assert_build_ran_against_work_file - the build step ran against the CLAIMED
+# batch, proving the rotate happened before the build (not against the live store).
+assert_build_ran_against_work_file() {
+  local witness
+  witness="$(cat "$DIGEST_BUILD_WITNESS" 2>/dev/null || true)"
+  if [[ $witness != claimed ]]; then
+    printf 'expected the build step to run against the rotated work file (batch claimed first), witness=%q\n' "$witness" >&2
+    return 1
+  fi
+}
+
+# assert_live_store_restored <n> - the batch is back as the live store with <n>
+# records, so the next daily run retries it.
+assert_live_store_restored() {
+  local want="$1" got
+  got="$(count_records "$OSQUERY_DIGEST_STORE")"
+  if [[ ! -s $OSQUERY_DIGEST_STORE || $got -ne $want ]]; then
+    printf 'expected the batch restored to the live store with %s record(s), got %s (store present=%s)\n' \
+      "$want" "$got" "$([[ -e $OSQUERY_DIGEST_STORE ]] && echo yes || echo no)" >&2
+    return 1
+  fi
+}
+
+# assert_no_work_file_left - no .build work file remains (the restore moved it back).
+assert_no_work_file_left() {
+  local leftovers=("$OSQUERY_DIGEST_STORE".*.build)
+  if [[ -e ${leftovers[0]} ]]; then
+    printf 'expected no .build work file after restore, found: %s\n' "${leftovers[*]}" >&2
+    return 1
+  fi
+}
+
 @test "an absent digest store produces no message and exits 0" {
   given_absent_store
   assert_silent_success
@@ -106,4 +212,33 @@ assert_silent_success() {
 @test "a whitespace-only digest store produces no message and exits 0" {
   given_whitespace_only_store
   assert_silent_success
+}
+
+@test "a store with real records is rotated to a work file, freeing the live store" {
+  seed_store \
+    "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')" \
+    "$(digest_record persistence_launchd com.bar.agent 'persistence_launchd com.bar.agent')"
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected exit 0 after the rotate, got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_live_store_freed
+  assert_work_file_holds 2
+  assert_no_send
+}
+
+@test "a build failure before the send restores the rotated batch to the live store" {
+  seed_store \
+    "$(digest_record sudoers /etc/sudoers.d/foo 'sudoers /etc/sudoers.d/foo')" \
+    "$(digest_record sudoers /etc/sudoers.d/bar 'sudoers /etc/sudoers.d/bar')"
+  run run_digest_with_failing_build
+  if [[ $status -eq 0 ]]; then
+    printf 'expected a nonzero exit from the forced pre-send build failure, got 0\n' >&2
+    return 1
+  fi
+  assert_build_ran_against_work_file
+  assert_live_store_restored 2
+  assert_no_work_file_left
+  assert_no_send
 }

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -548,26 +548,63 @@ assert_last_mode_600() {
   assert_sent_body_has '`42`'           # the numeric identity coerced to a string
 }
 
-@test "a failed send still rotates the batch to .last and never restores it for a re-send" {
-  seed_store "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')"
-  export SEND_ALERT_RC=1 # the spy simulates a HARD send failure
+@test "a hard send failure (persist failed) restores the batch to the live store for retry" {
+  # send_alert returns nonzero ONLY when its write-ahead persist failed: the page was neither
+  # delivered NOR stored ("the caller must not advance its cursor past it"), so the batch must be
+  # RESTORED, not rotated to .last, and the next run retries it. Restoring cannot double-store
+  # because nothing was stored.
+  seed_store "$(digest_record persistence_launchd com.foo.agent 'foo')"
+  export SEND_ALERT_RC=1
   run run_digest
   if [[ $status -ne 0 ]]; then
-    printf 'expected fire-and-forget exit 0 despite the failed send, got %s: %s\n' "$status" "$output" >&2
+    printf 'expected exit 0 despite the hard send failure, got %s: %s\n' "$status" "$output" >&2
     return 1
   fi
-  assert_sent_once        # exactly one send ATTEMPT, no restore-and-retry loop
-  assert_batch_in_last 1  # preserved to .last, NOT restored to the live store
-  assert_live_store_freed # durability lives in send_alert's write-ahead store, not a batch restore
-  # A second run finds a fresh (empty) store and is silent: this batch is never re-sent.
-  : >"$SEND_ALERT_LOG"
-  unset SEND_ALERT_RC
+  assert_sent_once
+  assert_live_store_restored 1 # RESTORED for retry (the page was neither delivered nor stored)
+  if [[ -e $OSQUERY_DIGEST_STORE.last ]]; then
+    printf 'expected NO .last on a hard-fail restore, but it exists\n' >&2
+    return 1
+  fi
+}
+
+@test "a stored send (delivery pending, rc 0) rotates the batch to .last, not restored" {
+  # send_alert returns 0 on every STORED outcome (delivered, stored-nosecret, stored-delivery-
+  # pending): durability is delegated to its write-ahead store + drainer, so the batch is rotated
+  # to .last, NOT restored (a restore would double-store and re-send a duplicate next run).
+  seed_store "$(digest_record persistence_launchd com.foo.agent 'foo')"
+  export SEND_ALERT_RC=0
   run run_digest
   if [[ $status -ne 0 ]]; then
-    printf 'expected the second run silent (exit 0), got %s\n' "$status" >&2
+    printf 'expected exit 0, got %s: %s\n' "$status" "$output" >&2
     return 1
   fi
-  assert_no_send
+  assert_sent_once
+  assert_batch_in_last 1  # rotated to .last (durability delegated to send_alert)
+  assert_live_store_freed # NOT restored
+}
+
+@test "restore preserves a finding appended to the fresh store during the build" {
+  # The alerter can append a NEW finding to the fresh live store WHILE the build runs. A restore
+  # that OVERWRITES the store (mv -f) destroys that concurrent append; an append-restore keeps it.
+  # Order within a grouped digest is irrelevant, so appending is safe.
+  seed_store \
+    "$(digest_record persistence_launchd com.batch.a 'A')" \
+    "$(digest_record persistence_launchd com.batch.b 'B')"
+  local concurrent
+  concurrent="$(digest_record sudoers /etc/sudoers.d/c 'C')"
+  # Drive the builder with a render step that appends a concurrent finding to the fresh store, then
+  # fails to force the pre-send restore.
+  CONCURRENT_RECORD="$concurrent" bash -c '
+    source "$DIGEST_BUILDER"
+    render_digest_body() { printf "%s\n" "$CONCURRENT_RECORD" >>"$OSQUERY_DIGEST_STORE"; return 1; }
+    main
+  ' digest-concurrent-restore-probe || true
+  local store_content
+  store_content="$(cat "$OSQUERY_DIGEST_STORE" 2>/dev/null || true)"
+  assert_body_has "$store_content" 'com.batch.a'     # the claimed batch is restored
+  assert_body_has "$store_content" 'com.batch.b'
+  assert_body_has "$store_content" '/etc/sudoers.d/c' # AND the concurrent append survives
 }
 
 @test "an all-torn store renders an empty body, so it sends nothing and preserves the batch to .last" {

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# The daily digest builder (digest.sh): drains the digest spool (NDJSON, written
+# by the alerter's digest_append) into ONE grouped, silent, non-paging message,
+# then rotates the live store aside. This suite exercises the builder as a black
+# box against a stubbed dispatch: a message-recording spy replaces the real
+# send_alert, so a test asserts whether (and how) the builder dispatched without
+# touching the network or the real SQLite store.
+#
+# B1 (this commit): empty-suppression. An absent, zero-byte, or whitespace-only
+# store produces no message and no error. Grouping, rotation, and the send land
+# in later behaviors.
+
+setup() { setup_digest_harness; }
+teardown() { teardown_digest_harness; }
+
+# setup_digest_harness (makeSUT factory) - stand up a throwaway HOME whose only
+# dispatch library is a recording spy, point the builder at a temp spool path,
+# and export the inputs the builder reads. Sets nothing at file-load time; every
+# export happens here, called from setup().
+setup_digest_harness() {
+  HARNESS_HOME="$(mktemp -d)"
+  # Record ownership only after our own mktemp, so teardown removes this path and
+  # never a pre-set or inherited HARNESS_HOME.
+  _DIGEST_HARNESS_OWNED_DIR="$HARNESS_HOME"
+  export HOME="$HARNESS_HOME"
+
+  # The recording spy for send_alert, at the exact libexec path the builder
+  # sources. It appends each call's argv to $SEND_ALERT_LOG, so "no dispatch" is
+  # an empty log and a later behavior can grep the log for the rendered body.
+  local dispatch_dir="$HARNESS_HOME/.local/libexec/osquery"
+  mkdir -p "$dispatch_dir"
+  export SEND_ALERT_LOG="$HARNESS_HOME/send-alert.log"
+  : >"$SEND_ALERT_LOG"
+  cat >"$dispatch_dir/alert-dispatch.sh" <<'SPY'
+# Recording spy for alert-dispatch.sh: capture each send_alert call so a test can
+# assert whether the builder dispatched, and with what, without a real send.
+send_alert() {
+  printf '%s\n' "$*" >>"$SEND_ALERT_LOG"
+}
+SPY
+
+  # A temp spool path the builder resolves via OSQUERY_DIGEST_STORE. Left ABSENT
+  # by default so a test opts in to a zero-byte or whitespace-only variant.
+  export OSQUERY_DIGEST_STORE="$HARNESS_HOME/.local/state/osquery-digest-spool/digest.ndjson"
+
+  DIGEST_BUILDER="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_digest.sh"
+}
+
+# teardown_digest_harness - remove ONLY a temp dir this harness created. The
+# ownership marker is set after our own mktemp, so a pre-set HARNESS_HOME (marker
+# unset) is left untouched.
+teardown_digest_harness() {
+  [[ -n ${_DIGEST_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_DIGEST_HARNESS_OWNED_DIR"
+  unset _DIGEST_HARNESS_OWNED_DIR
+}
+
+# run_digest - invoke the builder as a child process under the harness env.
+run_digest() { bash "$DIGEST_BUILDER"; }
+
+# given_absent_store - the spool file does not exist (the default, made explicit).
+given_absent_store() { rm -f "$OSQUERY_DIGEST_STORE"; }
+
+# given_empty_store - a zero-byte spool file.
+given_empty_store() {
+  mkdir -p "$(dirname "$OSQUERY_DIGEST_STORE")"
+  : >"$OSQUERY_DIGEST_STORE"
+}
+
+# given_whitespace_only_store - a spool with bytes but no non-whitespace content.
+given_whitespace_only_store() {
+  mkdir -p "$(dirname "$OSQUERY_DIGEST_STORE")"
+  printf ' \t\n  \n' >"$OSQUERY_DIGEST_STORE"
+}
+
+# assert_no_send - the recording spy captured no send_alert call.
+assert_no_send() {
+  if [[ -s $SEND_ALERT_LOG ]]; then
+    printf 'expected NO dispatch (an empty store is silent), but send_alert was called: %s\n' \
+      "$(cat "$SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_silent_success - the B1 behavior in one intent-named assertion: the
+# builder exits 0 AND sends nothing.
+assert_silent_success() {
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected the builder to exit 0 (silent success), got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_no_send
+}
+
+@test "an absent digest store produces no message and exits 0" {
+  given_absent_store
+  assert_silent_success
+}
+
+@test "a zero-byte digest store produces no message and exits 0" {
+  given_empty_store
+  assert_silent_success
+}
+
+@test "a whitespace-only digest store produces no message and exits 0" {
+  given_whitespace_only_store
+  assert_silent_success
+}

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -277,6 +277,15 @@ assert_sent_body_has() {
   fi
 }
 
+# assert_sent_title_has <fixed-needle> - the recorded send title contains the needle.
+assert_sent_title_has() {
+  local needle="$1"
+  if ! grep -qF -- "$needle" "$SEND_ALERT_TITLE" 2>/dev/null; then
+    printf 'expected the sent title to contain %q, title was:\n%s\n' "$needle" "$(cat "$SEND_ALERT_TITLE" 2>/dev/null || true)" >&2
+    return 1
+  fi
+}
+
 # assert_batch_in_last <n> - the built batch was preserved as $store.last with <n> records.
 assert_batch_in_last() {
   local want="$1" got
@@ -323,11 +332,13 @@ assert_last_mode_600() {
     return 1
   fi
   assert_sent_once
-  assert_sent_silent_crit # CRIT route + EMPTY sound => tier=muted (non-paging)
+  assert_sent_silent_crit             # CRIT route + EMPTY sound => tier=muted (non-paging)
+  assert_sent_title_has '· 2 item(s)' # the title carries the true item count (2 records)
   assert_sent_body_has '**persistence_launchd** (1)'
   assert_sent_body_has '**sudoers** (1)'
-  assert_live_store_freed # the live store is fresh for the next run
-  assert_batch_in_last 2  # the built batch is preserved for forensics
+  assert_live_store_freed  # the live store is fresh for the next run
+  assert_batch_in_last 2   # the built batch is preserved for forensics
+  assert_no_work_file_left # the .build is cleaned on the success path (no mv->cp leak)
   assert_last_mode_600
 }
 

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -6,15 +6,13 @@
 # send_alert, so a test asserts whether (and how) the builder dispatched without
 # touching the network or the real SQLite store.
 #
-# Behaviors covered so far:
-#   B1 empty-suppression: an absent, zero-byte, or whitespace-only store produces
-#      no message and no error.
-#   B2 atomic rotate + ERR-restore: a store with real records is claimed into a
-#      unique work file (freeing the live store for concurrent appends), and a
-#      build failure BEFORE the send restores the batch so nothing is lost.
-#   B3 grouped, capped, injection-safe body: findings group by detector into
-#      capped Discord-safe blocks, and a crafted field cannot inject extra lines.
-# The silent send and the rotation to .last land in later behaviors.
+# Covered end to end: empty-suppression (absent/zero-byte/whitespace/all-torn); the atomic claim
+# and append-restore (a build failure or a hard send failure restores the batch, preserving a
+# finding appended during the build); grouped, capped, injection-safe rendering (each attacker field
+# wrapped in a code span, four env-overridable caps with a non-numeric fallback, a codepoint body cap
+# with an honest marker); torn-line and valid-JSON wrong-shape resilience; the silent tier=muted send
+# with restore on a hard failure and rotation to .last on a stored one; and orphan recovery of a
+# killed run's work file. The launchd schedule wiring is covered by the sibling launchagent test.
 
 setup() { setup_digest_harness; }
 teardown() { teardown_digest_harness; }
@@ -636,6 +634,20 @@ assert_last_mode_600() {
   assert_sent_once
   assert_sent_body_has '`com.orphan.finding`' # the orphan finding recovered and sent
   assert_sent_body_has '`/etc/sudoers.d/new`' # and the current finding too
+}
+
+@test "a non-numeric cap env value falls back to the default instead of failing the render" {
+  # A typo'd env cap (DIGEST_MAX_GROUPS=abc) reaches --argjson as invalid JSON and fails the render,
+  # which would silently kill the daily digest. A non-integer must fall back to the default and send.
+  seed_store "$(digest_record persistence_launchd com.foo.agent 'foo')"
+  export DIGEST_MAX_GROUPS=abc
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected exit 0 (fall back to the default), got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_sent_once
+  assert_sent_body_has '`com.foo.agent`'
 }
 
 @test "an all-torn store renders an empty body, so it sends nothing and preserves the batch to .last" {

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -505,6 +505,25 @@ assert_last_mode_600() {
   assert_live_store_freed
 }
 
+@test "a valid-JSON wrong-shape line is coerced, not fatal, and the digest still sends" {
+  # These lines PARSE (survive try/catch) but carry a null/missing or numeric identity; a bare
+  # .identity | gsub aborts jq rc=5 ("cannot be matched, not a string") -> ERR-trap restore ->
+  # permanent silent digest death + an unbounded store. The field access must coerce, not abort.
+  seed_store \
+    "$(digest_record persistence_launchd com.good.one 'good one')" \
+    '{"detector":"persistence_launchd","summary":"missing identity"}' \
+    '{"detector":"persistence_launchd","identity":42,"summary":"numeric identity"}'
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected exit 0 (no abort on the wrong-shape lines), got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_sent_once
+  assert_sent_body_has '`com.good.one`' # the good finding still rendered
+  assert_sent_body_has '`?`'            # the missing-identity line coerced to ?
+  assert_sent_body_has '`42`'           # the numeric identity coerced to a string
+}
+
 @test "a failed send still rotates the batch to .last and never restores it for a re-send" {
   seed_store "$(digest_record persistence_launchd com.foo.agent 'persistence_launchd com.foo.agent')"
   export SEND_ALERT_RC=1 # the spy simulates a HARD send failure

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -400,3 +400,33 @@ body_byte_length() { printf '%s' "$1" | wc -c | tr -d '[:space:]'; }
     return 1
   fi
 }
+
+@test "a torn or malformed spool line is skipped, so the day's digest still builds" {
+  local records=(
+    "$(digest_record persistence_launchd com.good.one 'persistence_launchd com.good.one')"
+    '{"detector":"persistence_launchd","identity":"com.tor' # a truncated (torn) append
+    'this is not json at all'                               # non-JSON garbage
+    "$(digest_record persistence_launchd com.good.two 'persistence_launchd com.good.two')"
+    "$(digest_record sudoers /etc/sudoers.d/foo 'sudoers /etc/sudoers.d/foo')"
+  )
+  # The parse drops the torn and garbage lines; the valid findings still group and render.
+  local body
+  body="$(render_body "${records[@]}")"
+  assert_body_has "$body" '**persistence_launchd** (2)' # the two GOOD launchd findings; the torn one skipped
+  assert_body_has "$body" '- com.good.one - persistence_launchd com.good.one'
+  assert_body_has "$body" '- com.good.two - persistence_launchd com.good.two'
+  assert_body_has "$body" '**sudoers** (1)'
+  if grep -qF -- 'com.tor' <<<"$body"; then
+    printf 'expected the torn line skipped, but its fragment appeared:\n%s\n' "$body" >&2
+    return 1
+  fi
+  # The FULL builder survives the torn line: it exits 0 (no set -e abort), so the B2 ERR
+  # trap never restores the batch and the digest is not silently lost until the line ages out.
+  seed_store "${records[@]}"
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected the build to survive the torn line (exit 0), got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_live_store_freed
+}

--- a/test/integration/osquery-digest-builder.bats
+++ b/test/integration/osquery-digest-builder.bats
@@ -394,28 +394,52 @@ assert_last_mode_600() {
   assert_body_has "$body" 'and 3 more detector group(s)'
 }
 
-@test "the body stays under the char cap even with many findings" {
+@test "the body is codepoint-capped with an honest truncation marker" {
   local records=() i
   for i in $(seq 1 150); do
     records+=("$(printf '{"timestamp":"t","detector":"det_%s","category":"","identity":"identity_number_%s","action":"added","summary":"a summary long enough to add real bytes for finding number %s"}' "$((i % 15))" "$i" "$i")")
   done
-  # Default cap: the body renders content yet stays well under Discord's 2000.
-  local body bytes
+  # Default cap: content renders, the truncation is MARKED (a silent head -c byte cut is a bug),
+  # and the body stays well under Discord's 2000. Length is codepoints (jq slices codepoints).
+  local body cp
   body="$(render_body "${records[@]}")"
   assert_body_has "$body" '**det_'
-  bytes="$(body_byte_length "$body")"
-  if [[ $bytes -gt 1800 ]]; then
-    printf 'expected body <= the 1800 default cap (well under 2000), got %s\n' "$bytes" >&2
+  assert_body_has "$body" '(truncated)'
+  cp="$(printf '%s' "$body" | wc -m | tr -d '[:space:]')"
+  if [[ $cp -gt 1830 ]]; then
+    printf 'expected body <= ~1830 codepoints (1800 cap + marker), got %s\n' "$cp" >&2
     return 1
   fi
-  # Overridable: a tighter cap is honored, proving the hard head -c backstop and the knob.
+  # Overridable and still honest: a tighter cap is honored with the same marker.
   export DIGEST_MAX_BODY_CHARS=500
   body="$(render_body "${records[@]}")"
-  bytes="$(body_byte_length "$body")"
-  if [[ $bytes -gt 500 ]]; then
-    printf 'expected body <= the 500 override cap, got %s\n' "$bytes" >&2
+  assert_body_has "$body" '(truncated)'
+  cp="$(printf '%s' "$body" | wc -m | tr -d '[:space:]')"
+  if [[ $cp -gt 530 ]]; then
+    printf 'expected body <= ~530 codepoints (500 cap + marker), got %s\n' "$cp" >&2
     return 1
   fi
+}
+
+@test "an oversized body is capped inside jq and sent once, with no broken-pipe failure" {
+  # A body far larger than the macOS pipe buffer (which grows to ~64KB) made `jq | head -c` block
+  # on write and take SIGPIPE (rc 141), which tripped the ERR trap and sent nothing on busy days.
+  # Raise the field cap and seed large fields so the body far exceeds the buffer; the body cap must
+  # live INSIDE jq (no pipe) so an over-cap body truncates and sends exactly once.
+  local big records=() i
+  big="$(printf 'x%.0s' {1..5000})"
+  for i in $(seq 1 20); do # 2 detectors x 10 findings, ~10KB per bullet -> ~200KB pre-cap
+    records+=("$(digest_record "det_$((i % 2))" "id${i}_$big" "sum${i}_$big")")
+  done
+  export DIGEST_MAX_FIELD_CHARS=6000 # let the big fields through, so the body blows past the buffer
+  seed_store "${records[@]}"
+  run run_digest
+  if [[ $status -ne 0 ]]; then
+    printf 'expected the oversized body to cap and send (exit 0), got %s: %s\n' "$status" "$output" >&2
+    return 1
+  fi
+  assert_sent_once
+  assert_sent_body_has '(truncated)' # capped, and the truncation is marked
 }
 
 @test "the group and bullet caps are env-overridable named constants" {

--- a/test/integration/osquery-feature-set-location.sh
+++ b/test/integration/osquery-feature-set-location.sh
@@ -11,9 +11,9 @@ cd "$REPO_ROOT"
 
 fail=0
 
-# 1. The libexec home holds the five scripts (prefix dropped). A git ls-files
+# 1. The libexec home holds the six scripts (prefix dropped). A git ls-files
 # failure fails the test.
-for f in alert-dispatch enrich-finding firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+for f in alert-dispatch digest enrich-finding firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
   path="dot_local/libexec/osquery/executable_${f}.sh"
   if ! listed="$(git ls-files "$path")"; then
     printf 'FAIL: git ls-files failed while checking %s\n' "$path" >&2
@@ -44,15 +44,15 @@ assert_contains() {
   esac
 }
 
-# The three launchd plists' ProgramArguments point at the libexec home.
-for name in firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+# The four launchd plists' ProgramArguments point at the libexec home.
+for name in digest firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
   assert_contains ".local/libexec/osquery/${name}.sh" \
     "Library/LaunchAgents/com.webdavis.osquery-${name}.plist.tmpl"
 done
 
-# The three consumers source the dispatch library from the libexec home.
+# The four consumers source the dispatch library from the libexec home.
 # The needles below are literal source lines; $HOME must NOT expand here.
-for name in firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+for name in digest firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
   # shellcheck disable=SC2016
   assert_contains 'source "$HOME/.local/libexec/osquery/alert-dispatch.sh"' \
     "dot_local/libexec/osquery/executable_${name}.sh"

--- a/test/integration/osquery-feature-set-location.sh
+++ b/test/integration/osquery-feature-set-location.sh
@@ -67,6 +67,15 @@ done
 assert_contains '$HOME/.local/libexec/osquery/enrich-finding.sh' \
   "dot_local/libexec/osquery/results-alerter/route.sh"
 
+# Digest spool path parity: the digest builder (read side) and digest-store.sh (write side) each
+# define OSQUERY_DIGEST_STORE_DEFAULT as an INDEPENDENT literal. They must stay byte-identical, or
+# the reader watches a path nobody writes and the digest is silently empty forever. Pin the exact
+# literal in both. The needle carries a literal $HOME that must NOT expand here.
+# shellcheck disable=SC2016
+digest_store_default='OSQUERY_DIGEST_STORE_DEFAULT="$HOME/.local/state/osquery-digest-spool/digest.ndjson"'
+assert_contains "$digest_store_default" "dot_local/libexec/osquery/executable_digest.sh"
+assert_contains "$digest_store_default" "dot_local/libexec/osquery/results-alerter/digest-store.sh"
+
 if [[ $fail -ne 0 ]]; then
   printf 'osquery-feature-set-location: FAIL\n' >&2
   exit 1

--- a/test/unit/osquery-digest-launchagent.sh
+++ b/test/unit/osquery-digest-launchagent.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# The daily digest LaunchAgent: com.webdavis.osquery-digest runs the deployed
+# digest builder once a day at a time DECLARED IN DATA
+# (.chezmoidata/osquery.yaml digestHour/digestMinute), never hardcoded in the
+# plist. RunAtLoad is false: a daily digest fires at its StartCalendarInterval,
+# not at apply time (a load-time run would send a digest at an arbitrary hour).
+# It is a gui/<uid> USER agent, not a system daemon: the builder calls send_alert
+# (the user's local macOS notifier) and reads the user-scoped digest spool, not
+# any osquery table. Its loader chezmoiscript is wired like the sibling osquery
+# agents (darwin gate, plist-hash onchange trigger, bootout + bootstrap retry),
+# PLUS a rendered schedule line so a DATA-only osquery.yaml change re-fires it:
+# the plist-hash include hashes the template SOURCE, whose {{ }} placeholders do
+# not change when their values do.
+#
+# Unit test: render the plist and loader with the host chezmoi and assert their
+# content, including that the schedule is DATA-DRIVEN (a different osquery.yaml
+# renders a different StartCalendarInterval). No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-digest-launchagent.sh.tmpl"
+YAML="$REPO_ROOT/.chezmoidata/osquery.yaml"
+
+fail() {
+  printf 'osquery-digest-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+[[ -f $YAML ]] || fail "missing schedule data: $YAML"
+
+# Render both templates exactly as at apply time. --source pins the render to THIS
+# checkout (hermetic), mirroring the sibling launchagent tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key> with
+# the value element on the FOLLOWING line (same helper as the sibling agent tests).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, program, logs, RunAtLoad ------------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-digest</string>'
+# RunAtLoad false: a daily digest fires at its StartCalendarInterval, not at apply
+# time (a load-time run would send a digest at an arbitrary hour). Matches c69baab.
+assert_plist_kv RunAtLoad '<false/>'
+
+# ProgramArguments runs the DEPLOYED builder from the libexec home (the executable_
+# source prefix is dropped in the target).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/digest.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/digest.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/digest.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/digest.log</string>"
+
+# --- the schedule is DATA-DRIVEN, not a hardcoded plist literal --------------
+
+# Linkage: the rendered Hour/Minute equal the shipped osquery.yaml values.
+shipped_hour="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .osquery.digestHour }}')"
+shipped_minute="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .osquery.digestMinute }}')"
+assert_plist_kv Hour "<integer>$shipped_hour</integer>"
+assert_plist_kv Minute "<integer>$shipped_minute</integer>"
+
+# Data DRIVES it: render the SAME plist template against a source whose osquery.yaml
+# carries different values; the StartCalendarInterval must follow the data, which a
+# hardcoded <integer> literal never would. (The plist has no `include`, so a minimal
+# probe source suffices.)
+probe_src="$(mktemp -d)"
+trap 'rm -rf "$probe_src"' EXIT
+mkdir -p "$probe_src/.chezmoidata"
+printf 'osquery:\n  digestHour: 3\n  digestMinute: 7\n' >"$probe_src/.chezmoidata/osquery.yaml"
+probe_plist="$(CI=1 chezmoi --source "$probe_src" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist against the probe source"
+printf '%s\n' "$probe_plist" | grep -A1 -F '<key>Hour</key>' | grep -qF '<integer>3</integer>' ||
+  fail "a different osquery.yaml did not change the rendered Hour: the schedule is hardcoded, not data-driven"
+printf '%s\n' "$probe_plist" | grep -A1 -F '<key>Minute</key>' | grep -qF '<integer>7</integer>' ||
+  fail "a different osquery.yaml did not change the rendered Minute: the schedule is hardcoded, not data-driven"
+
+# --- the loader: darwin gate, onchange triggers, gui user target, bootout+bootstrap retry ----
+
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the digest plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+# The rendered schedule line is the SECOND (data) onchange trigger: the plist-hash
+# include hashes the template SOURCE (a {{ }} literal that never changes on a value
+# change), so the loader also renders the schedule, which DOES change with
+# osquery.yaml and re-fires run_onchange. Assert the shipped schedule is rendered in.
+printf '%s\n' "$rendered_loader" | grep -qF "schedule: $shipped_hour:$shipped_minute" ||
+  fail "rendered loader is missing the schedule ($shipped_hour:$shipped_minute) data-onchange trigger"
+
+# gui/<uid> USER agent (the builder needs the user session for the local notifier),
+# with the sibling bootout-then-bootstrap shape + retry loop. $HOME and $(id -u)
+# must NOT expand in these literal loader lines.
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-digest.plist"' ||
+  fail "rendered loader does not point at the digest plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-digest"' ||
+  fail "rendered loader does not target the digest label as a gui/<uid> user agent"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-digest-launchagent: OK (label + RunAtLoad false; gui/<uid> user agent; deployed libexec builder; data-driven StartCalendarInterval from osquery.yaml; loader gated, plist-hash + schedule onchange, bootout+bootstrap with retry)\n'


### PR DESCRIPTION
## Context

The osquery security-alerting pipeline sorts each finding into one of three tiers: a page (an immediate
CRIT to the operator's phone, via the Hermes webhook to a Discord channel), a daily digest, or log-only.
The page path already ships. This adds the digest path: findings the detectors judge non-urgent are
appended to a spool through the day, and a scheduled builder turns that spool into one silent, grouped
summary, so routine activity stays reviewable without paging.

The live machine applies from `integration/modernization`, not `main`, so merging this changes nothing on
any running machine (see Effect of merging).

## Summary

- A daily builder drains the accumulated non-paging findings into one grouped Discord digest.
- The digest posts on the silent muted tier, so it never pages like a CRIT.
- A LaunchAgent runs the builder daily on a schedule declared in `.chezmoidata/osquery.yaml`.
- The builder inherits delivery durability from the shared write-ahead sender, adding none of its own.
- Every attacker-influenceable field renders inside an inline-code span, inert to markdown injection.
- Empty, torn, wrong-shape, and killed-run inputs are handled without losing or misreporting findings.

Key files:

- `dot_local/libexec/osquery/executable_digest.sh` — the builder
- `.chezmoidata/osquery.yaml` — the declared schedule
- `Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl` — the daily agent
- `.chezmoiscripts/run_onchange_after_60-load-osquery-digest-launchagent.sh.tmpl` — the loader

## What the builder does

The builder runs the same whether launched by the agent or by hand: there is no internal time gate, so
the schedule lives in one declarative place. On each run it recovers any batch a killed prior run left
behind, moves the spool aside atomically (so findings appended mid-build are not consumed), renders a
grouped body, sends it silently, and keeps the spent batch as a forensic copy.

Rendering groups findings by detector, caps volume with four env-overridable knobs (bullets per group,
group count, per-field length, and total body length), and wraps every finding field in an inline-code
span. The wrap plus a sanitize step (strip backticks, squash newlines, coerce non-string values) means a
crafted field can neither forge a markdown line nor render a live mention or link. The body cap runs
inside the renderer, so an oversized digest truncates with a visible marker rather than dropping content
silently or failing to send.

## Delivery durability

The builder does not implement its own delivery. It calls the shared write-ahead sender, which persists a
record before the network attempt and retries from a scheduled drainer. The builder restores its batch
only when the sender reports it could not even persist (a return the sender documents as "the caller must
not advance past this"); on any stored outcome it advances, because restoring would double-store.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does
not change until a later cutover folds these branches forward. At that point the daily agent begins
running the digest on the declared schedule.
