### PR TITLE
fix(osquery): stop discarding failure status in the alerter routing path

### DIFF
--- a/dot_local/libexec/osquery/results-alerter/digest-store.sh
+++ b/dot_local/libexec/osquery/results-alerter/digest-store.sh
@@ -6,7 +6,13 @@
 # grouped summary. The read side is a separate slice; this helper only appends.
 #
 # Best-effort by design: failing to record a digest line must never abort
-# detection, so every step is guarded and the function always returns success.
+# detection, so every step is guarded and the function always returns success. Be
+# plain about what that costs. A failed append is NOT retried and the finding is
+# then recorded nowhere, so the append is the one step that says so on stderr,
+# which lands in the alerter's launchd log. That is the whole remedy here: a
+# trace, not a recovery. It is the same channel the routing stage uses for its own
+# degradations. The digest tier never pages, so this changes nothing about page
+# delivery, and it cannot: digest_append still returns success either way.
 #
 # Privacy posture (the F5-A lesson - secret digests must not spread to readable
 # files): the line carries only DERIVED triage fields (timestamp, detector,
@@ -28,7 +34,12 @@ digest_append() {
   # Set the dir to 700 BEFORE any file exists, so even the brief window before the
   # file's own 600 mode is applied is covered by an unreadable parent directory.
   chmod 700 "$dir" 2>/dev/null || true
-  jq -c --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  # jq's own stderr stays suppressed on purpose: a jq error message can quote the
+  # input it choked on, and the input here is a raw finding whose columns are the
+  # very thing the privacy posture above keeps out of readable files. The
+  # diagnostic below therefore names only the spool path (ours, never
+  # attacker-influenced), which is enough to find the fault in the log.
+  if ! jq -c --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     '{
       timestamp: $timestamp,
       detector: .q,
@@ -38,6 +49,9 @@ digest_append() {
                  else (.cols.label // .cols.identifier // .cols.target_path // .cols.path // .cols.username // "?") end),
       action: .act,
       summary: (.q + " " + ((.cols.label // .cols.identifier // .cols.target_path // .cols.path // .cols.username) // "?"))
-    }' <<<"$finding" >>"$store" 2>/dev/null || true
+    }' <<<"$finding" >>"$store" 2>/dev/null; then
+    printf 'digest-store.sh: could not append a digest line to %s; that finding is recorded nowhere and is NOT retried\n' \
+      "$store" >&2
+  fi
   chmod 600 "$store" 2>/dev/null || true
 }

--- a/dot_local/libexec/osquery/results-alerter/normalize.sh
+++ b/dot_local/libexec/osquery/results-alerter/normalize.sh
@@ -24,10 +24,20 @@
 # action row is a single finding, carried through unexploded.
 
 # normalize_findings: raw results-log lines on stdin -> normalized finding NDJSON
-# on stdout. jq -rR reads each line as a raw string; the per-line try/fromjson
-# means one malformed line yields nothing for that line instead of aborting the
-# whole batch, and a `2>/dev/null || true` keeps a jq-level hiccup from killing
-# the pipeline (a swallowed batch is caught by the cursor-retry logic in main).
+# on stdout. jq -rR reads each line as a raw string, and the per-line try/fromjson
+# means one malformed line yields nothing for THAT line instead of aborting the
+# whole batch - garbage rows drop out and the surrounding rows still normalize.
+#
+# jq's exit status is PROPAGATED, not swallowed. A jq that cannot run or is killed
+# partway (out of memory on a large batch, say) leaves the rows it never emitted
+# unjudged, and this stage cannot tell which. Reporting success there would hand
+# main a short batch that looks like a complete one: it would page nothing and
+# then checkpoint the cursor past those very rows, and nothing re-reads a byte
+# range the cursor has passed, so the findings would be gone. Failing instead
+# reaches main through its pipefail, which leaves the cursor put and re-reads the
+# same rows on the next tick (at-least-once). stderr is still suppressed: jq
+# reports a per-input error for any line that parses as valid non-object JSON, and
+# those are recovered from, not failures.
 normalize_findings() {
   jq -rR '
     # Known-query allowlist (the security select): the prefix-stripped names of
@@ -87,5 +97,5 @@ normalize_findings() {
         elif $q == "suid_bin_unexpected" then (.columns.path // "")
         else "" end) | gsub("[\t\n]"; " ")) as $ep
     | {q: $q, act: $act, cols: (.columns // {}), ep: $ep} | @json
-  ' 2>/dev/null || true
+  ' 2>/dev/null
 }

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -94,7 +94,20 @@ route_findings() {
   # Severity is safe to batch: route_severity emits a fixed-vocabulary token
   # (CRIT/NOTICE/INFO) per finding, in order, never an attacker-controlled value,
   # so a newline-delimited mapfile cannot be shifted by a crafted column.
-  mapfile -t sevs < <(printf '%s\n' "${objs[@]}" | route_severity)
+  #
+  # The batch is taken through a CHECKED command substitution, not a process
+  # substitution: `< <(... | route_severity)` discards the producer's exit status
+  # entirely, so a route_severity that died partway (its jq killed on a huge batch,
+  # say) would return fewer severities than there are findings with nothing to show
+  # for it. The status is captured here and reported by the per-finding fail-safe
+  # read below; it is NOT used to abort the pass, because a batch that cannot be
+  # fully classified must still be routed rather than left to a retry that would
+  # re-run the same failing classification on the same rows forever.
+  local sev_batch="" sev_status=0
+  sev_batch=$(printf '%s\n' "${objs[@]}" | route_severity) || sev_status=$?
+  # Guarded because a herestring of an empty batch is one empty LINE, which would
+  # read back as a severity slot that exists but says nothing.
+  if [[ -n $sev_batch ]]; then mapfile -t sevs <<<"$sev_batch"; fi
 
   # The signing enricher (enrich-finding.sh): given an inspectable path it emits a
   # trust fact string and exits 10 when the code is UNTRUSTED. Overridable for tests;
@@ -108,7 +121,23 @@ route_findings() {
     q=$(jq -r '.q' <<<"$obj")
     act=$(jq -r '.act' <<<"$obj")
     ep=$(jq -r '.ep // ""' <<<"$obj")
-    sev=${sevs[i]}
+    # FAIL-SAFE severity read. route_severity owes exactly one fixed-vocabulary
+    # token per finding, so an empty slot or an off-vocabulary value means the
+    # batch came back short or corrupted - never that the finding is benign.
+    # Resolve it to CRIT so the finding PAGES (over-paging is recoverable; a
+    # dropped security finding is not) and say so on stderr, which lands in the
+    # alerter's launchd log. Reading the slot with :- also keeps a short batch from
+    # tripping the entry's `set -u` and aborting mid-loop, which would lose the
+    # findings already classified in this pass as well as the unclassified ones.
+    sev=${sevs[i]:-}
+    case "$sev" in
+      CRIT | NOTICE | INFO) ;;
+      *)
+        printf 'route.sh: no severity for finding %d of %d (route_severity exit %d, %d severities returned); treating it as CRITICAL so it pages\n' \
+          "$((i + 1))" "${#objs[@]}" "$sev_status" "${#sevs[@]}" >&2
+        sev="CRIT"
+        ;;
+    esac
     # Enrichment runs BEFORE the per-detector case: for a finding with an inspectable
     # path and a CRIT/NOTICE base tier, get the signing verdict, attach it as .signing
     # for render-page, and promote NOTICE -> CRIT (louder, never quieter) when the

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -300,6 +300,18 @@ route_findings() {
     pages+=("$obj")
   done
   # Emit the page-candidates, in input order, with .sev stamped CRIT - one jq pass.
-  [[ ${#pages[@]} -gt 0 ]] && printf '%s\n' "${pages[@]}" | jq -c '.sev = "CRIT"'
-  return 0
+  #
+  # The emit's status is RETURNED, not swallowed by a blanket `return 0`. This is
+  # the last point at which a confirmed page can be lost: render_page counts only
+  # what it receives, and the entry checkpoints the cursor once the page is
+  # delivered or spooled, so a jq that died here while route_findings reported
+  # success would advance the cursor past rows whose pages were never written.
+  # Returning nonzero makes the entry's pipefail see it, which leaves the cursor
+  # put for the next tick. A batch with nothing to page skips the emit and is a
+  # plain success.
+  local emit_status=0
+  if [[ ${#pages[@]} -gt 0 ]]; then
+    printf '%s\n' "${pages[@]}" | jq -c '.sev = "CRIT"' || emit_status=$?
+  fi
+  return "$emit_status"
 }

--- a/test/e2e/osquery-alerter-entry.bats
+++ b/test/e2e/osquery-alerter-entry.bats
@@ -35,6 +35,27 @@ send_alert() {
 }
 STUB
 
+  # A jq shim for the normalize-failure case. It fails ONLY the `-rR` invocation,
+  # which is normalize_findings' program and nothing else in the pipeline (routing
+  # uses plain -r, the allowlist -Rc, render -s, the entry -r), and execs the real
+  # jq for every other call. One PATH entry therefore breaks normalization alone,
+  # leaving the rest of the flow real.
+  SHIM_BIN="$HOME/shim-bin"
+  mkdir -p "$SHIM_BIN"
+  REAL_JQ="$(command -v jq)"
+  export REAL_JQ
+  cat >"$SHIM_BIN/jq" <<'SHIM'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ $arg == -rR ]]; then
+    printf 'jq shim: simulated normalize failure\n' >&2
+    exit 5
+  fi
+done
+exec "$REAL_JQ" "$@"
+SHIM
+  chmod +x "$SHIM_BIN/jq"
+
   export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
   export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
   : >"$OSQUERY_RESULTS_LOG"
@@ -179,4 +200,23 @@ run_entry() { run bash "$ENTRY"; }
   local batch_pages
   batch_pages=$(grep -c 'title=🔴 \*\*CRITICAL\*\*' "$SEND_ALERT_SPY" 2>/dev/null || true)
   [ "$batch_pages" -eq 1 ]
+}
+
+# (j) A normalize stage that FAILS is not an all-clear. When jq dies partway the
+#     batch is truncated or empty, so the rows it never emitted were never judged;
+#     treating that as "no findings" and checkpointing past them loses them for
+#     good, because nothing re-reads a byte range the cursor has passed. The run
+#     must fail loudly and leave the cursor put so the next tick re-reads the rows.
+@test "T-ENTRY-normalize-failure: a failed normalize keeps the cursor put and the row is re-read" {
+  seed_cursor 0
+  append_row "$ADMIN_ROW"
+  PATH="$SHIM_BIN:$PATH" run bash "$ENTRY"     # normalization cannot run
+  [ "$status" -ne 0 ]                           # the failure is not swallowed
+  [ "$(crit_page_count)" -eq 0 ]                # nothing was paged
+  [ "$(cursor_offset)" -eq 0 ]                  # cursor did NOT advance past the row
+  # With normalization working again the SAME row is re-read and pages once.
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]
+  [ "$(cursor_offset)" -eq "$(log_size)" ]
 }

--- a/test/unit/osquery-digest-store.sh
+++ b/test/unit/osquery-digest-store.sh
@@ -83,4 +83,42 @@ jq -e 'has("sha256")' <<<"$l3" >/dev/null 2>&1 && fail "the digest line must not
 grep -q 'deadbeef' "$store" && fail "a raw sha256 leaked into the spool file"
 grep -q 'SUPERSECRETTOKEN' "$store" && fail "a secret value leaked into the spool file"
 
-printf 'osquery-digest-store: OK (one NDJSON line per append, accumulation, dir 700 / file 600, listening-port identity, no secret/sha256 leak)\n'
+# -- A FAILED append stays best-effort but must not be silent. The append is
+#    deliberately swallowed so a spool problem can never abort the detection path,
+#    which means the finding is recorded nowhere and is never retried. That loss
+#    has to leave a trace in the alerter's launchd log, or a digest-tier finding
+#    disappears with no signal at all. jq is shimmed to fail, which is the silent
+#    shape: the helper's own `2>/dev/null` hides jq's complaint, so the ONLY thing
+#    that can reach the log is the helper's own diagnostic. --
+fail_work="$work/append-failure"
+mkdir -p "$fail_work/bin"
+fail_store="$fail_work/spool/digest.ndjson"
+cat >"$fail_work/bin/jq" <<'SHIM'
+#!/usr/bin/env bash
+printf 'jq shim: simulated digest append failure\n' >&2
+exit 5
+SHIM
+chmod +x "$fail_work/bin/jq"
+
+fail_status=0
+fail_err="$(
+  OSQUERY_DIGEST_STORE="$fail_store" PATH="$fail_work/bin:$PATH" bash -c '
+    source "$1"
+    digest_append "{\"q\":\"system_extensions_new\",\"act\":\"added\",\"cols\":{\"identifier\":\"com.example.ext\"},\"ep\":\"\"}"
+    printf "APPEND_RC=%s\n" "$?" >&2
+  ' _ "$HELPER" 2>&1 >/dev/null
+)" || fail_status=$?
+
+[[ $fail_status -eq 0 ]] ||
+  fail "a failed append must never abort the caller, the pass exited $fail_status ($fail_err)"
+[[ $fail_err == *"APPEND_RC=0"* ]] ||
+  fail "digest_append must still return 0 on a failed append (best-effort), got: $fail_err"
+[[ $fail_err == *digest-store* ]] ||
+  fail "a failed append must announce itself on stderr; got: ${fail_err:-<nothing>}"
+[[ $fail_err == *"$fail_store"* ]] ||
+  fail "the diagnostic must name the spool it could not write, got: $fail_err"
+if [[ -s $fail_store ]]; then
+  fail "the failed append must not have written a line, got: $(cat "$fail_store")"
+fi
+
+printf 'osquery-digest-store: OK (one NDJSON line per append, accumulation, dir 700 / file 600, listening-port identity, no secret/sha256 leak, failed append stays best-effort but is logged)\n'

--- a/test/unit/osquery-route-emit-failure.sh
+++ b/test/unit/osquery-route-emit-failure.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# route_findings (results-alerter/route.sh) ends by stamping every page-candidate
+# with .sev = "CRIT" in one jq pass and writing it to stdout. That emit is the
+# LAST point at which a confirmed page can be lost: downstream, render_page counts
+# what it receives, and the entry checkpoints the cursor past the batch once the
+# page is delivered or spooled.
+#
+# This suite pins that the emit's status REACHES the caller. A jq that dies there
+# must not leave route_findings reporting a clean "nothing to page" - the entry
+# would then advance the cursor past rows whose pages were never written, and
+# those findings are gone for good.
+#
+# The gate pass runs WITHOUT `set -e` on purpose. Under the entry's options an
+# errexit abort masks the question, but a library must not owe its correctness to
+# the caller's shell options - this suite and the other route suites source
+# route.sh exactly this way, so a swallowed status would green them too.
+#
+# Unit test: one page-tier finding, with jq shimmed to fail only the emit call.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+
+fail() {
+  printf 'osquery-route-emit-failure: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+
+REAL_JQ="$(command -v jq)" || fail "jq is not on PATH"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+
+# A jq shim that fails ONLY the page emit, and only when armed. Every other call
+# (the per-field extractions, route_severity's classifier) passes through to the
+# real jq, and a disarmed shim passes the emit through too, so the same PATH
+# serves both the failure case and its control. The emit is identified by its
+# program text, which no other call in route.sh uses.
+cat >"$work/bin/jq" <<'SHIM'
+#!/usr/bin/env bash
+if [[ ${JQ_SHIM_FAIL_EMIT:-0} == 1 ]]; then
+  for arg in "$@"; do
+    if [[ $arg == '.sev = "CRIT"' ]]; then
+      printf 'jq shim: simulated page-emit failure\n' >&2
+      exit 5
+    fi
+  done
+fi
+exec "$REAL_JQ" "$@"
+SHIM
+chmod +x "$work/bin/jq"
+
+# run_gate <arm-shim: 0|1> <finding-json> -> route_findings' exit status on
+# stdout, its own stdout in $work/out and stderr in $work/err. No `set -e` in the
+# gate shell: see the docblock.
+run_gate() { # <arm-shim> <finding-json>
+  local arm="$1" finding="$2" status=0
+  printf '%s\n' "$finding" |
+    REAL_JQ="$REAL_JQ" PATH="$work/bin:$PATH" JQ_SHIM_FAIL_EMIT="$arm" \
+      OSQUERY_ENRICH_SCRIPT="$work/no-enricher.sh" \
+      bash -c '
+      set -o pipefail
+      source "$1"
+      digest_append() { :; }
+      route_findings
+    ' _ "$ROUTE" >"$work/out" 2>"$work/err" || status=$?
+  printf '%s' "$status"
+}
+
+# A page-tier finding: new_admin_user is CRIT with no gate arm, so it reaches the
+# emit as a page-candidate and nothing else decides its fate.
+page_finding='{"q":"new_admin_user","act":"added","cols":{"username":"adminTAG_A","uid":"501"},"ep":""}'
+
+# -- The emit fails: the status must reach the caller. --
+failed_status="$(run_gate 1 "$page_finding")"
+[[ $failed_status -ne 0 ]] ||
+  fail "a failed page emit must not report success; route_findings returned 0 with stdout: $(cat "$work/out")"
+
+# -- Control 1: the same finding with the shim disarmed still pages and exits 0,
+# -- so the fix cannot be a blanket nonzero return.
+healthy_status="$(run_gate 0 "$page_finding")"
+[[ $healthy_status -eq 0 ]] ||
+  fail "a healthy page emit must exit 0, exited $healthy_status ($(cat "$work/err"))"
+grep -qF TAG_A "$work/out" ||
+  fail "a healthy page emit must write the page-candidate, got: $(cat "$work/out")"
+
+# -- Control 2: a batch with NO page-candidates never reaches the emit, so an
+# -- armed shim is inert and the pass must still report success and write nothing.
+# -- homebrew_packages is INFO drift, log-only.
+logonly_status="$(run_gate 1 '{"q":"homebrew_packages","act":"added","cols":{"name":"pkgTAG_B"},"ep":""}')"
+[[ $logonly_status -eq 0 ]] ||
+  fail "a batch with no page-candidates must exit 0, exited $logonly_status ($(cat "$work/err"))"
+if [[ -s $work/out ]]; then
+  fail "a batch with no page-candidates must emit nothing, got: $(cat "$work/out")"
+fi
+
+printf 'osquery-route-emit-failure: OK (a failed page emit reports nonzero; a healthy emit pages and exits 0; nothing to page exits 0)\n'

--- a/test/unit/osquery-route-severity-shortfall.sh
+++ b/test/unit/osquery-route-severity-shortfall.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# route_findings (results-alerter/route.sh) computes the batch of base severities
+# by piping every finding through route_severity ONCE, then reads back one
+# severity per finding by index. This suite pins what must happen when that batch
+# comes back SHORT: route_severity (or a jq inside it) dies partway, so there are
+# fewer severities than findings.
+#
+# The invariant: a severity that is missing must NEVER turn a finding into a
+# silent all-clear. The unclassified finding resolves to CRIT - it PAGES, the
+# fail-safe direction - and the degradation is announced on stderr (the alerter's
+# launchd log). Over-paging is recoverable; a dropped security finding is not.
+#
+# Production faithfulness: the entry (results-alerter.sh) runs `set -euo
+# pipefail` and sources these helpers into one process, so the gate pass here
+# runs under exactly those options. That matters in both directions - under
+# `set -u` a missing index is a fatal unbound-variable abort that loses the WHOLE
+# batch, and without it the missing findings vanish silently - and neither is
+# acceptable, so route_findings must not rely on the caller's shell options to
+# notice the shortfall.
+#
+# Unit test: fixture normalized findings, each tagged with a unique token, run
+# through ONE gate pass with route_severity doubled. A token in stdout => paged.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
+ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
+fail() {
+  printf 'osquery-route-severity-shortfall: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+# A plain refute helper, NOT a bare `! grep`: an inverted pipeline returns 0 to
+# `set -e`, so `! grep -q ...` can never fail a test. This one calls fail itself.
+refute_contains() { # <haystack> <needle> <message>
+  if grep -qF -- "$2" <<<"$1"; then fail "$3"; fi
+}
+
+assert_contains() { # <haystack> <needle> <message>
+  grep -qF -- "$2" <<<"$1" || fail "$3"
+}
+
+[[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
+[[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+[[ -f $PIPELINE_HELPER ]] || fail "missing helper: $PIPELINE_HELPER"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Real normalize-shaped findings. TAG_A is classified by the truncated batch;
+# TAG_B and TAG_C are the ones whose severity never arrives. Both are page-tier
+# detectors whose gate arm does NOT set the severity itself (filevault_off has no
+# arm at all; suid_bin_unexpected relies on the base CRIT), so each one's outcome
+# is decided purely by the severity read - exactly the findings a shortfall would
+# lose. TAG_D is an INFO drift row, the control: it must stay log-only under a
+# HEALTHY batch, so a "page everything, always" implementation cannot pass.
+findings=(
+  '{"q":"new_admin_user","act":"added","cols":{"username":"adminTAG_A","uid":"501"},"ep":""}'
+  '{"q":"filevault_off","act":"added","cols":{"note":"TAG_B"},"ep":""}'
+  '{"q":"suid_bin_unexpected","act":"added","cols":{"path":"/tmp/suidTAG_C"},"ep":""}'
+  '{"q":"homebrew_packages","act":"added","cols":{"name":"pkgTAG_D"},"ep":""}'
+)
+
+# run_gate <severity-double-body> -> stdout on fd 1, stderr captured to $work/err,
+# route_findings' exit status echoed on the last line of $work/status.
+#
+# The gate pass runs under `set -euo pipefail` (the entry's options) in its own
+# bash so the doubles cannot leak into this test's shell. digest_append is doubled
+# to a no-op: no fixture here is digest-tier, and the spool is another suite's
+# subject. The enricher is pointed at a path that does not exist, so enrichment is
+# skipped and the severity read is the only variable.
+run_gate() { # <severity-double-body>
+  local double_body="$1"
+  local status=0
+  printf '%s\n' "${findings[@]}" |
+    OSQUERY_ENRICH_SCRIPT="$work/no-enricher.sh" \
+      OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" \
+      OSQUERY_PIPELINE_MANIFEST="$work/no-manifest.sha256" \
+      SEVERITY_DOUBLE="$double_body" \
+      bash -c '
+      set -euo pipefail
+      source "$1"
+      source "$2"
+      source "$3"
+      digest_append() { :; }
+      eval "$SEVERITY_DOUBLE"
+      route_findings
+    ' _ "$ROUTE" "$ALLOWLIST_HELPER" "$PIPELINE_HELPER" 2>"$work/err" || status=$?
+  printf '%s' "$status" >"$work/status"
+}
+
+# -- The shortfall: route_severity classifies the first finding, then dies (the
+# -- jq-killed-partway shape). Three severities are owed; one arrives.
+short_out="$(run_gate 'route_severity() { printf "CRIT\n"; return 5; }')"
+short_status="$(cat "$work/status")"
+short_err="$(cat "$work/err")"
+
+assert_contains "$short_out" TAG_A \
+  "the classified finding must still page (status=$short_status, out=$short_out, err=$short_err)"
+assert_contains "$short_out" TAG_B \
+  "filevault_off lost its severity and was DROPPED instead of paging (status=$short_status, out=$short_out, err=$short_err)"
+assert_contains "$short_out" TAG_C \
+  "suid_bin_unexpected lost its severity and was DROPPED instead of paging (status=$short_status, out=$short_out, err=$short_err)"
+
+# The pass must COMPLETE, not abort: aborting mid-batch loses the findings it had
+# already classified, and a deterministic failure would then wedge every later
+# batch behind an un-advancing cursor.
+[[ $short_status -eq 0 ]] ||
+  fail "route_findings must complete the batch on a severity shortfall, exited $short_status (err=$short_err)"
+
+# The degradation must be HUMAN-VISIBLE, not inferred from an over-page.
+[[ -n $short_err ]] ||
+  fail "a severity shortfall must announce itself on stderr; nothing was written"
+assert_contains "$short_err" severity \
+  "the stderr diagnostic must name the severity shortfall (got: $short_err)"
+# The double exits 5. Reporting that code proves route_severity's status is
+# CAPTURED rather than thrown away by a process substitution, which is what let a
+# failed batch look like a complete one in the first place.
+assert_contains "$short_err" "route_severity exit 5" \
+  "the diagnostic must report route_severity's real exit status (got: $short_err)"
+
+# -- The control: with a healthy route_severity the same batch routes normally,
+# -- so the fail-safe fallback cannot be a blanket page.
+healthy_out="$(run_gate ':')"
+healthy_status="$(cat "$work/status")"
+
+[[ $healthy_status -eq 0 ]] || fail "the healthy pass must exit 0, exited $healthy_status"
+assert_contains "$healthy_out" TAG_A "new_admin_user must page on a healthy batch"
+assert_contains "$healthy_out" TAG_B "filevault_off added must page on a healthy batch"
+assert_contains "$healthy_out" TAG_C "suid_bin_unexpected added must page on a healthy batch"
+refute_contains "$healthy_out" TAG_D \
+  "homebrew_packages is INFO drift and must stay log-only on a healthy batch"
+[[ -z "$(cat "$work/err")" ]] ||
+  fail "a healthy batch must not warn: $(cat "$work/err")"
+
+printf 'osquery-route-severity-shortfall: OK (a short severity batch pages the unclassified findings, completes, and warns; a healthy batch is unchanged)\n'


### PR DESCRIPTION
## Context

The osquery alerter reads new findings from the results log, decides whether each one pages, digests, or is
only logged, and then advances a cursor past the rows it handled. Nothing ever re-reads a byte range the
cursor has passed, so a finding that is not judged before the cursor moves is gone for good.

Four places in that path discarded the exit status of a command they depended on, which made a partial
failure look like a complete success. This fixes all four and corrects a comment that described a safety
net which did not exist.

## Summary

- A failed severity classification now pages the affected findings instead of losing the whole batch.
- A failed normalize stage now stops the run instead of checkpointing the cursor past unjudged findings.
- The page emit now reports its own failure instead of always returning success.
- A failed digest append now leaves a diagnostic line instead of vanishing without a trace.
- Corrects a comment that claimed the cursor retry covered a case it never covered.

Key files: `dot_local/libexec/osquery/results-alerter/` (`route.sh`, `normalize.sh`, `digest-store.sh`).

## What each failure looked like

**Severity classification.** The routing stage classified a batch of findings by piping them through a
severity helper and reading the results back by index. The helper's exit status was discarded. If it failed
partway, the results array came back short, and every finding past that point read an index that was never
set. Under the alerter's own shell settings that is a fatal error, so the entire pass died and produced
nothing, and because the failure reproduces on the same bytes every run, the cursor would never advance
again. One malformed batch could take the detector offline indefinitely.

**Normalize.** The stage that turns raw log rows into finding objects suppressed its parser's exit status
outright. A parser killed partway, by memory pressure on a large batch for instance, returned the rows it
had managed to emit and reported success. The caller could not distinguish that from a complete batch, so
it paged nothing for the missing rows and then checkpointed the cursor past them. Those findings were
unrecoverable. The comment above that line asserted the cursor retry logic would catch it, which was not
true: that path only holds the cursor when delivery fails, not when normalization silently comes up short.

**Page emit and digest append.** The emit returned success unconditionally, hiding a failure from the
caller. The digest append discarded its own failure, so a finding intended for the daily digest could be
recorded nowhere at all with no signal.

## Why the severity fix pages rather than aborts

Aborting the run would have been safe for the cursor, since the checkpoint only happens after a successful
delivery. It was rejected for a different reason: a classification failure that reproduces deterministically
would abort every run forever, so every later finding would be stuck behind the one bad batch, and the
repeated failures would trip the uptime watchdog's crash loop alarm. Resolving the ambiguity toward paging
keeps the pipeline moving and errs toward too much noise rather than silence. Detectors that decide before
consulting severity are unaffected, so the extra paging is limited to the cases where severity is the
deciding input.

## How it was reviewed

Each fix has a test that was confirmed to fail against the old code for the stated reason, then pass, then
fail again when the fix is reverted. The normalize case is pinned end to end through the real entry point,
asserting that the cursor stays put and the same finding pages on the next run.

The whole alerter helper set was swept for the same class of discarded status. Three instances were found
and fixed. Four more were examined and left alone because each one already resolves toward paging when it
fails, and the reasoning for each is recorded in the sweep.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover.
