### PR TITLE
feat(osquery): daily heartbeat proof-of-life for the osquery pipeline

### DIFF
--- a/.chezmoidata/osquery.yaml
+++ b/.chezmoidata/osquery.yaml
@@ -1,6 +1,11 @@
 # osquery alerting configuration consumed by templates.
 # digestHour/digestMinute drive the daily digest agent's StartCalendarInterval
 # (local time). 18:00 is an end-of-day glance; empty days stay silent.
+# heartbeatHour/heartbeatMinute drive the daily heartbeat agent's
+# StartCalendarInterval (local time). 09:00 is a morning proof-of-life: if the
+# silent daily message arrives, the osquery pipeline is scheduled and alive.
 osquery:
   digestHour: 18
   digestMinute: 0
+  heartbeatHour: 9
+  heartbeatMinute: 0

--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-heartbeat-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-heartbeat-launchagent.sh.tmpl
@@ -1,0 +1,25 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# run_onchange_after_60-load-osquery-heartbeat-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl" | sha256sum }}
+# schedule: {{ .osquery.heartbeatHour }}:{{ .osquery.heartbeatMinute }} (rendered here so a
+# data-only osquery.yaml change re-fires this loader; the include above hashes the plist
+# template SOURCE, whose heartbeatHour/heartbeatMinute placeholders are literals that do not
+# change when their values do).
+
+set -euo pipefail
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist"
+TARGET="gui/$(id -u)/com.webdavis.osquery-heartbeat"
+
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.osquery-heartbeat</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>{{ .chezmoi.homeDir }}/.local/libexec/osquery/heartbeat.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>{{ .osquery.heartbeatHour }}</integer>
+    <key>Minute</key>
+    <integer>{{ .osquery.heartbeatMinute }}</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/heartbeat.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/heartbeat.log</string>
+</dict>
+</plist>

--- a/dot_config/osquery/private_page-launchd-allowlist.txt
+++ b/dot_config/osquery/private_page-launchd-allowlist.txt
@@ -24,3 +24,4 @@
 {"label":"com.webdavis.osquery-firewall-gatekeeper-monitor","path":"~/Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/firewall-gatekeeper-monitor.sh","sha256":""}
 {"label":"com.webdavis.osquery-uptime-watchdog","path":"~/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/uptime-watchdog.sh","sha256":""}
 {"label":"com.webdavis.osquery-alert-drainer","path":"~/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/drain-undelivered-alerts.sh","sha256":""}
+{"label":"com.webdavis.osquery-heartbeat","path":"~/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/heartbeat.sh","sha256":""}

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -64,7 +64,9 @@ main() {
     age=$((now - last_ts))
     detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
     title="⚠️ osquery heartbeat · $(date -u +%Y-%m-%d)"
-    send_alert CRIT "$title" "$detail" "Glass" || true
+    # Muted too (empty sound): the heartbeat never pings, even when it reports a
+    # problem. The watchdog is what pages; this note is the silent daily record.
+    send_alert CRIT "$title" "$detail" "" || true
   fi
 }
 

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -52,7 +52,11 @@ main() {
     age=$((now - last_ts))
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
-    send_alert CRIT "$title" "$detail" "Glass" || true
+    # The EMPTY sound is deliberate: it keeps the message locally silent AND makes
+    # send_alert thread tier=muted into the webhook body. A proof-of-life must never
+    # ping like a real page. Fire-and-forget: the heartbeat advances no state, so a
+    # send failure is low-stakes (the next day re-fires; the watchdog is the pager).
+    send_alert CRIT "$title" "$detail" "" || true
   fi
 }
 

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -33,31 +33,37 @@ OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osquery
 canary_max_age="${OSQUERY_CANARY_MAX_AGE:-1800}"
 [[ $canary_max_age =~ ^[0-9]+$ ]] || canary_max_age=1800
 
+# newest_canary_timestamp - print the NEWEST heartbeat_canary row's timestamp as a
+# plain integer, or nothing when there is no readable, well-formed canary. Select the
+# canary rows by PARSED .name and take the last (newest). fromjson? drops a torn or
+# non-JSON line instead of aborting (the resilient idiom normalize.sh uses to read
+# these same logs), and matching the PARSED .name is whitespace-tolerant, so the read
+# does not couple to osquery's compact serialization. Prefer the envelope unixTime (an
+# integer); fall back to the snapshot column. This is the ONE place the log-derived
+# value is read AND validated numeric, so a non-numeric or malformed value can never
+# reach the freshness decision or the rendered message.
+newest_canary_timestamp() {
+  local candidate
+  [[ -r $OSQUERY_SNAPSHOTS_LOG ]] || return 0
+  candidate="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
+    | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
+    tail -1 || true)"
+  [[ $candidate =~ ^[0-9]+$ ]] || return 0
+  printf '%s' "$candidate"
+}
+
 main() {
-  local now last_ts age title detail
+  local now last_canary_timestamp age title detail
   now="$(date -u +%s)"
   [[ $now =~ ^[0-9]+$ ]] || now=0
 
-  # The NEWEST heartbeat_canary row's timestamp. Select the canary rows by PARSED
-  # .name and take the last (newest). fromjson? drops a torn or non-JSON line
-  # instead of aborting (the resilient idiom normalize.sh uses to read these same
-  # logs), and matching the PARSED .name is whitespace-tolerant, so the read does
-  # not couple to osquery's compact serialization. Prefer the envelope unixTime (an
-  # integer); fall back to the snapshot column. The extracted value is used ONLY
-  # after the numeric validation below, so no free-text log field can ever reach the
-  # rendered message.
-  last_ts=""
-  if [[ -r $OSQUERY_SNAPSHOTS_LOG ]]; then
-    last_ts="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
-      | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
-      tail -1 || true)"
-  fi
+  last_canary_timestamp="$(newest_canary_timestamp)"
 
-  if [[ $last_ts =~ ^[0-9]+$ ]] && ((now - last_ts <= canary_max_age)); then
-    age=$((now - last_ts))
-    # A future-dated canary (an NTP step-back leaving last_ts slightly ahead of now)
-    # is still fresh, but its age is negative; clamp it so the message never renders a
-    # nonsensical "(-120s ago)". An if (not `&& age=0`) keeps it set -e safe.
+  if [[ -n $last_canary_timestamp ]] && ((now - last_canary_timestamp <= canary_max_age)); then
+    age=$((now - last_canary_timestamp))
+    # A future-dated canary (an NTP step-back leaving the timestamp slightly ahead of
+    # now) is still fresh, but its age is negative; clamp it so the message never
+    # renders a nonsensical "(-120s ago)". An if (not `&& age=0`) keeps it set -e safe.
     if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
