### PR TITLE
feat(osquery): monitor Tailscale Funnel for public-internet exposure

### DIFF
--- a/.chezmoiscripts/run_onchange_after_60-load-osquery-tailscale-monitor-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_60-load-osquery-tailscale-monitor-launchagent.sh.tmpl
@@ -1,0 +1,21 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# run_onchange_after_60-load-osquery-tailscale-monitor-launchagent.sh
+# plist hash: {{ include "Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl" | sha256sum }}
+
+set -euo pipefail
+
+PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist"
+TARGET="gui/$(id -u)/com.webdavis.osquery-tailscale-monitor"
+
+launchctl bootout "$TARGET" 2>/dev/null || true
+
+for _ in 1 2 3; do
+  if launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+{{- end }}

--- a/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.webdavis.osquery-tailscale-monitor</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>{{ .chezmoi.homeDir }}/.local/libexec/osquery/tailscale-monitor.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/tailscale-monitor.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/.local/log/osquery/tailscale-monitor.log</string>
+</dict>
+</plist>

--- a/dot_config/osquery/private_page-launchd-allowlist.txt
+++ b/dot_config/osquery/private_page-launchd-allowlist.txt
@@ -25,3 +25,4 @@
 {"label":"com.webdavis.osquery-uptime-watchdog","path":"~/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/uptime-watchdog.sh","sha256":""}
 {"label":"com.webdavis.osquery-alert-drainer","path":"~/Library/LaunchAgents/com.webdavis.osquery-alert-drainer.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/drain-undelivered-alerts.sh","sha256":""}
 {"label":"com.webdavis.osquery-heartbeat","path":"~/Library/LaunchAgents/com.webdavis.osquery-heartbeat.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/heartbeat.sh","sha256":""}
+{"label":"com.webdavis.osquery-tailscale-monitor","path":"~/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/tailscale-monitor.sh","sha256":""}

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -160,6 +160,18 @@ case "$prev_funnel" in
   *) prev_funnel="" ;;
 esac
 
+# If the LAST persist FAILED (the persist-gap marker is present), the on-disk baseline
+# is stale and untrustworthy: a failed close-write can leave an "active" baseline that
+# would mask a later reopen (a missed public re-exposure). Distrust it, so an active
+# read pages after any persist failure - a duplicate page is safe, a missed one is not.
+# persist_baseline clears the marker on the next successful write (recovery). Honest
+# residual: if storage is so broken the marker itself cannot be written, the durable
+# degraded-monitor page (send_alert is durable independent of local state) is the
+# safety signal; unsolvable local-storage loss is not solved here.
+if [[ -f $PERSIST_GAP ]]; then
+  prev_funnel=""
+fi
+
 # A missing binary is a monitoring gap (the regression that left this monitor dead
 # on the formula install). CRIT so it reaches the remote channel, page-once. The
 # body names the local binary PATH (operator/env-controlled, not network data).

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -152,12 +152,21 @@ page_exposure_and_persist() {
 # Read the prior baseline. Only active/inactive is a valid funnel baseline; a
 # corrupt/absent value is treated as no trustworthy baseline (R2-5b).
 prev_funnel=""
+state_was_corrupt=0
 if [[ -f $STATE ]]; then
   prev_funnel=$(jq -r '.funnel // empty' <"$STATE" 2>/dev/null || echo "")
 fi
 case "$prev_funnel" in
   active | inactive) ;;
-  *) prev_funnel="" ;;
+  *)
+    # A PRESENT state file whose value is not active/inactive is CORRUPT, distinct from
+    # an ABSENT file (a first run). Flag it so a later non-paging tick surfaces the
+    # monitor-integrity anomaly instead of silently repairing it.
+    if [[ -f $STATE ]]; then
+      state_was_corrupt=1
+    fi
+    prev_funnel=""
+    ;;
 esac
 
 # If the LAST persist FAILED (the persist-gap marker is present), the on-disk baseline
@@ -245,6 +254,17 @@ rm -f "$GAP" 2>/dev/null || true
 if [[ $cur == "active" && $prev_funnel != "active" ]]; then
   page_exposure_and_persist "$funnel_json"
   exit 0
