### PR TITLE
feat(osquery): harden the uptime watchdog (agent liveness, backlog, fail-safe)

### DIFF
--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -433,11 +433,18 @@ _osquery_row_over_threshold_reason() { # <attempts> <created_at>
   return 1
 }
 
-# Print the number of rows in one alert table, read-only and fail-soft. Backs
-# the two public queue-health counters below. A missing database (nothing ever
-# stored), a missing table (bootstrapped later), or an absent sqlite3 all read
-# as zero, printed as a bare integer, never an error: a health probe must report
-# a number, not fail.
+# Print the number of rows in one alert table, read-only. Backs the two public
+# queue-health counters below. It distinguishes a VERIFIED-EMPTY zero from an
+# UNREADABLE store, because a health probe that reports zero on a read failure
+# would hide a real backlog behind a false all-clear (the watchdog then reads a
+# broken store as healthy). Prints a bare integer and returns 0 for the two
+# legitimately-empty cases: a MISSING database (nothing ever stored, a fresh
+# machine) and a present database whose table has not been bootstrapped yet (each
+# queue creates its table lazily on first store; SQLite reports "no such table").
+# For any OTHER failure once the database FILE EXISTS (sqlite3 absent, or the
+# SELECT erroring on a corrupt or malformed database), it prints NOTHING and
+# returns NONZERO, a present-but-unreadable signal the caller must fail safe on,
+# never a false zero.
 #
 # The connection is READ-ONLY (sqlite3 -readonly): it never modifies committed
 # data and never creates the main database when it is absent (the -f guard also
@@ -450,18 +457,34 @@ _osquery_row_over_threshold_reason() { # <attempts> <created_at>
 # a live queue, so it is NOT used. The table name is a fixed internal literal
 # (SQLite cannot parameterize an identifier), so there is no injection surface.
 _osquery_alert_row_count() { # <table>
-  local table="$1" sqlite3_bin count
+  local table="$1" sqlite3_bin count error_file status
+  # A legitimately absent database is a verified-empty zero (nothing ever stored).
   [[ -f $OSQUERY_UNDELIVERED_ALERTS_DB ]] || {
     printf '0'
     return 0
   }
-  sqlite3_bin="$(_osquery_sqlite3_bin)" || {
+  # From here the database FILE EXISTS, so an absent sqlite3 means the present
+  # store cannot be read at all: unreadable, not empty. Fail safe (nonzero).
+  sqlite3_bin="$(_osquery_sqlite3_bin)" || return 1
+  error_file="$(mktemp "${TMPDIR:-/tmp}/osquery-count-error.XXXXXX")" || return 1
+  status=0
+  count="$("$sqlite3_bin" -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" "SELECT COUNT(*) FROM $table;" 2>"$error_file")" || status=$?
+  if [[ $status -eq 0 && $count =~ ^[0-9]+$ ]]; then
+    rm -f "$error_file"
+    printf '%s' "$count"
+    return 0
+  fi
+  # The SELECT failed. A MISSING TABLE is a legitimately-empty queue (lazy
+  # bootstrap), so it reads zero. Any other error (a corrupt or malformed
+  # database, an I/O error) is an UNREADABLE store: print nothing, return nonzero,
+  # so the health probe fails safe instead of hiding real rows behind a zero.
+  if grep -qi 'no such table' "$error_file"; then
+    rm -f "$error_file"
     printf '0'
     return 0
-  }
-  count="$("$sqlite3_bin" -readonly "$OSQUERY_UNDELIVERED_ALERTS_DB" "SELECT COUNT(*) FROM $table;" 2>/dev/null)" || count=0
-  [[ $count =~ ^[0-9]+$ ]] || count=0
-  printf '%s' "$count"
+  fi
+  rm -f "$error_file"
+  return 1
 }
 
 # Delete one delivered page's pending_alerts row, keyed by request_id. Called

--- a/dot_local/libexec/osquery/executable_canary-freshness.sh
+++ b/dot_local/libexec/osquery/executable_canary-freshness.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# canary-freshness.sh, sourced helper, not run directly. The shared seam for
+# reading the freshness of osqueryd's OWN scheduled heartbeat_canary snapshot.
+# Sourced by the daily heartbeat (the proof-of-life) and the uptime watchdog (the
+# real-time alarm), so both judge the ROOT DAEMON by the same real artifact.
+#
+# R2-8: a standalone osqueryi one-shot answers even while osqueryd is stopped or
+# wedged (it spins up its own ephemeral engine), so it is a blind checkmark that
+# cannot prove the running daemon is alive. The daemon's scheduled canary can: only
+# a live daemon actively running its schedule writes a fresh heartbeat_canary row
+# (osquery.conf schedules it every 600s into osqueryd.snapshots.log). A fresh row
+# proves liveness AND scheduling; a stale or absent row means the daemon is not
+# producing scheduled results.
+#
+# Usage (from a sourcing script):
+#   source "$HOME/.local/libexec/osquery/canary-freshness.sh"
+#   timestamp="$(newest_canary_timestamp)"   # newest canary epoch, or empty
+
+# The daemon-scheduled canary snapshot log. osqueryd writes one heartbeat_canary
+# row here per interval; consumers read its freshness, never a one-shot.
+OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osqueryd.snapshots.log}"
+
+# newest_canary_timestamp, print the NEWEST heartbeat_canary row's timestamp as a
+# plain integer, or nothing when there is no readable, well-formed canary. Select the
+# canary rows by PARSED .name and take the last (newest). fromjson? drops a torn or
+# non-JSON line instead of aborting (the resilient idiom normalize.sh uses to read
+# these same logs), and matching the PARSED .name is whitespace-tolerant, so the read
+# does not couple to osquery's compact serialization. Prefer the envelope unixTime (an
+# integer); fall back to the snapshot column. This is the ONE place the log-derived
+# value is read AND validated numeric, so a non-numeric or malformed value can never
+# reach the freshness decision or the rendered message.
+newest_canary_timestamp() {
+  local candidate
+  [[ -r $OSQUERY_SNAPSHOTS_LOG ]] || return 0
+  candidate="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
+    | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
+    tail -1 || true)"
+  [[ $candidate =~ ^[0-9]+$ ]] || return 0
+  printf '%s' "$candidate"
+}

--- a/dot_local/libexec/osquery/executable_canary-freshness.sh
+++ b/dot_local/libexec/osquery/executable_canary-freshness.sh
@@ -28,14 +28,20 @@ OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osquery
 # these same logs), and matching the PARSED .name is whitespace-tolerant, so the read
 # does not couple to osquery's compact serialization. Prefer the envelope unixTime (an
 # integer); fall back to the snapshot column. This is the ONE place the log-derived
-# value is read AND validated numeric, so a non-numeric or malformed value can never
-# reach the freshness decision or the rendered message.
+# value is read AND validated, protecting BOTH consumers.
+#
+# The value is range-bound to a PLAUSIBLE base-10 unix epoch so it can never break a
+# consumer's bash arithmetic and let a freshness check fall through silent: a leading
+# zero is rejected (bash reads 09999999999 as octal and errors), and the value is
+# capped at 10 digits (<= 9999999999, year 2286), well inside signed 64-bit, so an
+# over-range epoch cannot overflow and wrap both freshness bounds to "fresh". A
+# rejected value returns empty, which every consumer treats as MISSING (fail-safe).
 newest_canary_timestamp() {
   local candidate
   [[ -r $OSQUERY_SNAPSHOTS_LOG ]] || return 0
   candidate="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
     | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
     tail -1 || true)"
-  [[ $candidate =~ ^[0-9]+$ ]] || return 0
+  [[ $candidate =~ ^(0|[1-9][0-9]{0,9})$ ]] || return 0
   printf '%s' "$candidate"
 }

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -21,10 +21,10 @@ set -euo pipefail
 # heartbeat inherits that durability without its own delivery machinery.
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
-
-# The daemon-scheduled canary snapshot log. osqueryd writes one heartbeat_canary
-# row here per interval; the heartbeat reads its freshness, never a one-shot.
-OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osqueryd.snapshots.log}"
+# The shared canary-freshness seam (OSQUERY_SNAPSHOTS_LOG + newest_canary_timestamp),
+# reused by the uptime watchdog so both judge the root daemon by the same artifact.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/canary-freshness.sh"
 
 # Freshness bound: the canary runs every 600s, so 1800s (three intervals)
 # tolerates a missed tick or two while still catching a genuinely stopped or
@@ -32,25 +32,6 @@ OSQUERY_SNAPSHOTS_LOG="${OSQUERY_SNAPSHOTS_LOG:-$HOME/.local/log/osquery/osquery
 # override can never render as free text or break the arithmetic.
 canary_max_age="${OSQUERY_CANARY_MAX_AGE:-1800}"
 [[ $canary_max_age =~ ^[0-9]+$ ]] || canary_max_age=1800
-
-# newest_canary_timestamp - print the NEWEST heartbeat_canary row's timestamp as a
-# plain integer, or nothing when there is no readable, well-formed canary. Select the
-# canary rows by PARSED .name and take the last (newest). fromjson? drops a torn or
-# non-JSON line instead of aborting (the resilient idiom normalize.sh uses to read
-# these same logs), and matching the PARSED .name is whitespace-tolerant, so the read
-# does not couple to osquery's compact serialization. Prefer the envelope unixTime (an
-# integer); fall back to the snapshot column. This is the ONE place the log-derived
-# value is read AND validated numeric, so a non-numeric or malformed value can never
-# reach the freshness decision or the rendered message.
-newest_canary_timestamp() {
-  local candidate
-  [[ -r $OSQUERY_SNAPSHOTS_LOG ]] || return 0
-  candidate="$(jq -rR 'fromjson? | select(.name == "heartbeat_canary")
-    | (.unixTime // .snapshot[0].unix_time) // empty' "$OSQUERY_SNAPSHOTS_LOG" 2>/dev/null |
-    tail -1 || true)"
-  [[ $candidate =~ ^[0-9]+$ ]] || return 0
-  printf '%s' "$candidate"
-}
 
 main() {
   local now last_canary_timestamp age skew title detail

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -9,11 +9,14 @@
 # healthy silence are expected.
 #
 # Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
-# unloaded or unknown-state agent, a wedged osqueryd, an unhealthy route) resolves
-# to a CRIT, never a silent all-healthy. A watchdog that fails quietly is worse
-# than no watchdog. It renders only KNOWN agent labels plus validated-numeric exit
-# codes plus static text, so a value influenced by a compromised launchd cannot
-# inject into the page.
+# unloaded or unknown-state agent, a wedged osqueryd, an unhealthy route, an
+# unreadable queue count) resolves to a CRIT, never a silent all-healthy. A
+# watchdog that fails quietly is worse than no watchdog.
+#
+# The watchdog only READS: it probes the delivery queue counts but never drains it
+# (the scheduled alert-drainer owns draining), and it renders only KNOWN agent
+# labels plus validated-numeric exit codes and counts plus static text, so a value
+# influenced by a compromised launchd cannot inject into the page.
 
 set -euo pipefail
 
@@ -22,8 +25,9 @@ OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
 # with a bare GET: no signing header, so the HMAC key never reaches this wire.
 HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
 ROUTE_TIMEOUT="${OSQUERY_WATCHDOG_ROUTE_TIMEOUT:-3}"
-# Cross-run state: per-agent {runs, streak}, so a crash-loop needs a genuine
-# RE-RUN, not a frozen daily exit. Owner-only, atomic.
+# Cross-run state: per-agent {runs, streak} (so a crash-loop needs a genuine
+# RE-RUN, not a frozen daily exit) and the pending backlog {count, growth_streak}
+# (so a sustained backlog, not a one-tick burst, pages). Owner-only, atomic.
 STATE="${OSQUERY_WATCHDOG_STATE:-$HOME/.local/state/osquery-watchdog-state.json}"
 # Every deployed osquery LaunchAgent EXCEPT this watchdog (which, if running, is
 # loaded by definition). No osquery plist sets KeepAlive, so launchd will not
@@ -137,10 +141,48 @@ case "$route_code" in
   *) problems+=("hermes #priority route unhealthy (HTTP $route_code) at $HERMES_PRIORITY_URL") ;;
 esac
 
+# 4) Delivery-backlog health. ANY dead-letter is a permanently-failed alert (the
+#    drainer gave up), so it pages unconditionally; an unreadable count is a broken
+#    store, which fails safe to a page. A pending backlog pages only on SUSTAINED
+#    growth (it grew across two consecutive checks, a growth streak), so a transient
+#    burst the drainer absorbs in its next cycle does not false-page. The counts
+#    come from the dispatch library's read-only counters; the watchdog never drains.
+dead_letter_count="$(osquery_dead_letter_count 2>/dev/null)" || dead_letter_count=""
+if [[ $dead_letter_count =~ ^[0-9]+$ ]]; then
+  if [[ $dead_letter_count -gt 0 ]]; then
+    problems+=("$dead_letter_count alert(s) permanently failed delivery (dead-lettered); the pipeline is broken")
+  fi
+else
+  problems+=("the dead-letter count is unreadable (the alert store may be broken)")
+fi
+
+pending_count="$(osquery_pending_alert_count 2>/dev/null)" || pending_count=""
+prev_pending="$(jq -r '.pending.count // -1' <<<"$prev_state" 2>/dev/null || printf -- '-1')"
+[[ $prev_pending =~ ^-?[0-9]+$ ]] || prev_pending=-1
+prev_growth_streak="$(jq -r '.pending.growth_streak // 0' <<<"$prev_state" 2>/dev/null || printf '0')"
+[[ $prev_growth_streak =~ ^[0-9]+$ ]] || prev_growth_streak=0
+if [[ $pending_count =~ ^[0-9]+$ ]]; then
+  pending_for_state=$pending_count
+  if [[ $prev_pending -ge 0 && $pending_count -gt $prev_pending ]]; then
+    growth_streak=$((prev_growth_streak + 1))
+  else
+    growth_streak=0
+  fi
+  if [[ $growth_streak -ge 2 ]]; then
+    problems+=("the undelivered-alert backlog has grown for $growth_streak consecutive checks (now $pending_count pending); delivery is not keeping up")
+  fi
+else
+  problems+=("the pending-alert count is unreadable (the alert store may be broken)")
+  pending_for_state=-1
+  growth_streak=0
+fi
+
 # The refreshed state to persist once the tick is resolved. Built now, written only
 # AFTER a page is durably queued (notify-before-persist), so a page that cannot be