@@ -73,8 +79,8 @@ main() {
     # no elapsed age, so it must not be dressed up as a stale age. Only the
     # arithmetic AGE (validated-numeric operands) is ever rendered, no raw log field.
     title="⚠️ osquery heartbeat · $(date -u +%Y-%m-%d)"
-    if [[ $last_ts =~ ^[0-9]+$ ]]; then
-      age=$((now - last_ts))
+    if [[ -n $last_canary_timestamp ]]; then
+      age=$((now - last_canary_timestamp))
       detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
     else
       detail="- osqueryd scheduled heartbeat canary is MISSING (no canary snapshot found). The root daemon is not producing scheduled results, or has never run the schedule. The uptime watchdog pages on this; this note is the silent daily record."
@@ -85,8 +91,8 @@ main() {
   fi
 }
 
-# Run only when executed, not when sourced: a test may source this file to
-# exercise an individual helper without launching the whole flow.
+# Run only when executed, not when sourced: a test sources this file to exercise
+# newest_canary_timestamp in isolation without launching the whole flow.
 if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
   main "$@"
 fi

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# heartbeat.sh - the daily proof-of-life. A user LaunchAgent fires it once a day
+# and it sends ONE silent message to the #priority route so the operator can
+# trust that silence means safe: if the daily message arrives, the osquery
+# pipeline is scheduled and alive. It is the POSITIVE complement of the uptime
+# watchdog (every 15 min), which is the ALARM that pages when a component is down.
+# This proof-of-life is always muted: it must never ping like a real page.
+#
+# R2-8: it verifies the ROOT DAEMON, not a fresh osqueryi. A standalone osqueryi
+# one-shot answers even while osqueryd is stopped or wedged (a blind checkmark).
+# Instead it reads the daemon's OWN scheduled heartbeat_canary snapshot
+# (osquery.conf, every 600s, written to osqueryd.snapshots.log) and checks it is
+# FRESH: a fresh canary proves the daemon is alive AND actively running its
+# schedule. A stale or absent canary means the daemon is not producing scheduled
+# results, so it reports unhealthy (still silent; the watchdog is what pages).
+set -euo pipefail
+
+# The shared dispatch library from the libexec home (the same deployed path the
+# other consumers source). send_alert is the write-ahead-durable sender, so the
+# heartbeat inherits that durability without its own delivery machinery.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+
+# The daemon-scheduled canary snapshot log. osqueryd writes one heartbeat_canary
+# row here per interval; the heartbeat reads its freshness, never a one-shot.
+OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osqueryd.snapshots.log}"
+
+# Freshness bound: the canary runs every 600s, so 1800s (three intervals)
+# tolerates a missed tick or two while still catching a genuinely stopped or
+# wedged daemon within the daily window. Validated numeric so a malformed env
+# override can never render as free text or break the arithmetic.
+canary_max_age="${OSQUERY_CANARY_MAX_AGE:-1800}"
+[[ $canary_max_age =~ ^[0-9]+$ ]] || canary_max_age=1800
+
+main() {
+  local now last_ts age title detail
+  now="$(date -u +%s)"
+  [[ $now =~ ^[0-9]+$ ]] || now=0
+
+  # The NEWEST heartbeat_canary row's timestamp. Prefer the envelope unixTime (the
+  # daemon log-write instant); fall back to the snapshot column. The extracted
+  # value is used ONLY after the numeric validation below, so no free-text log
+  # field can ever reach the rendered message.
+  last_ts=""
+  if [[ -r $OSQUERY_SNAPSHOTS_LOG ]]; then
+    last_ts="$(grep -F '"name":"heartbeat_canary"' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null | tail -1 |
+      jq -r '(.unixTime // .snapshot[0].unix_time) // empty' 2>/dev/null || true)"
+  fi
+
+  if [[ $last_ts =~ ^[0-9]+$ ]] && ((now - last_ts <= canary_max_age)); then
+    age=$((now - last_ts))
+    title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
+    detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
+    send_alert CRIT "$title" "$detail" "Glass" || true
+  fi
+}
+
+# Run only when executed, not when sourced: a test may source this file to
+# exercise an individual helper without launching the whole flow.
+if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
+  main "$@"
+fi

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -82,10 +82,13 @@ main() {
     if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- The root osqueryd daemon produced a scheduled heartbeat canary ${age}s ago, so it was scheduling and producing results as recently as that. This is a recent observation, not a real-time check: the uptime watchdog owns real-time liveness and pages if a monitor is down. Silence since the last message means all clear."
-    # The EMPTY sound is deliberate: it keeps the message locally silent AND makes
-    # send_alert thread tier=muted into the webhook body. A proof-of-life must never
-    # ping like a real page. Fire-and-forget: the heartbeat advances no state, so a
-    # send failure is low-stakes (the next day re-fires; the watchdog is the pager).
+    # The EMPTY sound keeps the message locally silent AND makes send_alert thread
+    # tier=muted into the webhook body: a proof-of-life must never ping like a real
+    # page. One honest exception, out of this slice's control: if send_alert's
+    # write-ahead persist itself FAILS (storage broken), it fires a shared loud
+    # durable "page LOST" banner (every producer's systemic last resort), which is not
+    # muted. Fire-and-forget otherwise: the heartbeat advances no state, so a send
+    # failure is low-stakes (the next day re-fires; the watchdog is the pager).
     send_alert CRIT "$title" "$detail" "" || true
   else
     # UNHEALTHY. Three honest sub-cases, each rendered with a POSITIVE number so the

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -57,6 +57,14 @@ main() {
     # ping like a real page. Fire-and-forget: the heartbeat advances no state, so a
     # send failure is low-stakes (the next day re-fires; the watchdog is the pager).
     send_alert CRIT "$title" "$detail" "" || true
+  else
+    # A stale canary: osqueryd is not producing scheduled results (stopped or
+    # wedged). Report unhealthy, never a blind checkmark. Only the arithmetic AGE
+    # (validated-numeric operands) is rendered, no raw log field.
+    age=$((now - last_ts))
+    detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
+    title="⚠️ osquery heartbeat · $(date -u +%Y-%m-%d)"
+    send_alert CRIT "$title" "$detail" "Glass" || true
   fi
 }
 

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -53,17 +53,32 @@ newest_canary_timestamp() {
 }
 
 main() {
-  local now last_canary_timestamp age title detail
-  now="$(date -u +%s)"
-  [[ $now =~ ^[0-9]+$ ]] || now=0
+  local now last_canary_timestamp age skew title detail
+
+  # A trustworthy clock is required FIRST. A failed or non-numeric `date` means
+  # freshness cannot be judged at all, so report unhealthy rather than fall back to
+  # now=0, which would make every historical canary look fresh: a false-healthy. The
+  # capture is guarded (|| true) so a date that exits nonzero does not abort under
+  # set -e; the numeric check then catches both a failed and a garbage read.
+  now="$(date -u +%s 2>/dev/null || true)"
+  if [[ ! $now =~ ^[0-9]+$ ]]; then
+    detail="- The heartbeat cannot determine the current time (the system clock read failed), so it cannot judge whether osqueryd is producing scheduled results. Treat this as unverified, not healthy. The uptime watchdog pages on a real outage; this note is the silent daily record."
+    send_alert CRIT "⚠️ osquery heartbeat · time unknown" "$detail" "" || true
+    return 0
+  fi
 
   last_canary_timestamp="$(newest_canary_timestamp)"
 
-  if [[ -n $last_canary_timestamp ]] && ((now - last_canary_timestamp <= canary_max_age)); then
+  # HEALTHY iff a canary sits within the freshness window in EITHER direction
+  # (|now - timestamp| <= canary_max_age): a small clock skew still counts, but a far
+  # future OR far past timestamp does not. Two-sided on purpose, so a future-dated row
+  # can never false-healthy the way a one-sided `now - ts <= max` would.
+  if [[ -n $last_canary_timestamp ]] &&
+    ((now - last_canary_timestamp <= canary_max_age)) &&
+    ((last_canary_timestamp - now <= canary_max_age)); then
     age=$((now - last_canary_timestamp))
-    # A future-dated canary (an NTP step-back leaving the timestamp slightly ahead of
-    # now) is still fresh, but its age is negative; clamp it so the message never
-    # renders a nonsensical "(-120s ago)". An if (not `&& age=0`) keeps it set -e safe.
+    # A within-window future skew has a negative age; clamp so the message renders
+    # "just now" (0s), never a nonsensical "(-120s ago)". An if keeps it set -e safe.
     if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
@@ -73,17 +88,20 @@ main() {
     # send failure is low-stakes (the next day re-fires; the watchdog is the pager).
     send_alert CRIT "$title" "$detail" "" || true
   else
-    # Not fresh: osqueryd is not producing scheduled results. Report unhealthy,
-    # never a blind checkmark. STALE (a real, over-bound age) and MISSING (no canary
-    # row at all) are reported HONESTLY as distinct states: an absent timestamp has
-    # no elapsed age, so it must not be dressed up as a stale age. Only the
-    # arithmetic AGE (validated-numeric operands) is ever rendered, no raw log field.
+    # UNHEALTHY. Three honest sub-cases, each rendered with a POSITIVE number so the
+    # message never shows a negative or garbage age: MISSING (no canary row),
+    # IMPLAUSIBLE (a timestamp implausibly far in the future, i.e. clock skew or a bad
+    # row), or STALE (a real, over-bound elapsed age). Only validated arithmetic is
+    # rendered, never a raw log field.
     title="⚠️ osquery heartbeat · $(date -u +%Y-%m-%d)"
-    if [[ -n $last_canary_timestamp ]]; then
+    if [[ -z $last_canary_timestamp ]]; then
+      detail="- osqueryd scheduled heartbeat canary is MISSING (no canary snapshot found). The root daemon is not producing scheduled results, or has never run the schedule. The uptime watchdog pages on this; this note is the silent daily record."
+    elif ((last_canary_timestamp - now > canary_max_age)); then
+      skew=$((last_canary_timestamp - now))
+      detail="- osqueryd scheduled heartbeat canary timestamp is IMPLAUSIBLE (${skew}s in the future, over ${canary_max_age}s). This is clock skew or a bad row, not a trustworthy liveness signal. The uptime watchdog pages on a real outage; this note is the silent daily record."
+    else
       age=$((now - last_canary_timestamp))
       detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
-    else
-      detail="- osqueryd scheduled heartbeat canary is MISSING (no canary snapshot found). The root daemon is not producing scheduled results, or has never run the schedule. The uptime watchdog pages on this; this note is the silent daily record."
     fi
     # Muted too (empty sound): the heartbeat never pings, even when it reports a
     # problem. The watchdog is what pages; this note is the silent daily record.

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -81,7 +81,7 @@ main() {
     # "just now" (0s), never a nonsensical "(-120s ago)". An if keeps it set -e safe.
     if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
-    detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
+    detail="- The root osqueryd daemon produced a scheduled heartbeat canary ${age}s ago, so it was scheduling and producing results as recently as that. This is a recent observation, not a real-time check: the uptime watchdog owns real-time liveness and pages if a monitor is down. Silence since the last message means all clear."
     # The EMPTY sound is deliberate: it keeps the message locally silent AND makes
     # send_alert thread tier=muted into the webhook body. A proof-of-life must never
     # ping like a real page. Fire-and-forget: the heartbeat advances no state, so a

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -38,14 +38,19 @@ main() {
   now="$(date -u +%s)"
   [[ $now =~ ^[0-9]+$ ]] || now=0
 
-  # The NEWEST heartbeat_canary row's timestamp. Prefer the envelope unixTime (the
-  # daemon log-write instant); fall back to the snapshot column. The extracted
-  # value is used ONLY after the numeric validation below, so no free-text log
-  # field can ever reach the rendered message.
+  # The NEWEST heartbeat_canary row's timestamp. Select the canary rows by PARSED
+  # .name and take the last (newest). fromjson? drops a torn or non-JSON line
+  # instead of aborting (the resilient idiom normalize.sh uses to read these same
+  # logs), and matching the PARSED .name is whitespace-tolerant, so the read does
+  # not couple to osquery's compact serialization. Prefer the envelope unixTime (an
+  # integer); fall back to the snapshot column. The extracted value is used ONLY
+  # after the numeric validation below, so no free-text log field can ever reach the
+  # rendered message.
   last_ts=""
   if [[ -r $OSQUERY_SNAPSHOTS_LOG ]]; then
-    last_ts="$(grep -F '"name":"heartbeat_canary"' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null | tail -1 |
-      jq -r '(.unixTime // .snapshot[0].unix_time) // empty' 2>/dev/null || true)"
+    last_ts="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
+      | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
+      tail -1 || true)"
   fi
 
   if [[ $last_ts =~ ^[0-9]+$ ]] && ((now - last_ts <= canary_max_age)); then

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -58,12 +58,18 @@ main() {
     # send failure is low-stakes (the next day re-fires; the watchdog is the pager).
     send_alert CRIT "$title" "$detail" "" || true
   else
-    # A stale canary: osqueryd is not producing scheduled results (stopped or
-    # wedged). Report unhealthy, never a blind checkmark. Only the arithmetic AGE
-    # (validated-numeric operands) is rendered, no raw log field.
-    age=$((now - last_ts))
-    detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
+    # Not fresh: osqueryd is not producing scheduled results. Report unhealthy,
+    # never a blind checkmark. STALE (a real, over-bound age) and MISSING (no canary
+    # row at all) are reported HONESTLY as distinct states: an absent timestamp has
+    # no elapsed age, so it must not be dressed up as a stale age. Only the
+    # arithmetic AGE (validated-numeric operands) is ever rendered, no raw log field.
     title="⚠️ osquery heartbeat · $(date -u +%Y-%m-%d)"
+    if [[ $last_ts =~ ^[0-9]+$ ]]; then
+      age=$((now - last_ts))
+      detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
+    else
+      detail="- osqueryd scheduled heartbeat canary is MISSING (no canary snapshot found). The root daemon is not producing scheduled results, or has never run the schedule. The uptime watchdog pages on this; this note is the silent daily record."
+    fi
     # Muted too (empty sound): the heartbeat never pings, even when it reports a
     # problem. The watchdog is what pages; this note is the silent daily record.
     send_alert CRIT "$title" "$detail" "" || true

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -55,6 +55,10 @@ main() {
 
   if [[ $last_ts =~ ^[0-9]+$ ]] && ((now - last_ts <= canary_max_age)); then
     age=$((now - last_ts))
+    # A future-dated canary (an NTP step-back leaving last_ts slightly ahead of now)
+    # is still fresh, but its age is negative; clamp it so the message never renders a
+    # nonsensical "(-120s ago)". An if (not `&& age=0`) keeps it set -e safe.
+    if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- osqueryd is alive and running its schedule: its heartbeat canary is fresh (${age}s ago). This verifies the root daemon itself. The uptime watchdog verifies each monitor agent is loaded and pages if one is down. Silence since the last message means all clear."
     # The EMPTY sound is deliberate: it keeps the message locally silent AND makes

--- a/test/integration/osquery-feature-set-location.sh
+++ b/test/integration/osquery-feature-set-location.sh
@@ -11,9 +11,9 @@ cd "$REPO_ROOT"
 
 fail=0
 
-# 1. The libexec home holds the six scripts (prefix dropped). A git ls-files
+# 1. The libexec home holds the seven scripts (prefix dropped). A git ls-files
 # failure fails the test.
-for f in alert-dispatch digest enrich-finding firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+for f in alert-dispatch digest enrich-finding firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
   path="dot_local/libexec/osquery/executable_${f}.sh"
   if ! listed="$(git ls-files "$path")"; then
     printf 'FAIL: git ls-files failed while checking %s\n' "$path" >&2
@@ -44,15 +44,15 @@ assert_contains() {
   esac
 }
 
-# The four launchd plists' ProgramArguments point at the libexec home.
-for name in digest firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+# The five launchd plists' ProgramArguments point at the libexec home.
+for name in digest firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
   assert_contains ".local/libexec/osquery/${name}.sh" \
     "Library/LaunchAgents/com.webdavis.osquery-${name}.plist.tmpl"
 done
 
-# The four consumers source the dispatch library from the libexec home.
+# The five consumers source the dispatch library from the libexec home.
 # The needles below are literal source lines; $HOME must NOT expand here.
-for name in digest firewall-gatekeeper-monitor results-alerter uptime-watchdog; do
+for name in digest firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
   # shellcheck disable=SC2016
   assert_contains 'source "$HOME/.local/libexec/osquery/alert-dispatch.sh"' \
     "dot_local/libexec/osquery/executable_${name}.sh"

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -249,3 +249,19 @@ run_heartbeat() {
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
 }
+
+@test "clock-skew: a future-dated canary reads healthy with a non-negative rendered age" {
+  # An NTP step-back can leave the newest canary timestamped slightly AHEAD of now. It
+  # is still fresh (the daemon is producing recent results), so it reads healthy; the
+  # rendered age is clamped to >= 0 so the silent daily message never shows a
+  # nonsensical negative age like "(-120s ago)".
+  local ts
+  ts=$(($(date -u +%s) + 120)) # 2 minutes in the future (the clock stepped back)
+  jq -cn --argjson t "$ts" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  grep -qiF "healthy" "$SEND_ALERT_TITLE"
+  refute_file_contains "(-" "$SEND_ALERT_BODY" # never a negative age such as "(-120s ago)"
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -266,6 +266,44 @@ run_heartbeat() {
   refute_file_contains "(-" "$SEND_ALERT_BODY" # never a negative age such as "(-120s ago)"
 }
 
+@test "implausible-future: a canary far in the future reports unhealthy IMPLAUSIBLE, not healthy" {
+  # GATE (fail-safe): the freshness window is TWO-SIDED. A canary timestamped well
+  # beyond the window in the FUTURE (clock skew or a bad row) is not a trustworthy
+  # liveness signal, so it fails the future half and reports unhealthy IMPLAUSIBLE,
+  # never healthy. (A small +120s skew stays healthy; see clock-skew.) The rendered
+  # skew is a POSITIVE number.
+  local ts
+  ts=$(($(date -u +%s) + 100000)) # far beyond any reasonable freshness window
+  jq -cn --argjson t "$ts" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
+  grep -qiE "implausible|future" "$SEND_ALERT_BODY"
+  refute_file_contains "(-" "$SEND_ALERT_BODY" # a positive skew, never a negative number
+}
+
+@test "clock-failure: a non-numeric clock reports unhealthy, never false-healthy via now=0" {
+  # GATE (fail-safe): if the system clock read returns non-numeric (or fails), the
+  # heartbeat cannot judge freshness. It must NOT fall back to now=0 (which makes
+  # every historical canary look fresh, a false-healthy); it reports unhealthy that it
+  # cannot determine the current time. A real, fresh canary is seeded to prove even
+  # that does not read healthy without a trustworthy clock.
+  seed_canary 30
+  cat >"$HARNESS_HOME/bin/date" <<'STUB'
+#!/usr/bin/env bash
+printf 'not-a-time\n'
+STUB
+  chmod +x "$HARNESS_HOME/bin/date"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
+  grep -qiE "cannot determine|current time" "$SEND_ALERT_BODY"
+}
+
 @test "seam: newest_canary_timestamp returns the newest validated integer, else empty" {
   # The read is extracted into a directly testable seam; the source-guard lets a test
   # source the script without launching main. An empty log -> empty; a well-formed

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -232,3 +232,20 @@ run_heartbeat() {
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
 }
+
+@test "format-tolerance: a spaced-JSON canary reads the same as compact (JSON-semantic reader)" {
+  # osquery 5.23.1 emits COMPACT single-line JSON (verified against the real deployed
+  # osqueryd.snapshots.log on this host), but the reader must not couple to that byte
+  # layout: it selects the canary by PARSED .name via fromjson? (the same idiom
+  # normalize.sh uses), so a spaced serialization is read identically. A compact
+  # grep -F would MISS a spaced line and false-report the canary MISSING (fail-safe,
+  # but perpetual daily noise). This line is deliberately spaced (space after each colon).
+  local ts
+  ts=$(($(date -u +%s) - 30))
+  printf '{"name": "heartbeat_canary", "action": "snapshot", "unixTime": %s, "snapshot": [{"unix_time": "%s"}]}\n' \
+    "$ts" "$ts" >>"$OSQUERY_SNAPSHOTS_LOG"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiF "healthy" "$SEND_ALERT_TITLE"
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -137,3 +137,13 @@ run_heartbeat() {
   ! grep -qiF "healthy" "$SEND_ALERT_BODY"
   [ ! -e "$OSQUERYI_CALLED" ] # never shelled a one-shot; it read the scheduled canary
 }
+
+@test "B4: the unhealthy message is also silent, the heartbeat never pings even degraded" {
+  # GATE (never-pings): even when it reports a problem the heartbeat stays muted. The
+  # watchdog owns paging; a degraded heartbeat that pinged would double-signal what
+  # the watchdog already pages, and desensitize the operator to real pages.
+  seed_canary 3600
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ -z "$(cat "$SEND_ALERT_SOUND")" ]
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -265,3 +265,20 @@ run_heartbeat() {
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
   refute_file_contains "(-" "$SEND_ALERT_BODY" # never a negative age such as "(-120s ago)"
 }
+
+@test "seam: newest_canary_timestamp returns the newest validated integer, else empty" {
+  # The read is extracted into a directly testable seam; the source-guard lets a test
+  # source the script without launching main. An empty log -> empty; a well-formed
+  # canary -> a plain integer; a non-numeric value -> validated to empty at this one site.
+  source "$HEARTBEAT"
+  run newest_canary_timestamp
+  [ "$status" -eq 0 ]
+  [ -z "$output" ] # no canary row yet
+  seed_canary 42
+  run newest_canary_timestamp
+  [[ "$output" =~ ^[0-9]+$ ]] # a plain integer
+  : >"$OSQUERY_SNAPSHOTS_LOG"
+  seed_raw_canary "not-a-number"
+  run newest_canary_timestamp
+  [ -z "$output" ] # malformed -> validated to empty, never reaches the decision
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# The daily heartbeat (heartbeat.sh): the POSITIVE proof-of-life. Fired daily, it
+# sends ONE silent message to #priority so the operator can trust silence = safe.
+# R2-8: it must verify the ROOT DAEMON. A standalone osqueryi one-shot answers even
+# while osqueryd is stopped or wedged, so instead the heartbeat checks that the
+# daemon's OWN scheduled heartbeat_canary snapshot is FRESH. Always muted (never
+# pings), honest (reports a stale canary rather than a blind checkmark); the uptime
+# watchdog is what PAGES.
+#
+# This suite exercises the script as a black box against a stubbed dispatch: a
+# message-recording spy replaces the real send_alert at the exact libexec path the
+# script sources, so a test asserts whether (and how) the heartbeat dispatched
+# without touching the network or the real SQLite store.
+
+HEARTBEAT="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_heartbeat.sh"
+
+setup() { setup_heartbeat_harness; }
+teardown() { teardown_heartbeat_harness; }
+
+# setup_heartbeat_harness (makeSUT factory) - a throwaway HOME whose only dispatch
+# library is a recording spy, plus a controllable daemon snapshot log the heartbeat
+# reads for canary freshness. Every export happens here, nothing at file-load time.
+setup_heartbeat_harness() {
+  HARNESS_HOME="$(mktemp -d)"
+  # Record ownership only after our own mktemp, so teardown removes this path and
+  # never a pre-set or inherited HARNESS_HOME.
+  _HEARTBEAT_HARNESS_OWNED_DIR="$HARNESS_HOME"
+  export HOME="$HARNESS_HOME"
+
+  # The recording spy for send_alert, at the exact libexec path the heartbeat
+  # sources. One CALL marker per call (so a test counts sends and "no dispatch" is
+  # an empty log) plus the severity/title/body/sound of the LAST call, so a test
+  # asserts HOW it dispatched without a real send. SEND_ALERT_RC (default 0) lets a
+  # test force a hard send failure.
+  local dispatch_dir="$HARNESS_HOME/.local/libexec/osquery"
+  mkdir -p "$dispatch_dir"
+  export SEND_ALERT_LOG="$HARNESS_HOME/send-alert.log"
+  export SEND_ALERT_SEVERITY="$HARNESS_HOME/send-alert.severity"
+  export SEND_ALERT_TITLE="$HARNESS_HOME/send-alert.title"
+  export SEND_ALERT_BODY="$HARNESS_HOME/send-alert.body"
+  export SEND_ALERT_SOUND="$HARNESS_HOME/send-alert.sound"
+  : >"$SEND_ALERT_LOG"
+  cat >"$dispatch_dir/alert-dispatch.sh" <<'SPY'
+# Recording spy for alert-dispatch.sh: capture each send_alert call so a test can
+# assert whether, and how, the heartbeat dispatched without a real send.
+send_alert() {
+  printf 'CALL\n' >>"$SEND_ALERT_LOG"
+  printf '%s' "${1-}" >"$SEND_ALERT_SEVERITY"
+  printf '%s' "${2-}" >"$SEND_ALERT_TITLE"
+  printf '%s' "${3-}" >"$SEND_ALERT_BODY"
+  printf '%s' "${4-}" >"$SEND_ALERT_SOUND"
+  return "${SEND_ALERT_RC:-0}"
+}
+SPY
+
+  # The daemon snapshot log the heartbeat reads for canary freshness. Left EMPTY by
+  # default (a fresh deploy: the daemon has written no canary yet), so a test opts in
+  # to a fresh, stale, or malformed canary.
+  export OSQUERY_SNAPSHOTS_LOG="$HARNESS_HOME/.local/log/osquery/osqueryd.snapshots.log"
+  mkdir -p "$(dirname "$OSQUERY_SNAPSHOTS_LOG")"
+  : >"$OSQUERY_SNAPSHOTS_LOG"
+}
+
+# teardown_heartbeat_harness - remove ONLY a temp dir this harness created. The
+# ownership marker is set after our own mktemp, so a pre-set HARNESS_HOME (marker
+# unset) is left untouched.
+teardown_heartbeat_harness() {
+  [[ -n ${_HEARTBEAT_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_HEARTBEAT_HARNESS_OWNED_DIR"
+  unset _HEARTBEAT_HARNESS_OWNED_DIR
+}
+
+# seed_canary <seconds-ago> - append a heartbeat_canary snapshot row timestamped
+# that many seconds in the past, in the shape osqueryd writes to the snapshot log.
+seed_canary() {
+  local ts
+  ts=$(($(date -u +%s) - $1))
+  jq -cn --argjson t "$ts" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+}
+
+# run_heartbeat - run the real heartbeat under the harness env (HOME is the temp
+# home so the sourced spy and default paths resolve inside the sandbox).
+run_heartbeat() {
+  HOME="$HARNESS_HOME" \
+    OSQUERY_SNAPSHOTS_LOG="$OSQUERY_SNAPSHOTS_LOG" \
+    bash "$HEARTBEAT"
+}
+
+@test "B1: a fresh canary sends exactly one message that reads healthy" {
+  seed_canary 30 # the daemon wrote a canary 30s ago -> alive and scheduling
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiF "healthy" "$SEND_ALERT_TITLE"
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -84,6 +84,20 @@ teardown_heartbeat_harness() {
   unset _HEARTBEAT_HARNESS_OWNED_DIR
 }
 
+# refute_file_contains <fixed-substring> <file> - fail (return 1) when the substring
+# (fixed, case-insensitive) appears in the file. This is the robust NEGATIVE
+# assertion: a bare `! grep ...` is NOT reliable in bats, because bats runs each test
+# under set -e and bash exempts a `!`-inverted command from set -e ("the return
+# status is being inverted with !"), so `! grep` NEVER fails the test - a silent
+# no-op. A plain function whose non-zero return set -e DOES catch closes that gap.
+refute_file_contains() {
+  if grep -qiF -- "$1" "$2"; then
+    printf 'expected %q NOT to appear in %s, but it does:\n%s\n' "$1" "$2" "$(cat "$2")" >&2
+    return 1
+  fi
+  return 0
+}
+
 # seed_canary <seconds-ago> - append a heartbeat_canary snapshot row timestamped
 # that many seconds in the past, in the shape osqueryd writes to the snapshot log.
 seed_canary() {
@@ -91,6 +105,16 @@ seed_canary() {
   ts=$(($(date -u +%s) - $1))
   jq -cn --argjson t "$ts" \
     '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+}
+
+# seed_raw_canary <unix_time-value> - append a heartbeat_canary row whose unix_time
+# and unixTime carry an ARBITRARY (possibly attacker-controlled) string, to model a
+# tampered or malformed snapshot log. jq JSON-encodes the value, so the heartbeat
+# reads it back verbatim as a string via jq -r.
+seed_raw_canary() {
+  jq -cn --arg t "$1" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:$t}],unixTime:$t,hostIdentifier:"dresden"}' \
     >>"$OSQUERY_SNAPSHOTS_LOG"
 }
 
@@ -133,8 +157,8 @@ run_heartbeat() {
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiE "stale|not producing" "$SEND_ALERT_BODY"
-  ! grep -qiF "healthy" "$SEND_ALERT_TITLE"
-  ! grep -qiF "healthy" "$SEND_ALERT_BODY"
+  refute_file_contains "healthy" "$SEND_ALERT_TITLE"
+  refute_file_contains "healthy" "$SEND_ALERT_BODY"
   [ ! -e "$OSQUERYI_CALLED" ] # never shelled a one-shot; it read the scheduled canary
 }
 
@@ -148,18 +172,6 @@ run_heartbeat() {
   [ -z "$(cat "$SEND_ALERT_SOUND")" ]
 }
 
-@test "B6: the healthy message is honest about what it verified (R2-8)" {
-  # R2-8 honesty: the healthy body claims only what the canary proves (the ROOT
-  # DAEMON is alive and running its schedule), points at the watchdog for per-agent
-  # liveness, and must NOT overclaim that every monitor is scheduled or loaded.
-  seed_canary 30
-  run run_heartbeat
-  [ "$status" -eq 0 ]
-  grep -qiE "daemon|schedule|canary" "$SEND_ALERT_BODY" # it verified the daemon, not a one-shot
-  grep -qiF "watchdog" "$SEND_ALERT_BODY"               # points at who owns agent liveness
-  ! grep -qiF "all monitors scheduled" "$SEND_ALERT_BODY"
-}
-
 @test "B5: no canary at all reports unhealthy as MISSING, never a blind checkmark" {
   # GATE (fail-safe): an empty or absent snapshots log (fresh deploy, or the daemon
   # never ran the schedule) carries no canary row. Not-fresh means unhealthy, the
@@ -170,7 +182,39 @@ run_heartbeat() {
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
-  ! grep -qiF "stale" "$SEND_ALERT_BODY"
-  ! grep -qiF "healthy" "$SEND_ALERT_TITLE"
-  ! grep -qiF "healthy" "$SEND_ALERT_BODY"
+  refute_file_contains "stale" "$SEND_ALERT_BODY"
+  refute_file_contains "healthy" "$SEND_ALERT_TITLE"
+  refute_file_contains "healthy" "$SEND_ALERT_BODY"
+}
+
+@test "B6: the healthy message is honest about what it verified (R2-8)" {
+  # R2-8 honesty: the healthy body claims only what the canary proves (the ROOT
+  # DAEMON is alive and running its schedule), points at the watchdog for per-agent
+  # liveness, and must NOT overclaim that every monitor is scheduled or loaded.
+  seed_canary 30
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  grep -qiE "daemon|schedule|canary" "$SEND_ALERT_BODY" # it verified the daemon, not a one-shot
+  grep -qiF "watchdog" "$SEND_ALERT_BODY"               # points at who owns agent liveness
+  refute_file_contains "all monitors scheduled" "$SEND_ALERT_BODY"
+}
+
+@test "B7: a malformed canary timestamp is rejected, unhealthy, and cannot inject" {
+  # GATE (injection-safety): the ONLY log-derived value the heartbeat touches is the
+  # canary timestamp, used solely as $((now - last_ts)) AFTER a ^[0-9]+$ check. A
+  # metacharacter-laden value is rejected (treated as MISSING -> unhealthy), never
+  # rendered into the message, and never executed. This is why the heartbeat needs
+  # no sanitize + code-span wrap: it renders no free-text field, only static text
+  # plus a validated-numeric age.
+  local payload='$(touch '"$HARNESS_HOME"'/PWNED)`touch '"$HARNESS_HOME"'/PWNED2`; DROP 9999'
+  seed_raw_canary "$payload"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiE "missing|no canary" "$SEND_ALERT_BODY" # rejected -> treated as missing
+  refute_file_contains "touch" "$SEND_ALERT_BODY"  # the raw value never reaches the body
+  refute_file_contains "$payload" "$SEND_ALERT_BODY"
+  refute_file_contains "touch" "$SEND_ALERT_TITLE"
+  [ ! -e "$HARNESS_HOME/PWNED" ]  # no command execution from the payload
+  [ ! -e "$HARNESS_HOME/PWNED2" ] # no command execution from the payload
 }

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -157,8 +157,9 @@ run_heartbeat() {
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiE "stale|not producing" "$SEND_ALERT_BODY"
-  refute_file_contains "healthy" "$SEND_ALERT_TITLE"
-  refute_file_contains "healthy" "$SEND_ALERT_BODY"
+  # Precise: refute the healthy TITLE signal, not the bare substring "healthy" (which
+  # also matches "unhealthy" - a case-insensitive substring would false-forbid it).
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
   [ ! -e "$OSQUERYI_CALLED" ] # never shelled a one-shot; it read the scheduled canary
 }
 
@@ -183,8 +184,8 @@ run_heartbeat() {
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
   refute_file_contains "stale" "$SEND_ALERT_BODY"
-  refute_file_contains "healthy" "$SEND_ALERT_TITLE"
-  refute_file_contains "healthy" "$SEND_ALERT_BODY"
+  # Precise healthy-signal refute (not the bare "healthy" substring, which matches "unhealthy").
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
 }
 
 @test "B6: the healthy message is honest about what it verified (R2-8)" {
@@ -264,6 +265,20 @@ run_heartbeat() {
   [ "$status" -eq 0 ]
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
   refute_file_contains "(-" "$SEND_ALERT_BODY" # never a negative age such as "(-120s ago)"
+}
+
+@test "healthy-honesty: the healthy body is a recent observation, not a present-tense overclaim" {
+  # A fresh canary proves only that osqueryd produced a scheduled result up to
+  # canary_max_age AGO, not that it is alive RIGHT NOW (real-time liveness is the
+  # watchdog's job). The healthy body must state that recent observation, not
+  # present-tense current liveness.
+  seed_canary 30
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  grep -qiF "produced a scheduled heartbeat canary" "$SEND_ALERT_BODY" # honest recent observation
+  grep -qiF "as recently as that" "$SEND_ALERT_BODY"
+  refute_file_contains "is alive and running its schedule" "$SEND_ALERT_BODY" # present-tense overclaim
+  refute_file_contains "verifies the root daemon" "$SEND_ALERT_BODY"
 }
 
 @test "implausible-future: a canary far in the future reports unhealthy IMPLAUSIBLE, not healthy" {

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -129,11 +129,15 @@ run_heartbeat() {
     bash "$HEARTBEAT"
 }
 
-@test "B1: a fresh canary sends exactly one message that reads healthy" {
+@test "B1: a fresh canary sends exactly one CRIT message that reads healthy" {
   seed_canary 30 # the daemon wrote a canary 30s ago -> alive and scheduling
   run run_heartbeat
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  # CRIT is load-bearing: only a CRIT reaches the #priority webhook, so a non-CRIT
+  # send would return after the local notification and the daily-message-means-alive
+  # protocol would die silently.
+  [ "$(cat "$SEND_ALERT_SEVERITY")" = "CRIT" ]
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
 }
 
@@ -156,6 +160,7 @@ run_heartbeat() {
   run run_heartbeat
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  [ "$(cat "$SEND_ALERT_SEVERITY")" = "CRIT" ] # only CRIT reaches #priority
   grep -qiE "stale|not producing" "$SEND_ALERT_BODY"
   # Precise: refute the healthy TITLE signal, not the bare substring "healthy" (which
   # also matches "unhealthy" - a case-insensitive substring would false-forbid it).
@@ -182,6 +187,7 @@ run_heartbeat() {
   run run_heartbeat
   [ "$status" -eq 0 ]
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  [ "$(cat "$SEND_ALERT_SEVERITY")" = "CRIT" ] # only CRIT reaches #priority
   grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
   refute_file_contains "stale" "$SEND_ALERT_BODY"
   # Precise healthy-signal refute (not the bare "healthy" substring, which matches "unhealthy").
@@ -334,4 +340,15 @@ STUB
   seed_raw_canary "not-a-number"
   run newest_canary_timestamp
   [ -z "$output" ] # malformed -> validated to empty, never reaches the decision
+}
+
+@test "fire-and-forget: a hard send failure never fails the heartbeat (exit 0)" {
+  # The heartbeat advances no state and delegates durability to send_alert, so a send
+  # that returns nonzero (a hard persist failure) must not fail the launchd job: the
+  # next day re-fires and the watchdog is the real safety net. SEND_ALERT_RC=1 forces
+  # the spy to fail; the heartbeat's `|| true` swallows it and still exits 0.
+  seed_canary 30
+  SEND_ALERT_RC=1 run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ] # it did attempt the send
 }

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -148,6 +148,18 @@ run_heartbeat() {
   [ -z "$(cat "$SEND_ALERT_SOUND")" ]
 }
 
+@test "B6: the healthy message is honest about what it verified (R2-8)" {
+  # R2-8 honesty: the healthy body claims only what the canary proves (the ROOT
+  # DAEMON is alive and running its schedule), points at the watchdog for per-agent
+  # liveness, and must NOT overclaim that every monitor is scheduled or loaded.
+  seed_canary 30
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  grep -qiE "daemon|schedule|canary" "$SEND_ALERT_BODY" # it verified the daemon, not a one-shot
+  grep -qiF "watchdog" "$SEND_ALERT_BODY"               # points at who owns agent liveness
+  ! grep -qiF "all monitors scheduled" "$SEND_ALERT_BODY"
+}
+
 @test "B5: no canary at all reports unhealthy as MISSING, never a blind checkmark" {
   # GATE (fail-safe): an empty or absent snapshots log (fresh deploy, or the daemon
   # never ran the schedule) carries no canary row. Not-fresh means unhealthy, the

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -147,3 +147,18 @@ run_heartbeat() {
   [ "$status" -eq 0 ]
   [ -z "$(cat "$SEND_ALERT_SOUND")" ]
 }
+
+@test "B5: no canary at all reports unhealthy as MISSING, never a blind checkmark" {
+  # GATE (fail-safe): an empty or absent snapshots log (fresh deploy, or the daemon
+  # never ran the schedule) carries no canary row. Not-fresh means unhealthy, the
+  # safe direction. The harness default snapshots log is empty, so seed nothing. The
+  # message must say MISSING honestly, never mislabel it STALE with a bogus age
+  # (an absent timestamp is not a real elapsed age).
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
+  ! grep -qiF "stale" "$SEND_ALERT_BODY"
+  ! grep -qiF "healthy" "$SEND_ALERT_TITLE"
+  ! grep -qiF "healthy" "$SEND_ALERT_BODY"
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -218,3 +218,17 @@ run_heartbeat() {
   [ ! -e "$HARNESS_HOME/PWNED" ]  # no command execution from the payload
   [ ! -e "$HARNESS_HOME/PWNED2" ] # no command execution from the payload
 }
+
+@test "B8: freshness is judged from the NEWEST canary row when several exist" {
+  # osqueryd appends one canary per interval, so the LAST line is the newest. A run
+  # of rows (an old one from before a gap, then a fresh one) must be judged by the
+  # freshest (last), not the first: a daemon that stopped and is producing again is
+  # healthy now. This pins the tail-1 selection (a head-1 bug would see only the old
+  # row and false-alarm).
+  seed_canary 5000 # an old canary, from before a gap
+  seed_canary 30   # the newest canary: the daemon is producing again
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiF "healthy" "$SEND_ALERT_TITLE"
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -95,3 +95,13 @@ run_heartbeat() {
   [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
   grep -qiF "healthy" "$SEND_ALERT_TITLE"
 }
+
+@test "B2: the healthy message is silent (empty sound), a proof-of-life never pings" {
+  # GATE (never-pings): the muted tier is the security invariant. An empty sound
+  # keeps the message locally silent AND threads tier=muted into the webhook body,
+  # so a daily proof-of-life can never desensitize the operator to a real page.
+  seed_canary 30
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ -z "$(cat "$SEND_ALERT_SOUND")" ]
+}

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -59,6 +59,20 @@ SPY
   export OSQUERY_SNAPSHOTS_LOG="$HARNESS_HOME/.local/log/osquery/osqueryd.snapshots.log"
   mkdir -p "$(dirname "$OSQUERY_SNAPSHOTS_LOG")"
   : >"$OSQUERY_SNAPSHOTS_LOG"
+
+  # A recording osqueryi stub on PATH (R2-8): if the heartbeat ever shelled a
+  # one-shot osqueryi (the reverted anti-pattern), this stub answers FRESH and
+  # leaves a marker. The heartbeat must NEVER call it: it reads the daemon's OWN
+  # scheduled canary log, so a stopped daemon (a stale canary) is still caught even
+  # though a one-shot osqueryi would lie with a fresh answer.
+  mkdir -p "$HARNESS_HOME/bin"
+  export OSQUERYI_CALLED="$HARNESS_HOME/osqueryi-was-called"
+  cat >"$HARNESS_HOME/bin/osqueryi" <<'STUB'
+#!/usr/bin/env bash
+touch "$OSQUERYI_CALLED"
+printf '[{"unix_time":"%s"}]\n' "$(date -u +%s)"
+STUB
+  chmod +x "$HARNESS_HOME/bin/osqueryi"
 }
 
 # teardown_heartbeat_harness - remove ONLY a temp dir this harness created. The
@@ -81,10 +95,13 @@ seed_canary() {
 }
 
 # run_heartbeat - run the real heartbeat under the harness env (HOME is the temp
-# home so the sourced spy and default paths resolve inside the sandbox).
+# home so the sourced spy and default paths resolve inside the sandbox; the temp
+# bin is first on PATH so the osqueryi one-shot stub would be found IF the heartbeat
+# ever called it, which it must not).
 run_heartbeat() {
   HOME="$HARNESS_HOME" \
     OSQUERY_SNAPSHOTS_LOG="$OSQUERY_SNAPSHOTS_LOG" \
+    PATH="$HARNESS_HOME/bin:$PATH" \
     bash "$HEARTBEAT"
 }
 
@@ -104,4 +121,19 @@ run_heartbeat() {
   run run_heartbeat
   [ "$status" -eq 0 ]
   [ -z "$(cat "$SEND_ALERT_SOUND")" ]
+}
+
+@test "B3: a stale canary reports unhealthy, the stopped-daemon case a one-shot would miss" {
+  # GATE (fail-safe, R2-8): osqueryd stopped an hour ago, so the newest scheduled
+  # canary is an hour old. A standalone osqueryi one-shot (the stub on PATH) would
+  # still answer FRESH and give a blind checkmark; reading the daemon's own canary
+  # freshness catches the stopped daemon instead. Reports unhealthy, never healthy.
+  seed_canary 3600
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiE "stale|not producing" "$SEND_ALERT_BODY"
+  ! grep -qiF "healthy" "$SEND_ALERT_TITLE"
+  ! grep -qiF "healthy" "$SEND_ALERT_BODY"
+  [ ! -e "$OSQUERYI_CALLED" ] # never shelled a one-shot; it read the scheduled canary
 }

--- a/test/integration/osquery-page-allowlist-seed.sh
+++ b/test/integration/osquery-page-allowlist-seed.sh
@@ -65,16 +65,24 @@ else
     fi
   done <"$new_file"
 
-  # The seed migrates this host's four own-agents (results-alerter,
-  # firewall-gatekeeper-monitor, uptime-watchdog, alert-drainer) to tuples.
-  if [[ $entry_count -ne 4 ]]; then
-    fail "expected 4 seeded tuples (the host's four own-agents), got $entry_count"
+  # The seed migrates this host's own-agents (results-alerter,
+  # firewall-gatekeeper-monitor, uptime-watchdog, alert-drainer, heartbeat) to tuples,
+  # so none false-pages the alerter's persistence_launchd detector (which
+  # default-denies an unallowlisted user LaunchAgent) when its plist first appears.
+  if [[ $entry_count -ne 5 ]]; then
+    fail "expected 5 seeded tuples (the host's own-agents), got $entry_count"
   fi
 
-  # The alert-drainer is one of the four: a real own-agent of the same class, so it
-  # does not false-page when the alerter goes live at the D1 cutover.
+  # The alert-drainer is one own-agent of the class: a real own-agent, so it does not
+  # false-page when the alerter goes live at the D1 cutover.
   if ! grep -qF '"label":"com.webdavis.osquery-alert-drainer"' "$new_file"; then
     fail "the alert-drainer own-agent tuple is missing from the seed"
+  fi
+
+  # The heartbeat is an own-agent added after the cutover: without its own tuple its
+  # plist would self-page the alerter (default-deny), so its tuple is seeded here too.
+  if ! grep -qF '"label":"com.webdavis.osquery-heartbeat"' "$new_file"; then
+    fail "the heartbeat own-agent tuple is missing from the seed"
   fi
 fi
 

--- a/test/unit/osquery-heartbeat-launchagent.sh
+++ b/test/unit/osquery-heartbeat-launchagent.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# The daily heartbeat LaunchAgent: com.webdavis.osquery-heartbeat runs the deployed
+# heartbeat detector once a day at a time DECLARED IN DATA (.chezmoidata/osquery.yaml
+# heartbeatHour/heartbeatMinute), never hardcoded in the plist. RunAtLoad is false: a
+# daily proof-of-life fires at its StartCalendarInterval, not at apply time. A
+# load-time run would fire the heartbeat at an arbitrary hour, and right after a boot
+# (before osqueryd has written its first 600s canary) it would false-report the
+# canary MISSING; the 09:00 daily fire plus the uptime watchdog (real-time liveness)
+# cover the job. It is a gui/<uid> USER agent, not a system daemon: the heartbeat
+# calls send_alert (the user's local notifier) and reads the user-scoped snapshot
+# log, not any osquery table. Its loader chezmoiscript is wired like the sibling
+# osquery agents (darwin gate, plist-hash onchange trigger, bootout + bootstrap
+# retry), PLUS a rendered schedule line so a DATA-only osquery.yaml change re-fires
+# it: the plist-hash include hashes the template SOURCE, whose {{ }} placeholders do
+# not change when their values do.
+#
+# Unit test: render the plist and loader with the host chezmoi and assert their
+# content, including that the schedule is DATA-DRIVEN (a different osquery.yaml
+# renders a different StartCalendarInterval). No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-heartbeat-launchagent.sh.tmpl"
+YAML="$REPO_ROOT/.chezmoidata/osquery.yaml"
+
+fail() {
+  printf 'osquery-heartbeat-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+[[ -f $YAML ]] || fail "missing schedule data: $YAML"
+
+# Render both templates exactly as at apply time. --source pins the render to THIS
+# checkout (hermetic), mirroring the sibling launchagent tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key> with
+# the value element on the FOLLOWING line (same helper as the sibling agent tests).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, program, logs, RunAtLoad ------------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-heartbeat</string>'
+# RunAtLoad false: a daily proof-of-life fires at its StartCalendarInterval, not at
+# apply time (a load-time run would fire at an arbitrary hour, and could false-report
+# the canary MISSING right after a boot before osqueryd has written its first one).
+assert_plist_kv RunAtLoad '<false/>'
+
+# ProgramArguments runs the DEPLOYED detector from the libexec home (the executable_
+# source prefix is dropped in the target).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/heartbeat.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/heartbeat.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/heartbeat.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/heartbeat.log</string>"
+
+# --- the schedule is DATA-DRIVEN, not a hardcoded plist literal --------------
+
+# Linkage: the rendered Hour/Minute equal the shipped osquery.yaml values.
+shipped_hour="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .osquery.heartbeatHour }}')"
+shipped_minute="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .osquery.heartbeatMinute }}')"
+assert_plist_kv Hour "<integer>$shipped_hour</integer>"
+assert_plist_kv Minute "<integer>$shipped_minute</integer>"
+
+# Data DRIVES it: render the SAME plist template against a source whose osquery.yaml
+# carries different values; the StartCalendarInterval must follow the data, which a
+# hardcoded <integer> literal never would. (The plist has no `include`, so a minimal
+# probe source suffices.)
+probe_src="$(mktemp -d)"
+trap 'rm -rf "$probe_src"' EXIT
+mkdir -p "$probe_src/.chezmoidata"
+printf 'osquery:\n  heartbeatHour: 4\n  heartbeatMinute: 8\n' >"$probe_src/.chezmoidata/osquery.yaml"
+probe_plist="$(CI=1 chezmoi --source "$probe_src" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist against the probe source"
+printf '%s\n' "$probe_plist" | grep -A1 -F '<key>Hour</key>' | grep -qF '<integer>4</integer>' ||
+  fail "a different osquery.yaml did not change the rendered Hour: the schedule is hardcoded, not data-driven"
+printf '%s\n' "$probe_plist" | grep -A1 -F '<key>Minute</key>' | grep -qF '<integer>8</integer>' ||
+  fail "a different osquery.yaml did not change the rendered Minute: the schedule is hardcoded, not data-driven"
+
+# --- the loader: darwin gate, onchange triggers, gui user target, bootout+bootstrap retry ----
+
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the heartbeat plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+# The rendered schedule line is the SECOND (data) onchange trigger: the plist-hash
+# include hashes the template SOURCE (a {{ }} literal that never changes on a value
+# change), so the loader also renders the schedule, which DOES change with
+# osquery.yaml and re-fires run_onchange. Assert the shipped schedule is rendered in.
+printf '%s\n' "$rendered_loader" | grep -qF "schedule: $shipped_hour:$shipped_minute" ||
+  fail "rendered loader is missing the schedule ($shipped_hour:$shipped_minute) data-onchange trigger"
+
+# gui/<uid> USER agent (the detector needs the user session for the local notifier),
+# with the sibling bootout-then-bootstrap shape + retry loop. $HOME and $(id -u)
+# must NOT expand in these literal loader lines.
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist"' ||
+  fail "rendered loader does not point at the heartbeat plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-heartbeat"' ||
+  fail "rendered loader does not target the heartbeat label as a gui/<uid> user agent"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-heartbeat-launchagent: OK (label + RunAtLoad false; gui/<uid> user agent; deployed libexec detector; data-driven StartCalendarInterval from osquery.yaml; loader gated, plist-hash + schedule onchange, bootout+bootstrap with retry)\n'


### PR DESCRIPTION
## Context

The osquery security-alerting pipeline pages on urgent findings and digests routine ones. But a monitor
that has silently died looks exactly like a healthy, quiet one: no message could mean "all clear" or "the
whole pipeline is dead, and you will never hear from it again." This slice adds a daily proof-of-life, a
silent message that confirms the root osquery daemon is actually producing scheduled results, so that
silence can be trusted rather than feared.

The live machine applies from `integration/modernization`, not `main`, so merging this changes nothing on
any running machine (see Effect of merging).

## Summary

- A daily LaunchAgent sends one silent proof-of-life that the osquery daemon is scheduling and producing results.
- It reads the daemon's own scheduled canary, not a one-shot query that answers even when the daemon is wedged.
- Any doubt (stale, missing, future-dated, or unreadable canary) reports unhealthy, never a false all-clear.
- Every message is muted, so the proof-of-life never pages like a real alert (the watchdog is the pager).
- The schedule lives in `.chezmoidata/osquery.yaml`, and a schedule edit reschedules the running agent.

Key files:

- `dot_local/libexec/osquery/executable_heartbeat.sh` — the proof-of-life
- `.chezmoidata/osquery.yaml` — the declared schedule
- `Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist.tmpl` — the daily agent
- `.chezmoiscripts/run_onchange_after_60-load-osquery-heartbeat-launchagent.sh.tmpl` — the loader
- `dot_config/osquery/private_page-launchd-allowlist.txt` — the heartbeat's own allowlist tuple

## What it verifies, and what it does not

osqueryd (the root daemon that does the actual monitoring) runs a scheduled `heartbeat_canary` query every
600 seconds and writes a row to its snapshot log. The heartbeat reads the newest such row and checks it is
recent. This deliberately avoids a one-shot `osqueryi` query: a one-shot spins up a fresh osquery that
answers even while the long-running daemon is stopped or wedged, a green light on a dead system. Only the
scheduled daemon can produce a fresh canary, so a fresh canary is real evidence the daemon is alive and
running its schedule.

The healthy message is careful to claim only what it can prove: the daemon produced a scheduled result
recently, which is a recent observation, not a live check. Real-time liveness is the uptime watchdog's
job. The heartbeat is the slower positive daily record that complements it.

## Fail-safe by design

A liveness check must never fabricate calm, so every ambiguous case resolves to unhealthy. A missing
canary, a stale one, a system clock that cannot be read, and a timestamp implausibly far in the future
(clock skew or a corrupt row) each produce an honest unhealthy note rather than a green all-clear. The
freshness window is two-sided on purpose: a canary is fresh only when its timestamp is within the bound in
either direction, so a future-dated row cannot slip through as fresh.

The only value the heartbeat renders from the log is the canary timestamp, and it is validated as an
integer before any use, so no free-text log field can reach the message or the shell.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does
not change until a later cutover folds these branches forward, at which point the daily agent begins
sending the proof-of-life on the declared schedule.