+fi
+
+# A present-but-corrupt state file is a monitor-integrity anomaly the operator should
+# SEE (no-silent-failures), even when there is nothing to page (an idle read has no
+# exposure). Fire ONE CRIT corruption gap before persist_baseline recovers the state,
+# so it does not repeat (the next tick reads a valid baseline). A corrupt+ACTIVE read
+# already paged the exposure at the transition path above and exited, so this never
+# double-pages. send_alert is durable, so a store failure is not lost.
+if [[ $state_was_corrupt -eq 1 ]]; then
+  corrupt_body="$GAP_LEAD"$'\n'"- The funnel monitor state file was CORRUPT (an unreadable baseline); it is being reset."$'\n'"$GAP_CLOSE"
+  send_alert CRIT "$CRIT_TITLE" "$corrupt_body" "Sosumi" || true
 fi
 
 # No transition to page: refresh the baseline (steady active, steady inactive, or a

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+#
+# tailscale-monitor.sh, polled every 60s by a launchd StartInterval agent. The
+# public-exposure monitor: it reads `tailscale funnel status --json`, classifies
+# whether a Funnel is exposing a local service to the PUBLIC internet, compares
+# against the previous run's baseline, and pages CRIT only on a funnel turning ON
+# (an off->on transition, a first-observation active funnel, or a monitoring gap).
+# Silent in steady state and when a funnel is closed.
+#
+# Funnel traffic tunnels through tailscaled, so osquery cannot see it as a
+# listening port; polling the CLI is the only way to catch it.
+#
+# The funnel signal is read from --json, not the human text: an active PUBLIC
+# funnel is an AllowFunnel entry set true (tailscale ipn/serve.go, "AllowFunnel is
+# the set of SNI:port values for which funnel traffic is allowed"), which a
+# tailnet-only `serve` never sets. So a private serve does not false-page, and the
+# read does not couple to the CLI's human wording.
+#
+# R2-5: a MONITORING GAP of a public-exposure detector is itself CRIT (a blind
+# funnel monitor is an undetectable public-exposure risk). So a missing binary, a
+# failed status command, empty output, or malformed JSON is NOT swallowed into a
+# false "inactive": it pages once (via a .gap marker), preserves the prior valid
+# funnel baseline, and never advances state on a blind read. Every page is a CRIT
+# page (non-empty sound), so it reaches the remote #priority channel and pings.
+
+set -euo pipefail
+
+STATE="${OSQUERY_TAILSCALE_STATE:-$HOME/.local/state/osquery-tailscale-funnel.json}"
+GAP="$STATE.gap"                 # page-once marker for a monitoring gap (R2-5)
+PERSIST_GAP="$STATE.persist-gap" # page-once marker for a baseline-persist failure
+
+# Resolution order: explicit override -> PATH (the headless homebrew formula this
+# machine runs) -> the GUI-app path (the future tailscale-app cask). See CLAUDE.md
+# the Tailscale section.
+TAILSCALE="${OSQUERY_TAILSCALE_BIN:-$(command -v tailscale || echo /Applications/Tailscale.app/Contents/MacOS/Tailscale)}"
+
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+
+mkdir -p "$(dirname "$STATE")"
+
+# Never leave a partial temp baseline behind, on any exit path.
+trap 'rm -f "$STATE.tmp"' EXIT
+
+CRIT_TITLE='🔴 **CRITICAL**'
+# The BLIND-gap body shares one lead line + closer; the caller supplies the middle
+# reason. Kept apostrophe-free for the alerting stack.
+GAP_LEAD='**Tailscale funnel monitoring is BLIND - public-exposure paging is not running.**'
+GAP_CLOSE='- A funnel could be opened to the PUBLIC internet without a page while this is blind. **Fix now.**'
+# A literal backtick, so a command name renders as Discord inline-code. Built as a
+# variable because shfmt -s would single-quote a no-expansion string and SC2016
+# would then flag the bare backticks (the monolith hit this same conflict).
+bt='`'
+
+# write_state <funnel-value> -- atomically persist the baseline owner-only (0600),
+# via a private temp file plus an atomic rename.
+write_state() {
+  (
+    umask 077
+    jq -cn --arg funnel "$1" '{funnel: $funnel}' >"$STATE.tmp"
+  ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
+}
+
+# page_gap_once <marker> <body> -- the shared page-once-via-marker discipline for
+# both the monitoring gap and the persist gap. If the marker is absent, send_alert
+# FIRST (a CRIT page tier) and write the marker ONLY on success; return 0 when
+# paged or already marked, nonzero when send_alert could not store the page (so a
+# persisting condition re-pages). Best effort: a marker in an unwritable dir cannot
+# be written, so the page may re-fire, acceptable for a serious ongoing fault.
+page_gap_once() {
+  local marker="$1" body="$2"
+  if [[ -f $marker ]]; then
+    return 0
+  fi
+  if send_alert CRIT "$CRIT_TITLE" "$body" "Sosumi"; then
+    : >"$marker" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+# gap_and_exit <reason-line> -- page the monitoring gap once (page-once via GAP)
+# and exit. On a send_alert store-failure, write no marker and exit nonzero so the
+# next tick re-pages. The body is static text plus the caller's reason: it never
+# renders the raw (attacker-influenceable) CLI output.
+gap_and_exit() {
+  local body
+  body="$GAP_LEAD"$'\n'"$1"$'\n'"$GAP_CLOSE"
+  if ! page_gap_once "$GAP" "$body"; then
+    printf 'tailscale-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
+    exit 1
+  fi
+  exit 0
+}
+
+# persist_baseline <funnel-value> -- persist the baseline, making a persistence
+# FAILURE loud rather than silent. A failed write cannot advance the baseline, so a
+# stale baseline could later mask a real re-exposure (a stale prev=active reads the
+# next real active as steady, silent, forever). Page a degraded-monitor gap ONCE
+# via its own marker, then exit nonzero so launchd retries. On success clear the
+# marker (recovery).
+persist_baseline() {
+  if write_state "$1"; then
+    rm -f "$PERSIST_GAP" 2>/dev/null || true
+    return 0
+  fi
+  local body
+  body="**Tailscale funnel monitor degraded.**"$'\n'"- The funnel monitor could not persist its baseline: it cannot advance state, so a stale baseline could mask the next real public exposure and blind the monitor."$'\n'"- Check the state directory free space and permissions. **Check now.**"
+  page_gap_once "$PERSIST_GAP" "$body" || true
+  exit 1
+}
+
+# render_exposure <funnel-json> -- the public-exposure page body. The exposed
+# SNI:port values come from AllowFunnel and are ATTACKER-INFLUENCEABLE (an attacker
+# who opened the funnel controls the string), so each crosses into the body as
+# INERT data through the same chokepoint render-page.sh uses: backticks stripped
+# (they end an inline-code span), \r\n\t squashed to spaces (a newline also breaks
+# the span and could forge a markdown line), then length-capped and wrapped in a
+# Discord inline-code span. Display-only.
+render_exposure() {
+  local exposed
+  exposed=$(printf '%s' "$1" | jq -r '
+    def code:
+      (gsub("`"; "") | gsub("[\r\n\t]"; " ")) as $v
+      | "`" + (if ($v | length) > 200 then ($v[0:200] + "…(truncated)") else $v end) + "`";
+    [.. | objects | .AllowFunnel // empty | to_entries[] | select(.value == true) | .key]
+    | unique
+    | if length == 0 then "`(unknown)`" else (map("- " + code) | join("\n")) end
+  ' 2>/dev/null || printf '%s' '(unknown)')
+  printf '%s\n' \
+    "**Tailscale Funnel is exposing a local service to the PUBLIC internet.**" \
+    "- Did you set this up? If not, close it now: **tailscale funnel reset**" \
+    "- Exposed to the public internet:" \
+    "$exposed"
+}
+
+# page_exposure_and_persist <funnel-json> -- emit one CRIT public-exposure page,
+# then advance the baseline to active. Notify-before-persist: send_alert is
+# write-ahead durable, so the baseline advances ONLY after the page is durably
+# enqueued; on a send_alert store-failure the baseline is left as-is and the
+# monitor exits nonzero, so a PERSISTING exposure re-pages next tick.
+page_exposure_and_persist() {
+  local body
+  body=$(render_exposure "$1")
+  if ! send_alert CRIT "$CRIT_TITLE" "$body" "Sosumi"; then
+    printf 'tailscale-monitor: send_alert could not queue the funnel-exposure page; baseline not advanced, retrying next tick\n' >&2
+    exit 1
+  fi
+  persist_baseline active
+}
+
+# Read the prior baseline. Only active/inactive is a valid funnel baseline; a
+# corrupt/absent value is treated as no trustworthy baseline (R2-5b).
+prev_funnel=""
+if [[ -f $STATE ]]; then
+  prev_funnel=$(jq -r '.funnel // empty' <"$STATE" 2>/dev/null || echo "")
+fi
+case "$prev_funnel" in
+  active | inactive) ;;
+  *) prev_funnel="" ;;
+esac
+
+# A missing binary is a monitoring gap (the regression that left this monitor dead
+# on the formula install). CRIT so it reaches the remote channel, page-once. The
+# body names the local binary PATH (operator/env-controlled, not network data).
+if [[ ! -x $TAILSCALE ]]; then
+  printf 'WARN: no tailscale binary (%s) - funnel monitoring is blind\n' "$TAILSCALE" >&2
+  gap_and_exit "- No tailscale binary found at [$TAILSCALE]."
+fi
+
+# Run the status command, capturing its exit code (do NOT || true a failure into a
+# false inactive).
+rc=0
+funnel_json=$("$TAILSCALE" funnel status --json 2>/dev/null) || rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  gap_and_exit "- ${bt}tailscale funnel status --json${bt} exited $rc, so the funnel state is unreadable."
+fi
+if [[ -z $funnel_json ]]; then
+  gap_and_exit "- ${bt}tailscale funnel status --json${bt} returned no output, so the funnel state is unreadable."
+fi
+# Malformed (non-JSON) output is a gap, not a silent inactive. jq empty validates
+# JSON (any value, including {} and null) and fails only on a PARSE error.
+if ! printf '%s' "$funnel_json" | jq empty >/dev/null 2>&1; then
+  gap_and_exit "- ${bt}tailscale funnel status --json${bt} returned output that is not valid JSON, so the funnel state is unreadable."
+fi
+
+# Valid JSON: classify. A PUBLIC funnel is active iff any AllowFunnel entry is true
+# at ANY depth (top-level, a Foreground session, or a Service), so a tailnet-only
+# serve (Web/TCP without AllowFunnel) is correctly inactive.
+active=$(printf '%s' "$funnel_json" |
+  jq -r '[.. | objects | .AllowFunnel // empty | .[]?] | any(. == true)' 2>/dev/null || printf 'error')
+case "$active" in
+  true) cur="active" ;;
+  false) cur="inactive" ;;
+  *)
+    # An unexpected classifier result is a gap (fail-safe), never a silent inactive.
+    gap_and_exit "- the funnel status JSON could not be classified, so the funnel state is unreadable."
+    ;;
+esac
+
+# A valid read cleared the gap (recovery): drop the marker so a future gap pages again.
+rm -f "$GAP" 2>/dev/null || true
+
+# Page on a fresh off->on transition, a first-observation active funnel (no prior
+# baseline), or an active read on recovery from a blind window (prev was cleared).
+# A steady active funnel (prev already active) is silent, and an on->off (funnel
+# closed) is silent too. R2-5: an active reading after a gap MUST page, never be
+# accepted as a silent new baseline.
+if [[ $cur == "active" && $prev_funnel != "active" ]]; then
+  page_exposure_and_persist "$funnel_json"
+  exit 0
+fi
+
+# No transition to page: refresh the baseline (steady active, steady inactive, or a
+# funnel just closed). A persistence failure here is a loud degraded-monitor gap.
+persist_baseline "$cur"

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -196,17 +196,29 @@ if ! printf '%s' "$funnel_json" | jq empty >/dev/null 2>&1; then
   gap_and_exit "- ${bt}tailscale funnel status --json${bt} returned output that is not valid JSON, so the funnel state is unreadable."
 fi
 
-# Valid JSON: classify. A PUBLIC funnel is active iff any AllowFunnel entry is true
-# at ANY depth (top-level, a Foreground session, or a Service), so a tailnet-only
-# serve (Web/TCP without AllowFunnel) is correctly inactive.
-active=$(printf '%s' "$funnel_json" |
-  jq -r '[.. | objects | .AllowFunnel // empty | .[]?] | any(. == true)' 2>/dev/null || printf 'error')
-case "$active" in
-  true) cur="active" ;;
-  false) cur="inactive" ;;
+# Valid JSON: classify into active / inactive / gap. A PUBLIC funnel is active iff
+# an AllowFunnel entry is boolean true at ANY depth (top-level, a Foreground
+# session, or a Service), so a tailnet-only serve (Web/TCP without AllowFunnel) is
+# correctly inactive. AllowFunnel is map[HostPort]bool: an entry value that is NOT a
+# boolean, or an AllowFunnel that is not a map, is an UNEXPECTED shape and resolves
+# to a gap (fail-safe), never a silent inactive that could miss a real exposure.
+classification=$(printf '%s' "$funnel_json" | jq -r '
+  [.. | objects | .AllowFunnel // empty] as $funnels
+  | if ($funnels | any(type != "object")) then "gap"
+    else ([$funnels[] | .[]?]) as $values
+      | if ($values | any(type != "boolean")) then "gap"
+        elif ($values | any(. == true)) then "active"
+        else "inactive" end
+    end
+' 2>/dev/null || printf 'error')
+case "$classification" in
+  active) cur="active" ;;
+  inactive) cur="inactive" ;;
   *)