-# stored never advances a streak baseline and masks the signal.
-new_state="$(jq -cn --argjson agents "$agent_state_json" '{agents: $agents}')"
+# stored never advances a streak or growth baseline and masks the signal.
+new_state="$(jq -cn --argjson agents "$agent_state_json" \
+  --argjson pc "$pending_for_state" --argjson gs "$growth_streak" \
+  '{agents: $agents, pending: {count: $pc, growth_streak: $gs}}')"
 
 # Healthy: persist the refreshed baselines (no page to order against) and exit
 # silent. A persist failure here only forgets one cycle of streak memory.

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -55,13 +55,16 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/canary-freshness.sh"
 
-# Never leave a partial temp state behind, on any exit path.
-trap 'rm -f "$STATE.tmp"' EXIT
+# Never leave a partial temp state (or the writability probe) behind, on any exit path.
+trap 'rm -f "$STATE.tmp" "$STATE.probe"' EXIT
 
 # write_state <compact-json>, atomically persist the cross-run state owner-only
-# (0600) via a private temp file plus an atomic rename. Returns nonzero on failure
-# so the caller can log it (a lost state file only costs one cycle of streak
-# memory, never a page: every unhealthy condition re-pages next tick regardless).
+# (0600) via a private temp file plus an atomic rename. Returns nonzero on failure.
+# A persistently unpersistable state is NOT harmless: it resets prev_state to {}
+# every tick, so a crash-loop or backlog-growth streak can never accrue and its
+# alarm is silently disabled. That is why writability is probed up front and an
+# unpersistable state PAGES (see the state-persistability probe below), rather than
+# being swallowed as a best-effort log.
 write_state() {
   local dir
   dir="$(dirname "$STATE")"
@@ -94,6 +97,19 @@ printf '%s' "$prev_state" | jq -e . >/dev/null 2>&1 || prev_state="{}"
 
 uid="$(id -u)"
 problems=()
+
+# The cross-run state must be writable, or the streak alarms silently degrade: an
+# unpersistable state resets prev_state to {} every tick (see write_state), so a
+# crash-looping agent's streak resets to 1 each run and never reaches the loop
+# threshold, and a backlog's growth streak likewise never accrues. Probe writability
+# up front and treat an unpersistable state as an unhealthy condition that PAGES.
+if ! mkdir -p "$(dirname "$STATE")" 2>/dev/null || ! (
+  umask 077
+  : >"$STATE.probe"
+) 2>/dev/null; then
+  problems+=("the watchdog cannot persist its state ($STATE); the crash-loop and backlog-growth alarms are degraded until this is fixed")
+fi
+rm -f "$STATE.probe" 2>/dev/null || true
 
 # 1) osqueryd present AND actually PRODUCING SCHEDULED RESULTS. pgrep proves the
 #    process exists; the daemon's OWN scheduled heartbeat canary proves it is alive
@@ -253,8 +269,11 @@ body+=$'\n'"- Restart the down component, then re-check."
 # failure it returns nonzero: leave the state as-is and exit nonzero, so launchd
 # logs the failure and the next tick re-detects instead of masking the signal.
 if send_alert CRIT "$title" "$body" "Sosumi"; then
-  write_state "$new_state" || printf 'uptime-watchdog: could not persist state (%s)\n' "$STATE" >&2
-  exit 0
+  if write_state "$new_state"; then
+    exit 0
+  fi
+  printf 'uptime-watchdog: state could not be persisted (%s); the streak alarms are degraded, retrying next tick\n' "$STATE" >&2
+  exit 1
 fi
 printf 'uptime-watchdog: send_alert could not durably queue the CRIT page; state not advanced, retrying next tick\n' >&2
 exit 1

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -1,60 +1,85 @@
 #!/usr/bin/env bash
 #
-# uptime-watchdog.sh, polled every 15 min by launchd. Asserts the
-# osquery notification pipeline is actually ALIVE, because a dead pipeline
-# otherwise looks identical to "all quiet" (the alerter is edge-triggered and
-# the queries are differential, so genuine silence is normal). Fires a single
-# CRITICAL alert via the shared dispatcher if any component is down or wedged;
-# silent when everything is healthy. Deliberately does NOT use results.log
-# mtime as a signal: hours of healthy silence are expected.
+# uptime-watchdog.sh, polled every 15 min by launchd. Asserts the osquery
+# notification pipeline is actually ALIVE, because a dead pipeline otherwise looks
+# identical to "all quiet" (the alerter is edge-triggered and the queries are
+# differential, so genuine silence is normal). Fires a single CRITICAL page via the
+# shared dispatcher if any component is down or wedged; silent when everything is
+# healthy. Deliberately does NOT use results.log mtime as a signal: hours of
+# healthy silence are expected.
+#
+# Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
+# unloaded agent, a wedged osqueryd, an unhealthy route) resolves to a CRIT, never
+# a silent all-healthy. A watchdog that fails quietly is worse than no watchdog.
 
 set -euo pipefail
 
 OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
-HERMES_URL="${OSQUERY_HERMES_URL:-http://127.0.0.1:8644/webhooks/osquery}"
+# The #priority route the pages actually use (the one send_alert POSTs). Probed
+# with a bare GET: no signing header, so the HMAC key never reaches this wire.
+HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
+ROUTE_TIMEOUT="${OSQUERY_WATCHDOG_ROUTE_TIMEOUT:-3}"
+# Every deployed osquery LaunchAgent EXCEPT this watchdog (which, if running, is
+# loaded by definition). No osquery plist sets KeepAlive, so launchd will not
+# reload an unloaded agent: this list is the sole liveness backstop. A calendar or
+# interval agent that is merely idle between runs still reports loaded, so listing
+# it here cannot false-alarm.
 AGENTS=(
   "com.webdavis.osquery-results-alerter"
   "com.webdavis.osquery-firewall-gatekeeper-monitor"
+  "com.webdavis.osquery-alert-drainer"
+  "com.webdavis.osquery-digest"
+  "com.webdavis.osquery-heartbeat"
+  "com.webdavis.osquery-tailscale-monitor"
 )
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 
+uid="$(id -u)"
 problems=()
 
-# 1) osqueryd present AND answering: a wedged daemon passes pgrep but can't
-#    answer a one-shot query, which is the failure mode KeepAlive won't catch.
+# 1) osqueryd present AND answering. A wedged daemon passes pgrep but cannot answer
+#    a one-shot query, the failure mode KeepAlive would not catch.
 if ! pgrep -fq '/opt/osquery/.*osqueryd'; then
   problems+=("osqueryd is not running")
 elif ! "$OSQUERYI" --json "SELECT 1 AS ok FROM time" >/dev/null 2>&1; then
   problems+=("osqueryd is wedged (not answering queries)")
 fi
 
-# 2) Both notifier LaunchAgents are loaded.
-for agent in "${AGENTS[@]}"; do
-  if ! launchctl list "$agent" >/dev/null 2>&1; then
-    problems+=("LaunchAgent not loaded: $agent")
+# 2) Every watched agent is loaded. `launchctl print` failing means the agent is
+#    not loaded (fail-safe: page).
+for label in "${AGENTS[@]}"; do
+  if ! launchctl print "gui/$uid/$label" >/dev/null 2>&1; then
+    problems+=("LaunchAgent not loaded: $label")
   fi
 done
 
-# 3) hermes gateway reachable (any HTTP status = up; 000 = unreachable). The
-#    local alerter in send_alert still fires even if this is what is down.
-http_status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "$HERMES_URL" 2>/dev/null)" || http_status=000
-if [[ $http_status == "000" ]]; then
-  problems+=("hermes gateway unreachable at $HERMES_URL")
-fi
+# 3) The hermes #priority route is configured and reachable. A GET to the POST-only
+#    route returns 405 (route present, rejects GET) or 2xx = healthy; 000 (gateway
+#    down), 404 (route not configured), or 5xx (gateway erroring) are unhealthy.
+route_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time "$ROUTE_TIMEOUT" "$HERMES_PRIORITY_URL" 2>/dev/null)" || route_code=000
+[[ $route_code =~ ^[0-9]+$ ]] || route_code=000
+case "$route_code" in
+  2[0-9][0-9] | 405) : ;; # route present and reachable
+  *) problems+=("hermes #priority route unhealthy (HTTP $route_code) at $HERMES_PRIORITY_URL") ;;
+esac
 
 if [[ ${#problems[@]} -eq 0 ]]; then exit 0; fi
 
-# A dead pipeline is always CRITICAL → #priority. Focused block: what is down
-# (one bullet each) plus instructive diagnostic + restart steps. backtick holds a
-# literal backtick so the command renders as Discord inline-code without shell
-# expansion.
-backtick='`'
+# Unhealthy: page ONE CRIT (level-triggered, so a persisting outage keeps
+# reminding every tick). A dead pipeline is always CRITICAL and always carries a
+# sound, so it reaches the #priority channel and pings. bt holds a literal backtick
+# so a command name renders as Discord inline-code without shell expansion. The
+# body renders only known labels + a validated numeric route code + static text.
+bt='`'
+title="🔴 **CRITICAL**"
+if [[ ${#problems[@]} -gt 1 ]]; then title="🔴 **CRITICAL** (${#problems[@]} issues)"; fi
 body="**Monitoring is DOWN**"
 for problem in "${problems[@]}"; do body+=$'\n'"- $problem"; done
-body+=$'\n'"- **Diagnose:** ${backtick}launchctl list | grep -i osquery${backtick}"
+body+=$'\n'"- **Diagnose:** ${bt}launchctl list | grep -i osquery${bt}"
 body+=$'\n'"- Restart the down component, then re-check."
-title="🔴 **CRITICAL**"
-if [[ ${#problems[@]} -gt 1 ]]; then title="🔴 **CRITICAL** · ${#problems[@]}"; fi
-send_alert CRIT "$title" "$body" "Sosumi"
+
+# send_alert is write-ahead durable, so a hard delivery failure is already loudly
+# surfaced: keep it off set -e's abort path (the page is fire-and-forget here).
+send_alert CRIT "$title" "$body" "Sosumi" || true

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -72,16 +72,16 @@ write_state() {
   ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
-# agent_field <launchctl-print-output> <field-label>, print the validated integer
-# value of a launchctl-print field ("runs" or "last exit code"). Only the leading
-# signed integer after "= " is taken, so a hostile value appended to the line by an
-# influenced launchctl cannot inject: the number is all that is ever used, and a
-# non-numeric or absent field prints nothing and returns nonzero.
-agent_field() {
+# field_raw <launchctl-print-output> <field-label>, print the RAW text after
+# "<label> = " on its first matching line, or return nonzero when the field line is
+# absent. Extraction is kept separate from policy so the caller can demand an integer
+# for "runs" while CLASSIFYING "last exit code" (a number, the "(never exited)"
+# sentinel, or an unknown value that must fail safe). Every caller validates before
+# use, so nothing raw is ever used in arithmetic or rendered into a page.
+field_raw() {
   local text="$1" label="$2" line
   line="$(printf '%s\n' "$text" | grep -m1 -F "$label = ")" || return 1
-  [[ $line =~ =\ *(-?[0-9]+) ]] || return 1
-  printf '%s' "${BASH_REMATCH[1]}"
+  printf '%s' "${line#*"$label = "}"
 }
 
 # Prior cross-run state. Absent or corrupt (unparseable) starts fresh, never a
@@ -134,27 +134,45 @@ for label in "${AGENTS[@]}"; do
     continue
   fi
   runs_readable=1
-  runs="$(agent_field "$print_out" 'runs')" || {
+  runs_raw="$(field_raw "$print_out" 'runs')" || runs_raw=""
+  if [[ $runs_raw =~ ^[0-9]+$ ]]; then
+    runs=$runs_raw
+  else
     runs=-1
     runs_readable=0
-  }
-  exit_code="$(agent_field "$print_out" 'last exit code')" || exit_code=0
+  fi
   prev_runs="$(jq -r --arg l "$label" '.agents[$l].runs // -1' <<<"$prev_state" 2>/dev/null || printf -- '-1')"
   [[ $prev_runs =~ ^-?[0-9]+$ ]] || prev_runs=-1
   prev_streak="$(jq -r --arg l "$label" '.agents[$l].streak // 0' <<<"$prev_state" 2>/dev/null || printf '0')"
   [[ $prev_streak =~ ^[0-9]+$ ]] || prev_streak=0
-  if [[ $exit_code -eq 0 ]]; then
-    streak=0 # healthy or recovered
-  elif [[ $runs_readable -eq 1 && $runs -eq $prev_runs ]]; then
-    streak=$prev_streak # a FROZEN nonzero exit (no re-run): do not accumulate
+  # Classify the last-exit-code field. An ABSENT field, or one present but neither a
+  # number nor the "(never exited)" sentinel, is an UNKNOWN agent state: fail SAFE to
+  # a page, never default the exit to 0 (which would read every agent as healthy and
+  # silently disable crash-loop detection, the fail-open trap). "(never exited)" is a
+  # running or never-run process, a legitimate not-a-failure. A number drives the
+  # runs-gated streak. Only the validated leading integer is ever used or rendered.
+  streak=$prev_streak
+  if ! exit_raw="$(field_raw "$print_out" 'last exit code')"; then
+    problems+=("LaunchAgent state is unreadable (launchctl print has no last-exit-code field): $label")
+  elif [[ $exit_raw =~ ^[[:space:]]*(-?[0-9]+) ]]; then
+    exit_code="${BASH_REMATCH[1]}"
+    if [[ $exit_code -eq 0 ]]; then
+      streak=0 # healthy or recovered
+    elif [[ $runs_readable -eq 1 && $runs -eq $prev_runs ]]; then
+      streak=$prev_streak # a FROZEN nonzero exit (no re-run): do not accumulate
+    else
+      streak=$((prev_streak + 1)) # a fresh failing re-run (or unreadable runs: fail-safe)
+    fi
+    if [[ $streak -ge 2 ]]; then
+      problems+=("LaunchAgent crash-looping (last exit $exit_code, $streak failing re-runs): $label")
+    fi
+  elif [[ $exit_raw == *"never exited"* ]]; then
+    streak=0 # not exited: currently running or never run, not a failure
   else
-    streak=$((prev_streak + 1)) # a fresh failing re-run (or unreadable runs: fail-safe)
+    problems+=("LaunchAgent exit state is unreadable (unexpected last-exit-code value): $label")
   fi
   agent_state_json="$(jq -c --arg l "$label" --argjson r "$runs" --argjson s "$streak" \
     '. + {($l): {runs: $r, streak: $s}}' <<<"$agent_state_json")"
-  if [[ $streak -ge 2 ]]; then
-    problems+=("LaunchAgent crash-looping (last exit $exit_code, $streak failing re-runs): $label")
-  fi
 done
 
 # 3) The hermes #priority route is configured and reachable. A GET to the POST-only

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -20,11 +20,15 @@
 
 set -euo pipefail
 
-OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
 # The #priority route the pages actually use (the one send_alert POSTs). Probed
 # with a bare GET: no signing header, so the HMAC key never reaches this wire.
 HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
 ROUTE_TIMEOUT="${OSQUERY_WATCHDOG_ROUTE_TIMEOUT:-3}"
+# Canary freshness bound (shared with the heartbeat via OSQUERY_CANARY_MAX_AGE): the
+# scheduled canary runs every 600s, so 1800s (three intervals) tolerates a missed
+# tick while still catching a stopped or wedged daemon within one watchdog cycle.
+canary_max_age="${OSQUERY_CANARY_MAX_AGE:-1800}"
+[[ $canary_max_age =~ ^[0-9]+$ ]] || canary_max_age=1800
 # Cross-run state: per-agent {runs, streak} (so a crash-loop needs a genuine
 # RE-RUN, not a frozen daily exit) and the pending backlog {count, growth_streak}
 # (so a sustained backlog, not a one-tick burst, pages). Owner-only, atomic.
@@ -45,6 +49,11 @@ AGENTS=(
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
+# The shared canary-freshness seam (newest_canary_timestamp), the same one the daily
+# heartbeat uses, so the watchdog judges the root daemon by the REAL artifact (a live
+# daemon's scheduled canary), never a blind osqueryi one-shot.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/canary-freshness.sh"
 
 # Never leave a partial temp state behind, on any exit path.
 trap 'rm -f "$STATE.tmp"' EXIT
@@ -86,12 +95,29 @@ printf '%s' "$prev_state" | jq -e . >/dev/null 2>&1 || prev_state="{}"
 uid="$(id -u)"
 problems=()
 
-# 1) osqueryd present AND answering. A wedged daemon passes pgrep but cannot answer
-#    a one-shot query, the failure mode KeepAlive would not catch.
-if ! pgrep -fq '/opt/osquery/.*osqueryd'; then
+# 1) osqueryd present AND actually PRODUCING SCHEDULED RESULTS. pgrep proves the
+#    process exists; the daemon's OWN scheduled heartbeat canary proves it is alive
+#    AND running its schedule. A standalone osqueryi one-shot is deliberately NOT
+#    used: it spins up its own ephemeral engine and answers even when the running
+#    daemon is wedged or stopped (R2-8, a blind checkmark). A missing, stale, or
+#    future-dated canary means the daemon is not scheduling. The freshness read needs
+#    a trustworthy clock first: a failed clock read cannot judge freshness, so it
+#    fails safe to a page rather than treating every old canary as fresh. Only
+#    validated numerics reach the message.
+now="$(date -u +%s 2>/dev/null || true)"
+if [[ ! $now =~ ^[0-9]+$ ]]; then
+  problems+=("the watchdog cannot read the system clock, so it cannot verify osqueryd is producing scheduled results")
+elif ! pgrep -fq '/opt/osquery/.*osqueryd'; then
   problems+=("osqueryd is not running")
-elif ! "$OSQUERYI" --json "SELECT 1 AS ok FROM time" >/dev/null 2>&1; then
-  problems+=("osqueryd is wedged (not answering queries)")
+else
+  canary_timestamp="$(newest_canary_timestamp)"
+  if [[ -z $canary_timestamp ]]; then
+    problems+=("osqueryd is not producing scheduled results (the heartbeat canary is MISSING); the daemon is stopped or wedged")
+  elif ((now - canary_timestamp > canary_max_age)); then
+    problems+=("osqueryd is not producing scheduled results (the heartbeat canary is STALE, $((now - canary_timestamp))s old); the daemon is stopped or wedged")
+  elif ((canary_timestamp - now > canary_max_age)); then
+    problems+=("osqueryd heartbeat canary timestamp is IMPLAUSIBLE ($((canary_timestamp - now))s in the future); clock skew or a bad row, not a trustworthy liveness signal")
+  fi
 fi
 
 # 2) Every watched agent is loaded AND not crash-looping. `launchctl print` failing

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -127,12 +127,19 @@ elif ! pgrep -fq '/opt/osquery/.*osqueryd'; then
   problems+=("osqueryd is not running")
 else
   canary_timestamp="$(newest_canary_timestamp)"
+  # Fail-safe structure, mirroring the heartbeat: HEALTHY only when a canary sits
+  # inside the freshness window in EITHER direction; anything else PAGES. The default
+  # (else) is to page, so an unexpected value cannot fall through silent. The seam
+  # range-bounds the timestamp, so the arithmetic below can never overflow or be
+  # misread as octal; the fail-safe default is defense in depth on top of that.
   if [[ -z $canary_timestamp ]]; then
     problems+=("osqueryd is not producing scheduled results (the heartbeat canary is MISSING); the daemon is stopped or wedged")
-  elif ((now - canary_timestamp > canary_max_age)); then
-    problems+=("osqueryd is not producing scheduled results (the heartbeat canary is STALE, $((now - canary_timestamp))s old); the daemon is stopped or wedged")
-  elif ((canary_timestamp - now > canary_max_age)); then
+  elif ((now - canary_timestamp <= canary_max_age)) && ((canary_timestamp - now <= canary_max_age)); then
+    : # a canary within the window in either direction: osqueryd is alive and scheduling
+  elif ((canary_timestamp > now)); then
     problems+=("osqueryd heartbeat canary timestamp is IMPLAUSIBLE ($((canary_timestamp - now))s in the future); clock skew or a bad row, not a trustworthy liveness signal")
+  else
+    problems+=("osqueryd is not producing scheduled results (the heartbeat canary is STALE, $((now - canary_timestamp))s old); the daemon is stopped or wedged")
   fi
 fi
 

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -9,8 +9,11 @@
 # healthy silence are expected.
 #
 # Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
-# unloaded agent, a wedged osqueryd, an unhealthy route) resolves to a CRIT, never
-# a silent all-healthy. A watchdog that fails quietly is worse than no watchdog.
+# unloaded or unknown-state agent, a wedged osqueryd, an unhealthy route) resolves
+# to a CRIT, never a silent all-healthy. A watchdog that fails quietly is worse
+# than no watchdog. It renders only KNOWN agent labels plus validated-numeric exit
+# codes plus static text, so a value influenced by a compromised launchd cannot
+# inject into the page.
 
 set -euo pipefail
 
@@ -19,6 +22,9 @@ OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
 # with a bare GET: no signing header, so the HMAC key never reaches this wire.
 HERMES_PRIORITY_URL="${OSQUERY_HERMES_PRIORITY_URL:-http://127.0.0.1:8644/webhooks/osquery-priority}"
 ROUTE_TIMEOUT="${OSQUERY_WATCHDOG_ROUTE_TIMEOUT:-3}"
+# Cross-run state: per-agent {runs, streak}, so a crash-loop needs a genuine
+# RE-RUN, not a frozen daily exit. Owner-only, atomic.
+STATE="${OSQUERY_WATCHDOG_STATE:-$HOME/.local/state/osquery-watchdog-state.json}"
 # Every deployed osquery LaunchAgent EXCEPT this watchdog (which, if running, is
 # loaded by definition). No osquery plist sets KeepAlive, so launchd will not
 # reload an unloaded agent: this list is the sole liveness backstop. A calendar or
@@ -36,6 +42,43 @@ AGENTS=(
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 
+# Never leave a partial temp state behind, on any exit path.
+trap 'rm -f "$STATE.tmp"' EXIT
+
+# write_state <compact-json>, atomically persist the cross-run state owner-only
+# (0600) via a private temp file plus an atomic rename. Returns nonzero on failure
+# so the caller can log it (a lost state file only costs one cycle of streak
+# memory, never a page: every unhealthy condition re-pages next tick regardless).
+write_state() {
+  local dir
+  dir="$(dirname "$STATE")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  (
+    umask 077
+    printf '%s\n' "$1" >"$STATE.tmp"
+  ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
+}
+
+# agent_field <launchctl-print-output> <field-label>, print the validated integer
+# value of a launchctl-print field ("runs" or "last exit code"). Only the leading
+# signed integer after "= " is taken, so a hostile value appended to the line by an
+# influenced launchctl cannot inject: the number is all that is ever used, and a
+# non-numeric or absent field prints nothing and returns nonzero.
+agent_field() {
+  local text="$1" label="$2" line
+  line="$(printf '%s\n' "$text" | grep -m1 -F "$label = ")" || return 1
+  [[ $line =~ =\ *(-?[0-9]+) ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
+# Prior cross-run state. Absent or corrupt (unparseable) starts fresh, never a
+# crash: a fresh start means empty streaks and no false growth signal.
+prev_state="{}"
+if [[ -r $STATE ]]; then
+  prev_state="$(cat "$STATE" 2>/dev/null || printf '{}')"
+fi
+printf '%s' "$prev_state" | jq -e . >/dev/null 2>&1 || prev_state="{}"
+
 uid="$(id -u)"
 problems=()
 
@@ -47,11 +90,40 @@ elif ! "$OSQUERYI" --json "SELECT 1 AS ok FROM time" >/dev/null 2>&1; then
   problems+=("osqueryd is wedged (not answering queries)")
 fi
 
-# 2) Every watched agent is loaded. `launchctl print` failing means the agent is
-#    not loaded (fail-safe: page).
+# 2) Every watched agent is loaded AND not crash-looping. `launchctl print` failing
+#    means the agent is not loaded (fail-safe: page). A loaded agent that exits
+#    nonzero is a crash-loop candidate, but ONLY when it actually RE-RAN: launchd's
+#    `runs` counter must have advanced since the last check. A daily agent's exit
+#    is FROZEN between the 15-min checks, so gating on `runs` stops a single daily
+#    failure from paging every tick forever. Two failing re-runs (streak >= 2) is
+#    the loop; one is a tolerated transient.
+agent_state_json="{}"
 for label in "${AGENTS[@]}"; do
-  if ! launchctl print "gui/$uid/$label" >/dev/null 2>&1; then
+  if ! print_out="$(launchctl print "gui/$uid/$label" 2>/dev/null)"; then
     problems+=("LaunchAgent not loaded: $label")
+    continue
+  fi
+  runs_readable=1
+  runs="$(agent_field "$print_out" 'runs')" || {
+    runs=-1
+    runs_readable=0
+  }
+  exit_code="$(agent_field "$print_out" 'last exit code')" || exit_code=0
+  prev_runs="$(jq -r --arg l "$label" '.agents[$l].runs // -1' <<<"$prev_state" 2>/dev/null || printf -- '-1')"
+  [[ $prev_runs =~ ^-?[0-9]+$ ]] || prev_runs=-1
+  prev_streak="$(jq -r --arg l "$label" '.agents[$l].streak // 0' <<<"$prev_state" 2>/dev/null || printf '0')"
+  [[ $prev_streak =~ ^[0-9]+$ ]] || prev_streak=0
+  if [[ $exit_code -eq 0 ]]; then
+    streak=0 # healthy or recovered
+  elif [[ $runs_readable -eq 1 && $runs -eq $prev_runs ]]; then
+    streak=$prev_streak # a FROZEN nonzero exit (no re-run): do not accumulate
+  else
+    streak=$((prev_streak + 1)) # a fresh failing re-run (or unreadable runs: fail-safe)
+  fi
+  agent_state_json="$(jq -c --arg l "$label" --argjson r "$runs" --argjson s "$streak" \
+    '. + {($l): {runs: $r, streak: $s}}' <<<"$agent_state_json")"
+  if [[ $streak -ge 2 ]]; then
+    problems+=("LaunchAgent crash-looping (last exit $exit_code, $streak failing re-runs): $label")
   fi
 done
 
@@ -65,13 +137,23 @@ case "$route_code" in
   *) problems+=("hermes #priority route unhealthy (HTTP $route_code) at $HERMES_PRIORITY_URL") ;;
 esac
 
-if [[ ${#problems[@]} -eq 0 ]]; then exit 0; fi
+# The refreshed state to persist once the tick is resolved. Built now, written only
+# AFTER a page is durably queued (notify-before-persist), so a page that cannot be
+# stored never advances a streak baseline and masks the signal.
+new_state="$(jq -cn --argjson agents "$agent_state_json" '{agents: $agents}')"
+
+# Healthy: persist the refreshed baselines (no page to order against) and exit
+# silent. A persist failure here only forgets one cycle of streak memory.
+if [[ ${#problems[@]} -eq 0 ]]; then
+  write_state "$new_state" || printf 'uptime-watchdog: could not persist state (%s)\n' "$STATE" >&2
+  exit 0
+fi
 
 # Unhealthy: page ONE CRIT (level-triggered, so a persisting outage keeps
 # reminding every tick). A dead pipeline is always CRITICAL and always carries a
 # sound, so it reaches the #priority channel and pings. bt holds a literal backtick
 # so a command name renders as Discord inline-code without shell expansion. The
-# body renders only known labels + a validated numeric route code + static text.
+# body renders only known labels + validated numerics + static text, no raw output.
 bt='`'
 title="🔴 **CRITICAL**"
 if [[ ${#problems[@]} -gt 1 ]]; then title="🔴 **CRITICAL** (${#problems[@]} issues)"; fi
@@ -80,6 +162,13 @@ for problem in "${problems[@]}"; do body+=$'\n'"- $problem"; done
 body+=$'\n'"- **Diagnose:** ${bt}launchctl list | grep -i osquery${bt}"
 body+=$'\n'"- Restart the down component, then re-check."
 
-# send_alert is write-ahead durable, so a hard delivery failure is already loudly
-# surfaced: keep it off set -e's abort path (the page is fire-and-forget here).
-send_alert CRIT "$title" "$body" "Sosumi" || true
+# Notify-before-persist: only advance the persisted baselines after send_alert
+# durably queues the page. send_alert is write-ahead durable, so on a hard store
+# failure it returns nonzero: leave the state as-is and exit nonzero, so launchd
+# logs the failure and the next tick re-detects instead of masking the signal.
+if send_alert CRIT "$title" "$body" "Sosumi"; then
+  write_state "$new_state" || printf 'uptime-watchdog: could not persist state (%s)\n' "$STATE" >&2
+  exit 0
+fi
+printf 'uptime-watchdog: send_alert could not durably queue the CRIT page; state not advanced, retrying next tick\n' >&2
+exit 1

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -150,6 +150,10 @@ fi
 #    is FROZEN between the 15-min checks, so gating on `runs` stops a single daily
 #    failure from paging every tick forever. Two failing re-runs (streak >= 2) is
 #    the loop; one is a tolerated transient.
+# The EXACT (whitespace-tolerant) launchd not-exited sentinel. Matched anchored, not
+# as a substring, so a malformed value that merely CONTAINS "(never exited)" with junk
+# around it is an unknown state that pages, not a healthy free pass.
+never_exited_re='^[[:space:]]*\(never exited\)[[:space:]]*$'
 agent_state_json="{}"
 for label in "${AGENTS[@]}"; do
   if ! print_out="$(launchctl print "gui/$uid/$label" 2>/dev/null)"; then
@@ -189,8 +193,8 @@ for label in "${AGENTS[@]}"; do
     if [[ $streak -ge 2 ]]; then
       problems+=("LaunchAgent crash-looping (last exit $exit_code, $streak failing re-runs): $label")
     fi
-  elif [[ $exit_raw == *"never exited"* ]]; then
-    streak=0 # not exited: currently running or never run, not a failure
+  elif [[ $exit_raw =~ $never_exited_re ]]; then
+    streak=0 # exactly "(never exited)": currently running or never run, not a failure
   else
     problems+=("LaunchAgent exit state is unreadable (unexpected last-exit-code value): $label")
   fi

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -46,15 +46,20 @@ setup_watchdog_harness() {
   mkdir -p "$WD_HOME/bin" \
     "$WD_HOME/.local/libexec/osquery" \
     "$WD_HOME/.local/state" \
+    "$WD_HOME/.local/log/osquery" \
     "$WD_HOME/agents"
 
   export WD_AGENTS_DIR="$WD_HOME/agents"
   export OSQUERY_WATCHDOG_STATE="$WD_HOME/.local/state/osquery-watchdog-state.json"
+  # The daemon-scheduled canary snapshot log the watchdog reads for real-time
+  # osqueryd liveness (the real artifact, R2-8). Seeded fresh by default below.
+  export OSQUERY_SNAPSHOTS_LOG="$WD_HOME/.local/log/osquery/osqueryd.snapshots.log"
 
-  # Default programmable knobs (a healthy pipeline): osqueryd running and
-  # answering, the #priority route present (405 to a GET), an empty queue.
+  # Default programmable knobs (a healthy pipeline): osqueryd running with a fresh
+  # scheduled canary, a readable clock, the #priority route present (405 to a GET),
+  # an empty queue.
   export WATCHDOG_OSQUERYD_RUNNING=1
-  export WATCHDOG_OSQUERYI_OK=1
+  export WATCHDOG_CLOCK_OK=1
   export WATCHDOG_HTTP_CODE=405
   export WATCHDOG_PENDING_COUNT=0
   export WATCHDOG_DEAD_LETTER_COUNT=0
@@ -68,12 +73,24 @@ setup_watchdog_harness() {
 exit 1
 SHIM
 
-  # osqueryi stub (via OSQUERYI): a one-shot query succeeds (answering) or fails
-  # (a wedged daemon that passes pgrep but cannot answer).
+  # osqueryi tripwire (R2-8): the watchdog must NEVER shell a standalone one-shot to
+  # judge daemon liveness, since a fresh osqueryi answers even when osqueryd is
+  # wedged (a blind checkmark). If the watchdog ever calls it, this leaves a marker
+  # a test fails on; it sits on PATH for exactly that trap.
+  export OSQUERYI_CALLED="$WD_HOME/osqueryi-was-called"
   cat >"$WD_HOME/bin/osqueryi" <<'SHIM'
 #!/usr/bin/env bash
-[[ ${WATCHDOG_OSQUERYI_OK:-1} == 1 ]] && exit 0
-exit 1
+touch "$OSQUERYI_CALLED"
+printf '[{"ok":1}]\n'
+SHIM
+
+  # date stub: models a failed system-clock read (WATCHDOG_CLOCK_OK=0 -> nonzero), so
+  # the watchdog's fail-safe clock-unreadable path is testable; otherwise delegates
+  # to the system date so freshness arithmetic uses the real clock.
+  cat >"$WD_HOME/bin/date" <<'SHIM'
+#!/usr/bin/env bash
+[[ ${WATCHDOG_CLOCK_OK:-1} == 1 ]] || exit 1
+exec /bin/date "$@"
 SHIM
 
   # launchctl stub: only `print gui/<uid>/<label>` is used. Each loaded agent has a
@@ -113,7 +130,13 @@ printf '%s' "${WATCHDOG_HTTP_CODE:-405}"
 SHIM
 
   chmod +x "$WD_HOME/bin/pgrep" "$WD_HOME/bin/osqueryi" \
-    "$WD_HOME/bin/launchctl" "$WD_HOME/bin/curl"
+    "$WD_HOME/bin/launchctl" "$WD_HOME/bin/curl" "$WD_HOME/bin/date"
+
+  # The watchdog sources the shared canary-freshness seam from the deployed libexec
+  # path (real-time osqueryd liveness); install the real helper into the sandbox so
+  # that source resolves, exactly as the deploy would.
+  cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_canary-freshness.sh" \
+    "$WD_HOME/.local/libexec/osquery/canary-freshness.sh"
 
   # Recording send_alert spy plus the two public read-only queue counters, at the
   # NEW dispatch path the watchdog sources. send_alert records each call's severity
@@ -151,6 +174,9 @@ SHIM
   for label in "${WD_WATCHED_AGENTS[@]}"; do
     set_agent "$label" 1 0
   done
+
+  # Default: a fresh scheduled canary (osqueryd alive and producing results).
+  seed_canary 30
 }
 
 teardown_watchdog_harness() {
@@ -181,6 +207,36 @@ unload_agent() {
   rm -f "$WD_AGENTS_DIR/$1.runs" "$WD_AGENTS_DIR/$1.exit"
 }
 
+# ---- programming the osqueryd scheduled canary -----------------------------
+
+# seed_canary <seconds-ago> -- append a heartbeat_canary snapshot row timestamped
+# that many seconds in the past, in the shape osqueryd writes to the snapshot log.
+# A small age is a FRESH canary (osqueryd alive and scheduling); a large one is
+# STALE (the daemon stopped or wedged, producing no scheduled results).
+seed_canary() {
+  local ts
+  ts=$(($(date -u +%s) - $1))
+  jq -cn --argjson t "$ts" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+}
+
+# seed_future_canary <seconds-ahead> -- a canary timestamped in the FUTURE (clock
+# skew or a tampered row): an implausible, untrustworthy liveness signal.
+seed_future_canary() {
+  local ts
+  ts=$(($(date -u +%s) + $1))
+  jq -cn --argjson t "$ts" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:($t|tostring)}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+}
+
+# clear_canary -- empty the snapshot log (no canary row at all: the daemon has
+# produced no scheduled result, MISSING).
+clear_canary() {
+  : >"$OSQUERY_SNAPSHOTS_LOG"
+}
+
 # ---- programming prior cross-run state ------------------------------------
 
 # seed_watchdog_state <compact-json> -- write the prior state file at 0600, so a
@@ -199,9 +255,9 @@ seed_watchdog_state() {
 run_watchdog() {
   HOME="$WD_HOME" \
     PATH="$WD_HOME/bin:$PATH" \
-    OSQUERYI="$WD_HOME/bin/osqueryi" \
     OSQUERY_HERMES_PRIORITY_URL="http://127.0.0.1:8644/webhooks/osquery-priority" \
     OSQUERY_WATCHDOG_STATE="$OSQUERY_WATCHDOG_STATE" \
+    OSQUERY_SNAPSHOTS_LOG="$OSQUERY_SNAPSHOTS_LOG" \
     bash "$WD_TOOL"
 }
 
@@ -303,6 +359,17 @@ assert_curl_probe_unsigned() {
   if grep -qiE 'X-Webhook-Signature|X-Request-ID|Authorization' "$WD_CURL_ARGS"; then
     printf 'expected the route probe to carry NO signing header, but the argv has one:\n%s\n' \
       "$(cat "$WD_CURL_ARGS")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_osqueryi_not_called -- the watchdog never shelled a standalone osqueryi
+# one-shot (R2-8: it answers even when osqueryd is wedged, so using it to judge
+# daemon liveness is a blind checkmark; the watchdog reads the scheduled canary).
+assert_osqueryi_not_called() {
+  if [[ -e $OSQUERYI_CALLED ]]; then
+    printf 'expected the watchdog NOT to shell a one-shot osqueryi (R2-8 blind checkmark), but it did\n' >&2
     return 1
   fi
   return 0

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -140,35 +140,34 @@ SHIM
   cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_canary-freshness.sh" \
     "$WD_HOME/.local/libexec/osquery/canary-freshness.sh"
 
-  # Recording send_alert spy plus the two public read-only queue counters, at the
-  # NEW dispatch path the watchdog sources. send_alert records each call's severity
-  # (one line per call, so a test counts pages), sound (the page/muted tier), full
-  # argv (for body assertions), and the state file as it stood at call time (to
-  # prove notify-before-persist). The counters echo the programmed values; a
-  # non-numeric value models an unreadable count (the fail-safe path).
+  # The fake dispatch library the watchdog sources. It SOURCES the REAL library so
+  # the queue-health counters (osquery_pending_alert_count / osquery_dead_letter_count)
+  # are the REAL ones reading the real SQLite store, then overrides ONLY send_alert
+  # with a recording spy that never delivers. So a test drives the counters through a
+  # real database (seeded rows, or an on-disk corruption) and still asserts exactly
+  # what the watchdog dispatched. send_alert records each call's severity (one line
+  # per call, so a test counts pages), sound (the page/muted tier), and full argv (for
+  # body assertions); WD_SEND_ALERT_EXIT models a hard store failure (nonzero return).
   export WD_SEND_ALERT_SEVERITY="$WD_HOME/send-alert-severity.log"
   export WD_SEND_ALERT_SOUND="$WD_HOME/send-alert-sound.log"
   export WD_SEND_ALERT_LOG="$WD_HOME/send-alert.log"
-  export WD_SEND_ALERT_STATE_AT_CALL="$WD_HOME/send-alert-state-at-call.log"
   : >"$WD_SEND_ALERT_SEVERITY"
   : >"$WD_SEND_ALERT_SOUND"
   : >"$WD_SEND_ALERT_LOG"
-  : >"$WD_SEND_ALERT_STATE_AT_CALL"
+  export WD_REAL_DISPATCH="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_alert-dispatch.sh"
+  # The real store the real counters poll; absent by default (a fresh machine reads
+  # zero), seeded to rows or corrupted by the helpers below.
+  export OSQUERY_UNDELIVERED_ALERTS_DB="$WD_HOME/.local/state/osquery-undelivered-alerts.sqlite3"
   cat >"$WD_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
 # shellcheck shell=bash
+# shellcheck source=/dev/null
+source "$WD_REAL_DISPATCH"
 send_alert() {
   printf '%s\n' "${1:-}" >>"$WD_SEND_ALERT_SEVERITY"
   printf '%s\n' "${4:-}" >>"$WD_SEND_ALERT_SOUND"
   printf '%s\n' "$*" >>"$WD_SEND_ALERT_LOG"
-  if [[ -f ${OSQUERY_WATCHDOG_STATE:-/nonexistent} ]]; then
-    cat "$OSQUERY_WATCHDOG_STATE" >>"$WD_SEND_ALERT_STATE_AT_CALL"
-  else
-    printf '(no-state-file)\n' >>"$WD_SEND_ALERT_STATE_AT_CALL"
-  fi
   return "${WD_SEND_ALERT_EXIT:-0}"
 }
-osquery_pending_alert_count() { printf '%s' "${WATCHDOG_PENDING_COUNT:-0}"; }
-osquery_dead_letter_count() { printf '%s' "${WATCHDOG_DEAD_LETTER_COUNT:-0}"; }
 SHIM
 
   # Default: every watched agent loaded, one clean run each.
@@ -272,7 +271,52 @@ run_watchdog() {
     OSQUERY_HERMES_PRIORITY_URL="http://127.0.0.1:8644/webhooks/osquery-priority" \
     OSQUERY_WATCHDOG_STATE="$OSQUERY_WATCHDOG_STATE" \
     OSQUERY_SNAPSHOTS_LOG="$OSQUERY_SNAPSHOTS_LOG" \
+    OSQUERY_UNDELIVERED_ALERTS_DB="$OSQUERY_UNDELIVERED_ALERTS_DB" \
     bash "$WD_TOOL"
+}
+
+# ---- programming the real alert store (the counters read it read-only) ------
+
+# _wd_sqlite3 -- the sqlite3 the real counters prefer (macOS always ships
+# /usr/bin/sqlite3; fall back to PATH), so a test seeds the same store the probe reads.
+_wd_sqlite3() {
+  if [[ -x /usr/bin/sqlite3 ]]; then
+    /usr/bin/sqlite3 "$@"
+  else
+    sqlite3 "$@"
+  fi
+}
+
+# seed_pending_alerts <n> / seed_dead_letter_alerts <n> -- create the real store (if
+# absent) with a minimal table and <n> rows, so the REAL queue counter the watchdog
+# polls returns <n>. Only COUNT(*) is exercised, so a minimal table suffices.
+seed_pending_alerts() {
+  local n="$1" i
+  _wd_sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    'CREATE TABLE IF NOT EXISTS pending_alerts (request_id TEXT, next_attempt_after INTEGER);'
+  for ((i = 0; i < n; i++)); do
+    _wd_sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+      "INSERT INTO pending_alerts (request_id, next_attempt_after) VALUES ('p$i', 0);"
+  done
+}
+
+seed_dead_letter_alerts() {
+  local n="$1" i
+  _wd_sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    'CREATE TABLE IF NOT EXISTS dead_letter_alerts (request_id TEXT);'
+  for ((i = 0; i < n; i++)); do
+    _wd_sqlite3 "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+      "INSERT INTO dead_letter_alerts (request_id) VALUES ('d$i');"
+  done
+}
+
+# seed_corrupt_alert_db -- write a garbage (non-SQLite) file at the store path, so the
+# REAL counter's read fails and returns the present-but-unreadable signal (the watchdog
+# then fail-safe pages). Models an on-disk corruption of the alert store.
+seed_corrupt_alert_db() {
+  rm -f "$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    "$OSQUERY_UNDELIVERED_ALERTS_DB-wal" "$OSQUERY_UNDELIVERED_ALERTS_DB-shm"
+  printf 'this is not a sqlite database, it is garbage\n' >"$OSQUERY_UNDELIVERED_ALERTS_DB"
 }
 
 # ---- assertions ------------------------------------------------------------

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -250,6 +250,16 @@ clear_canary() {
   : >"$OSQUERY_SNAPSHOTS_LOG"
 }
 
+# seed_raw_canary <unixtime-value> -- append a heartbeat_canary row whose timestamp
+# is the given RAW string, to model a value that would break a naive consumer's bash
+# arithmetic: a huge over-range epoch (64-bit overflow) or a leading-zero value (read
+# as octal). The seam must range-bound it so the value can never fall through silent.
+seed_raw_canary() {
+  jq -cn --arg t "$1" \
+    '{name:"heartbeat_canary",action:"snapshot",snapshot:[{unix_time:$t}],unixTime:$t,hostIdentifier:"dresden"}' \
+    >>"$OSQUERY_SNAPSHOTS_LOG"
+}
+
 # ---- programming prior cross-run state ------------------------------------
 
 # seed_watchdog_state <compact-json> -- write the prior state file at 0600, so a

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -1,0 +1,343 @@
+# Test harness for the uptime watchdog
+# (dot_local/libexec/osquery/executable_uptime-watchdog.sh).
+#
+# The watchdog runs as a user LaunchAgent every 15 min. It asserts the osquery
+# notification pipeline is ALIVE (a dead pipeline looks identical to "all quiet"),
+# and pages ONE CRIT if any component is down or wedged, silent when healthy. It
+# has four probes: osqueryd present-and-answering, every OTHER osquery LaunchAgent
+# loaded-and-not-crash-looping, the hermes #priority route reachable, and the
+# delivery backlog (dead-letter count and a sustained pending-growth streak).
+#
+# This harness stands the watchdog up in isolation against recording spies, with
+# no real launchd / osquery / hermes dependency:
+#
+#   - stub `pgrep`, `launchctl`, `curl` on a sandbox PATH, plus a stub `osqueryi`
+#     via OSQUERYI. The launchctl stub answers `print gui/<uid>/<label>` from a
+#     per-agent spec dir (a `runs` counter and a `last exit code`), or exits
+#     nonzero for an unloaded agent, so a test programs each agent's launchd state;
+#   - a recording send_alert spy plus the two read-only queue counters, installed
+#     as a stand-in dispatch library at the libexec path the watchdog sources.
+#     send_alert never delivers; it records each call's severity, sound, and argv,
+#     and the state file as it stood at call time (to prove notify-before-persist).
+#
+# A fresh temp HOME keeps every run off the operator's real ~/.local/state and
+# ~/.local/libexec. Sourced by the watchdog suite; no main.
+
+WD_TOOL="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_uptime-watchdog.sh"
+
+# The six watched agents (every deployed osquery LaunchAgent except the watchdog
+# itself). Kept here so a test can iterate them; the watchdog owns its own copy.
+WD_WATCHED_AGENTS=(
+  "com.webdavis.osquery-results-alerter"
+  "com.webdavis.osquery-firewall-gatekeeper-monitor"
+  "com.webdavis.osquery-alert-drainer"
+  "com.webdavis.osquery-digest"
+  "com.webdavis.osquery-heartbeat"
+  "com.webdavis.osquery-tailscale-monitor"
+)
+
+setup_watchdog_harness() {
+  export WD_HOME
+  WD_HOME="$(mktemp -d)"
+  # Ownership marker set only after our own mktemp, so teardown removes this path
+  # and never a pre-set or inherited WD_HOME.
+  _WD_HARNESS_OWNED_DIR="$WD_HOME"
+
+  mkdir -p "$WD_HOME/bin" \
+    "$WD_HOME/.local/libexec/osquery" \
+    "$WD_HOME/.local/state" \
+    "$WD_HOME/agents"
+
+  export WD_AGENTS_DIR="$WD_HOME/agents"
+  export OSQUERY_WATCHDOG_STATE="$WD_HOME/.local/state/osquery-watchdog-state.json"
+
+  # Default programmable knobs (a healthy pipeline): osqueryd running and
+  # answering, the #priority route present (405 to a GET), an empty queue.
+  export WATCHDOG_OSQUERYD_RUNNING=1
+  export WATCHDOG_OSQUERYI_OK=1
+  export WATCHDOG_HTTP_CODE=405
+  export WATCHDOG_PENDING_COUNT=0
+  export WATCHDOG_DEAD_LETTER_COUNT=0
+  export WD_SEND_ALERT_EXIT=0
+
+  # pgrep stub: the watchdog calls `pgrep -fq '<osqueryd pattern>'`. Exit 0 when
+  # osqueryd is "running", nonzero otherwise.
+  cat >"$WD_HOME/bin/pgrep" <<'SHIM'
+#!/usr/bin/env bash
+[[ ${WATCHDOG_OSQUERYD_RUNNING:-1} == 1 ]] && exit 0
+exit 1
+SHIM
+
+  # osqueryi stub (via OSQUERYI): a one-shot query succeeds (answering) or fails
+  # (a wedged daemon that passes pgrep but cannot answer).
+  cat >"$WD_HOME/bin/osqueryi" <<'SHIM'
+#!/usr/bin/env bash
+[[ ${WATCHDOG_OSQUERYI_OK:-1} == 1 ]] && exit 0
+exit 1
+SHIM
+
+  # launchctl stub: only `print gui/<uid>/<label>` is used. Each loaded agent has a
+  # `<label>.runs` file (the launchd run counter) and an optional `<label>.exit`
+  # file (the raw last-exit-code line value, so an injection test can plant a
+  # hostile string). An absent `.runs` file models an UNLOADED agent (exit 113,
+  # the real not-found status). The stub prints the two fields the watchdog reads.
+  cat >"$WD_HOME/bin/launchctl" <<'SHIM'
+#!/usr/bin/env bash
+if [[ ${1:-} == print ]]; then
+  target="${2:-}"
+  label="${target##*/}"
+  runs_file="$WD_AGENTS_DIR/$label.runs"
+  exit_file="$WD_AGENTS_DIR/$label.exit"
+  [[ -f $runs_file ]] || exit 113
+  printf '\tstate = not running\n'
+  printf '\truns = %s\n' "$(cat "$runs_file")"
+  if [[ -f $exit_file ]]; then
+    printf '\tlast exit code = %s\n' "$(cat "$exit_file")"
+  else
+    printf '\tlast exit code = 0\n'
+  fi
+  exit 0
+fi
+exit 0
+SHIM
+
+  # curl stub: the route probe is `curl -s -o /dev/null -w '%{http_code}' ... URL`.
+  # Record the argv (so a test can prove NO signing header / secret is on the wire)
+  # and print the programmed HTTP code, exactly as the real -w would.
+  export WD_CURL_ARGS="$WD_HOME/curl-args.log"
+  : >"$WD_CURL_ARGS"
+  cat >"$WD_HOME/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$WD_CURL_ARGS"
+printf '%s' "${WATCHDOG_HTTP_CODE:-405}"
+SHIM
+
+  chmod +x "$WD_HOME/bin/pgrep" "$WD_HOME/bin/osqueryi" \
+    "$WD_HOME/bin/launchctl" "$WD_HOME/bin/curl"
+
+  # Recording send_alert spy plus the two public read-only queue counters, at the
+  # NEW dispatch path the watchdog sources. send_alert records each call's severity
+  # (one line per call, so a test counts pages), sound (the page/muted tier), full
+  # argv (for body assertions), and the state file as it stood at call time (to
+  # prove notify-before-persist). The counters echo the programmed values; a
+  # non-numeric value models an unreadable count (the fail-safe path).
+  export WD_SEND_ALERT_SEVERITY="$WD_HOME/send-alert-severity.log"
+  export WD_SEND_ALERT_SOUND="$WD_HOME/send-alert-sound.log"
+  export WD_SEND_ALERT_LOG="$WD_HOME/send-alert.log"
+  export WD_SEND_ALERT_STATE_AT_CALL="$WD_HOME/send-alert-state-at-call.log"
+  : >"$WD_SEND_ALERT_SEVERITY"
+  : >"$WD_SEND_ALERT_SOUND"
+  : >"$WD_SEND_ALERT_LOG"
+  : >"$WD_SEND_ALERT_STATE_AT_CALL"
+  cat >"$WD_HOME/.local/libexec/osquery/alert-dispatch.sh" <<'SHIM'
+# shellcheck shell=bash
+send_alert() {
+  printf '%s\n' "${1:-}" >>"$WD_SEND_ALERT_SEVERITY"
+  printf '%s\n' "${4:-}" >>"$WD_SEND_ALERT_SOUND"
+  printf '%s\n' "$*" >>"$WD_SEND_ALERT_LOG"
+  if [[ -f ${OSQUERY_WATCHDOG_STATE:-/nonexistent} ]]; then
+    cat "$OSQUERY_WATCHDOG_STATE" >>"$WD_SEND_ALERT_STATE_AT_CALL"
+  else
+    printf '(no-state-file)\n' >>"$WD_SEND_ALERT_STATE_AT_CALL"
+  fi
+  return "${WD_SEND_ALERT_EXIT:-0}"
+}
+osquery_pending_alert_count() { printf '%s' "${WATCHDOG_PENDING_COUNT:-0}"; }
+osquery_dead_letter_count() { printf '%s' "${WATCHDOG_DEAD_LETTER_COUNT:-0}"; }
+SHIM
+
+  # Default: every watched agent loaded, one clean run each.
+  local label
+  for label in "${WD_WATCHED_AGENTS[@]}"; do
+    set_agent "$label" 1 0
+  done
+}
+
+teardown_watchdog_harness() {
+  [[ -n ${_WD_HARNESS_OWNED_DIR:-} ]] || return 0
+  rm -rf "$_WD_HARNESS_OWNED_DIR"
+  unset _WD_HARNESS_OWNED_DIR
+}
+
+# ---- programming the launchd state ----------------------------------------
+
+# set_agent <label> <runs> [exit-code] -- the agent is loaded; launchctl print
+# reports <runs> and the given last exit code (default 0).
+set_agent() {
+  printf '%s' "$2" >"$WD_AGENTS_DIR/$1.runs"
+  printf '%s' "${3:-0}" >"$WD_AGENTS_DIR/$1.exit"
+}
+
+# set_agent_raw_exit <label> <runs> <raw-exit-line> -- like set_agent but the raw
+# text after "last exit code = " is planted verbatim (an injection payload), so a
+# test proves the watchdog extracts only the validated number, never the raw line.
+set_agent_raw_exit() {
+  printf '%s' "$2" >"$WD_AGENTS_DIR/$1.runs"
+  printf '%s' "$3" >"$WD_AGENTS_DIR/$1.exit"
+}
+
+# unload_agent <label> -- the agent is not loaded (launchctl print exits nonzero).
+unload_agent() {
+  rm -f "$WD_AGENTS_DIR/$1.runs" "$WD_AGENTS_DIR/$1.exit"
+}
+
+# ---- programming prior cross-run state ------------------------------------
+
+# seed_watchdog_state <compact-json> -- write the prior state file at 0600, so a
+# streak/growth test starts from a known baseline.
+seed_watchdog_state() {
+  mkdir -p "$(dirname "$OSQUERY_WATCHDOG_STATE")"
+  printf '%s\n' "$1" >"$OSQUERY_WATCHDOG_STATE"
+  chmod 600 "$OSQUERY_WATCHDOG_STATE"
+}
+
+# ---- running ---------------------------------------------------------------
+
+# run_watchdog -- run the watchdog under the sandbox env. HOME is the temp home so
+# the sourced dispatch spy and the default state path resolve inside the sandbox;
+# the stub bin dir shadows pgrep/launchctl/curl; OSQUERYI points at the stub.
+run_watchdog() {
+  HOME="$WD_HOME" \
+    PATH="$WD_HOME/bin:$PATH" \
+    OSQUERYI="$WD_HOME/bin/osqueryi" \
+    OSQUERY_HERMES_PRIORITY_URL="http://127.0.0.1:8644/webhooks/osquery-priority" \
+    OSQUERY_WATCHDOG_STATE="$OSQUERY_WATCHDOG_STATE" \
+    bash "$WD_TOOL"
+}
+
+# ---- assertions ------------------------------------------------------------
+
+# refute_file_contains <fixed-substring> <file> -- fail (return 1) when the
+# substring (fixed, case-insensitive) appears in the file. The robust NEGATIVE
+# assertion: a bare `! grep` is exempted from set -e in bats and silently no-ops,
+# so a plain function whose nonzero return set -e DOES catch closes that gap.
+refute_file_contains() {
+  if grep -qiF -- "$1" "$2"; then
+    printf 'expected %q NOT to appear in %s, but it does:\n%s\n' "$1" "$2" "$(cat "$2")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_mode <octal> <path> -- the path carries the expected permission bits.
+# GNU stat first (the nix shell), BSD stat as the fallback (the portable order).
+assert_mode() {
+  local mode
+  mode=$(stat -c '%a' "$2" 2>/dev/null || stat -f '%Lp' "$2" 2>/dev/null)
+  if [[ $mode != "$1" ]]; then
+    printf 'expected mode %s on %s, got %s\n' "$1" "$2" "$mode" >&2
+    return 1
+  fi
+}
+
+# assert_no_page -- the watchdog did not call send_alert at all (silent).
+assert_no_page() {
+  if [[ -s $WD_SEND_ALERT_LOG ]]; then
+    printf 'expected NO page, but send_alert was called:\n%s\n' \
+      "$(cat "$WD_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_count <n> -- send_alert was called exactly <n> times (one severity
+# line per call; the body may span many lines, so the severity log is the count).
+assert_page_count() {
+  local count
+  count=$(wc -l <"$WD_SEND_ALERT_SEVERITY")
+  count=${count//[[:space:]]/}
+  if [[ $count -ne $1 ]]; then
+    printf 'expected %s page(s), got %s; send_alert log:\n%s\n' \
+      "$1" "$count" "$(cat "$WD_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_page_severity_is <severity> -- a page fired and every page carried
+# <severity> (only a CRIT reaches the #priority webhook, so the severity arg is the
+# security-relevant one, not just the title text).
+assert_page_severity_is() {
+  if [[ ! -s $WD_SEND_ALERT_SEVERITY ]]; then
+    printf 'expected a %s page, but send_alert was never called\n' "$1" >&2
+    return 1
+  fi
+  if grep -qvxF "$1" "$WD_SEND_ALERT_SEVERITY"; then
+    printf 'expected every page at severity %s, got:\n%s\n' \
+      "$1" "$(cat "$WD_SEND_ALERT_SEVERITY")" >&2
+    return 1
+  fi
+}
+
+# assert_page_sound_nonempty -- a page fired and every page carried a NON-EMPTY
+# sound (the page tier). An empty sound is the muted tier: a down-pipeline page
+# must ping, never mute.
+assert_page_sound_nonempty() {
+  if [[ ! -s $WD_SEND_ALERT_SOUND ]]; then
+    printf 'expected a page with a non-empty sound, but send_alert was never called\n' >&2
+    return 1
+  fi
+  if grep -qxF '' "$WD_SEND_ALERT_SOUND"; then
+    printf 'expected every page to carry a non-empty sound (page tier), got a muted call:\n%s\n' \
+      "$(sed 's/^$/<empty>/' "$WD_SEND_ALERT_SOUND")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_page_body_has <substring> -- some page's argv contained <substring>.
+assert_page_body_has() {
+  if ! grep -qF -- "$1" "$WD_SEND_ALERT_LOG"; then
+    printf 'expected a page naming %s; send_alert log:\n%s\n' \
+      "$1" "$(cat "$WD_SEND_ALERT_LOG")" >&2
+    return 1
+  fi
+}
+
+# assert_curl_probe_unsigned -- the recorded route-probe argv carries NO webhook
+# signing header and no secret: it is a bare reachability GET, so the HMAC key can
+# never leak onto the wire through it.
+assert_curl_probe_unsigned() {
+  if [[ ! -s $WD_CURL_ARGS ]]; then
+    printf 'expected the route probe to call curl, but it did not\n' >&2
+    return 1
+  fi
+  if grep -qiE 'X-Webhook-Signature|X-Request-ID|Authorization' "$WD_CURL_ARGS"; then
+    printf 'expected the route probe to carry NO signing header, but the argv has one:\n%s\n' \
+      "$(cat "$WD_CURL_ARGS")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# assert_file_absent <path> -- the path does not exist (an injection payload must
+# not have executed and created its marker file).
+assert_file_absent() {
+  if [[ -e $1 ]]; then
+    printf 'expected %s NOT to exist, but it does\n' "$1" >&2
+    return 1
+  fi
+}
+
+# snapshot_watchdog_state / assert_watchdog_state_unchanged -- copy the state file
+# aside, then prove a run left it byte-for-byte identical (notify-before-persist: a
+# page that could not be queued must not advance the persisted baseline).
+snapshot_watchdog_state() {
+  cp "$OSQUERY_WATCHDOG_STATE" "$WD_HOME/state.snapshot"
+}
+
+assert_watchdog_state_unchanged() {
+  if ! cmp -s "$WD_HOME/state.snapshot" "$OSQUERY_WATCHDOG_STATE"; then
+    printf 'expected the state byte-for-byte preserved.\nsnapshot:\n%s\nnow:\n%s\n' \
+      "$(cat "$WD_HOME/state.snapshot" 2>/dev/null || echo '(no snapshot)')" \
+      "$(cat "$OSQUERY_WATCHDOG_STATE" 2>/dev/null || echo '(missing)')" >&2
+    return 1
+  fi
+}
+
+# assert_state_has <substring> -- the persisted state file contains <substring>.
+assert_state_has() {
+  if ! grep -qF -- "$1" "$OSQUERY_WATCHDOG_STATE" 2>/dev/null; then
+    printf 'expected the state to contain %s; state:\n%s\n' \
+      "$1" "$(cat "$OSQUERY_WATCHDOG_STATE" 2>/dev/null || echo '(no state file)')" >&2
+    return 1
+  fi
+}

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -108,7 +108,9 @@ if [[ ${1:-} == print ]]; then
   [[ -f $runs_file ]] || exit 113
   printf '\tstate = not running\n'
   printf '\truns = %s\n' "$(cat "$runs_file")"
-  if [[ -f $exit_file ]]; then
+  if [[ -f "$WD_AGENTS_DIR/$label.noexit" ]]; then
+    : # the last-exit-code field is ABSENT (models a launchctl output-shape change)
+  elif [[ -f $exit_file ]]; then
     printf '\tlast exit code = %s\n' "$(cat "$exit_file")"
   else
     printf '\tlast exit code = 0\n'
@@ -192,19 +194,31 @@ teardown_watchdog_harness() {
 set_agent() {
   printf '%s' "$2" >"$WD_AGENTS_DIR/$1.runs"
   printf '%s' "${3:-0}" >"$WD_AGENTS_DIR/$1.exit"
+  rm -f "$WD_AGENTS_DIR/$1.noexit"
 }
 
-# set_agent_raw_exit <label> <runs> <raw-exit-line> -- like set_agent but the raw
-# text after "last exit code = " is planted verbatim (an injection payload), so a
-# test proves the watchdog extracts only the validated number, never the raw line.
+# set_agent_raw_exit <label> <runs> <raw-exit-value> -- like set_agent but the raw
+# text after "last exit code = " is planted verbatim: a non-numeric sentinel such as
+# "(never exited)", garbage, or an injection payload, so a test proves the watchdog
+# classifies it (number / never-exited / unknown) and renders only validated data.
 set_agent_raw_exit() {
   printf '%s' "$2" >"$WD_AGENTS_DIR/$1.runs"
   printf '%s' "$3" >"$WD_AGENTS_DIR/$1.exit"
+  rm -f "$WD_AGENTS_DIR/$1.noexit"
+}
+
+# set_agent_no_exit_field <label> <runs> -- the agent is loaded and has RUN, but its
+# launchctl print output carries NO last-exit-code field at all (an output-shape
+# change): the watchdog cannot read the exit state, an UNKNOWN state it must page.
+set_agent_no_exit_field() {
+  printf '%s' "$2" >"$WD_AGENTS_DIR/$1.runs"
+  rm -f "$WD_AGENTS_DIR/$1.exit"
+  : >"$WD_AGENTS_DIR/$1.noexit"
 }
 
 # unload_agent <label> -- the agent is not loaded (launchctl print exits nonzero).
 unload_agent() {
-  rm -f "$WD_AGENTS_DIR/$1.runs" "$WD_AGENTS_DIR/$1.exit"
+  rm -f "$WD_AGENTS_DIR/$1.runs" "$WD_AGENTS_DIR/$1.exit" "$WD_AGENTS_DIR/$1.noexit"
 }
 
 # ---- programming the osqueryd scheduled canary -----------------------------

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -53,6 +53,12 @@ send_alert() {
 }
 SPY
 
+  # The heartbeat sources the shared canary-freshness seam from the deployed libexec
+  # path (newest_canary_timestamp lives there now, shared with the uptime watchdog);
+  # install the real helper into the sandbox so that source resolves.
+  cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_canary-freshness.sh" \
+    "$dispatch_dir/canary-freshness.sh"
+
   # The daemon snapshot log the heartbeat reads for canary freshness. Left EMPTY by
   # default (a fresh deploy: the daemon has written no canary yet), so a test opts in
   # to a fresh, stale, or malformed canary.

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -232,6 +232,33 @@ run_heartbeat() {
   [ ! -e "$HARNESS_HOME/PWNED2" ] # no command execution from the payload
 }
 
+@test "B7a: an over-range canary epoch is rejected (fail-safe MISSING), never a 64-bit-overflow false fresh" {
+  # A timestamp of 2^64 + now wraps in bash's signed 64-bit back to ~now, so both
+  # freshness bounds read fresh and the heartbeat would false-report HEALTHY. The
+  # shared seam range-bounds the value, so it is rejected and the heartbeat reports
+  # MISSING (unhealthy) instead.
+  local overflow
+  overflow="$(/usr/bin/bc <<<"$(date -u +%s) + 18446744073709551616")"
+  seed_raw_canary "$overflow"
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
+}
+
+@test "B7b: a leading-zero canary epoch is rejected (fail-safe MISSING), never an octal-parse fall-through" {
+  # A leading-zero value (09999999999) makes bash arithmetic parse it as octal and
+  # error. The shared seam rejects it, so the heartbeat reports MISSING (unhealthy)
+  # instead of aborting or falling through.
+  seed_raw_canary '09999999999'
+  run run_heartbeat
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^CALL$' "$SEND_ALERT_LOG")" -eq 1 ]
+  grep -qiE "missing|no canary" "$SEND_ALERT_BODY"
+  refute_file_contains "pipeline healthy" "$SEND_ALERT_TITLE"
+}
+
 @test "B8: freshness is judged from the NEWEST canary row when several exist" {
   # osqueryd appends one canary per interval, so the LAST line is the newest. A run
   # of rows (an old one from before a gap, then a fresh one) must be judged by the

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -255,6 +255,50 @@ teardown() { teardown_watchdog_harness; }
   assert_no_page # the frozen exit is not a fresh failure, so it never streaks to a page
 }
 
+@test "T-WATCH-agent-never-exited-healthy: a loaded agent that has not exited (running or never run) is healthy, not a gap" {
+  # launchctl reports "last exit code = (never exited)" for a process that is
+  # currently running or has never run: a legitimate not-a-failure state, not an
+  # unreadable one, so it must NOT page.
+  set_agent_raw_exit com.webdavis.osquery-tailscale-monitor 3 '(never exited)'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}
+
+@test "T-WATCH-agent-exit-garbage-pages: a loaded agent whose exit field is unparseable garbage pages a fail-safe gap (never silent-healthy)" {
+  # If the last-exit-code value is neither a number nor the never-exited sentinel,
+  # the agent state is UNKNOWN. The watchdog must fail safe to a page, not default
+  # the exit code to 0 and read every agent as healthy (the fail-open trap).
+  set_agent_raw_exit com.webdavis.osquery-digest 5 'wat-not-a-code'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'unreadable'
+  assert_page_body_has 'com.webdavis.osquery-digest'
+}
+
+@test "T-WATCH-agent-exit-field-absent-pages: a loaded agent whose launchctl output lacks the exit field pages a fail-safe gap" {
+  # A launchctl output-shape change that drops the last-exit-code field would, under
+  # a default-to-0, silently disable crash-loop detection for every agent. Instead
+  # the absent field is an unknown state that pages.
+  set_agent_no_exit_field com.webdavis.osquery-heartbeat 5
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'unreadable'
+}
+
 # --- notify-before-persist ------------------------------------------------------
 
 @test "T-WATCH-notify-before-persist: a page that cannot be durably queued does not advance the state" {

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -303,6 +303,22 @@ teardown() { teardown_watchdog_harness; }
   assert_no_page
 }
 
+@test "T-WATCH-agent-never-exited-with-junk-pages: an exit value CONTAINING '(never exited)' plus junk is UNKNOWN and pages (not a substring free pass)" {
+  # A substring match would read 'unknown (never exited) trailing-junk' as the healthy
+  # never-exited sentinel and reset the streak. Only an EXACT, whitespace-tolerant
+  # sentinel is healthy; anything else is an unknown state that fails safe to a page.
+  set_agent_raw_exit com.webdavis.osquery-digest 5 'unknown (never exited) trailing-junk'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'unreadable'
+  assert_page_body_has 'com.webdavis.osquery-digest'
+}
+
 @test "T-WATCH-agent-exit-garbage-pages: a loaded agent whose exit field is unparseable garbage pages a fail-safe gap (never silent-healthy)" {
   # If the last-exit-code value is neither a number nor the never-exited sentinel,
   # the agent state is UNKNOWN. The watchdog must fail safe to a page, not default

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -133,6 +133,41 @@ teardown() { teardown_watchdog_harness; }
   assert_page_severity_is CRIT
 }
 
+@test "T-WATCH-osqueryd-canary-huge-epoch-pages: an over-range canary epoch cannot 64-bit-overflow into a false fresh" {
+  # sol's overflow: a timestamp of 2^64 + now wraps in bash's signed 64-bit back to
+  # ~now (verified: (( now - (2^64+now) )) == 0), so BOTH freshness bounds read fresh
+  # and the watchdog stays SILENT. The seam range-bounds it (>10 digits rejected), so
+  # it is treated as no valid canary and pages instead.
+  clear_canary
+  local overflow
+  overflow="$(/usr/bin/bc <<<"$(date -u +%s) + 18446744073709551616")"
+  seed_raw_canary "$overflow"
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'scheduled results'
+}
+
+@test "T-WATCH-osqueryd-canary-leading-zero-pages: a leading-zero canary epoch cannot break arithmetic into a silent fall-through" {
+  # A leading-zero value (09999999999) makes bash arithmetic parse it as octal and
+  # error, which a naive elif chain swallows into silence. The seam rejects it, so the
+  # watchdog pages instead of falling through.
+  clear_canary
+  seed_raw_canary '09999999999'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'scheduled results'
+}
+
 @test "T-WATCH-clock-unreadable-pages: a failed system-clock read is a CRIT gap, never a silent healthy" {
   export WATCHDOG_CLOCK_OK=0
   run run_watchdog

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -396,7 +396,7 @@ teardown() { teardown_watchdog_harness; }
 # --- delivery-backlog health: dead-letters, unreadable counts, sustained growth --
 
 @test "T-WATCH-deadletter-pages: any dead-letter entry pages CRIT (delivery permanently failed)" {
-  export WATCHDOG_DEAD_LETTER_COUNT=2
+  seed_dead_letter_alerts 2 # two real rows in the real store the counter reads
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
@@ -408,8 +408,11 @@ teardown() { teardown_watchdog_harness; }
   assert_page_body_has 'dead-letter'
 }
 
-@test "T-WATCH-count-unreadable-pages: an unreadable queue count is a CRIT gap, never a silent healthy" {
-  export WATCHDOG_DEAD_LETTER_COUNT='not-a-number'
+@test "T-WATCH-count-unreadable-pages: a corrupt alert store is a CRIT gap, never a silent healthy" {
+  # Drive the REAL counter's failure path: an on-disk corruption of the store makes
+  # the read fail, so the counter returns the present-but-unreadable signal and the
+  # watchdog fail-safe pages. A store hiding real dead-letters must never read healthy.
+  seed_corrupt_alert_db
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
@@ -421,10 +424,10 @@ teardown() { teardown_watchdog_harness; }
 }
 
 @test "T-WATCH-backlog-growing-pages: a backlog that grows across two consecutive checks pages CRIT" {
-  # Seed a prior growth (count 5, growth_streak 1); this tick grows again to 8, so
-  # the streak reaches the sustained-growth threshold and pages.
+  # Seed a prior growth (count 5, growth_streak 1); this tick grows again to 8 real
+  # rows, so the streak reaches the sustained-growth threshold and pages.
   seed_watchdog_state '{"agents":{},"pending":{"count":5,"growth_streak":1}}'
-  export WATCHDOG_PENDING_COUNT=8
+  seed_pending_alerts 8
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
@@ -436,10 +439,10 @@ teardown() { teardown_watchdog_harness; }
 }
 
 @test "T-WATCH-backlog-steady-silent: a non-growing backlog (even a large one) does not page" {
-  # A prior growth streak, but this tick did NOT grow (count flat at 5): a transient
-  # burst the drainer absorbs must not false-page. Only SUSTAINED growth pages.
+  # A prior growth streak, but this tick did NOT grow (count flat at 5 real rows): a
+  # transient burst the drainer absorbs must not false-page. Only SUSTAINED growth pages.
   seed_watchdog_state '{"agents":{},"pending":{"count":5,"growth_streak":1}}'
-  export WATCHDOG_PENDING_COUNT=5
+  seed_pending_alerts 5
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -18,13 +18,14 @@ teardown() { teardown_watchdog_harness; }
 
 # --- a healthy pipeline is silent -----------------------------------------------
 
-@test "T-WATCH-all-healthy: osqueryd answering, all agents loaded, route 405, empty queue -> no page" {
+@test "T-WATCH-all-healthy: fresh canary, all agents loaded, route 405, empty queue -> no page (and no blind osqueryi)" {
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
     false
   }
   assert_no_page
+  assert_osqueryi_not_called # daemon liveness comes from the scheduled canary, R2-8
 }
 
 # --- an unloaded agent pages CRIT, naming it; the full six-agent set -------------
@@ -90,8 +91,12 @@ teardown() { teardown_watchdog_harness; }
   assert_page_body_has 'osqueryd'
 }
 
-@test "T-WATCH-osqueryd-wedged: osqueryd running but not answering a one-shot query pages CRIT" {
-  export WATCHDOG_OSQUERYI_OK=0
+@test "T-WATCH-osqueryd-wedged-stale-canary: osqueryd running but its scheduled canary is STALE pages CRIT (R2-8, the wedge a one-shot would miss)" {
+  # osqueryd is alive (pgrep passes) but not producing scheduled results: its
+  # heartbeat canary has gone stale. A standalone osqueryi one-shot would answer and
+  # hide this, so the watchdog reads the daemon's OWN scheduled canary instead.
+  clear_canary
+  seed_canary 4000 # last scheduled result ~67 min ago, well past the freshness bound
   run run_watchdog
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
@@ -99,7 +104,45 @@ teardown() { teardown_watchdog_harness; }
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'wedged'
+  assert_page_body_has 'scheduled results'
+  assert_osqueryi_not_called # never a blind one-shot checkmark
+}
+
+@test "T-WATCH-osqueryd-canary-missing: no scheduled canary at all pages CRIT (daemon never produced a result)" {
+  clear_canary
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'scheduled results'
+  assert_osqueryi_not_called
+}
+
+@test "T-WATCH-osqueryd-canary-implausible-future: a future-dated canary is NOT trusted as healthy (two-sided freshness)" {
+  clear_canary
+  seed_future_canary 4000 # ~67 min in the future: clock skew or a tampered row
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+}
+
+@test "T-WATCH-clock-unreadable-pages: a failed system-clock read is a CRIT gap, never a silent healthy" {
+  export WATCHDOG_CLOCK_OK=0
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'clock'
 }
 
 # --- route health (the R2-7 strictening) ----------------------------------------

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -364,6 +364,25 @@ teardown() { teardown_watchdog_harness; }
   }
 }
 
+@test "T-WATCH-state-unpersistable-pages: an unwritable state dir pages CRIT (the streak alarms would otherwise silently degrade)" {
+  # With the state unwritable, prev_state resets to {} every tick, so a crash-looping
+  # agent's streak resets to 1 each run and never reaches the loop threshold: the
+  # alarm is silently disabled. So an unpersistable state is itself a paging condition,
+  # and the run surfaces nonzero.
+  local state_dir
+  state_dir="$(dirname "$OSQUERY_WATCHDOG_STATE")"
+  chmod 500 "$state_dir"
+  run run_watchdog
+  chmod 700 "$state_dir" # restore before asserting / teardown
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the state cannot be persisted, got $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'persist'
+}
+
 # --- injection defeated by validation -------------------------------------------
 
 @test "T-WATCH-injection-inert: a hostile launchctl LastExitStatus is numeric-sanitized and never reaches the body or executes" {

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -305,3 +305,58 @@ teardown() { teardown_watchdog_harness; }
   refute_file_contains '`touch' "$WD_SEND_ALERT_LOG"
   refute_file_contains 'injected **bold**' "$WD_SEND_ALERT_LOG"
 }
+
+# --- delivery-backlog health: dead-letters, unreadable counts, sustained growth --
+
+@test "T-WATCH-deadletter-pages: any dead-letter entry pages CRIT (delivery permanently failed)" {
+  export WATCHDOG_DEAD_LETTER_COUNT=2
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'dead-letter'
+}
+
+@test "T-WATCH-count-unreadable-pages: an unreadable queue count is a CRIT gap, never a silent healthy" {
+  export WATCHDOG_DEAD_LETTER_COUNT='not-a-number'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'unreadable'
+}
+
+@test "T-WATCH-backlog-growing-pages: a backlog that grows across two consecutive checks pages CRIT" {
+  # Seed a prior growth (count 5, growth_streak 1); this tick grows again to 8, so
+  # the streak reaches the sustained-growth threshold and pages.
+  seed_watchdog_state '{"agents":{},"pending":{"count":5,"growth_streak":1}}'
+  export WATCHDOG_PENDING_COUNT=8
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'backlog'
+}
+
+@test "T-WATCH-backlog-steady-silent: a non-growing backlog (even a large one) does not page" {
+  # A prior growth streak, but this tick did NOT grow (count flat at 5): a transient
+  # burst the drainer absorbs must not false-page. Only SUSTAINED growth pages.
+  seed_watchdog_state '{"agents":{},"pending":{"count":5,"growth_streak":1}}'
+  export WATCHDOG_PENDING_COUNT=5
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -158,3 +158,150 @@ teardown() { teardown_watchdog_harness; }
   }
   assert_curl_probe_unsigned
 }
+
+# --- a crash-looping agent pages, but a transient / frozen exit does not ---------
+
+@test "T-WATCH-crashloop-streak-pages: a loaded agent nonzero on two consecutive RE-RUNS pages, naming it" {
+  # First observation is a transient (no page); a second failing re-run (runs
+  # advanced) is the loop and pages.
+  set_agent com.webdavis.osquery-firewall-gatekeeper-monitor 40 1
+  run run_watchdog # observation 1: streak 1, not yet a loop
+  [[ $status -eq 0 ]] || {
+    echo "run1 status $status: $output"
+    false
+  }
+  assert_no_page
+
+  set_agent com.webdavis.osquery-firewall-gatekeeper-monitor 41 1 # it re-ran and failed again
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "run2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'com.webdavis.osquery-firewall-gatekeeper-monitor'
+  assert_page_body_has 'crash'
+}
+
+@test "T-WATCH-crashloop-transient-silent: a single nonzero exit does not page (one bad run is tolerated)" {
+  set_agent com.webdavis.osquery-firewall-gatekeeper-monitor 40 1
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}
+
+@test "T-WATCH-crashloop-daily-frozen-silent: a DAILY agent's stale nonzero exit (runs frozen between checks) never pages forever" {
+  # The digest and heartbeat run once a day, so their launchctl LastExitStatus is
+  # FROZEN between the watchdog's 15-min checks. A crash-loop signal must reflect an
+  # actual RE-RUN (runs advanced), not the same frozen exit seen every tick, or a
+  # single daily failure would page every 15 min for a day. runs stays 7 across both
+  # checks, so the streak never reaches the loop threshold.
+  set_agent com.webdavis.osquery-digest 7 1
+  run run_watchdog # observation 1: streak 1
+  assert_no_page
+  set_agent com.webdavis.osquery-digest 7 1 # SAME runs: it did not re-run
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page # the frozen exit is not a fresh failure, so it never streaks to a page
+}
+
+# --- notify-before-persist ------------------------------------------------------
+
+@test "T-WATCH-notify-before-persist: a page that cannot be durably queued does not advance the state" {
+  # A send_alert store-failure must leave the persisted baseline untouched and
+  # surface nonzero, so the next tick re-detects instead of masking the signal.
+  seed_watchdog_state '{"agents":{}}'
+  snapshot_watchdog_state
+  unload_agent com.webdavis.osquery-heartbeat # a problem to page
+  export WD_SEND_ALERT_EXIT=1                  # dispatch cannot durably queue the page
+
+  run run_watchdog
+  [[ $status -ne 0 ]] || {
+    echo "expected nonzero when the page could not be queued, got $status: $output"
+    false
+  }
+  assert_page_count 1             # it DID attempt the page
+  assert_watchdog_state_unchanged # but the state did NOT advance
+}
+
+@test "T-WATCH-persist-on-success: a page-free healthy tick advances the persisted state" {
+  seed_watchdog_state '{"agents":{}}'
+  set_agent com.webdavis.osquery-digest 7 1
+  run run_watchdog # observation 1 advances digest's streak to 1 in the state
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_state_has 'com.webdavis.osquery-digest' # the state advanced
+}
+
+# --- the state file is owner-only (0600), atomic, and fresh on corruption -------
+
+@test "T-WATCH-state-0600: the watchdog persists cross-run state owner-only (0600) with no temp left behind" {
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  [[ -f $OSQUERY_WATCHDOG_STATE ]] || {
+    echo "expected the state at $OSQUERY_WATCHDOG_STATE, but it is missing"
+    false
+  }
+  assert_mode 600 "$OSQUERY_WATCHDOG_STATE"
+  [[ ! -e $OSQUERY_WATCHDOG_STATE.tmp ]] || {
+    echo "expected the state temp file to be gone, but $OSQUERY_WATCHDOG_STATE.tmp remains"
+    false
+  }
+}
+
+@test "T-WATCH-state-corrupt-fresh: a corrupt state file is treated as fresh, never a crash, and is repaired" {
+  seed_watchdog_state 'not-json-garbage'
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page # a corrupt state is not itself a page; it starts fresh
+  # The garbage is replaced by a valid JSON state (a fresh, healthy baseline).
+  run jq -e . "$OSQUERY_WATCHDOG_STATE"
+  [[ $status -eq 0 ]] || {
+    echo "expected the corrupt state to be repaired to valid JSON"
+    false
+  }
+}
+
+# --- injection defeated by validation -------------------------------------------
+
+@test "T-WATCH-injection-inert: a hostile launchctl LastExitStatus is numeric-sanitized and never reaches the body or executes" {
+  # An attacker who could influence launchctl output plants a command-substitution
+  # payload, a real newline, and forged markdown in the exit-code line. The watchdog
+  # extracts ONLY the leading number and validates it, so the raw payload never
+  # reaches a rendered variable and never executes. Escaped backticks keep the TEST
+  # itself from running it.
+  local payload
+  payload="1\`touch ${WD_HOME}/PWNED\`"$'\n'"injected **bold** @everyone"
+  # Drive the digest to the crash-loop render (streak 2) so the exit value is used.
+  seed_watchdog_state '{"agents":{"com.webdavis.osquery-digest":{"runs":7,"streak":1}}}'
+  set_agent_raw_exit com.webdavis.osquery-digest 8 "$payload" # runs advanced (7 -> 8): a fresh failing run
+
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'com.webdavis.osquery-digest' # it paged the crash-loop
+  # No command execution from the payload.
+  assert_file_absent "$WD_HOME/PWNED"
+  # The raw hostile string never reaches the rendered body (only the number 1 did).
+  refute_file_contains '`touch' "$WD_SEND_ALERT_LOG"
+  refute_file_contains 'injected **bold**' "$WD_SEND_ALERT_LOG"
+}

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# The uptime watchdog (executable_uptime-watchdog.sh) runs as a user LaunchAgent
+# every 15 min. A dead pipeline looks identical to "all quiet" (the alerter is
+# edge-triggered and the queries are differential), so the watchdog is the sole
+# liveness backstop: it verifies osqueryd is answering, every OTHER osquery agent
+# is loaded, and the hermes #priority route is reachable, then pages ONE CRIT if
+# anything is down.
+#
+# Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
+# unloaded agent, a wedged osqueryd, an unhealthy route) resolves to a CRIT, never
+# a silent all-healthy. Every page is CRIT with a non-empty sound (it must reach
+# #priority and ping).
+
+load ../fixtures/osquery-watchdog-lib
+
+setup() { setup_watchdog_harness; }
+teardown() { teardown_watchdog_harness; }
+
+# --- a healthy pipeline is silent -----------------------------------------------
+
+@test "T-WATCH-all-healthy: osqueryd answering, all agents loaded, route 405, empty queue -> no page" {
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}
+
+# --- an unloaded agent pages CRIT, naming it; the full six-agent set -------------
+
+@test "T-WATCH-agent-not-loaded: an unloaded agent pages one CRIT naming it" {
+  unload_agent com.webdavis.osquery-results-alerter
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'not loaded'
+  assert_page_body_has 'com.webdavis.osquery-results-alerter'
+}
+
+@test "T-WATCH-watches-new-labels: each agent the basic version did not watch (digest, heartbeat, tailscale, drainer) pages when unloaded" {
+  # The re-land expands the watched set from the pre-S9 two agents to the full six.
+  local label
+  for label in com.webdavis.osquery-alert-drainer \
+    com.webdavis.osquery-digest \
+    com.webdavis.osquery-heartbeat \
+    com.webdavis.osquery-tailscale-monitor; do
+    setup_watchdog_harness # a clean, all-healthy baseline per label
+    unload_agent "$label"
+    run run_watchdog
+    [[ $status -eq 0 ]] || {
+      echo "status $status for $label: $output"
+      false
+    }
+    assert_page_count 1
+    assert_page_body_has "$label"
+  done
+}
+
+@test "T-WATCH-excludes-self: a full outage names the six watched agents but NOT the watchdog itself" {
+  # The watchdog is loaded by definition if it is running, so it must not probe its
+  # own label (that would be a guaranteed self-page).
+  local label
+  for label in "${WD_WATCHED_AGENTS[@]}"; do unload_agent "$label"; done
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  refute_file_contains 'com.webdavis.osquery-uptime-watchdog' "$WD_SEND_ALERT_LOG"
+}
+
+# --- osqueryd down and wedged ---------------------------------------------------
+
+@test "T-WATCH-osqueryd-down: osqueryd not running pages CRIT" {
+  export WATCHDOG_OSQUERYD_RUNNING=0
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'osqueryd'
+}
+
+@test "T-WATCH-osqueryd-wedged: osqueryd running but not answering a one-shot query pages CRIT" {
+  export WATCHDOG_OSQUERYI_OK=0
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'wedged'
+}
+
+# --- route health (the R2-7 strictening) ----------------------------------------
+
+@test "T-WATCH-route-404-pages: a 404 (priority route not configured) is NOT healthy" {
+  export WATCHDOG_HTTP_CODE=404
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'route'
+}
+
+@test "T-WATCH-route-502-pages: a 5xx route response is NOT healthy" {
+  export WATCHDOG_HTTP_CODE=502
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'route'
+}
+
+@test "T-WATCH-route-000-pages: an unreachable gateway (000) is NOT healthy" {
+  export WATCHDOG_HTTP_CODE=000
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'route'
+}
+
+@test "T-WATCH-route-405-healthy: a 405 (POST-only route present, rejects GET) is healthy and silent" {
+  export WATCHDOG_HTTP_CODE=405
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}
+
+@test "T-WATCH-route-probe-unsigned: the route probe is a bare GET carrying NO signing header or secret" {
+  # The reachability probe must never put the HMAC key on the wire.
+  export WATCHDOG_HTTP_CODE=405
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_curl_probe_unsigned
+}

--- a/test/unit/osquery-queue-counts.sh
+++ b/test/unit/osquery-queue-counts.sh
@@ -64,4 +64,21 @@ SQL
 assert_eq 3 "$(osquery_pending_alert_count)" "seeded: pending count"
 assert_eq 2 "$(osquery_dead_letter_count)" "seeded: dead-letter count"
 
-printf 'osquery-queue-counts: OK (missing-DB, missing-table, and populated all counted read-only)\n'
+# (d) The DB file EXISTS but is CORRUPT (not a valid SQLite database). A health
+# probe must NOT report a false zero here (that would hide a real backlog behind an
+# all-clear). The counters print NOTHING and return NONZERO, the present-but-
+# unreadable fail-safe signal the watchdog turns into a page.
+rm -f "$OSQUERY_UNDELIVERED_ALERTS_DB" "$OSQUERY_UNDELIVERED_ALERTS_DB-wal" "$OSQUERY_UNDELIVERED_ALERTS_DB-shm"
+printf 'this is not a sqlite database, it is garbage\n' >"$OSQUERY_UNDELIVERED_ALERTS_DB"
+if osquery_pending_alert_count >/dev/null 2>&1; then
+  fail "corrupt DB: pending count returned success (a false zero hides a real backlog)"
+fi
+[[ -z "$(osquery_pending_alert_count 2>/dev/null)" ]] ||
+  fail "corrupt DB: pending count printed a value instead of nothing"
+if osquery_dead_letter_count >/dev/null 2>&1; then
+  fail "corrupt DB: dead-letter count returned success (a false zero hides a real backlog)"
+fi
+[[ -z "$(osquery_dead_letter_count 2>/dev/null)" ]] ||
+  fail "corrupt DB: dead-letter count printed a value instead of nothing"
+
+printf 'osquery-queue-counts: OK (missing-DB, missing-table, populated, and corrupt-store fail-safe, all read-only)\n'

--- a/test/unit/osquery-uptime-watchdog-launchagent.sh
+++ b/test/unit/osquery-uptime-watchdog-launchagent.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# The uptime-watchdog LaunchAgent: com.webdavis.osquery-uptime-watchdog must run
+# the deployed watchdog every 900 seconds (15 min) AND at load time. RunAtLoad is
+# true on purpose (real-time monitor parity with the poller and tailscale monitor):
+# on load the watchdog surfaces an already-down pipeline immediately instead of
+# waiting a full interval. It is a gui/<uid> USER agent (it calls send_alert, the
+# user's local notifier and #priority page). Its loader chezmoiscript is wired
+# exactly like the sibling osquery agents (darwin gate, plist-hash onchange
+# trigger, bootout + bootstrap with the retry loop).
+#
+# Unit test: render the plist and loader templates with the host chezmoi and assert
+# their content. No launchctl, no side effects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLIST="$REPO_ROOT/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist.tmpl"
+LOADER="$REPO_ROOT/.chezmoiscripts/run_onchange_after_60-load-osquery-uptime-watchdog-launchagent.sh.tmpl"
+
+fail() {
+  printf 'osquery-uptime-watchdog-launchagent: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the templates\n'
+  exit 0
+}
+[[ -f $PLIST ]] || fail "missing plist template: $PLIST"
+[[ -f $LOADER ]] || fail "missing loader chezmoiscript: $LOADER"
+
+# Render both templates exactly as at apply time. --source pins the render to THIS
+# checkout (hermetic), mirroring the sibling launchagent tests.
+rendered_plist="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$PLIST")" ||
+  fail "chezmoi failed to render the plist"
+[[ -n $rendered_plist ]] || fail "empty plist render"
+rendered_loader="$(CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty <"$LOADER")" ||
+  fail "chezmoi failed to render the loader"
+
+home_dir="$(chezmoi --source "$REPO_ROOT" execute-template --no-tty <<<'{{ .chezmoi.homeDir }}')"
+
+# assert_plist_kv <key> <expected-value-line-fragment> -- a plist pairs a <key>
+# with the value element on the FOLLOWING line, so match the key then its next line
+# (same helper shape as the sibling launchagent tests).
+assert_plist_kv() {
+  local key="$1" want="$2"
+  if ! printf '%s\n' "$rendered_plist" | grep -A1 -F "<key>$key</key>" | grep -qF "$want"; then
+    printf 'rendered plist:\n%s\n' "$rendered_plist" >&2
+    fail "expected <key>$key</key> followed by '$want'"
+  fi
+}
+
+# --- the plist: label, schedule, program path, logs -------------------------
+
+assert_plist_kv Label '<string>com.webdavis.osquery-uptime-watchdog</string>'
+assert_plist_kv StartInterval '<integer>900</integer>'
+# RunAtLoad true: on load the watchdog surfaces an already-down pipeline
+# immediately, not a full 15-min interval later. Matches the real-time sibling
+# monitors (poller, tailscale); diverges from the daily heartbeat.
+assert_plist_kv RunAtLoad '<true/>'
+
+# ProgramArguments runs the DEPLOYED watchdog from the libexec home (the
+# executable_ source prefix is dropped in the target).
+printf '%s\n' "$rendered_plist" |
+  grep -qF "<string>$home_dir/.local/libexec/osquery/uptime-watchdog.sh</string>" ||
+  fail "ProgramArguments does not run $home_dir/.local/libexec/osquery/uptime-watchdog.sh"
+
+# Both log streams land in the osquery log dir, like every sibling agent.
+assert_plist_kv StandardOutPath "<string>$home_dir/.local/log/osquery/uptime-watchdog.log</string>"
+assert_plist_kv StandardErrorPath "<string>$home_dir/.local/log/osquery/uptime-watchdog.log</string>"
+
+# --- the loader: darwin gate, onchange trigger, gui user target, bootout+bootstrap retry ----
+
+# The loader re-runs when the plist CONTENT changes: the plist-hash include line is
+# the onchange trigger, and it must name the watchdog's own plist template.
+grep -qF 'include "Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist.tmpl"' "$LOADER" ||
+  fail "loader is missing the plist-hash onchange trigger for the watchdog plist"
+grep -qE 'eq \.chezmoi\.os "darwin"' "$LOADER" ||
+  fail "loader is not darwin-gated like the sibling osquery loaders"
+
+# The rendered loader targets the watchdog's label and plist as a gui/<uid> USER
+# agent, and keeps the sibling bootout-then-bootstrap shape with the retry loop.
+# The needles below are literal loader lines; $HOME and $(id -u) must NOT expand
+# here (same rule as the feature-set-location test's source-line needles).
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'PLIST="$HOME/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist"' ||
+  fail "rendered loader does not point at the watchdog plist"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" |
+  grep -qF 'TARGET="gui/$(id -u)/com.webdavis.osquery-uptime-watchdog"' ||
+  fail "rendered loader does not target the watchdog label as a gui/<uid> user agent"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootout "$TARGET"' ||
+  fail "rendered loader is missing the bootout step"
+# shellcheck disable=SC2016
+printf '%s\n' "$rendered_loader" | grep -qF 'launchctl bootstrap "gui/$(id -u)" "$PLIST"' ||
+  fail "rendered loader is missing the bootstrap step"
+printf '%s\n' "$rendered_loader" | grep -qF 'for _ in 1 2 3; do' ||
+  fail "rendered loader is missing the bootstrap retry loop"
+
+printf 'osquery-uptime-watchdog-launchagent: OK (label + 900s interval + RunAtLoad true; gui/<uid> user agent; deployed libexec program; loader gated, hashed, bootout+bootstrap with retry)\n'


### PR DESCRIPTION
## Context

The osquery alerting pipeline is edge-triggered and its queries are differential, so genuine silence is
normal and expected. That makes a dead pipeline indistinguishable from a healthy quiet one: if a monitor
agent crashes, the daemon wedges, the delivery route dies, or alerts pile up undelivered, nothing says so.
The uptime watchdog is the monitor of the monitors, the real-time alarm that pairs with the daily
heartbeat's proof-of-life.

A basic watchdog already existed on the machine (it pre-dates this alerting work, so the earlier revert
left it in place), but it watched only two agents, probed a decommissioned route, had no crash-loop or
backlog check, kept no state, and had no tests. This hardens it in place and adds the missing coverage.

The live machine applies from `integration/modernization`, not `main`, so merging this changes nothing on
any running machine (see Effect of merging).

## Summary

- A 15-minute LaunchAgent pages the moment any part of the notification pipeline is down or wedged.
- It confirms the osquery daemon is alive by reading its own scheduled canary, not a one-shot that answers when the daemon is wedged.
- It verifies each of the six monitor agents is loaded and not crash-looping, without false-paging a daily agent between its runs.
- It probes the delivery backlog: any dead-lettered alert pages, and a sustained pending-alert growth pages.
- Every ambiguous or failed check resolves to a page, never a silent all-clear.

Key files:

- `dot_local/libexec/osquery/executable_uptime-watchdog.sh` — the watchdog
- `dot_local/libexec/osquery/canary-freshness.sh` — a shared daemon-liveness helper, now used by both the watchdog and the heartbeat
- `test/integration/osquery-watchdog.bats`, `test/fixtures/osquery-watchdog-lib.bash`, `test/unit/osquery-uptime-watchdog-launchagent.sh` — the previously-missing coverage

## Fail-safe by design

A watchdog that fails quietly is worse than none, so every probe fails toward paging. A daemon that is
running but wedged (its canary stale or missing), an agent launchd cannot report on, a delivery route that
returns the wrong status, a store the alert counters cannot read, a state file it cannot persist, and a
system clock it cannot read all page rather than read as healthy. The one value it takes from launchd (an
exit code) and the one from the canary log (a timestamp) are both validated as bounded integers before use,
so a malformed or influenced value cannot inject into the page or slip a broken component past a check.

The daemon-liveness check reads the canary that only a live, scheduling osquery daemon produces, the same
signal the heartbeat uses. That logic now lives in one shared helper both scripts call, so the "verify the
real thing, not a proxy" rule holds identically in both.

## Crash-loop detection without false alarms

An agent that exits nonzero is only a crash-loop when it actually re-ran: the check gates on launchd's
monotonic run counter, so a daily agent whose last exit is frozen between the fifteen-minute checks never
accumulates a false streak, while an agent failing on two real consecutive re-runs pages. A running agent
that has never exited is healthy; an exit state the tool cannot parse pages.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover, at which point the agent begins watching the pipeline every fifteen minutes.
