### PR TITLE
fix(osquery): close four silent-failure paths in the alerting pipeline

### DIFF
--- a/.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh
+++ b/.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh
@@ -42,6 +42,17 @@
 # rewrite local refs. The boundary this buys is post-deployment integrity, not
 # supply-chain integrity of the source.
 #
+# Nor is the root install a boundary against a user-level attacker on this host.
+# The manifest is written root-owned 0644 so a process at the user's privilege
+# level cannot rewrite it, and the consumer refuses a manifest that is not (see
+# _pipeline_manifest_is_trustworthy in pipeline-verdict.sh). That raises the bar and
+# stops an unprivileged process from whitelisting a file it just tampered, but the
+# operator account here has passwordless sudo, so a process running AS the operator
+# can escalate with no prompt and rewrite the manifest at will. Every unattended
+# chezmoi script depends on that sudo configuration, this one included, so the limit
+# is recorded rather than closed: root ownership buys a higher bar and a loud
+# failure mode, not integrity against a determined user-level attacker.
+#
 # Blind spot, recorded honestly: the manifest binds CONTENT only. An
 # ATTRIBUTES_MODIFIED event (for example `chmod g+w` on a pipeline script) carries
 # the unchanged hash, matches its tuple, and stays silent. A mode/owner column is a

--- a/dot_local/libexec/osquery/executable_alert-dispatch.sh
+++ b/dot_local/libexec/osquery/executable_alert-dispatch.sh
@@ -814,6 +814,18 @@ _osquery_show_banner_confirm_delete() { # <notification_id-or-empty> <title> <me
 # when this same storage is unwritable), the banner still fires best-effort and
 # the loss of durability is logged loudly (LOCAL-NOTIFY-STORE-FAILED), but the
 # caller is never aborted, it is already on its worst-case path.
+#
+# DELIBERATELY LOUD FOR EVERY CALLER. The sound is fixed here rather than taken
+# from the caller, so a MUTED caller (the heartbeat and the digest, which pass an
+# empty sound) still gets an audible banner from this path. That is not an
+# oversight and it does not break their promise: a caller's mute covers ITS OWN
+# message, while every call reaching this function reports the delivery pipeline
+# itself as broken, which is systemic and belongs to no single caller. It matters
+# most exactly where it is most surprising: on a machine whose only regular
+# traffic is the muted heartbeat and digest, a silent alarm would leave a dead
+# pipeline indistinguishable from a quiet, healthy one, which is the failure the
+# whole durable design exists to prevent. Two pins in the dispatch suite hold the
+# split honest, the caller's own banner silent and this alarm loud.
 _osquery_notify_local_durable() { # <title> <message> [notification_seed]
   local title="$1" message="$2" notification_seed="${3-}"
   local occurrence_timestamp

--- a/dot_local/libexec/osquery/executable_digest.sh
+++ b/dot_local/libexec/osquery/executable_digest.sh
@@ -4,6 +4,10 @@
 # written by the alerter's digest_append) into ONE grouped, silent, non-paging
 # message, then rotates the live store aside for forensics. Empty-suppressed: an
 # absent, zero-byte, or whitespace-only store produces no message and no error.
+# The silence is a property of the MESSAGE, not of the run: send_alert's two
+# pipeline-broken alarms (a failed write-ahead persist, a missing webhook secret)
+# stay audible for every producer by design, so a dead delivery pipeline is never
+# reported silently. The send site below carries the same qualifier.
 #
 # Cadence is owned by the daily launchd agent, NOT this script: there is no
 # internal time gate, so a manual invocation builds (or stays silent) exactly the
@@ -205,8 +209,13 @@ main() {
   # steps, and the send outcome is handled EXPLICITLY below, not by the trap.
   trap - ERR
 
-  # CRIT selects the #priority route; the EMPTY sound makes it locally silent AND threads tier=muted
-  # into the POST so the Hermes adapter suppresses the ping (a digest must never notify like a page).
+  # CRIT selects the #priority route; the EMPTY sound makes THIS MESSAGE locally silent AND threads
+  # tier=muted into the POST so the Hermes adapter suppresses the ping (a digest must never notify
+  # like a page). The mute covers this message, not the two shared alarms send_alert raises when the
+  # delivery pipeline itself is broken (a failed write-ahead persist, or a missing webhook secret):
+  # those stay audible for every producer, deliberately, because a dead pipeline on a machine whose
+  # only regular traffic is muted would otherwise read as a quiet, healthy one. See the
+  # loud-for-every-caller note on _osquery_notify_local_durable.
   # No occurrence id is threaded, so send_alert derives a per-send-unique request id (distinct days
   # never collide); the dedup is the atomic CLAIM at the start (which already emptied the live store),
   # not this rotate. send_alert returns nonzero ONLY when its write-ahead persist FAILED (the page was

--- a/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
+++ b/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
@@ -61,11 +61,17 @@ take_single_instance_lock() {
   # No lockf available: the documented non-darwin fallback. Proceed unlocked so
   # the drain still runs; there is no lock to fail closed on.
   [[ -x $lockf_bin ]] || return 0
-  # From here the lock is REQUIRED. Any failure to set it up fails CLOSED.
+  # From here the lock is REQUIRED. Any failure to set it up fails CLOSED. The brace
+  # group scopes the stderr silence to the exec itself; a bare `exec 9>>f 2>/dev/null`
+  # (no command word) would redirect the WHOLE script's stderr to /dev/null for good,
+  # eating every diagnostic the sweep prints afterwards. That matters more here than
+  # almost anywhere: the drain always exits 0 by design, so stderr is its ONLY channel
+  # for an unreadable or broken store. Same shape and same reason as the allowlist
+  # writer's take_allowlist_write_lock.
   local lock_directory
   lock_directory="$(dirname "$OSQUERY_DRAIN_LOCK_FILE")"
   mkdir -p "$lock_directory" 2>/dev/null || return 1
-  exec 9>>"$OSQUERY_DRAIN_LOCK_FILE" 2>/dev/null || return 1
+  { exec 9>>"$OSQUERY_DRAIN_LOCK_FILE"; } 2>/dev/null || return 1
   "$lockf_bin" -s -t 0 9
 }
 

--- a/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
+++ b/dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh
@@ -37,9 +37,11 @@ OSQUERY_DRAIN_LOCK_FILE="${OSQUERY_DRAIN_LOCK_FILE:-${OSQUERY_UNDELIVERED_ALERTS
 
 # Take the single-instance lock and report whether this run may proceed (0 to
 # proceed, nonzero to skip). Uses the kernel lock /usr/bin/lockf on a held file
-# descriptor: the kernel releases it on ANY exit, normal or crash, so a drain
-# SIGKILLed mid-run can never wedge the lock and block every later drain (there
-# is no stale-lock state to clean up). The acquire is non-blocking (-t 0): an
+# descriptor: the kernel releases it once the LAST descriptor on that open file
+# description closes, which for a drain that keeps fd 9 to itself (see main) is
+# any exit, normal or crash, so a drain SIGKILLed mid-run can never wedge the lock
+# and block every later drain (there is no stale-lock state to clean up). The
+# acquire is non-blocking (-t 0): an
 # overlapping run fails to take the lock and returns nonzero, so the caller skips
 # rather than queueing behind the running drain. House precedent: hue-pulse.sh,
 # homebrew-weekly-upgrade.sh, and update-skills.sh all guard with this same
@@ -68,12 +70,39 @@ take_single_instance_lock() {
 }
 
 # main -- take the single-instance lock, drain the store once, and exit 0.
+#
+# fd-inheritance discipline: `exec 9>>` leaves fd 9 inheritable, so every process
+# forked under the lock inherits it, and the kernel lock releases only once EVERY
+# descriptor on that open file description is closed. One child that outlives this
+# run would therefore keep the lock held, and the drain is not free of such
+# children by design: the degraded-pipeline banner backgrounds an alerter watcher
+# that blocks for the banner's whole 60-second life and is documented as free to
+# outlive its caller. The non-blocking acquire keeps the damage bounded (a later
+# tick SKIPS its sweep instead of hanging), but a skipped sweep still delays every
+# queued page, so the sweep runs with fd 9 CLOSED.
+#
+# The whole sweep runs in a SUBSHELL that closes fd 9 with `exec`, so the close is
+# real and inherited by every descendant. A redirection scoped to the call
+# (`retry_undelivered_alerts 9>&-`) is NOT enough and was measured failing here:
+# bash implements a scoped close by first duplicating fd 9 to a high fd so it can
+# restore it afterwards, and a forked subshell inherits that DUPLICATE. The
+# banner watcher is exactly such a subshell (several commands, so bash cannot
+# collapse it into a bare exec), and it was observed still holding the lock file
+# on fd 10 after the drainer exited. Closing inside the subshell leaves no
+# duplicate to inherit; the parent shell keeps its own fd 9, so the lock stays
+# held for the whole sweep (both halves verified). Nothing needs to escape the
+# subshell: retry_undelivered_alerts always returns 0 and all its effects are in
+# the store and on the wire. The library stays free of any knowledge of this
+# script's lock fd.
 main() {
   if ! take_single_instance_lock; then
     # Another drain already holds the lock and covers every stored row; skip.
     return 0
   fi
-  retry_undelivered_alerts
+  (
+    exec 9>&-
+    retry_undelivered_alerts
+  )
   return 0
 }
 

--- a/dot_local/libexec/osquery/executable_heartbeat.sh
+++ b/dot_local/libexec/osquery/executable_heartbeat.sh
@@ -5,7 +5,11 @@
 # trust that silence means safe: if the daily message arrives, the osquery
 # pipeline is scheduled and alive. It is the POSITIVE complement of the uptime
 # watchdog (every 15 min), which is the ALARM that pages when a component is down.
-# This proof-of-life is always muted: it must never ping like a real page.
+# This proof-of-life is always muted: its message must never ping like a real page.
+# The mute is a property of the MESSAGE, not of the process: send_alert's two
+# pipeline-broken alarms (a failed write-ahead persist, a missing webhook secret)
+# stay audible for every producer by design, so a dead delivery pipeline is never
+# reported silently. Each send site below repeats the qualifier where it applies.
 #
 # R2-8: it verifies the ROOT DAEMON, not a fresh osqueryi. A standalone osqueryi
 # one-shot answers even while osqueryd is stopped or wedged (a blind checkmark).
@@ -63,13 +67,16 @@ main() {
     if ((age < 0)); then age=0; fi
     title="✅ osquery pipeline healthy · $(date -u +%Y-%m-%d)"
     detail="- The root osqueryd daemon produced a scheduled heartbeat canary ${age}s ago, so it was scheduling and producing results as recently as that. This is a recent observation, not a real-time check: the uptime watchdog owns real-time liveness and pages if a monitor is down. Silence since the last message means all clear."
-    # The EMPTY sound keeps the message locally silent AND makes send_alert thread
+    # The EMPTY sound keeps THIS MESSAGE locally silent AND makes send_alert thread
     # tier=muted into the webhook body: a proof-of-life must never ping like a real
-    # page. One honest exception, out of this slice's control: if send_alert's
-    # write-ahead persist itself FAILS (storage broken), it fires a shared loud
-    # durable "page LOST" banner (every producer's systemic last resort), which is not
-    # muted. Fire-and-forget otherwise: the heartbeat advances no state, so a send
-    # failure is low-stakes (the next day re-fires; the watchdog is the pager).
+    # page. The mute covers this message, not the two shared alarms send_alert
+    # raises when the delivery pipeline itself is broken (a failed write-ahead
+    # persist, or a missing webhook secret): those stay audible for every producer,
+    # deliberately, because a dead pipeline on a machine whose only regular traffic
+    # is this heartbeat would otherwise be indistinguishable from a quiet, healthy
+    # one. See the loud-for-every-caller note on _osquery_notify_local_durable.
+    # Fire-and-forget otherwise: the heartbeat advances no state, so a send failure
+    # is low-stakes (the next day re-fires; the watchdog is the pager).
     send_alert CRIT "$title" "$detail" "" || true
   else
     # UNHEALTHY. Three honest sub-cases, each rendered with a POSITIVE number so the
@@ -87,8 +94,10 @@ main() {
       age=$((now - last_canary_timestamp))
       detail="- osqueryd scheduled heartbeat canary is STALE (last ${age}s ago, over ${canary_max_age}s). The root daemon is not producing scheduled results (stopped or wedged). The uptime watchdog pages on this; this note is the silent daily record."
     fi
-    # Muted too (empty sound): the heartbeat never pings, even when it reports a
-    # problem. The watchdog is what pages; this note is the silent daily record.
+    # Muted too (empty sound): the heartbeat's own message never pings, even when it
+    # reports a problem. The watchdog is what pages; this note is the silent daily
+    # record. The same pipeline-broken exception as the healthy branch applies here,
+    # and for the same reason.
     send_alert CRIT "$title" "$detail" "" || true
   fi
 }

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -79,11 +79,21 @@ _pipeline_mtime() {
 }
 
 # _pipeline_manifest_is_trustworthy <path>: 0 when the manifest may be trusted to
-# SUPPRESS a page. The whole design rests on the manifest being root-owned and not
-# group/world-writable (an attacker who could write it could self-whitelist a file
-# they just tampered), so verify that rather than assume it: a permissions drift
-# then degrades LOUDLY (everything pages) instead of silently (anything can be
-# blessed).
+# SUPPRESS a page. Whoever can write the manifest can self-whitelist a file they
+# just tampered, so root ownership and a not-group/world-writable mode are VERIFIED
+# here rather than assumed: a permissions drift then degrades LOUDLY (everything
+# pages) instead of silently (anything can be blessed).
+#
+# What that ownership actually buys, stated without overclaiming. It stops a process
+# that stays at the user's privilege level, which cannot rewrite a root-owned 0644
+# file, and it turns a drifted mode into loud pages. It is NOT a boundary against a
+# determined user-level attacker on a host with passwordless sudo, which this one
+# is: a process running as the operator can escalate with no prompt and rewrite the
+# manifest at will, whitelisting whatever it just tampered. Requiring a password
+# would be the only thing that changed that, and every unattended chezmoi script
+# depends on the current configuration, so this is a recorded limit of the layer,
+# not a defect to fix here. The honest summary is a raised bar plus a loud failure
+# mode, not an integrity guarantee that survives a user-level attacker.
 #
 # Test seam: the check applies only at the PRODUCTION DEFAULT path. Tests point
 # OSQUERY_PIPELINE_MANIFEST at a fixture manifest they own, which is by definition

--- a/test/e2e/osquery-alert-drainer.bats
+++ b/test/e2e/osquery-alert-drainer.bats
@@ -23,7 +23,20 @@ setup() {
   cp "$DISPATCH" "$HARNESS_HOME/.local/libexec/osquery/alert-dispatch.sh"
   DRAINER="$BATS_TEST_DIRNAME/../../dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh"
 }
-teardown() { teardown_dispatch_harness; }
+# Reap any banner stub the fd-leak pin left running before the harness HOME is
+# removed, so a failed assertion cannot orphan a sleeping process on the machine.
+# Guarded on the pid file existing, so every other test in this file is unaffected.
+teardown() {
+  if [[ -n ${BANNER_PID_FILE:-} && -s ${BANNER_PID_FILE:-} ]]; then
+    local banner_pid
+    while read -r banner_pid || [[ -n $banner_pid ]]; do
+      if [[ -n $banner_pid ]]; then
+        kill "$banner_pid" 2>/dev/null || true
+      fi
+    done <"$BANNER_PID_FILE"
+  fi
+  teardown_dispatch_harness
+}
 
 @test "T-DRAIN-lock-single-send: two overlapping drains deliver each stored page exactly once" {
   # The single-instance lock is a kernel lock (/usr/bin/lockf). A host without
@@ -76,6 +89,79 @@ STUB
   done
   # Delivery really happened: the store is empty, no row left behind.
   assert_pending_alert_count 0
+}
+
+@test "T-DRAIN-lock-fd-leak: a banner child outliving the drain does not keep the lock held" {
+  # The lock lives on fd 9, and a fork inherits an open fd. Every child the drain
+  # spawns while the lock is held therefore inherits fd 9, and flock releases only
+  # once EVERY descriptor on that open file description is closed, so one surviving
+  # child keeps the lock after the drainer exits. The acquire is non-blocking, so
+  # the damage is a SKIPPED sweep on each later tick until that child dies, not a
+  # hang; a skipped sweep still delays every queued page.
+  #
+  # The child used here is the real one, not a contrived stub: the drain's
+  # PIPELINE-DEGRADED path fires a durable banner whose alerter watcher is
+  # BACKGROUNDED on purpose and documented as free to outlive its caller (alerter
+  # blocks for the banner's whole 60-second life). darwin-only, like the lock.
+  [[ -x /usr/bin/lockf ]] || skip "no /usr/bin/lockf; the single-instance lock is a darwin-only guarantee"
+
+  # A max-attempts ceiling of zero puts the seeded row past the dead-letter
+  # threshold immediately, so the drain dead-letters it BEFORE any POST and fires
+  # the one PIPELINE-DEGRADED banner for the pass. No network stubbing needed.
+  export OSQUERY_DRAIN_MAX_ATTEMPTS=0
+  local url='http://127.0.0.1:8644/webhooks/osquery-priority' body_b64
+  body_b64=$(printf '{"event_type":"osquery.alert"}' | base64 | tr -d '\n')
+  _osquery_store_alert_row 1000 osquery-fd-leak "$url" "$body_b64"
+
+  # An alerter stub shaped like the real binary: it stays alive for the banner's
+  # lifetime instead of exiting at once, which is what lets it outlive the drainer.
+  # It records its pid so the test can prove it is still running (and teardown can
+  # reap it) rather than assume it.
+  export BANNER_PID_FILE="$HARNESS_HOME/banner.pid"
+  : >"$BANNER_PID_FILE"
+  cat >"$HARNESS_HOME/bin/alerter" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >>"$BANNER_PID_FILE"
+sleep 30
+STUB
+  chmod +x "$HARNESS_HOME/bin/alerter"
+
+  # Run the drainer DIRECTLY, not through bats `run`: `run` reaps the command's
+  # whole process group, which would kill the very surviving child this pin needs
+  # (verified: a backgrounded grandchild is dead after `run` and alive after a
+  # direct call).
+  local drain_status=0
+  bash "$DRAINER" >/dev/null 2>&1 || drain_status=$?
+  [[ $drain_status -eq 0 ]] # a drain always exits 0
+
+  # The banner child must genuinely still be running, or this pin proves nothing
+  # about fd inheritance and would pass for the wrong reason.
+  local banner_pid=""
+  local attempt
+  for ((attempt = 0; attempt < 40; attempt++)); do
+    [[ -s $BANNER_PID_FILE ]] && break
+    sleep 0.05
+  done
+  read -r banner_pid <"$BANNER_PID_FILE" || true
+  if [[ -z $banner_pid ]]; then
+    printf 'the drain never fired the degraded-pipeline banner, so no surviving child exists to test\n' >&2
+    return 1
+  fi
+  if ! kill -0 "$banner_pid" 2>/dev/null; then
+    printf 'the banner child (pid %s) already exited; the test cannot prove fd release\n' "$banner_pid" >&2
+    return 1
+  fi
+
+  # The bound: with the drainer gone, the lock is free. A surviving child holding
+  # an inherited fd 9 would keep it and this acquisition would fail (75).
+  local lock_file="${OSQUERY_UNDELIVERED_ALERTS_DB}.drain.lock"
+  local probe_status=0
+  (exec 7>>"$lock_file" && /usr/bin/lockf -s -t 0 7) || probe_status=$?
+  if [[ $probe_status -ne 0 ]]; then
+    printf 'the drain lock is STILL held after the drainer exited (rc %s): a surviving child inherited fd 9\n' \
+      "$probe_status" >&2
+    return 1
+  fi
 }
 
 # --- fail-closed lock setup (a mutual-exclusion lock must never run unlocked) ---

--- a/test/e2e/osquery-alert-drainer.bats
+++ b/test/e2e/osquery-alert-drainer.bats
@@ -164,6 +164,40 @@ STUB
   fi
 }
 
+@test "T-DRAIN-stderr-audible: a store failure inside the locked sweep reaches stderr" {
+  # The lock is taken with `exec 9>>FILE`, and an `exec` carrying NO COMMAND WORD
+  # applies its redirections to the SHELL, permanently. A `2>/dev/null` on that line
+  # is therefore not scoped to the open: it silences the whole rest of the script, so
+  # every diagnostic the sweep would print afterwards is eaten. That is fail-quiet on
+  # a delivery-path component, where the drain's only channel for an unreadable store
+  # is exactly that stderr line (the drain always exits 0 by design, so the exit
+  # status can never carry the news).
+  #
+  # A lockf stub makes the "lock is REQUIRED" path run on any platform, so the exec
+  # is reached here exactly as it is in production.
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$HARNESS_HOME/bin/lockf-stub"
+  chmod +x "$HARNESS_HOME/bin/lockf-stub"
+  export OSQUERY_DRAIN_LOCKF_BIN="$HARNESS_HOME/bin/lockf-stub"
+
+  # A store that EXISTS but is not a database: the sweep gets past its missing-store
+  # guard, sqlite3 then fails, and the library reports that on stderr.
+  mkdir -p "$(dirname "$OSQUERY_UNDELIVERED_ALERTS_DB")"
+  printf 'this file is not a sqlite database\n' >"$OSQUERY_UNDELIVERED_ALERTS_DB"
+
+  local captured="$HARNESS_HOME/drain-stderr.txt" drain_status=0
+  bash "$DRAINER" >/dev/null 2>"$captured" || drain_status=$?
+  [[ $drain_status -eq 0 ]] # still a best-effort sweep: the news is on stderr, not in the status
+
+  if [[ ! -s $captured ]]; then
+    printf 'the drain said NOTHING on stderr about an unreadable store: the lock exec redirected the whole script to /dev/null\n' >&2
+    return 1
+  fi
+  if ! grep -qiE 'not a database' "$captured"; then
+    printf 'the drain wrote to stderr but not the store failure; got: %s\n' "$(cat "$captured")" >&2
+    return 1
+  fi
+}
+
 # --- fail-closed lock setup (a mutual-exclusion lock must never run unlocked) ---
 
 # Seed one deliverable page and queue a 200: if the sweep RUNS it delivers, if it

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -115,6 +115,48 @@ assert_mode() {
   fi
 }
 
+# _alerter_banner_line <title-substring> -- print the recorded alerter invocation
+# whose argv contains <title-substring>, or nothing when none did. The stub records
+# one line per invocation, so a substring unique to a banner's title selects it.
+_alerter_banner_line() {
+  grep -F -- "$1" "$ALERTER_LOG" 2>/dev/null || true
+}
+
+# assert_banner_sound <title-substring> <sound> -- the named banner was fired WITH
+# that notification sound (an audible banner). A banner that never fired fails,
+# so this can never pass vacuously.
+assert_banner_sound() {
+  local line
+  line="$(_alerter_banner_line "$1")"
+  if [[ -z $line ]]; then
+    printf 'no alerter banner matching %s was fired; alerter log: %s\n' "$1" "$(cat "$ALERTER_LOG")" >&2
+    return 1
+  fi
+  if [[ $line != *"--sound $2"* ]]; then
+    printf 'expected the %s banner to carry --sound %s; recorded: %s\n' "$1" "$2" "$line" >&2
+    return 1
+  fi
+}
+
+# refute_banner_sound <title-substring> -- the named banner was fired with NO
+# notification sound at all (a silent banner). A plain refute helper, never a bare
+# `! grep`: an inverted status is ignored under set -e, so the assertion would be a
+# silent no-op. The banner must have FIRED, or this fails rather than passing on
+# its absence.
+refute_banner_sound() {
+  local line
+  line="$(_alerter_banner_line "$1")"
+  if [[ -z $line ]]; then
+    printf 'no alerter banner matching %s was fired, so its silence proves nothing; alerter log: %s\n' \
+      "$1" "$(cat "$ALERTER_LOG")" >&2
+    return 1
+  fi
+  if [[ $line == *--sound* ]]; then
+    printf 'expected the %s banner to be SILENT (no --sound); recorded: %s\n' "$1" "$line" >&2
+    return 1
+  fi
+}
+
 # assert_post_count <n> -- the curl stub recorded exactly <n> POSTs.
 assert_post_count() {
   local count

--- a/test/helpers/build-dispatch-harness.sh
+++ b/test/helpers/build-dispatch-harness.sh
@@ -157,6 +157,31 @@ refute_banner_sound() {
   fi
 }
 
+# refute_file_contains <fixed-substring> <file> -- fail when the substring appears.
+# The house negative-assertion shape (same spelling as the tailscale and watchdog
+# fixtures). A bare `! grep -q ...` must never be used instead: set -e ignores a
+# status inverted by `!`, so such a line only fails a test when it happens to be
+# the LAST command in the body, and silently guards nothing anywhere else.
+refute_file_contains() {
+  if grep -qiF -- "$1" "$2"; then
+    printf 'expected %q NOT to appear in %s, but it does:\n%s\n' "$1" "$2" "$(cat "$2")" >&2
+    return 1
+  fi
+  return 0
+}
+
+# refute_tree_contains <fixed-substring> <directory> -- fail when the substring
+# appears in ANY file under the directory. The recursive companion to
+# refute_file_contains, for assertions over a directory of captured output.
+refute_tree_contains() {
+  if grep -rqiF -- "$1" "$2"; then
+    printf 'expected %q NOT to appear anywhere under %s, but it does:\n%s\n' \
+      "$1" "$2" "$(grep -riF -- "$1" "$2")" >&2
+    return 1
+  fi
+  return 0
+}
+
 # assert_post_count <n> -- the curl stub recorded exactly <n> POSTs.
 assert_post_count() {
   local count

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -149,6 +149,44 @@ teardown() { teardown_dispatch_harness; }
   wait_for_log_line 'FAILED|lost|could not' "$ALERTER_LOG"
 }
 
+# --- what MUTED covers, and what it deliberately does not -------------------------
+# A muted caller (the heartbeat, the digest) passes an empty sound so its own
+# message is locally silent and goes on the wire as tier=muted. That promise covers
+# THAT MESSAGE. It does not cover the two shared alarms send_alert raises when the
+# delivery pipeline itself is broken, which stay audible for every caller: a broken
+# pipeline is a systemic condition, and on a machine whose only regular traffic is
+# the muted heartbeat and digest a silent alarm would leave a dead pipeline
+# indistinguishable from a quiet, healthy one, the exact failure the whole durable
+# design exists to prevent. These two pins hold that split honest in both
+# directions: the caller's own banner silent, the systemic alarm loud.
+
+@test "T-DISP-muted-store-broken-loud: a muted caller stays silent while the store-broken alarm is LOUD" {
+  # The DB parent is a FILE, so the write-ahead persist fails for any uid (the same
+  # deterministic trick the other hard-fail pins use).
+  : >"$ALERTER_LOG"
+  set_curl_codes 503 503 503
+  touch "$HARNESS_HOME/mutednotdir"
+  export OSQUERY_UNDELIVERED_ALERTS_DB="$HARNESS_HOME/mutednotdir/store.sqlite3"
+  run_dispatch send_output send_status CRIT "🗒️ daily digest" "detail body" "" "occ:muted-hardfail:1"
+  [[ $send_status -ne 0 ]] # the page was neither delivered nor stored
+  wait_for_log_line 'page LOST' "$ALERTER_LOG"
+  refute_banner_sound "daily digest"        # the caller's OWN message keeps its promise
+  assert_banner_sound "page LOST" "Funk"    # the systemic alarm breaks silence on purpose
+}
+
+@test "T-DISP-muted-no-secret-loud: a muted caller stays silent while the missing-key alarm is LOUD" {
+  # No signing key: the page is stored durably, but the Discord channel is broken
+  # until the secret is restored, which is the second systemic alarm.
+  unset OSQUERY_WEBHOOK_SECRET
+  : >"$ALERTER_LOG"
+  run_dispatch send_output send_status CRIT "🗒️ daily digest" "detail body" "" "occ:muted-nosecret:1"
+  [[ $send_status -eq 0 ]]     # the page is safely stored, so the caller is not failed
+  assert_pending_alert_count 1
+  wait_for_log_line 'paging BROKEN' "$ALERTER_LOG"
+  refute_banner_sound "daily digest"
+  assert_banner_sound "paging BROKEN" "Funk"
+}
+
 @test "T-DISP-tier-page: a real page (non-empty sound) POSTs tier=page (R2-11)" {
   send_alert CRIT "🔴 title" "detail" "Sosumi"
   assert_post_count 1

--- a/test/integration/osquery-dispatch.bats
+++ b/test/integration/osquery-dispatch.bats
@@ -197,7 +197,7 @@ teardown() { teardown_dispatch_harness; }
   send_alert CRIT "🗒️ daily digest" "detail" ""
   assert_post_count 1 # it DOES reach the remote POST (not moot)
   grep -qF '"tier":"muted"' "$CURL_LOG"
-  ! grep -qF '"tier":"page"' "$CURL_LOG"
+  refute_file_contains '"tier":"page"' "$CURL_LOG"
 }
 
 @test "T-DISP-body-ts: a CRIT body carries a numeric occurrence ts (the drain ordering key)" {
@@ -259,7 +259,9 @@ STUB
   for i in 1 2; do
     [[ "$(cat "$status_dir/drain-$i.status")" == "0" ]]
   done
-  ! grep -rqi 'database is locked' "$status_dir" # busy_timeout serializes, never errors
+  # busy_timeout plus the locked-retry serialize the writers: no producer or drain
+  # ever SAW a locked error, not merely "recovered from one".
+  refute_tree_contains 'database is locked' "$status_dir"
   [[ "$(sqlite3_query 'SELECT COUNT(*) FROM pending_alerts;')" == "$producer_count" ]]
   [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT request_id) FROM pending_alerts;')" == "$producer_count" ]]
   [[ "$(sqlite3_query 'SELECT COUNT(DISTINCT sequence_number) FROM pending_alerts;')" == "$producer_count" ]]
@@ -340,7 +342,7 @@ STUB
   export OSQUERY_WEBHOOK_SECRET="SUPERSECRET-argv-probe"
   send_alert CRIT "🔴 title" "detail" "Sosumi"
   [[ -s $OPENSSL_ARGV_LOG ]] # openssl WAS invoked (sanity)
-  ! grep -qF 'SUPERSECRET-argv-probe' "$OPENSSL_ARGV_LOG"
+  refute_file_contains 'SUPERSECRET-argv-probe' "$OPENSSL_ARGV_LOG"
 }
 
 @test "T-DISP-signing-failure: a failed signature makes NO POST and retains the write-ahead record" {

--- a/test/integration/osquery-heartbeat.bats
+++ b/test/integration/osquery-heartbeat.bats
@@ -3,9 +3,11 @@
 # sends ONE silent message to #priority so the operator can trust silence = safe.
 # R2-8: it must verify the ROOT DAEMON. A standalone osqueryi one-shot answers even
 # while osqueryd is stopped or wedged, so instead the heartbeat checks that the
-# daemon's OWN scheduled heartbeat_canary snapshot is FRESH. Always muted (never
-# pings), honest (reports a stale canary rather than a blind checkmark); the uptime
-# watchdog is what PAGES.
+# daemon's OWN scheduled heartbeat_canary snapshot is FRESH. Always muted (its
+# message never pings; send_alert's pipeline-broken alarms are audible for every
+# producer by design, and this suite stubs send_alert so it judges only the sound
+# the heartbeat ASKS for), honest (reports a stale canary rather than a blind
+# checkmark); the uptime watchdog is what PAGES.
 #
 # This suite exercises the script as a black box against a stubbed dispatch: a
 # message-recording spy replaces the real send_alert at the exact libexec path the


### PR DESCRIPTION
## Context

Five small independent fixes to the osquery alerting pipeline, gathered from adversarial reviews of the
recently re-landed slices. Three are behavioral, two correct documentation that promised more than the code
delivers.

The common thread is silence: a lock that outlived its holder, a redirection that muted an entire script,
comments that described protections which do not exist, and three test assertions that could never fail.

## Summary

- The alert drainer no longer leaks its lock file descriptor to a backgrounded child.
- The drainer's error output is no longer silenced for the whole script by its lock setup.
- Muted callers and the shared sender now tell one consistent story about what a mute actually covers.
- The manifest comments no longer claim a protection that passwordless sudo removes on this host.
- Three dispatch assertions that could not fail are converted so they can.

Key files: `dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh`,
`executable_alert-dispatch.sh`, `test/integration/osquery-dispatch.bats`.

## The two behavioral fixes

**The lock outlived its holder.** The drainer takes a single-instance lock on a file descriptor. The
prescribed remedy for this class is to close that descriptor on the commands the script forks, but that
was not sufficient here, and measuring showed why. The child holding the lock open was not an external
command at all: it was a backgrounded watcher subshell. Bash implements a redirection scoped to a single
command by first duplicating the descriptor so it can restore it afterward, and the forked subshell
inherited that duplicate. With the scoped close in place, the surviving watcher was still holding the lock
on a different descriptor number. The fix closes the descriptor for real, inside a subshell, leaving no
duplicate to inherit.

**The lock setup silenced the whole script.** The line acquiring that lock redirected its own error output
away, but it had no command word, so bash applied the redirection to the shell itself and it never came
back. Every later error from the drain went nowhere. Since the drain deliberately always exits zero, its
error output was its only channel, which meant an unreadable alert store looked exactly like an empty one.
Measured against a corrupt store: the underlying library reports a parse error and the drainer emitted
nothing at all.

## The documentation fixes

A caller that asks for a silent notification is making a promise about its own message. The shared sender
also raises a loud alarm when the delivery pipeline itself is broken, and that alarm belongs to no single
caller. Silencing it would be worst precisely where it looks most correct: on a machine whose only routine
traffic is a daily heartbeat and digest, a silent alarm makes a dead pipeline indistinguishable from a
quiet healthy one, which is the failure the durable design exists to prevent. The behavior is unchanged and
correct; the documentation now says so consistently across the sender and both muted callers. A second
loud path, a missing webhook secret, is far likelier than a broken store and is now covered by the same
wording and its own test.

Separately, the pipeline manifest is root-owned so that a process running as the user cannot bless a file
it just tampered with. Verified on this host, `sudo` requires no password, so that process can simply
escalate. The configuration is deliberate and every unattended script depends on it, so nothing changed
except the wording, which now states what root ownership actually buys and what it does not.

## The three assertions that could not fail

A negative assertion written as a bare inverted command is exempted from the shell's error checking, so it
reports nothing when it fails. Whether it works at all turns out to depend on its position: as the final
line of a test it is read as the result, and anywhere else it is inert. Of the three found here, two worked
by that accident and one had been contributing nothing since it was written. All three are converted, and
each was confirmed to fail under a faithful regression before being accepted.

## How it was reviewed

Every behavioral change has a test confirmed to fail against the old code, pass after the fix, and fail
again when the fix is reverted. The documentation changes are pinned by tests asserting both directions:
the caller's own message stays silent while the systemic alarm stays audible.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover.