-    # An unexpected classifier result is a gap (fail-safe), never a silent inactive.
-    gap_and_exit "- the funnel status JSON could not be classified, so the funnel state is unreadable."
+    # "gap" (an unexpected AllowFunnel shape) or an unclassifiable/empty result: a
+    # public-exposure detector treats an unreadable funnel state as a gap, never a
+    # silent inactive (R2-5).
+    gap_and_exit "- the funnel status JSON has an unexpected AllowFunnel shape, so the funnel state is unclassifiable and unreadable."
     ;;
 esac
 

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -169,9 +169,20 @@ if [[ ! -x $TAILSCALE ]]; then
 fi
 
 # Run the status command, capturing its exit code (do NOT || true a failure into a
-# false inactive).
+# false inactive). Bound it so a WEDGED tailscaled (the CLI blocks on the local API
+# socket) becomes a monitoring gap, not silent blindness: without a bound, launchd
+# skips ticks while the process lives and the monitor never pages. gtimeout
+# preferred, timeout fallback (the codebase convention); if neither is on PATH,
+# degrade to an unbounded read (no worse than before). The bound is well under the
+# 60s tick and env-overridable. On timeout the CLI is killed (nonzero rc), which
+# the gap gate below pages.
+status_command=("$TAILSCALE" funnel status --json)
+timeout_bin="$(command -v gtimeout || command -v timeout || true)"
+if [[ -n $timeout_bin ]]; then
+  status_command=("$timeout_bin" "${OSQUERY_TAILSCALE_TIMEOUT:-10}" "${status_command[@]}")
+fi
 rc=0
-funnel_json=$("$TAILSCALE" funnel status --json 2>/dev/null) || rc=$?
+funnel_json=$("${status_command[@]}" 2>/dev/null) || rc=$?
 
 if [[ $rc -ne 0 ]]; then
   gap_and_exit "- ${bt}tailscale funnel status --json${bt} exited $rc, so the funnel state is unreadable."

--- a/test/fixtures/osquery-tailscale-lib.bash
+++ b/test/fixtures/osquery-tailscale-lib.bash
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Test harness (makeSUT) for the public-exposure monitor
+# (dot_local/libexec/osquery/executable_tailscale-monitor.sh).
+#
+# The monitor runs as a user LaunchAgent every 60s: it reads
+# `tailscale funnel status --json`, classifies whether a Funnel is exposing a
+# local service to the PUBLIC internet, compares against the previous run's
+# baseline, and pages CRIT only on an off->on transition (or a first-observation
+# active, or a monitoring gap). This harness stands the monitor up in isolation
+# and records what it does through two recording spies:
+#
+#   - a programmable, recording `tailscale` stub: it appends the argv it was
+#     handed to $TS_TAILSCALE_ARGS, then prints $TAILSCALE_FUNNEL_JSON and exits
+#     $TAILSCALE_FUNNEL_RC, so a test sets a known funnel status (or forces a
+#     command failure) with no real tailscale/launchd dependency; and
+#   - a recording send_alert spy, installed as a stand-in dispatch library at the
+#     new libexec path the monitor sources ($HOME/.local/libexec/osquery/
+#     alert-dispatch.sh). It never delivers; it records each call's severity,
+#     sound, and argv, and the baseline as it stood at call time, so a test can
+#     prove the monitor stays silent AND that any page fires only BEFORE the
+#     baseline advances (notify-before-persist).
+#
+# A fresh temp HOME keeps every run off the operator's real ~/.local/state and
+# ~/.local/libexec. Sourced by the tailscale suite; no main.
+
+TS_TOOL="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_tailscale-monitor.sh"
+
+# set_funnel <json> -- the JSON body the `tailscale funnel status --json` stub
+# prints. Empty models an empty (blank) status output.
+set_funnel() {
+  export TAILSCALE_FUNNEL_JSON="$1"
+}
+
+# set_funnel_rc <rc> -- the exit code the `tailscale` stub returns (default 0),
+# so a test can force a status-command failure.
+set_funnel_rc() {
+  export TAILSCALE_FUNNEL_RC="$1"
+}
+
+setup_tailscale_harness() {
+  export TS_HOME
+  TS_HOME="$(mktemp -d)"
+  # Ownership marker set only after our own mktemp, so teardown removes this
+  # path and never a pre-set or inherited TS_HOME.
+  _TS_HARNESS_OWNED_DIR="$TS_HOME"
+
+  mkdir -p "$TS_HOME/bin" \
+    "$TS_HOME/.local/libexec/osquery" \
+    "$TS_HOME/.local/state"
+
+  # The env-overridable state path, under the sandbox HOME.
+  export OSQUERY_TAILSCALE_STATE="$TS_HOME/.local/state/osquery-tailscale-funnel.json"
+
+  # Recording `tailscale` stub: log the argv (so a test proves the monitor asked
+  # for `funnel status --json`), then print the programmed JSON and exit the
+  # programmed code. printf '%s' (no newline) keeps an empty program truly empty
+  # so the empty-output gap path is exercised.
+  export TS_TAILSCALE_ARGS="$TS_HOME/tailscale-args.log"
+  : >"$TS_TAILSCALE_ARGS"
+  cat >"$TS_HOME/bin/tailscale" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TS_TAILSCALE_ARGS"
+printf '%s' "${TAILSCALE_FUNNEL_JSON:-}"
+exit "${TAILSCALE_FUNNEL_RC:-0}"
+SHIM
+  chmod +x "$TS_HOME/bin/tailscale"
+  export TS_TAILSCALE_BIN="$TS_HOME/bin/tailscale"
+
+  # Recording send_alert spy at the NEW dispatch path the monitor sources. It
+  # never delivers; it records each call's severity (one line per call, so a test
+  # counts pages), sound (the page/muted tier), full argv (for body assertions),
+  # and the baseline as it stood at call time (to prove notify-before-persist).
+  export TS_SEND_ALERT_SEVERITY="$TS_HOME/send-alert-severity.log"
+  export TS_SEND_ALERT_SOUND="$TS_HOME/send-alert-sound.log"
+  export TS_SEND_ALERT_LOG="$TS_HOME/send-alert.log"
+  export TS_SEND_ALERT_STATE_AT_CALL="$TS_HOME/send-alert-state-at-call.log"
+  : >"$TS_SEND_ALERT_SEVERITY"
+  : >"$TS_SEND_ALERT_SOUND"
+  : >"$TS_SEND_ALERT_LOG"
+  : >"$TS_SEND_ALERT_STATE_AT_CALL"
+  cat >"$TS_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
+# shellcheck shell=bash
+send_alert() {
+  # Severity (arg 1) on its own line: one line per call, so a test counts pages.
+  printf '%s\n' "${1:-}" >>"$TS_SEND_ALERT_SEVERITY"
+  # Sound (arg 4) on its own line: a non-empty sound is the page tier, an empty
+  # sound is muted. A funnel exposure and every gap must page, never mute.
+  printf '%s\n' "${4:-}" >>"$TS_SEND_ALERT_SOUND"
+  # Full argv (severity, title, body, sound) for body/naming assertions.
+  printf '%s\n' "$*" >>"$TS_SEND_ALERT_LOG"
+  # The baseline as it stood when the page fired, so a test can prove the ordering
+  # (notify-before-persist: the baseline has NOT yet advanced to active).
+  if [[ -f ${OSQUERY_TAILSCALE_STATE:-/nonexistent} ]]; then
+    cat "$OSQUERY_TAILSCALE_STATE" >>"$TS_SEND_ALERT_STATE_AT_CALL"
+  fi
+  # TS_SEND_ALERT_EXIT models a dispatch that could NOT durably queue the page
+  # (nonzero). Default 0 (queued): the monitor then advances the baseline.
+  return "${TS_SEND_ALERT_EXIT:-0}"
+}
+SHIM
+
+  # Default: no prior baseline, no funnel configured (idle), status succeeds.
+  set_funnel '{}'
+  set_funnel_rc 0
+}
+
+teardown_tailscale_harness() {
+  [[ -n ${_TS_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_TS_HARNESS_OWNED_DIR"
+  unset _TS_HARNESS_OWNED_DIR
+}
+
+# seed_funnel_state <token> -- write the prior baseline (and gap marker) the run
+# starts from. "" removes it (first run); active/inactive write the 0600 JSON
+# baseline; gap writes an inactive baseline PLUS the page-once gap marker (a prior
+# blind window); corrupt writes non-JSON garbage.
+seed_funnel_state() {
+  local marker="$OSQUERY_TAILSCALE_STATE.gap"
+  rm -f "$OSQUERY_TAILSCALE_STATE" "$marker"
+  case "$1" in
+    "") : ;;
+    active) _write_state_0600 '{"funnel":"active"}' ;;
+    inactive) _write_state_0600 '{"funnel":"inactive"}' ;;
+    gap)
+      _write_state_0600 '{"funnel":"inactive"}'
+      : >"$marker"
+      ;;
+    corrupt) printf 'not-json-garbage\n' >"$OSQUERY_TAILSCALE_STATE" ;;
+    *)
+      printf 'seed_funnel_state: unknown token %q\n' "$1" >&2
+      return 1
+      ;;
+  esac
+}
+
+# _write_state_0600 <compact-json> -- write a known-good baseline at 0600, so a
+# sad-path test can prove a gap read leaves it untouched.
+_write_state_0600() {
+  mkdir -p "$(dirname "$OSQUERY_TAILSCALE_STATE")"
+  printf '%s\n' "$1" >"$OSQUERY_TAILSCALE_STATE"
+  chmod 600 "$OSQUERY_TAILSCALE_STATE"
+}
+
+# run_tailscale_monitor -- run the monitor under the harness env. HOME is the temp
+# home so the sourced dispatch spy and the default state path resolve inside the
+# sandbox; OSQUERY_TAILSCALE_BIN points at the recording stub.
+run_tailscale_monitor() {
+  HOME="$TS_HOME" \
+    OSQUERY_TAILSCALE_BIN="$TS_TAILSCALE_BIN" \
+    OSQUERY_TAILSCALE_STATE="$OSQUERY_TAILSCALE_STATE" \
+    bash "$TS_TOOL"
+}
+
+# run_tailscale_monitor_missing_bin -- the configured binary does not exist (the
+# dead-monitor regression that left funnel paging silently disabled).
+run_tailscale_monitor_missing_bin() {
+  HOME="$TS_HOME" \
+    OSQUERY_TAILSCALE_BIN="$TS_HOME/bin/no-such-tailscale" \
+    OSQUERY_TAILSCALE_STATE="$OSQUERY_TAILSCALE_STATE" \
+    bash "$TS_TOOL" 2>/dev/null
+}
+
+# run_tailscale_monitor_path_resolved -- NO env override: the monitor must find
+# the stub via `command -v` on PATH (the homebrew-formula resolution path).
+run_tailscale_monitor_path_resolved() {
+  HOME="$TS_HOME" \
+    PATH="$TS_HOME/bin:$PATH" \
+    OSQUERY_TAILSCALE_STATE="$OSQUERY_TAILSCALE_STATE" \
+    env -u OSQUERY_TAILSCALE_BIN bash "$TS_TOOL"
+}
+
+# ---- assertions ------------------------------------------------------------
+
+# refute_file_contains <fixed-substring> <file> -- fail (return 1) when the
+# substring (fixed, case-insensitive) appears in the file. The robust NEGATIVE
+# assertion: a bare `! grep` is exempted from set -e in bats and silently no-ops,
+# so a plain function whose nonzero return set -e DOES catch closes that gap.
+refute_file_contains() {
+  if grep -qiF -- "$1" "$2"; then
+    printf 'expected %q NOT to appear in %s, but it does:\n%s\n' "$1" "$2" "$(cat "$2")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_mode <octal> <path> -- the path carries the expected permission bits.
+# GNU stat first (the nix shell), BSD stat as the fallback (the portable order).
+assert_mode() {
+  local mode
+  mode=$(stat -c '%a' "$2" 2>/dev/null || stat -f '%Lp' "$2" 2>/dev/null)
+  if [[ $mode != "$1" ]]; then
+    printf 'expected mode %s on %s, got %s\n' "$1" "$2" "$mode" >&2
+    return 1
+  fi
+}
+
+# assert_tailscale_called_with <substring> -- the recorded tailscale argv
+# contains <substring> (proves the monitor read via the verified --json path).
+assert_tailscale_called_with() {
+  if ! grep -qF -- "$1" "$TS_TAILSCALE_ARGS"; then
+    printf 'expected the tailscale argv to contain %s; argv was:\n%s\n' \
+      "$1" "$(cat "$TS_TAILSCALE_ARGS")" >&2
+    return 1
+  fi
+}
+
+# assert_no_page -- the monitor did not call send_alert at all (silent).
+assert_no_page() {
+  if [[ -s $TS_SEND_ALERT_LOG ]]; then
+    printf 'expected NO page, but send_alert was called:\n%s\n' \
+      "$(cat "$TS_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_count <n> -- send_alert was called exactly <n> times (one severity
+# line per call; the body may span many lines, so the severity log is the count).
+assert_page_count() {
+  local count
+  count=$(wc -l <"$TS_SEND_ALERT_SEVERITY")
+  count=${count//[[:space:]]/}
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s page(s), got %s; send_alert log:\n%s\n' \
+      "$1" "$count" "$(cat "$TS_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_severity_is <severity> -- a page fired and every page carried
+# <severity> (only a CRIT reaches the #priority webhook, so the severity arg is
+# the security-relevant one, not just the title text).
+assert_page_severity_is() {
+  if [[ ! -s $TS_SEND_ALERT_SEVERITY ]]; then
+    printf 'expected a %s page, but send_alert was never called\n' "$1" >&2
+    return 1
+  fi
+  if grep -qvxF "$1" "$TS_SEND_ALERT_SEVERITY"; then
+    printf 'expected every page at severity %s, got:\n%s\n' \
+      "$1" "$(cat "$TS_SEND_ALERT_SEVERITY")" >&2
+    return 1
+  fi
+}
+
+# assert_page_sound_nonempty -- a page fired and every page carried a NON-EMPTY
+# sound (the page tier). An empty sound is the muted tier: a public-exposure or
+# blind-monitor page must ping, never mute.
+assert_page_sound_nonempty() {
+  if [[ ! -s $TS_SEND_ALERT_SOUND ]]; then
+    printf 'expected a page with a non-empty sound, but send_alert was never called\n' >&2
+    return 1
+  fi
+  # One sound line per call; an EMPTY line is a muted (empty-sound) call. grep -xF ''
+  # matches only whole empty lines, so this fails if any page was muted.
+  if grep -qxF '' "$TS_SEND_ALERT_SOUND"; then
+    printf 'expected every page to carry a non-empty sound (page tier), got a muted call:\n%s\n' \
+      "$(sed 's/^$/<empty>/' "$TS_SEND_ALERT_SOUND")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_page_body_has <substring> -- some page's argv contained <substring>.
+assert_page_body_has() {
+  if ! grep -qF -- "$1" "$TS_SEND_ALERT_LOG"; then
+    printf 'expected a page naming %s; send_alert log:\n%s\n' \
+      "$1" "$(cat "$TS_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_baseline_funnel <value> -- the persisted baseline's .funnel equals <value>.
+assert_baseline_funnel() {
+  local got
+  got=$(jq -r '.funnel // empty' "$OSQUERY_TAILSCALE_STATE" 2>/dev/null || echo "")
+  if [[ $got != "$1" ]]; then
+    printf 'expected baseline .funnel == %s, got %q; baseline:\n%s\n' \
+      "$1" "$got" "$(cat "$OSQUERY_TAILSCALE_STATE" 2>/dev/null || echo '(no file)')" >&2
+    return 1
+  fi
+}
+
+# snapshot_baseline -- copy the baseline aside so assert_baseline_unchanged can
+# compare byte-for-byte after a run.
+snapshot_baseline() {
+  cp "$OSQUERY_TAILSCALE_STATE" "$TS_HOME/baseline.snapshot"
+}
+
+# assert_baseline_unchanged -- the baseline is byte-for-byte identical to the last
+# snapshot (a gap read must neither clobber nor blank it).
+assert_baseline_unchanged() {
+  if ! cmp -s "$TS_HOME/baseline.snapshot" "$OSQUERY_TAILSCALE_STATE"; then
+    printf 'expected the baseline byte-for-byte preserved.\nsnapshot:\n%s\nnow:\n%s\n' \
+      "$(cat "$TS_HOME/baseline.snapshot" 2>/dev/null || echo '(no snapshot)')" \
+      "$(cat "$OSQUERY_TAILSCALE_STATE" 2>/dev/null || echo '(missing)')" >&2
+    return 1
+  fi
+}
+
+# assert_gap_marker -- the page-once monitoring-gap marker (STATE.gap) exists.
+assert_gap_marker() {
+  if [[ ! -f $OSQUERY_TAILSCALE_STATE.gap ]]; then
+    printf 'expected the gap marker %s.gap to exist, but it does not\n' "$OSQUERY_TAILSCALE_STATE" >&2
+    return 1
+  fi
+}
+
+# assert_no_gap_marker -- the monitoring-gap marker does not exist (never paged,
+# or cleared on recovery).
+assert_no_gap_marker() {
+  if [[ -f $OSQUERY_TAILSCALE_STATE.gap ]]; then
+    printf 'expected NO gap marker, but %s.gap exists\n' "$OSQUERY_TAILSCALE_STATE" >&2
+    return 1
+  fi
+}
+
+# assert_page_saw_prior_not_active -- at the moment send_alert fired, the persisted
+# baseline was NOT yet active (either absent, or holding the prior inactive value),
+# proving the page fired BEFORE the baseline advanced (notify-before-persist).
+assert_page_saw_prior_not_active() {
+  if grep -qF '"funnel":"active"' "$TS_SEND_ALERT_STATE_AT_CALL"; then
+    printf 'expected the baseline NOT to be active at page time (notify-before-persist), saw:\n%s\n' \
+      "$(cat "$TS_SEND_ALERT_STATE_AT_CALL")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_no_state -- no baseline file exists (a first-observation page whose
+# send_alert failed must not have seeded one).
+assert_no_state() {
+  if [[ -f $OSQUERY_TAILSCALE_STATE ]]; then
+    printf 'expected NO baseline file, but %s exists with:\n%s\n' \
+      "$OSQUERY_TAILSCALE_STATE" "$(cat "$OSQUERY_TAILSCALE_STATE")" >&2
+    return 1
+  fi
+}
+
+# assert_file_absent <path> -- the path does not exist (an injection payload must
+# not have executed and created its marker file).
+assert_file_absent() {
+  if [[ -e $1 ]]; then
+    printf 'expected %s NOT to exist, but it does\n' "$1" >&2
+    return 1
+  fi
+}

--- a/test/fixtures/osquery-tailscale-lib.bash
+++ b/test/fixtures/osquery-tailscale-lib.bash
@@ -320,6 +320,31 @@ assert_no_gap_marker() {
   fi
 }
 
+# assert_persist_gap_marker / assert_no_persist_gap_marker -- the baseline-persist
+# failure page-once marker (STATE.persist-gap): set when write_state fails, cleared
+# on the next successful persist.
+assert_persist_gap_marker() {
+  if [[ ! -f $OSQUERY_TAILSCALE_STATE.persist-gap ]]; then
+    printf 'expected the persist-gap marker %s.persist-gap to exist, but it does not\n' "$OSQUERY_TAILSCALE_STATE" >&2
+    return 1
+  fi
+}
+
+assert_no_persist_gap_marker() {
+  if [[ -f $OSQUERY_TAILSCALE_STATE.persist-gap ]]; then
+    printf 'expected NO persist-gap marker, but %s.persist-gap exists\n' "$OSQUERY_TAILSCALE_STATE" >&2
+    return 1
+  fi
+}
+
+# block_state_write / unblock_state_write -- make write_state FAIL while keeping the
+# state DIR writable, so the persist-gap marker can still be written (the failure mode
+# FIX A protects: a failed close-write that DID record the marker). write_state
+# redirects into "$STATE.tmp"; pre-creating that path as a DIRECTORY makes the redirect
+# fail, so the atomic write fails without touching the dir permissions.
+block_state_write() { mkdir -p "$OSQUERY_TAILSCALE_STATE.tmp"; }
+unblock_state_write() { rmdir "$OSQUERY_TAILSCALE_STATE.tmp" 2>/dev/null || true; }
+
 # assert_page_saw_prior_not_active -- at the moment send_alert fired, the persisted
 # baseline was NOT yet active (either absent, or holding the prior inactive value),
 # proving the page fired BEFORE the baseline advanced (notify-before-persist).

--- a/test/fixtures/osquery-tailscale-lib.bash
+++ b/test/fixtures/osquery-tailscale-lib.bash
@@ -60,6 +60,13 @@ setup_tailscale_harness() {
   cat >"$TS_HOME/bin/tailscale" <<'SHIM'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$TS_TAILSCALE_ARGS"
+# TAILSCALE_FUNNEL_SLEEP models a wedged tailscaled (the CLI blocks on the local
+# API socket). exec into sleep so this is a SINGLE process (no child holding
+# stdout open): a timeout kill then closes the pipe at the bound. It never emits,
+# so a bounded monitor reads empty and gaps.
+if [[ -n ${TAILSCALE_FUNNEL_SLEEP:-} ]]; then
+  exec sleep "$TAILSCALE_FUNNEL_SLEEP"
+fi
 printf '%s' "${TAILSCALE_FUNNEL_JSON:-}"
 exit "${TAILSCALE_FUNNEL_RC:-0}"
 SHIM

--- a/test/integration/osquery-feature-set-location.sh
+++ b/test/integration/osquery-feature-set-location.sh
@@ -11,9 +11,9 @@ cd "$REPO_ROOT"
 
 fail=0
 
-# 1. The libexec home holds the seven scripts (prefix dropped). A git ls-files
+# 1. The libexec home holds the eight scripts (prefix dropped). A git ls-files
 # failure fails the test.
-for f in alert-dispatch digest enrich-finding firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
+for f in alert-dispatch digest enrich-finding firewall-gatekeeper-monitor heartbeat results-alerter tailscale-monitor uptime-watchdog; do
   path="dot_local/libexec/osquery/executable_${f}.sh"
   if ! listed="$(git ls-files "$path")"; then
     printf 'FAIL: git ls-files failed while checking %s\n' "$path" >&2
@@ -44,15 +44,15 @@ assert_contains() {
   esac
 }
 
-# The five launchd plists' ProgramArguments point at the libexec home.
-for name in digest firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
+# The six launchd plists' ProgramArguments point at the libexec home.
+for name in digest firewall-gatekeeper-monitor heartbeat results-alerter tailscale-monitor uptime-watchdog; do
   assert_contains ".local/libexec/osquery/${name}.sh" \
     "Library/LaunchAgents/com.webdavis.osquery-${name}.plist.tmpl"
 done
 
-# The five consumers source the dispatch library from the libexec home.
+# The six consumers source the dispatch library from the libexec home.
 # The needles below are literal source lines; $HOME must NOT expand here.
-for name in digest firewall-gatekeeper-monitor heartbeat results-alerter uptime-watchdog; do
+for name in digest firewall-gatekeeper-monitor heartbeat results-alerter tailscale-monitor uptime-watchdog; do
   # shellcheck disable=SC2016
   assert_contains 'source "$HOME/.local/libexec/osquery/alert-dispatch.sh"' \
     "dot_local/libexec/osquery/executable_${name}.sh"

--- a/test/integration/osquery-page-allowlist-seed.sh
+++ b/test/integration/osquery-page-allowlist-seed.sh
@@ -66,11 +66,12 @@ else
   done <"$new_file"
 
   # The seed migrates this host's own-agents (results-alerter,
-  # firewall-gatekeeper-monitor, uptime-watchdog, alert-drainer, heartbeat) to tuples,
-  # so none false-pages the alerter's persistence_launchd detector (which
-  # default-denies an unallowlisted user LaunchAgent) when its plist first appears.
-  if [[ $entry_count -ne 5 ]]; then
-    fail "expected 5 seeded tuples (the host's own-agents), got $entry_count"
+  # firewall-gatekeeper-monitor, uptime-watchdog, alert-drainer, heartbeat,
+  # tailscale-monitor) to tuples, so none false-pages the alerter's
+  # persistence_launchd detector (which default-denies an unallowlisted user
+  # LaunchAgent) when its plist first appears.
+  if [[ $entry_count -ne 6 ]]; then
+    fail "expected 6 seeded tuples (the host's own-agents), got $entry_count"
   fi
 
   # The alert-drainer is one own-agent of the class: a real own-agent, so it does not
@@ -83,6 +84,12 @@ else
   # plist would self-page the alerter (default-deny), so its tuple is seeded here too.
   if ! grep -qF '"label":"com.webdavis.osquery-heartbeat"' "$new_file"; then
     fail "the heartbeat own-agent tuple is missing from the seed"
+  fi
+
+  # The tailscale funnel monitor is an own-agent added after the cutover too: its
+  # plist would self-page the alerter (default-deny) without its own tuple.
+  if ! grep -qF '"label":"com.webdavis.osquery-tailscale-monitor"' "$new_file"; then
+    fail "the tailscale-monitor own-agent tuple is missing from the seed"
   fi
 fi
 

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -1,0 +1,528 @@
+#!/usr/bin/env bats
+# The public-exposure monitor (executable_tailscale-monitor.sh) runs as a user
+# LaunchAgent every 60s. It reads `tailscale funnel status --json`, classifies
+# whether a Funnel exposes a local service to the PUBLIC internet (an AllowFunnel
+# entry set true, distinct from a tailnet-only serve), compares against the prior
+# baseline, and pages CRIT only on an off->on transition, a first-observation
+# active funnel, or a monitoring gap. It is silent in steady state and when a
+# funnel is closed. Every page precedes the state advance (notify-before-persist).
+#
+# R2-5: a MONITORING GAP of a public-exposure detector is itself CRIT. A missing
+# binary, a failed status command, empty output, or malformed JSON is NOT swallowed
+# into a false "inactive"; it pages once, preserves the prior valid baseline, and
+# never advances state on a blind read. The funnel status is network-influenceable,
+# so the exposure page renders it as inert data (sanitized + inline-code-wrapped),
+# and gap pages render only the local binary path, a numeric rc, and static text.
+
+load ../fixtures/osquery-tailscale-lib
+
+setup() { setup_tailscale_harness; }
+teardown() { teardown_tailscale_harness; }
+
+# A realistic active-funnel ServeConfig: AllowFunnel true for one SNI:port, plus
+# the Web handler that proxies it. Shape verified against tailscale v1.98.8
+# ipn/serve.go (AllowFunnel map[HostPort]bool).
+FUNNEL_ON='{"AllowFunnel":{"dresden.tailnet.ts.net:443":true},"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8000"}}}}}'
+# A tailnet-only serve: Web/TCP populated, but NO AllowFunnel (not public).
+SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8000"}}}}}'
+
+# --- B1: binary resolution ------------------------------------------------------
+
+@test "T-TS-resolve-path: with no env override the monitor finds tailscale via PATH" {
+  seed_funnel_state inactive
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor_path_resolved
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1 # resolved the stub on PATH and paged the funnel
+  assert_tailscale_called_with '--json'
+}
+
+# --- B2/B3: an idle funnel is silent; first run seeds inactive silently ----------
+
+@test "T-TS-idle-silent: an idle funnel status with an inactive baseline pages nothing" {
+  seed_funnel_state inactive
+  set_funnel '{}'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel inactive
+  assert_tailscale_called_with 'funnel status --json' # read via the verified JSON path
+}
+
+@test "T-TS-firstrun-idle-seeds-silent: a first run with no baseline and an idle funnel seeds inactive silently" {
+  seed_funnel_state "" # no prior baseline
+  set_funnel '{}'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel inactive # seeded, so the next tick is quiet
+}
+
+# --- B4: an off->on transition pages CRIT (public exposure) ----------------------
+
+@test "T-TS-funnel-on-pages: a funnel turning on pages one CRIT naming the public exposure" {
+  seed_funnel_state inactive
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT   # only a CRIT reaches the #priority webhook
+  assert_page_sound_nonempty     # the page tier, never muted
+  assert_page_body_has 'Funnel'
+  assert_page_body_has 'PUBLIC'
+  # Notify-before-persist: at page time the baseline had NOT advanced to active.
+  assert_page_saw_prior_not_active
+  # Once the page is durably queued, the baseline advances to active.
+  assert_baseline_funnel active
+}
+
+# --- B5: an already-active funnel is silent (steady state) -----------------------
+
+@test "T-TS-funnel-steady-silent: an already-active funnel does not re-page" {
+  seed_funnel_state active
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel active
+}
+
+# --- B6: a first-observation active funnel (no baseline) pages -------------------
+
+@test "T-TS-firstrun-active-pages: a first run with the funnel already active pages CRIT" {
+  seed_funnel_state "" # no prior baseline
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'Funnel'
+  assert_baseline_funnel active # seeded only after the page succeeds
+}
+
+# --- on->off: closing a funnel removes the exposure and is SILENT ----------------
+
+@test "T-TS-funnel-off-silent: a funnel turning OFF (closed) is silent and updates the baseline to inactive" {
+  seed_funnel_state active
+  set_funnel '{}' # the funnel was reset/closed
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page # closing an exposure is good news, not actionable
+  assert_baseline_funnel inactive
+}
+
+# --- B22: a tailnet-only serve is NOT a public exposure and does not page --------
+
+@test "T-TS-serve-only-silent: a tailnet-only serve (Web set, no AllowFunnel) does not page" {
+  # DIVERGENCE from c69baab: its coarse text-grep pages on ANY non-empty status,
+  # so a private `tailscale serve` would false-page as a public exposure. Reading
+  # AllowFunnel from --json pages only a real public funnel.
+  seed_funnel_state inactive
+  set_funnel "$SERVE_ONLY"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel inactive
+}
+
+@test "T-TS-allowfunnel-false-silent: an AllowFunnel entry set FALSE is not an active funnel" {
+  seed_funnel_state inactive
+  set_funnel '{"AllowFunnel":{"dresden.tailnet.ts.net:443":false}}'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel inactive
+}
+
+@test "T-TS-foreground-funnel-pages: a funnel in a Foreground session is detected and pages" {
+  # `tailscale funnel <port>` (no --bg) nests the config under Foreground.<session>,
+  # each a ServeConfig that itself carries AllowFunnel. A funnel there is still a
+  # public exposure, so the recursive classifier must catch it.
+  seed_funnel_state inactive
+  set_funnel '{"Foreground":{"sess-abc":{"AllowFunnel":{"dresden.tailnet.ts.net:443":true}}}}'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+}
+
+# --- B7: notify-before-persist; a store failure never loses the page -------------
+
+@test "T-TS-page-failure-keeps-baseline: a send_alert failure does not advance the baseline, so the next tick re-detects and re-pages" {
+  seed_funnel_state inactive
+  snapshot_baseline
+  set_funnel "$FUNNEL_ON"
+  export TS_SEND_ALERT_EXIT=1 # dispatch cannot durably queue the page
+
+  run run_tailscale_monitor
+  [[ $status -ne 0 ]] || {
+    echo "expected the monitor to surface the send_alert failure (nonzero), got $status: $output"
+    false
+  }
+  assert_page_count 1       # it DID attempt the page
+  assert_baseline_unchanged # but the baseline did NOT advance to active
+
+  # Next tick: dispatch now succeeds. The still-inactive baseline re-detects the
+  # transition and re-pages (at-least-once), then advances. Nothing was lost.
+  export TS_SEND_ALERT_EXIT=0
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "retry status $status: $output"
+    false
+  }
+  assert_page_count 2 # re-detected and re-paged, never silently lost
+  assert_baseline_funnel active
+}
+
+@test "T-TS-firstrun-active-page-failure-no-seed: a first-observation page whose send_alert fails seeds no baseline, exits nonzero, and re-pages next tick" {
+  seed_funnel_state "" # no prior baseline
+  set_funnel "$FUNNEL_ON"
+  export TS_SEND_ALERT_EXIT=1
+
+  run run_tailscale_monitor
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the first-observation page could not be queued, got $status: $output"
+    false
+  }
+  assert_no_state     # no baseline seeded on failure, so the exposure is re-detected
+  assert_page_count 1 # it attempted the page
+
+  export TS_SEND_ALERT_EXIT=0
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "retry status $status: $output"
+    false
+  }
+  assert_page_count 2            # re-detected the still-unbaselined exposure and re-paged
+  assert_baseline_funnel active  # now seeded
+}
+
+# --- B8: the baseline is owner-only (0600) and atomic ---------------------------
+
+@test "T-TS-persist-0600: the monitor persists the baseline owner-only (0600) with no temp left behind" {
+  seed_funnel_state inactive
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  [[ -f $OSQUERY_TAILSCALE_STATE ]] || {
+    echo "expected the baseline at $OSQUERY_TAILSCALE_STATE, but it is missing"
+    false
+  }
+  assert_mode 600 "$OSQUERY_TAILSCALE_STATE"
+  [[ ! -e $OSQUERY_TAILSCALE_STATE.tmp ]] || {
+    echo "expected the write_state temp file to be gone, but $OSQUERY_TAILSCALE_STATE.tmp remains"
+    false
+  }
+}
+
+# --- B9: a missing binary is a CRIT gap, page-once (R2-5) ------------------------
+
+@test "T-TS-missing-bin-pages: a missing tailscale binary pages a CRIT BLIND gap (blindness reaches the remote)" {
+  # The dead-monitor regression: a GUI-path default silently disabled funnel paging
+  # on the headless-formula install. Now it is a CRIT page (was a WARN the dispatcher dropped).
+  seed_funnel_state inactive
+  run run_tailscale_monitor_missing_bin
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+}
+
+@test "T-TS-missing-bin-once: the missing-binary gap pages once, not every 60s (R2-5)" {
+  seed_funnel_state gap # a prior blind window: the gap marker is already set
+  run run_tailscale_monitor_missing_bin
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page # already blind: the marker suppresses a re-page
+}
+
+# --- B10/B11: a failing status command is a CRIT gap and preserves the baseline --
+
+@test "T-TS-status-fail-pages-gap: a failing funnel status (rc=1) is a CRIT gap, not a silent inactive (R2-5)" {
+  seed_funnel_state active
+  set_funnel '' # no output
+  set_funnel_rc 1
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+}
+
+@test "T-TS-status-fail-preserves-baseline: a status failure preserves the prior valid funnel baseline (R2-5)" {
+  # rc=1 must not overwrite a known-active baseline with a false "inactive": the
+  # prior state is preserved so a real transition is still detectable on recovery.
+  seed_funnel_state active
+  snapshot_baseline
+  set_funnel ''
+  set_funnel_rc 1
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_baseline_funnel active
+  assert_baseline_unchanged
+}
+
+# --- B12: empty output and malformed JSON are CRIT gaps --------------------------
+
+@test "T-TS-empty-output-pages-gap: an empty (rc=0) status output is a CRIT gap, not a silent inactive (R2-5)" {
+  seed_funnel_state active
+  set_funnel '' # succeeds but prints nothing
+  set_funnel_rc 0
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+  assert_baseline_funnel active # a gap never overwrites the baseline
+}
+
+@test "T-TS-malformed-json-pages-gap: a malformed (non-JSON) status output is a CRIT gap, not a silent inactive" {
+  seed_funnel_state active
+  set_funnel '{not valid json'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+  assert_baseline_funnel active
+}
+
+# --- B13: a corrupt prior state is NOT a baseline -------------------------------
+
+@test "T-TS-corrupt-state-active-pages: a corrupt prior state is not a baseline, so an active funnel pages (R2-5)" {
+  # A garbage state file must not be trusted as an "active" baseline that would
+  # suppress the page.
+  seed_funnel_state corrupt
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Funnel'
+  assert_baseline_funnel active
+}
+
+# --- B14: a funnel found active on recovery from a blind window pages ------------
+
+@test "T-TS-funnel-after-blind-pages: a funnel found active on recovery from a blind window pages" {
+  seed_funnel_state gap # prior blind window (inactive baseline + gap marker)
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Funnel'
+  assert_no_gap_marker # a valid read cleared the blind-window marker
+  assert_baseline_funnel active
+}
+
+# --- B15: a valid read after a gap clears the marker, so a later gap re-pages -----
+
+@test "T-TS-gap-recovery-clears-marker: a valid read after a gap clears the marker, so a later gap pages again" {
+  seed_funnel_state inactive
+
+  set_funnel '' # gap 1: empty output pages and writes the marker
+  set_funnel_rc 0
+  run run_tailscale_monitor
+  assert_page_count 1
+  assert_gap_marker
+
+  set_funnel '{}' # recovery: a valid idle read clears the marker, steady inactive (no page)
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "recovery status $status: $output"
+    false
+  }
+  assert_no_gap_marker
+
+  set_funnel '' # gap 2: the marker was cleared, so it pages again
+  run run_tailscale_monitor
+  assert_page_count 2 # the second gap is not suppressed by a stale marker
+  assert_gap_marker
+}
+
+@test "T-TS-gap-page-failure-no-marker: a gap whose send_alert fails writes no marker, exits nonzero, and re-pages next tick" {
+  seed_funnel_state inactive
+  set_funnel ''
+  export TS_SEND_ALERT_EXIT=1 # dispatch cannot queue the gap page
+
+  run run_tailscale_monitor
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the gap page could not be queued, got $status: $output"
+    false
+  }
+  assert_no_gap_marker # no marker on failure, so the next tick retries
+  assert_page_count 1  # it attempted the page
+
+  export TS_SEND_ALERT_EXIT=0
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "retry status $status: $output"
+    false
+  }
+  assert_page_count 2 # re-detected the still-unmarked gap and re-paged (at-least-once)
+  assert_gap_marker
+}
+
+# --- B16: the funnel status is network-influenceable and rendered INERT ----------
+
+@test "T-TS-injection-inert: a hostile funnel host:port is sanitized, cannot break the code span, and never executes" {
+  seed_funnel_state inactive
+  # A hostile AllowFunnel key: a backtick + command-substitution payload, a real
+  # newline, and forged Discord markdown. An attacker who opened the funnel controls
+  # this SNI:port string. Escaped backticks keep the TEST itself from executing it.
+  local payload
+  payload="evil\`touch ${TS_HOME}/PWNED\`"$'\n'"Injected **bold** @everyone:443"
+  set_funnel "$(jq -cn --arg k "$payload" '{AllowFunnel: {($k): true}}')"
+
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  # No command execution from the payload (the body is passed as data, never eval'd).
+  assert_file_absent "$TS_HOME/PWNED"
+  # Backticks are stripped: the raw `touch sequence cannot survive to break out of
+  # the inline-code span. (The legitimate wrapping backticks remain, so we refute
+  # the payload's specific backtick-touch, not all backticks.)
+  refute_file_contains '`touch' "$TS_SEND_ALERT_LOG"
+  # The newline is squashed to a space: the payload cannot inject a standalone
+  # markdown line, so PWNED and Injected land on ONE line, not two.
+  if ! grep -F 'PWNED' "$TS_SEND_ALERT_LOG" | grep -qF 'Injected'; then
+    echo "expected the newline-squashed payload on one line; send_alert log:"
+    cat "$TS_SEND_ALERT_LOG"
+    false
+  fi
+}
+
+@test "T-TS-gap-body-no-raw-output: a malformed status does not leak raw CLI output into the gap page" {
+  seed_funnel_state inactive
+  set_funnel "GARBAGE\`touch ${TS_HOME}/PWNED\`{not json"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  # A gap page renders only static text + the local path + a numeric rc: the raw
+  # (attacker-influenceable) output must never reach it.
+  refute_file_contains 'GARBAGE' "$TS_SEND_ALERT_LOG"
+  refute_file_contains '`touch' "$TS_SEND_ALERT_LOG"
+  assert_file_absent "$TS_HOME/PWNED"
+}
+
+# --- B17: every dispatch is the page tier (CRIT + non-empty sound), never muted --
+
+@test "T-TS-tier-page-not-muted: a funnel-on page is CRIT with a non-empty sound (page tier)" {
+  # GATE: an empty sound threads tier=muted into the webhook and skips the phone
+  # ping. A public-exposure page must ping. CRIT and a non-empty sound are BOTH
+  # load-bearing (mutation-verified: CRIT->INFO and sound->"" each red a test).
+  seed_funnel_state inactive
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+}
+
+@test "T-TS-gap-tier-page-not-muted: a monitoring-gap page is also CRIT with a non-empty sound" {
+  seed_funnel_state inactive
+  run run_tailscale_monitor_missing_bin
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+}
+
+# --- B23: a baseline-write failure is a loud degraded-monitor gap ----------------
+
+@test "T-TS-persist-failure-pages-degraded: a baseline-write failure pages a degraded-monitor gap, never silently trusts a stale baseline" {
+  # A funnel closing (active->inactive) is a SILENT path that still must persist the
+  # new baseline. Make the state dir unwritable so write_state fails on this tick.
+  # Without a loud failure, the stale prev=active would mask a later re-exposure
+  # (cur=active vs stale active reads as steady, silent, forever).
+  seed_funnel_state active
+  set_funnel '{}' # funnel closed: a silent path that must persist inactive
+  chmod 500 "$(dirname "$OSQUERY_TAILSCALE_STATE")"
+  run run_tailscale_monitor
+  chmod 700 "$(dirname "$OSQUERY_TAILSCALE_STATE")" # restore before asserting / teardown
+
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the baseline could not be persisted, got $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'degraded'
+}

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -401,6 +401,26 @@ SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http
   assert_baseline_funnel active
 }
 
+@test "T-TS-corrupt-state-idle-gaps: a corrupt existing state on an idle read pages a CRIT corruption gap and recovers the baseline" {
+  # FIX B (visibility, B13): a present-but-corrupt state file is a monitor-integrity
+  # anomaly the operator should SEE (no-silent-failures). A corrupt+ACTIVE read
+  # already pages the exposure; a corrupt+IDLE read must not silently repair the
+  # garbage - it fires a CRIT corruption gap, then recovers. An ABSENT state (a first
+  # run) stays silent; only a PRESENT corrupt file signals.
+  seed_funnel_state corrupt
+  set_funnel '{}' # idle: nothing to expose, but the corruption must be surfaced
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'CORRUPT'
+  assert_baseline_funnel inactive # the garbage is recovered to a valid baseline
+}
+
 # --- B14: a funnel found active on recovery from a blind window pages ------------
 
 @test "T-TS-funnel-after-blind-pages: a funnel found active on recovery from a blind window pages" {

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -162,6 +162,25 @@ SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http
   assert_baseline_funnel inactive
 }
 
+@test "T-TS-allowfunnel-nonboolean-gaps: a non-boolean AllowFunnel value is an unexpected shape and pages a gap, not a silent inactive" {
+  # AllowFunnel is map[HostPort]bool: tailscale always serializes booleans. A
+  # non-boolean value (a serialization change or a tampered read) is an
+  # unclassifiable funnel state, so fail-safe to a CRIT gap, never a silent
+  # inactive that could miss a real public exposure (R2-5).
+  seed_funnel_state inactive
+  set_funnel '{"AllowFunnel":{"dresden.tailnet.ts.net:443":"true"}}'
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+  assert_baseline_funnel inactive # a gap never advances the baseline
+}
+
 @test "T-TS-foreground-funnel-pages: a funnel in a Foreground session is detected and pages" {
   # `tailscale funnel <port>` (no --bg) nests the config under Foreground.<session>,
   # each a ServeConfig that itself carries AllowFunnel. A funnel there is still a

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -294,6 +294,27 @@ SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http
   assert_gap_marker
 }
 
+@test "T-TS-status-hang-pages-gap: a funnel status that outlasts the bound is killed and pages a gap (R2-5)" {
+  # A wedged tailscaled (the CLI blocks on the local API socket) must become a
+  # monitoring gap, not silent blindness: without a bound, launchd skips ticks
+  # while the process lives and the monitor never pages. The bound kills the read
+  # and the gap gate pages it.
+  seed_funnel_state active
+  snapshot_baseline
+  export OSQUERY_TAILSCALE_TIMEOUT=1 # bound the read at 1s
+  export TAILSCALE_FUNNEL_SLEEP=30   # tailscaled wedges far past the bound
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'BLIND'
+  assert_gap_marker
+  assert_baseline_unchanged # a wedged read is a gap: it never persists
+}
+
 @test "T-TS-status-fail-preserves-baseline: a status failure preserves the prior valid funnel baseline (R2-5)" {
   # rc=1 must not overwrite a known-active baseline with a false "inactive": the
   # prior state is preserved so a real transition is still detectable on recovery.

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -547,6 +547,41 @@ SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http
 
 # --- B23: a baseline-write failure is a loud degraded-monitor gap ----------------
 
+@test "T-TS-reopen-after-failed-close-pages: a funnel reopen after a failed close-write is not masked by the stale baseline" {
+  # FIX A (fail-open): a failed close-write leaves a stale "active" baseline. Without
+  # distrusting it, a later reopen (cur=active, stale prev=active) is silently
+  # suppressed - a MISSED public re-exposure. The persist-gap marker makes the on-disk
+  # baseline untrustworthy, so the reopen pages.
+  seed_funnel_state active
+
+  # Tick 1: the funnel closes, but write_state FAILS (the dir stays writable so the
+  # persist-gap marker IS recorded), leaving the stale "active" baseline.
+  set_funnel '{}'
+  block_state_write
+  run run_tailscale_monitor
+  [[ $status -ne 0 ]] || {
+    echo "tick1 expected nonzero on the failed persist, got $status: $output"
+    false
+  }
+  assert_page_count 1           # the degraded-monitor page
+  assert_persist_gap_marker     # the marker was written (dir stayed writable)
+  assert_baseline_funnel active # the stale "active" baseline remains (write failed)
+  unblock_state_write
+
+  # Tick 2: storage recovered; the funnel REOPENS active. The stale "active" baseline
+  # must NOT suppress the exposure page.
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 2 # a SECOND page: the reopen exposure (reds now - stale prev=active suppresses it)
+  assert_page_body_has 'Funnel'
+  assert_baseline_funnel active
+  assert_no_persist_gap_marker # the successful persist cleared the marker (recovery)
+}
+
 @test "T-TS-persist-failure-pages-degraded: a baseline-write failure pages a degraded-monitor gap, never silently trusts a stale baseline" {
   # A funnel closing (active->inactive) is a SILENT path that still must persist the
   # new baseline. Make the state dir unwritable so write_state fails on this tick.

--- a/test/unit/osquery-tailscale-monitor-launchagent.sh
+++ b/test/unit/osquery-tailscale-monitor-launchagent.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# The public-exposure monitor LaunchAgent: com.webdavis.osquery-tailscale-monitor
+# must run the deployed monitor every 60 seconds AND at load time. RunAtLoad is
+# true on purpose (poller parity): on load the monitor establishes the baseline
+# and, via the first-observation floor, surfaces an already-active funnel
+# immediately instead of waiting a full interval. This diverges from the daily
+# heartbeat (RunAtLoad false): the heartbeat is a non-urgent daily check where a
+# cold-boot false report is pure noise, whereas this is a real-time threat monitor
+# where immediate public-exposure coverage matters, and the one-time provisioning
+# gap page is page-once-capped and self-clears. It is a gui/<uid> USER agent (it
+# calls send_alert, the user's local notifier). Its loader chezmoiscript is wired
+# exactly like the sibling osquery agents (darwin gate, plist-hash onchange
+# trigger, bootout + bootstrap with the retry loop).
+#
+# Unit test: render the plist and loader templates with the host chezmoi and
+# assert their content. No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-tailscale-monitor-launchagent.sh.tmpl"
+
+fail() {
+  printf 'osquery-tailscale-monitor-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+
+# Render both templates exactly as at apply time. --source pins the render to
+# THIS checkout (hermetic), mirroring the sibling launchagent tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key>
+# with the value element on the FOLLOWING line, so match the key then its next
+# line (same helper shape as the sibling launchagent tests).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, schedule, program path, logs -------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-tailscale-monitor</string>'
+assert_plist_kv StartInterval '<integer>60</integer>'
+# RunAtLoad true: on load the monitor establishes the baseline and surfaces an
+# already-active funnel immediately (the first-observation floor), not a full
+# interval later. Matches the poller sibling; diverges from the heartbeat.
+assert_plist_kv RunAtLoad '<true/>'
+
+# ProgramArguments runs the DEPLOYED monitor from the libexec home (the
+# executable_ source prefix is dropped in the target).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/tailscale-monitor.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/tailscale-monitor.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/tailscale-monitor.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/tailscale-monitor.log</string>"
+
+# --- the loader: darwin gate, onchange trigger, gui user target, bootout+bootstrap retry ----
+
+# The loader re-runs when the plist CONTENT changes: the plist-hash include line
+# is the onchange trigger, and it must name the monitor's own plist template.
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the monitor plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+
+# The rendered loader targets the monitor's label and plist as a gui/<uid> USER
+# agent, and keeps the sibling bootout-then-bootstrap shape with the retry loop.
+# The needles below are literal loader lines; $HOME and $(id -u) must NOT expand
+# here (same rule as the feature-set-location test's source-line needles).
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist"' ||
+  fail "rendered loader does not point at the monitor plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-tailscale-monitor"' ||
+  fail "rendered loader does not target the monitor label as a gui/<uid> user agent"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-tailscale-monitor-launchagent: OK (label + 60s interval + RunAtLoad true; gui/<uid> user agent; deployed libexec program; loader gated, hashed, bootout+bootstrap with retry)\n'


### PR DESCRIPTION
## Context

The osquery security-alerting pipeline pages the operator on urgent findings. Tailscale Funnel exposes a
local service to the public internet, and because Funnel traffic tunnels through tailscaled, osquery
cannot see it as a listening port, so nothing in the existing pipeline would catch it. This adds a
real-time monitor that polls the tailscale CLI and pages the moment a Funnel turns on.

The live machine applies from `integration/modernization`, not `main`, so merging this changes nothing on
any running machine (see Effect of merging).

## Summary

- A 60-second LaunchAgent pages the moment a Tailscale Funnel exposes a local service to the public internet.
- It reads the daemon's own status JSON, not osquery, since Funnel traffic tunnels past the listening-port view.
- It tells a public Funnel from a tailnet-only serve via the status, so a private serve never pages.
- Any monitoring gap (missing binary, wedged read, malformed output, corrupt state) pages a CRIT, never a silent all-clear.
- The attacker-controlled exposure label renders inert, so it cannot forge markdown or inject into the alert.

Key files:

- `dot_local/libexec/osquery/executable_tailscale-monitor.sh` — the monitor
- `Library/LaunchAgents/com.webdavis.osquery-tailscale-monitor.plist.tmpl` — the 60-second agent
- `.chezmoiscripts/run_onchange_after_60-load-osquery-tailscale-monitor-launchagent.sh.tmpl` — the loader
- `dot_config/osquery/private_page-launchd-allowlist.txt` — the monitor's own allowlist tuple

## What it catches, and how it stays honest

Tailscale Funnel and Tailscale serve both expose a local service, but a serve reaches only the private
tailnet while a Funnel reaches the public internet. The monitor reads `tailscale funnel status --json` and
treats a service as exposed only when the status marks it funnel-allowed at any depth, so a tailnet-only
serve does not raise a false page. It reads the JSON rather than the human-readable text, so the check
does not break when the CLI rewords its output.

A blind monitor is itself a public-exposure risk, so anything the monitor cannot read is a CRIT, not a
quiet inactive: a missing binary, a nonzero status, empty or non-JSON output, a wedged daemon that times
out the read, an unrecognized status shape, and a corrupt state file each page once and preserve the last
known-good baseline. The healthy path only ever declares "no exposure" when it actually read a clean,
funnel-free status.

## Delivery and durability

The monitor pages the exposure before it records the new baseline, so a crash between the two re-pages on
the next run rather than losing the alert. It delegates delivery to the shared write-ahead sender, which
persists a page before the network attempt. If recording the baseline itself fails, the monitor distrusts
the stale baseline on the next run, so a funnel that closes and reopens across a failed write is still
paged rather than masked.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does
not change until a later cutover, at which point the 60-second agent begins watching for a public Funnel
exposure.
