### PR TITLE
feat(osquery): periodic manifest content audit in the uptime watchdog

### DIFF
--- a/dot_local/libexec/osquery/executable_pipeline-audit.sh
+++ b/dot_local/libexec/osquery/executable_pipeline-audit.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# pipeline-audit.sh, sourced helper, not run directly. The PERIODIC CONTENT AUDIT
+# of the osquery pipeline: it reads the root-owned pipeline-integrity manifest,
+# hashes every path the manifest lists, and reports each path whose CURRENT state
+# disagrees with its recorded tuple. Sourced by the uptime watchdog, which runs it
+# once per 15-minute tick.
+#
+# WHY A SCHEDULED AUDIT AND NOT ANOTHER EVENT CHECK. Until this existed, the
+# manifest was enforced only through osquery file_events, and osquery watches
+# PATHS. An attacker who hard-links a manifested script to a writable path outside
+# the pipeline home and then overwrites the outside alias mutates the SAME INODE:
+# the filesystem event names the attacker's path, nothing fires for the watched
+# path, no verdict runs, and the tampered script executes with nothing paged. A
+# symlink referent gives the same blind spot. That is a gap in EVENT GENERATION,
+# not in the verdict, so no amount of judging events can close it. Comparing bytes
+# on a schedule can, because it never depends on an event having fired.
+#
+# Usage (from a sourcing script):
+#   source "$HOME/.local/libexec/osquery/pipeline-audit.sh"
+#   findings="$(pipeline_audit_scan)" || reason="$findings"
+#
+# The manifest path constant and the root-ownership check are REUSED from the
+# verdict helper rather than copied: the producer/consumer agreement on a
+# security-critical file is already pinned by a test, and a third copy of either
+# would be a third thing to drift. Sourced unconditionally, exactly as the
+# watchdog sources its other two helpers: if a pipeline helper is missing, the
+# subsystem is already broken and the alerter pages the DELETED file event.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
+# COST, measured rather than assumed. The real manifest lists 25 files totalling
+# about 224 KiB, and a full scan of them takes ~0.75s wall clock on this host: one
+# stat (~4ms) and one shasum (~28ms) fork per file, with the hashing itself lost in
+# the noise. shasum is a Perl script, so its startup, not the SHA-256, is nearly all
+# of that. A single batched shasum over every path would cut it to ~0.05s, and is
+# deliberately not done: it would have to be parsed back by path (an output line is
+# absent for a file that vanished mid-scan, and some implementations escape unusual
+# filenames), which trades an obviously-correct loop for a false-page vector. At one
+# scan per 15-minute tick this is a 0.08% duty cycle, and the audit runs LAST, so it
+# delays none of the other probes.
+#
+# Bounds, so one tick cannot become a long-running process. Every one of them
+# fails toward a page, never toward a quiet skip:
+#   MAX_ENTRIES  - a manifest longer than this is refused whole (a partial audit
+#                  that reported "clean" would be a lie about the unread tail).
+#                  The real manifest lists roughly 25 files.
+#   MAX_BYTES    - a manifested file larger than this is NOT hashed; hashing is
+#                  the only work an attacker can inflate, and a pipeline script
+#                  that suddenly weighs megabytes is itself a divergence.
+#   BUDGET       - a wall-clock ceiling for the whole scan.
+# Each is validated as a plain decimal and clamped on BOTH sides, so a hostile or
+# fat-fingered environment cannot turn a bound into unbounded work (or into
+# nonsense arithmetic).
+OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES="${OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES:-500}"
+OSQUERY_PIPELINE_AUDIT_MAX_BYTES="${OSQUERY_PIPELINE_AUDIT_MAX_BYTES:-8388608}"
+OSQUERY_PIPELINE_AUDIT_BUDGET_SECONDS="${OSQUERY_PIPELINE_AUDIT_BUDGET_SECONDS:-60}"
+
+# _pipeline_audit_clamp <value> <min> <max> <default>: print <value> when it is a
+# plain decimal inside [min, max], else <default>. The regex bounds the DIGIT
+# COUNT before the value ever reaches arithmetic, so an over-range value cannot
+# overflow, and a leading zero cannot be read as octal.
+_pipeline_audit_clamp() {
+  local value="$1" low="$2" high="$3" fallback="$4"
+  [[ $value =~ ^(0|[1-9][0-9]{0,9})$ ]] || {
+    printf '%s' "$fallback"
+    return 0
+  }
+  if ((value < low)) || ((value > high)); then
+    printf '%s' "$fallback"
+    return 0
+  fi
+  printf '%s' "$value"
+}
+
+# _pipeline_audit_now: current epoch seconds, without a fork where bash 5 provides
+# it (the same idiom the verdict helper uses).
+_pipeline_audit_now() {
+  printf '%s' "${EPOCHSECONDS:-$(date +%s)}"
+}
+
+# _pipeline_audit_size <path>: byte size, or empty when it cannot be read. GNU stat
+# first (the nix shell), BSD stat as the fallback (the portable order used
+# throughout this feature-set).
+_pipeline_audit_size() {
+  stat -c '%s' "$1" 2>/dev/null || stat -f '%z' "$1" 2>/dev/null
+}
+
+# pipeline_audit_scan: audit every manifested path against its recorded tuple.
+#
+#   return 0 - the scan COMPLETED. Each divergence is one stdout line,
+#              "<kind> <path>", in manifest order; no output means the deployed
+#              tree matches the manifest exactly. Kinds:
+#                content     the bytes on disk differ from the recorded hash
+#                missing     nothing exists at the manifested path
+#                irregular   a symlink or a non-regular file stands there
+#                oversize    too large to hash within the tick's bound
+#                unreadable  present and regular, but its size or hash failed
+#   return 1 - the scan could NOT be completed, and stdout is a single reason
+#              TOKEN: missing (absent, unreadable, or empty manifest),
+#              untrustworthy (not root-owned, or group/world-writable),
+#              malformed (a line that is not "<sha256>  <absolute-path>"),
+#              overlong (more entries than the audit will examine), budget (the
+#              wall-clock ceiling was reached first).
+#
+# The completion/return split is the fail-safe hinge. "No output" alone would read
+# identically for "nothing diverged" and "the scan never got started", and a
+# monitor that goes quiet when its own input breaks is the failure mode this whole
+# subsystem exists to avoid. Every refusal is the caller's cue to page.
+#
+# SCOPE, recorded honestly: this audits MANIFEST -> DISK. A file planted under the
+# pipeline home that the manifest does not list is not found here; that direction
+# is the alerter's, which pages any tracked path whose tuple it cannot confirm.
+pipeline_audit_scan() {
+  local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
+  local max_entries max_bytes budget
+  max_entries="$(_pipeline_audit_clamp "$OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES" 1 100000 500)"
+  max_bytes="$(_pipeline_audit_clamp "$OSQUERY_PIPELINE_AUDIT_MAX_BYTES" 1 1073741824 8388608)"
+  # A zero budget is a legitimate (if drastic) setting: it refuses immediately and
+  # therefore pages, which is the safe direction, and it makes the exhausted-budget
+  # path testable without a sleep.
+  budget="$(_pipeline_audit_clamp "$OSQUERY_PIPELINE_AUDIT_BUDGET_SECONDS" 0 300 60)"
+
+  # An unusable manifest is refused before anything is judged: without a trustworthy
+  # list there is no known-good to compare against, and "found nothing" would be a
+  # false all-clear. -s rejects an empty manifest, which a truncated write leaves.
+  [[ -r $manifest && -s $manifest ]] || {
+    printf 'missing\n'
+    return 1
+  }
+  _pipeline_manifest_is_trustworthy "$manifest" || {
+    printf 'untrustworthy\n'
+    return 1
+  }
+
+  # The manifest is shasum format, "<sha256>  <path>" with exactly two spaces. The
+  # line is matched WHOLE rather than split into fields: a path may contain spaces,
+  # and word-splitting would silently truncate it into a path that exists nowhere
+  # (which would then report as a bogus divergence forever). The path must be
+  # absolute, because the audit resolves nothing itself and a relative path would be
+  # read against whatever directory launchd happened to start the caller in.
+  local line_pattern='^([0-9a-fA-F]{64}) {2}(/.+)$'
+  local deadline entries=0 line want_hash target size disk_hash
+  deadline=$(($(_pipeline_audit_now) + budget))
+
+  # `|| [[ -n $line ]]` so a final line with no trailing newline is still examined
+  # (the same idiom the verdict helper reads the manifest with).
+  while IFS= read -r line || [[ -n $line ]]; do
+    entries=$((entries + 1))
+    if ((entries > max_entries)); then
+      printf 'overlong\n'
+      return 1
+    fi
+    if (($(_pipeline_audit_now) >= deadline)); then
+      printf 'budget\n'
+      return 1
+    fi
+    if [[ ! $line =~ $line_pattern ]]; then
+      printf 'malformed\n'
+      return 1
+    fi
+    # Lower-cased on both sides: shasum and osquery both emit lowercase, so this is
+    # documented defense in depth against a future producer, and it costs nothing.
+    want_hash="${BASH_REMATCH[1],,}"
+    target="${BASH_REMATCH[2]}"
+    # A manifested path must hold a REGULAR FILE, and links are never followed. A
+    # symlink standing where a pipeline script belongs would otherwise be hashed
+    # THROUGH to content the manifest vouches for, while the bytes that actually
+    # execute live somewhere the manifest does not cover and nothing watches: the
+    # same blind spot in a second shape.
+    if [[ -L $target ]]; then
+      printf 'irregular %s\n' "$target"
+    elif [[ ! -e $target ]]; then
+      printf 'missing %s\n' "$target"
+    elif [[ ! -f $target ]]; then
+      printf 'irregular %s\n' "$target"
+    else
+      size="$(_pipeline_audit_size "$target")"
+      if [[ ! $size =~ ^(0|[1-9][0-9]{0,18})$ ]]; then
+        printf 'unreadable %s\n' "$target"
+      elif ((size > max_bytes)); then
+        printf 'oversize %s\n' "$target"
+      else
+        # The hash is cut with parameter expansion rather than piped through awk:
+        # the audit runs this once per manifested file, and a saved fork per file is
+        # most of the tick's cost. shasum prints "<hash>  <path>", so everything from
+        # the first space on is dropped.
+        disk_hash="$(shasum -a 256 -- "$target" 2>/dev/null)"
+        disk_hash="${disk_hash%% *}"
+        disk_hash="${disk_hash,,}"
+        if [[ ! $disk_hash =~ ^[0-9a-f]{64}$ ]]; then
+          printf 'unreadable %s\n' "$target"
+        elif [[ $disk_hash != "$want_hash" ]]; then
+          printf 'content %s\n' "$target"
+        fi
+      fi
+    fi
+  done <"$manifest"
+  return 0
+}

--- a/dot_local/libexec/osquery/executable_pipeline-audit.sh
+++ b/dot_local/libexec/osquery/executable_pipeline-audit.sh
@@ -23,11 +23,19 @@
 # The manifest path constant and the root-ownership check are REUSED from the
 # verdict helper rather than copied: the producer/consumer agreement on a
 # security-critical file is already pinned by a test, and a third copy of either
-# would be a third thing to drift. Sourced unconditionally, exactly as the
-# watchdog sources its other two helpers: if a pipeline helper is missing, the
-# subsystem is already broken and the alerter pages the DELETED file event.
-# shellcheck source=/dev/null
-source "$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+# would be a third thing to drift.
+#
+# Sourced CONDITIONALLY, and its absence is reported by the scan rather than
+# thrown. Every caller runs under `set -euo pipefail`, so an unconditional source
+# of a file someone had deleted would abort the caller mid-run: the watchdog would
+# die in the middle of its tick and page nothing at all, which is precisely the
+# silent-monitor failure this audit exists to prevent. A missing dependency has to
+# be loud, and the only way to be loud is to survive long enough to say so.
+_pipeline_audit_verdict_helper="$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+if [[ -r $_pipeline_audit_verdict_helper ]]; then
+  # shellcheck source=/dev/null
+  source "$_pipeline_audit_verdict_helper"
+fi
 
 # COST, measured rather than assumed. The real manifest lists 25 files totalling
 # about 224 KiB, and a full scan of them takes ~0.75s wall clock on this host: one
@@ -98,6 +106,7 @@ _pipeline_audit_size() {
 #                unreadable  present and regular, but its size or hash failed
 #   return 1 - the scan could NOT be completed, and stdout is a single reason
 #              TOKEN: missing (absent, unreadable, or empty manifest),
+#              unavailable (the verdict helper it reuses is not installed),
 #              untrustworthy (not root-owned, or group/world-writable),
 #              malformed (a line that is not "<sha256>  <absolute-path>"),
 #              overlong (more entries than the audit will examine), budget (the
@@ -112,7 +121,13 @@ _pipeline_audit_size() {
 # pipeline home that the manifest does not list is not found here; that direction
 # is the alerter's, which pages any tracked path whose tuple it cannot confirm.
 pipeline_audit_scan() {
-  local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
+  # The reused seam has to actually be here. Checked by NAME rather than assumed,
+  # so a partial deploy reports a broken audit instead of an all-clear.
+  if ! declare -F _pipeline_manifest_is_trustworthy >/dev/null 2>&1; then
+    printf 'unavailable\n'
+    return 1
+  fi
+  local manifest="${OSQUERY_PIPELINE_MANIFEST:-${PIPELINE_MANIFEST:-}}"
   local max_entries max_bytes budget
   max_entries="$(_pipeline_audit_clamp "$OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES" 1 100000 500)"
   max_bytes="$(_pipeline_audit_clamp "$OSQUERY_PIPELINE_AUDIT_MAX_BYTES" 1 1073741824 8388608)"

--- a/dot_local/libexec/osquery/executable_pipeline-audit.sh
+++ b/dot_local/libexec/osquery/executable_pipeline-audit.sh
@@ -38,10 +38,10 @@ if [[ -r $_pipeline_audit_verdict_helper ]]; then
 fi
 
 # COST, measured rather than assumed. The real manifest lists 25 files totalling
-# about 224 KiB, and a full scan of them takes ~0.75s wall clock on this host: one
-# stat (~4ms) and one shasum (~28ms) fork per file, with the hashing itself lost in
-# the noise. shasum is a Perl script, so its startup, not the SHA-256, is nearly all
-# of that. A single batched shasum over every path would cut it to ~0.05s, and is
+# about 230 KiB, and a full scan of them takes 0.6 to 0.8s wall clock on this host:
+# one stat (~4ms) and one shasum (~28ms) fork per file, with the hashing itself lost
+# in the noise. shasum is a Perl script, so its startup, not the SHA-256, is nearly
+# all of that. A single batched shasum over every path would cut it to ~0.05s, and is
 # deliberately not done: it would have to be parsed back by path (an output line is
 # absent for a file that vanished mid-scan, and some implementations escape unusual
 # filenames), which trades an obviously-correct loop for a false-page vector. At one

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -364,6 +364,9 @@ if [[ $audit_should_page -eq 1 ]]; then
       missing)
         problems+=("the pipeline-integrity manifest is missing or unreadable, so the periodic content audit cannot verify the deployed pipeline; tampering would go unseen until it is restored")
         ;;
+      unavailable)
+        problems+=("the periodic content audit is not installed completely (the pipeline-integrity manifest helper it reads is missing), so the deployed pipeline is unverified")
+        ;;
       untrustworthy)
         problems+=("the pipeline-integrity manifest is no longer root-owned (or is group/world-writable), so it can no longer vouch for the deployed pipeline")
         ;;

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -66,8 +66,17 @@ source "$HOME/.local/libexec/osquery/canary-freshness.sh"
 # The periodic content audit of the pipeline-integrity manifest (probe 5). It also
 # pulls in the verdict helper, which owns the manifest path and the root-ownership
 # check both consumers share.
-# shellcheck source=/dev/null
-source "$HOME/.local/libexec/osquery/pipeline-audit.sh"
+#
+# Sourced CONDITIONALLY, unlike the two helpers above. Those are hard dependencies:
+# without the dispatcher nothing can page at all, and without the canary seam probe
+# 1 has nothing to read. Probe 5 is not: the other four probes work perfectly well
+# without it, so a missing audit seam must degrade to a LOUD probe-5 failure rather
+# than abort the tick under errexit and leave a genuinely down pipeline unreported.
+_watchdog_audit_seam="$HOME/.local/libexec/osquery/pipeline-audit.sh"
+if [[ -r $_watchdog_audit_seam ]]; then
+  # shellcheck source=/dev/null
+  source "$_watchdog_audit_seam"
+fi
 
 # Never leave a partial temp state (or the writability probe) behind, on any exit path.
 trap 'rm -f "$STATE.tmp" "$STATE.probe"' EXIT
@@ -274,7 +283,12 @@ fi
 #    token) rather than report a false all-clear when the manifest itself cannot be
 #    used, and it is bounded on entries, per-file bytes, and wall clock.
 audit_rc=0
-audit_report="$(pipeline_audit_scan 2>/dev/null)" || audit_rc=$?
+if declare -F pipeline_audit_scan >/dev/null 2>&1; then
+  audit_report="$(pipeline_audit_scan 2>/dev/null)" || audit_rc=$?
+else
+  audit_rc=1
+  audit_report="unavailable"
+fi
 audit_reason=""
 audit_divergence_count=0
 if [[ $audit_rc -ne 0 ]]; then
@@ -365,7 +379,7 @@ if [[ $audit_should_page -eq 1 ]]; then
         problems+=("the pipeline-integrity manifest is missing or unreadable, so the periodic content audit cannot verify the deployed pipeline; tampering would go unseen until it is restored")
         ;;
       unavailable)
-        problems+=("the periodic content audit is not installed completely (the pipeline-integrity manifest helper it reads is missing), so the deployed pipeline is unverified")
+        problems+=("the periodic content audit is not installed completely (a helper it needs is missing), so the deployed pipeline is unverified against the pipeline-integrity manifest")
         ;;
       untrustworthy)
         problems+=("the pipeline-integrity manifest is no longer root-owned (or is group/world-writable), so it can no longer vouch for the deployed pipeline")

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -8,15 +8,24 @@
 # healthy. Deliberately does NOT use results.log mtime as a signal: hours of
 # healthy silence are expected.
 #
+# It also carries the pipeline's only SCHEDULED integrity check. The rest of the
+# pipeline-integrity manifest is enforced through osquery file_events, and osquery
+# watches PATHS, so tampering that generates no event on a watched path (a hard link
+# or a symlink pointing the executed bytes somewhere else) is invisible to it. The
+# content audit below hashes every manifested path on each tick, which needs no
+# event to have fired.
+#
 # Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
 # unloaded or unknown-state agent, a wedged osqueryd, an unhealthy route, an
-# unreadable queue count) resolves to a CRIT, never a silent all-healthy. A
-# watchdog that fails quietly is worse than no watchdog.
+# unreadable queue count, a manifest the audit cannot use) resolves to a CRIT, never
+# a silent all-healthy. A watchdog that fails quietly is worse than no watchdog.
 #
 # The watchdog only READS: it probes the delivery queue counts but never drains it
-# (the scheduled alert-drainer owns draining), and it renders only KNOWN agent
-# labels plus validated-numeric exit codes and counts plus static text, so a value
-# influenced by a compromised launchd cannot inject into the page.
+# (the scheduled alert-drainer owns draining), it hashes the manifested files but
+# never repairs them, and it renders only KNOWN agent labels plus validated-numeric
+# exit codes and counts plus static text, so a value influenced by a compromised
+# launchd, or a path influenced by whoever tampered with the pipeline, cannot inject
+# into the page.
 
 set -euo pipefail
 
@@ -54,6 +63,11 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # daemon's scheduled canary), never a blind osqueryi one-shot.
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/canary-freshness.sh"
+# The periodic content audit of the pipeline-integrity manifest (probe 5). It also
+# pulls in the verdict helper, which owns the manifest path and the root-ownership
+# check both consumers share.
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/pipeline-audit.sh"
 
 # Never leave a partial temp state (or the writability probe) behind, on any exit path.
 trap 'rm -f "$STATE.tmp" "$STATE.probe"' EXIT
@@ -248,12 +262,138 @@ else
   growth_streak=0
 fi
 
+# 5) Periodic CONTENT AUDIT of the pipeline-integrity manifest. Every other check
+#    of that manifest hangs off osquery file_events, and osquery watches PATHS: an
+#    attacker who hard-links a manifested pipeline script to a writable path outside
+#    the pipeline home and overwrites the outside alias mutates the SAME INODE, so
+#    the event names their path, nothing fires for the watched one, no verdict runs,
+#    and the tampered script executes with nothing paged. A symlink referent is the
+#    same blind spot in a second shape. That gap is in event GENERATION, so it can
+#    only be closed by comparing bytes on a SCHEDULE. The seam hashes every
+#    manifested path and reports what disagrees; it refuses (nonzero, with a reason
+#    token) rather than report a false all-clear when the manifest itself cannot be
+#    used, and it is bounded on entries, per-file bytes, and wall clock.
+audit_rc=0
+audit_report="$(pipeline_audit_scan 2>/dev/null)" || audit_rc=$?
+audit_reason=""
+audit_divergence_count=0
+if [[ $audit_rc -ne 0 ]]; then
+  # A refusal token, validated against the shape of the fixed vocabulary before it
+  # can select a message; anything unexpected still pages, via the default arm.
+  audit_reason="$audit_report"
+  [[ $audit_reason =~ ^[a-z]{1,32}$ ]] || audit_reason="unknown"
+elif [[ -n $audit_report ]]; then
+  audit_divergence_count="$(printf '%s\n' "$audit_report" | wc -l | tr -d '[:space:]')"
+  # A count that cannot be read must not read as ZERO (that would silently discard a
+  # real divergence): fall back to the refusal path, which pages.
+  if [[ ! $audit_divergence_count =~ ^[1-9][0-9]{0,5}$ ]]; then
+    audit_reason="unknown"
+    audit_divergence_count=0
+  fi
+fi
+
+# Page-once discipline, on the watchdog's existing streak conventions. The audit is
+# LEVEL-triggered against a condition that can persist for days, so re-paging every
+# 15 minutes would train the operator to ignore it. The findings are reduced to a
+# FINGERPRINT (a sha256 over the sorted report), which is what the state remembers:
+# the raw report holds attacker-influenceable paths, and a hash both keeps them out
+# of the persisted state and answers the only question that matters across ticks -
+# is this the same condition as last time?
+#
+#   - the SAME fingerprint on two consecutive ticks is the confirmation threshold;
+#     one tick alone is the in-flight-apply shape (the deployed files have changed
+#     and the manifest has not been regenerated yet), and it resolves itself;
+#   - a fingerprint already paged for does not page again;
+#   - a CHANGED fingerprint restarts the confirmation, so new tampering is reported;
+#   - a clean audit forgets both, so a recurrence pages again.
+#
+# The fingerprint covers WHICH paths disagree and HOW, not the bytes they now hold,
+# so re-tampering with an already-reported file does not page a second time. That is
+# deliberate: the operator has already been told that file is compromised, and the
+# alternative re-pages on every keystroke an attacker makes.
+audit_fingerprint=""
+audit_fingerprint_is_valid=1
+if [[ $audit_rc -ne 0 || -n $audit_report ]]; then
+  audit_fingerprint="$(printf '%s\n' "$audit_report" | LC_ALL=C sort | shasum -a 256 2>/dev/null)"
+  audit_fingerprint="${audit_fingerprint%% *}"
+  if [[ ! $audit_fingerprint =~ ^[0-9a-f]{64}$ ]]; then
+    audit_fingerprint=""
+    audit_fingerprint_is_valid=0
+  fi
+fi
+
+prev_audit_fingerprint="$(jq -r '.pipeline_audit.fingerprint // ""' <<<"$prev_state" 2>/dev/null || printf '')"
+[[ $prev_audit_fingerprint =~ ^[0-9a-f]{64}$ ]] || prev_audit_fingerprint=""
+prev_audit_paged="$(jq -r '.pipeline_audit.paged_fingerprint // ""' <<<"$prev_state" 2>/dev/null || printf '')"
+[[ $prev_audit_paged =~ ^[0-9a-f]{64}$ ]] || prev_audit_paged=""
+prev_audit_streak="$(jq -r '.pipeline_audit.streak // 0' <<<"$prev_state" 2>/dev/null || printf '0')"
+[[ $prev_audit_streak =~ ^[0-9]{1,3}$ ]] || prev_audit_streak=0
+if [[ $prev_audit_streak -gt 99 ]]; then prev_audit_streak=99; fi
+
+audit_should_page=0
+audit_streak=0
+audit_paged_fingerprint=""
+if [[ $audit_rc -eq 0 && -z $audit_report ]]; then
+  : # a completed, clean audit: forget the streak and the paged marker
+elif [[ $audit_fingerprint_is_valid -eq 0 ]]; then
+  # Without a fingerprint a repeat cannot be told from a new condition, so the
+  # page-once machinery cannot run. Page every tick rather than risk going silent.
+  audit_should_page=1
+else
+  if [[ $audit_fingerprint == "$prev_audit_fingerprint" ]]; then
+    audit_streak=$((prev_audit_streak + 1))
+    if [[ $audit_streak -gt 99 ]]; then audit_streak=99; fi
+  else
+    audit_streak=1
+  fi
+  audit_paged_fingerprint="$prev_audit_paged"
+  if [[ $audit_streak -ge 2 && $audit_fingerprint != "$prev_audit_paged" ]]; then
+    audit_should_page=1
+    audit_paged_fingerprint="$audit_fingerprint"
+  fi
+fi
+
+# The rendered problem carries a VALIDATED COUNT and static text only. The
+# manifested paths are deliberately not rendered: in the very scenario this audit
+# exists to catch they are attacker-influenceable, and the operator's next step is
+# the same either way. That keeps this watchdog's rule intact - known labels,
+# validated numerics, and static text reach a page body, nothing else.
+if [[ $audit_should_page -eq 1 ]]; then
+  if [[ -n $audit_reason ]]; then
+    case "$audit_reason" in
+      missing)
+        problems+=("the pipeline-integrity manifest is missing or unreadable, so the periodic content audit cannot verify the deployed pipeline; tampering would go unseen until it is restored")
+        ;;
+      untrustworthy)
+        problems+=("the pipeline-integrity manifest is no longer root-owned (or is group/world-writable), so it can no longer vouch for the deployed pipeline")
+        ;;
+      malformed)
+        problems+=("the pipeline-integrity manifest holds a malformed entry, so the periodic content audit cannot verify the deployed pipeline")
+        ;;
+      overlong)
+        problems+=("the pipeline-integrity manifest lists more files than one audit tick will examine, so the deployed pipeline cannot be fully verified")
+        ;;
+      budget)
+        problems+=("the periodic content audit ran out of its time budget before checking every file in the pipeline-integrity manifest, so the deployed pipeline cannot be fully verified")
+        ;;
+      *)
+        problems+=("the periodic content audit could not verify the deployed pipeline against the pipeline-integrity manifest")
+        ;;
+    esac
+  else
+    problems+=("$audit_divergence_count file(s) in the pipeline-integrity manifest no longer match it (content changed, missing, or not a regular file); no file event reported this, which is what a hard-linked or relocated pipeline script looks like")
+  fi
+fi
+
 # The refreshed state to persist once the tick is resolved. Built now, written only
 # AFTER a page is durably queued (notify-before-persist), so a page that cannot be
 # stored never advances a streak or growth baseline and masks the signal.
 new_state="$(jq -cn --argjson agents "$agent_state_json" \
   --argjson pc "$pending_for_state" --argjson gs "$growth_streak" \
-  '{agents: $agents, pending: {count: $pc, growth_streak: $gs}}')"
+  --arg afp "$audit_fingerprint" --argjson as "$audit_streak" \
+  --arg apfp "$audit_paged_fingerprint" \
+  '{agents: $agents, pending: {count: $pc, growth_streak: $gs},
+    pipeline_audit: {fingerprint: $afp, streak: $as, paged_fingerprint: $apfp}}')"
 
 # Healthy: persist the refreshed baselines (no page to order against) and exit
 # silent. A persist failure here only forgets one cycle of streak memory.

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -29,11 +29,10 @@
 #     names that path, nothing fires for the watched one, and no verdict runs at
 #     all. This is a property of path-based file-integrity monitoring, not of the
 #     judgment below (before the manifest existed, no event meant no page either).
-#     Closing it needs a PERIODIC CONTENT AUDIT that hashes every manifested path on
-#     a schedule and compares, which is a scheduled feature in its own right; the
-#     symlink and regular-file checks below are the cheap partial. Filed as a
-#     follow-up (the uptime watchdog is its natural home: it already runs every
-#     15 minutes).
+#     Now covered by the PERIODIC CONTENT AUDIT in ../pipeline-audit.sh, which the
+#     uptime watchdog runs every 15 minutes: it hashes every manifested path and
+#     pages on a divergence, needing no event to have fired. The symlink and
+#     regular-file checks below remain the immediate answer on the event path.
 #   - SOURCE COMPROMISE. The manifest is generated from chezmoi's source state,
 #     which is user-writable, so tampering with a managed file's SOURCE and letting
 #     a legitimate apply deploy it is signed as known-good. See the runner's

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -4,9 +4,11 @@
 # The watchdog runs as a user LaunchAgent every 15 min. It asserts the osquery
 # notification pipeline is ALIVE (a dead pipeline looks identical to "all quiet"),
 # and pages ONE CRIT if any component is down or wedged, silent when healthy. It
-# has four probes: osqueryd present-and-answering, every OTHER osquery LaunchAgent
-# loaded-and-not-crash-looping, the hermes #priority route reachable, and the
-# delivery backlog (dead-letter count and a sustained pending-growth streak).
+# has five probes: osqueryd present-and-answering, every OTHER osquery LaunchAgent
+# loaded-and-not-crash-looping, the hermes #priority route reachable, the delivery
+# backlog (dead-letter count and a sustained pending-growth streak), and a periodic
+# content audit of the pipeline-integrity manifest (the backstop for tampering that
+# generates no file event at all).
 #
 # This harness stands the watchdog up in isolation against recording spies, with
 # no real launchd / osquery / hermes dependency:
@@ -18,7 +20,10 @@
 #   - a recording send_alert spy plus the two read-only queue counters, installed
 #     as a stand-in dispatch library at the libexec path the watchdog sources.
 #     send_alert never delivers; it records each call's severity, sound, and argv,
-#     and the state file as it stood at call time (to prove notify-before-persist).
+#     and the state file as it stood at call time (to prove notify-before-persist);
+#   - a fixture pipeline home with a real manifest over it, so the content audit
+#     runs against real files and real hashes. A test tampers with a deployed file,
+#     or the manifest, and the audit judges what is actually on disk.
 #
 # A fresh temp HOME keeps every run off the operator's real ~/.local/state and
 # ~/.local/libexec. Sourced by the watchdog suite; no main.
@@ -140,6 +145,25 @@ SHIM
   cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_canary-freshness.sh" \
     "$WD_HOME/.local/libexec/osquery/canary-freshness.sh"
 
+  # The periodic content audit and the verdict helper it reuses the manifest
+  # constant and root-ownership check from, both at their deployed paths.
+  mkdir -p "$WD_HOME/.local/libexec/osquery/results-alerter"
+  cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_pipeline-audit.sh" \
+    "$WD_HOME/.local/libexec/osquery/pipeline-audit.sh"
+  cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh" \
+    "$WD_HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+  # A stand-in deployed pipeline script for the tamper cases: tampering with a file
+  # the watchdog does not itself source keeps the audit's behavior separable from
+  # the harness's own machinery.
+  export WD_MANIFESTED_SCRIPT="$WD_HOME/.local/libexec/osquery/digest.sh"
+  printf 'echo digest\n' >"$WD_MANIFESTED_SCRIPT"
+  # A second one, so a test can make the divergence SET change without touching a
+  # file the watchdog sources.
+  export WD_MANIFESTED_SCRIPT_ALT="$WD_HOME/.local/libexec/osquery/enrich-finding.sh"
+  printf 'echo enrich\n' >"$WD_MANIFESTED_SCRIPT_ALT"
+  export OSQUERY_PIPELINE_MANIFEST="$WD_HOME/pipeline-known-good.sha256"
+  regenerate_pipeline_manifest
+
   # The fake dispatch library the watchdog sources. It SOURCES the REAL library so
   # the queue-health counters (osquery_pending_alert_count / osquery_dead_letter_count)
   # are the REAL ones reading the real SQLite store, then overrides ONLY send_alert
@@ -260,6 +284,57 @@ seed_raw_canary() {
     >>"$OSQUERY_SNAPSHOTS_LOG"
 }
 
+# ---- programming the pipeline-integrity manifest ---------------------------
+
+# regenerate_pipeline_manifest -- rewrite the fixture manifest from the sandbox's
+# CURRENT deployed pipeline tree, the way a legitimate `chezmoi apply` regenerates
+# the real one after writing the files. Discovery is materialized under a checked
+# status: a `find` that failed midway would otherwise yield a short manifest and a
+# green audit over an unexamined tail.
+regenerate_pipeline_manifest() {
+  local listing target file_hash
+  listing="$WD_HOME/manifest-listing"
+  find "$WD_HOME/.local/libexec/osquery" -type f | LC_ALL=C sort >"$listing" || return 1
+  : >"$OSQUERY_PIPELINE_MANIFEST"
+  while IFS= read -r target; do
+    file_hash="$(shasum -a 256 -- "$target")"
+    printf '%s  %s\n' "${file_hash%% *}" "$target" >>"$OSQUERY_PIPELINE_MANIFEST"
+  done <"$listing"
+}
+
+# tamper_manifested_file -- overwrite the stand-in pipeline script IN PLACE, with
+# the manifest left untouched: exactly what an attacker who writes through a hard
+# link outside the watched tree achieves, and exactly what generates NO file event
+# on the watched path.
+tamper_manifested_file() {
+  printf 'echo tampered\n' >"$WD_MANIFESTED_SCRIPT"
+}
+
+# tamper_second_manifested_file -- the same, on the OTHER stand-in script, so a
+# test can enlarge the divergence set (a genuinely new condition) mid-run.
+tamper_second_manifested_file() {
+  printf 'echo also-tampered\n' >"$WD_MANIFESTED_SCRIPT_ALT"
+}
+
+# restore_manifested_file -- put the known-good bytes back.
+restore_manifested_file() {
+  printf 'echo digest\n' >"$WD_MANIFESTED_SCRIPT"
+}
+
+# symlink_manifested_file -- replace the manifested regular file with a SYMLINK to
+# a copy holding the exact bytes the manifest vouches for. Hashing through the link
+# would call this clean; the executed bytes now live outside the watched tree.
+symlink_manifested_file() {
+  mv "$WD_MANIFESTED_SCRIPT" "$WD_HOME/relocated-payload.sh"
+  ln -s "$WD_HOME/relocated-payload.sh" "$WD_MANIFESTED_SCRIPT"
+}
+
+# remove_pipeline_manifest -- the audit's input is gone (a monitor whose known-good
+# list disappeared must not read as all-clear).
+remove_pipeline_manifest() {
+  rm -f "$OSQUERY_PIPELINE_MANIFEST"
+}
+
 # ---- programming prior cross-run state ------------------------------------
 
 # seed_watchdog_state <compact-json> -- write the prior state file at 0600, so a
@@ -282,6 +357,7 @@ run_watchdog() {
     OSQUERY_WATCHDOG_STATE="$OSQUERY_WATCHDOG_STATE" \
     OSQUERY_SNAPSHOTS_LOG="$OSQUERY_SNAPSHOTS_LOG" \
     OSQUERY_UNDELIVERED_ALERTS_DB="$OSQUERY_UNDELIVERED_ALERTS_DB" \
+    OSQUERY_PIPELINE_MANIFEST="$OSQUERY_PIPELINE_MANIFEST" \
     bash "$WD_TOOL"
 }
 

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -68,10 +68,40 @@ export OSQUERY_PIPELINE_MANIFEST="$MF_MANIFEST" OSQUERY_PIPELINE_REHASH_DELAY=0
 export OSQUERY_PIPELINE_SETTLE_SECONDS=0
 
 hash_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+# run_verdict <target> <hash> <verb> [settle-seconds] -- invoke the real verdict for
+# ONE case, in a SUBSHELL. Every call site below goes through here; nothing in this
+# file calls pipeline_verdict directly.
+#
+# Why the subshell, and why this is not a workaround for a production bug. The settle
+# budget is deliberately ONE per alerter INVOCATION, not one per finding: findings are
+# judged sequentially while the alerter holds its single-instance lock, so a per-finding
+# wait would let anyone who plants N files stall the pipeline for N times the bound and
+# delay unrelated security findings. The alerter sources this helper once per run, so in
+# production every invocation genuinely starts with an empty _pipeline_settle_deadline.
+#
+# This file drives many cases inside ONE shell, which production never does. Without
+# isolation, a case that opens the window (a tuple miss on a target NEWER than the
+# manifest) leaves the deadline SPENT in the shell, and every later case inherits it and
+# answers immediately: the 4-second settle case below then returns PAGE where it must
+# return SILENT. Whether the earlier case opens the window at all depends on whole-second
+# stat mtime granularity, so the leak surfaced as an intermittent failure under load.
+#
+# A subshell per case gives each one its own copy of that global, which is exactly what
+# re-sourcing gives a real alerter run. It is structural rather than a reset someone has
+# to remember, so a case added to this file later cannot silently inherit a spent budget.
+run_verdict() {
+  local target="$1" hash_value="$2" verb="$3" settle="${4:-$OSQUERY_PIPELINE_SETTLE_SECONDS}"
+  (
+    export HOME="$MF_HOME" OSQUERY_PIPELINE_SETTLE_SECONDS="$settle"
+    pipeline_verdict "$target" "$hash_value" "$verb"
+  )
+}
+
 # expect_verdict <expected-rc> <label> <target> <hash> <verb>
 expect_verdict() {
   local want="$1" label="$2" got=0
-  HOME="$MF_HOME" pipeline_verdict "$3" "$4" "$5" || got=$?
+  run_verdict "$3" "$4" "$5" || got=$?
   [[ $got == "$want" ]] || fail "$label: expected rc $want, got $got"
 }
 
@@ -145,7 +175,7 @@ touch -t 200001010000 "$MF_MANIFEST"
 ) &
 settle_pid=$!
 got=0
-HOME="$MF_HOME" OSQUERY_PIPELINE_SETTLE_SECONDS=4 pipeline_verdict "$settle_target" "$settle_hash" UPDATED || got=$?
+run_verdict "$settle_target" "$settle_hash" UPDATED 4 || got=$?
 wait "$settle_pid"
 [[ $got -eq 1 ]] ||
   fail "a manifest that lands during the settle window must resolve to SILENT (got rc $got)"
@@ -155,7 +185,7 @@ printf 'deadbeef  /nowhere\n' >"$MF_MANIFEST"
 touch -t 200001010000 "$MF_MANIFEST"
 start=$(date +%s)
 got=0
-HOME="$MF_HOME" OSQUERY_PIPELINE_SETTLE_SECONDS=2 pipeline_verdict "$settle_target" "$settle_hash" UPDATED || got=$?
+run_verdict "$settle_target" "$settle_hash" UPDATED 2 || got=$?
 elapsed=$(($(date +%s) - start))
 [[ $got -eq 0 ]] || fail "a tuple that never arrives must still PAGE (got rc $got)"
 ((elapsed <= 6)) || fail "the settle wait is not bounded (${elapsed}s for a 2s window)"
@@ -167,6 +197,11 @@ elapsed=$(($(date +%s) - start))
 # under the tracked home stall the whole pipeline for N x the bound, delaying
 # UNRELATED security findings. The budget is one shared deadline per invocation:
 # the first miss opens it, and once it is spent every later miss answers at once.
+#
+# This case runs its misses inside ONE `bash -c`, deliberately NOT through
+# run_verdict: it is the case that asserts the budget IS shared, so its misses must
+# land in a single invocation. run_verdict isolates CASES from each other; this
+# asserts what happens WITHIN one case. The two are the same rule from both sides.
 miss_manifest="$MF_ROOT/miss.sha256"
 printf 'deadbeef  /nowhere\n' >"$miss_manifest"
 touch -t 200001010000 "$miss_manifest"

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -520,3 +520,150 @@ teardown() { teardown_watchdog_harness; }
   }
   assert_no_page
 }
+
+# --- the periodic content audit: tamper that generates NO file event ------------
+#
+# osquery watches PATHS. An attacker who hard-links a manifested pipeline script to
+# a writable path outside the pipeline home and overwrites that alias mutates the
+# SAME INODE: the filesystem event names the attacker's path, nothing fires for the
+# watched one, no verdict runs, and the tampered script executes with nothing paged.
+# The audit closes that by comparing bytes on a schedule, so it never depends on an
+# event having fired. Every case below tampers IN PLACE with no event involved.
+#
+# A divergence must persist across two consecutive ticks before it pages. A
+# legitimate `chezmoi apply` writes the deployed files and then regenerates the
+# manifest, so a tick landing inside that window sees a divergence that is gone by
+# the next one; requiring the SAME divergence twice spends 15 minutes of detection
+# delay on a backstop (the event path already pages instantly for tamper it can see)
+# and buys immunity from false-paging every apply.
+
+@test "T-WATCH-audit-tamper-pages: a manifested file whose content diverges pages CRIT, with no file event anywhere" {
+  tamper_manifested_file
+  run run_watchdog # tick 1: first observation, a transient is tolerated
+  [[ $status -eq 0 ]] || {
+    echo "tick1 status $status: $output"
+    false
+  }
+  assert_no_page
+
+  run run_watchdog # tick 2: the same divergence is still there
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'pipeline-integrity manifest'
+}
+
+@test "T-WATCH-audit-tamper-body-inert: the diverging PATH never reaches the page body" {
+  # The manifest is attacker-influenceable in the shape this audit exists to catch,
+  # so its paths are counted, never rendered. The body carries a validated count and
+  # static text only, exactly like every other probe in this watchdog.
+  tamper_manifested_file
+  run run_watchdog
+  run run_watchdog
+  assert_page_count 1
+  refute_file_contains "$WD_MANIFESTED_SCRIPT" "$WD_SEND_ALERT_LOG"
+}
+
+@test "T-WATCH-audit-apply-race-silent: a divergence that resolves before the next tick never pages" {
+  # The in-flight apply: the deployed file has changed, the manifest has not been
+  # regenerated yet. One tick sees it, the next sees a regenerated manifest. A
+  # legitimate apply must not page.
+  tamper_manifested_file
+  run run_watchdog # tick 1 lands inside the window
+  [[ $status -eq 0 ]] || {
+    echo "tick1 status $status: $output"
+    false
+  }
+  assert_no_page
+
+  regenerate_pipeline_manifest # the apply finishes: the manifest now covers the new bytes
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_no_page
+}
+
+@test "T-WATCH-audit-symlink-pages: a symlink at a manifested path pages even when its referent matches" {
+  # The second shape of the same blind spot: the bytes the manifest vouches for are
+  # still readable THROUGH the link, but the file that executes now lives outside
+  # the watched tree. An audit that followed links would call this clean.
+  symlink_manifested_file
+  run run_watchdog
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'pipeline-integrity manifest'
+}
+
+@test "T-WATCH-audit-manifest-missing-pages: an absent manifest pages instead of reading as all-clear" {
+  # A monitor must not go quiet because its own input broke: with no known-good list
+  # there is nothing to compare against, so tampering would pass unseen.
+  remove_pipeline_manifest
+  run run_watchdog
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'pipeline-integrity manifest'
+}
+
+@test "T-WATCH-audit-page-once: a persistent divergence pages once, not every 15 minutes forever" {
+  tamper_manifested_file
+  run run_watchdog # tick 1: confirming
+  run run_watchdog # tick 2: pages
+  assert_page_count 1
+  run run_watchdog # tick 3: the SAME divergence, already reported
+  [[ $status -eq 0 ]] || {
+    echo "tick3 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  run run_watchdog # tick 4: still the same
+  assert_page_count 1
+}
+
+@test "T-WATCH-audit-repages-on-change: a divergence that CHANGES after being reported pages again" {
+  # Page-once must not become page-never: a second file going bad after the first
+  # was reported is new information, so it pages on its own confirmation.
+  tamper_manifested_file
+  run run_watchdog
+  run run_watchdog
+  assert_page_count 1
+
+  tamper_second_manifested_file
+  run run_watchdog # the divergence set changed: confirming
+  assert_page_count 1
+  run run_watchdog # confirmed: a second page
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 2
+}
+
+@test "T-WATCH-audit-clean-silent: an untampered manifested tree is silent across many ticks" {
+  # The audit must not itself become a source of noise: nothing diverges, so no
+  # amount of ticking produces a page.
+  run run_watchdog
+  run run_watchdog
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+}

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -621,6 +621,25 @@ teardown() { teardown_watchdog_harness; }
   assert_page_body_has 'pipeline-integrity manifest'
 }
 
+@test "T-WATCH-audit-helper-missing-pages: the audit's own dependency going missing pages, instead of killing the tick silently" {
+  # The audit reuses the verdict helper for the manifest constant and the ownership
+  # check. Under the watchdog's errexit shell, sourcing a deleted helper would abort
+  # the whole tick: no probe would report, and nothing would page. A monitor that
+  # dies quietly when part of it is removed is worse than no monitor, so the missing
+  # dependency has to come out as a page.
+  rm -f "$WD_HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+  run run_watchdog
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'not installed'
+}
+
 @test "T-WATCH-audit-page-once: a persistent divergence pages once, not every 15 minutes forever" {
   tamper_manifested_file
   run run_watchdog # tick 1: confirming

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -640,6 +640,23 @@ teardown() { teardown_watchdog_harness; }
   assert_page_body_has 'not installed'
 }
 
+@test "T-WATCH-audit-seam-missing-pages: the audit seam itself going missing pages, instead of killing the tick silently" {
+  # One level up from the case above, and the same rule: the watchdog sources the
+  # audit seam, so a deleted seam would abort the tick before ANY probe reported.
+  # Probes 1 to 4 do not depend on it, so the tick must survive and say so.
+  rm -f "$WD_HOME/.local/libexec/osquery/pipeline-audit.sh"
+  run run_watchdog
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'not installed'
+}
+
 @test "T-WATCH-audit-page-once: a persistent divergence pages once, not every 15 minutes forever" {
   tamper_manifested_file
   run run_watchdog # tick 1: confirming

--- a/test/unit/osquery-pipeline-audit.sh
+++ b/test/unit/osquery-pipeline-audit.sh
@@ -95,7 +95,8 @@ run_scan() {
   # analysis, hence the explicit directive.
   # shellcheck disable=SC2016
   SCAN_OUT="$(env HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" "$@" \
-    bash -c 'source "$1"
+    bash -c 'set -euo pipefail
+      source "$1"
       pipeline_audit_scan' _ "$pipeline/pipeline-audit.sh")" || SCAN_RC=$?
 }
 
@@ -213,6 +214,17 @@ run_scan OSQUERY_PIPELINE_MANIFEST="$rel_manifest"
 expect_rc "a relative manifested path refuses" 1
 expect_out "a relative manifested path reports the malformed token" "malformed"
 
+# --- the audit's own dependency going missing is a REFUSAL, not a silent death --
+# The scan reuses the verdict helper for the manifest constant and the ownership
+# check. Sourcing that helper unconditionally would abort the caller under errexit
+# if it were absent, and the caller here is the watchdog: it would die mid-tick and
+# page nothing, which is the exact failure mode this subsystem exists to prevent.
+mv "$pipeline/results-alerter/pipeline-verdict.sh" "$work/verdict.stashed"
+run_scan
+expect_rc "an absent verdict helper refuses instead of aborting the caller" 1
+expect_out "an absent verdict helper reports the unavailable token" "unavailable"
+mv "$work/verdict.stashed" "$pipeline/results-alerter/pipeline-verdict.sh"
+
 # --- the manifest must be root-owned before its verdict means anything --------
 # Driven with the OSQUERY_PIPELINE_MANIFEST override UNSET, because that override
 # is the test seam that skips the ownership check for fixture manifests (the same
@@ -221,6 +233,7 @@ expect_out "a relative manifested path reports the malformed token" "malformed"
 trust_rc=0
 # shellcheck disable=SC2016 # $1/$2 are expanded by the child shell, as above
 trust_out="$(env HOME="$home" bash -c '
+  set -euo pipefail
   source "$1"
   unset OSQUERY_PIPELINE_MANIFEST
   PIPELINE_MANIFEST="$2"
@@ -234,4 +247,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-audit: OK (a matching tree is clean; tampered content, a missing path, a symlink whose referent matches, a directory, and an over-cap file are each reported without any file event; spaced paths are read whole; an absent, empty, malformed, relative-path, over-long, or non-root-owned manifest and an exhausted budget all refuse LOUDLY)\n'
+printf 'osquery-pipeline-audit: OK (a matching tree is clean; tampered content, a missing path, a symlink whose referent matches, a directory, and an over-cap file are each reported without any file event; spaced paths are read whole; an absent, empty, malformed, relative-path, over-long, or non-root-owned manifest, an absent verdict helper, and an exhausted budget all refuse LOUDLY)\n'

--- a/test/unit/osquery-pipeline-audit.sh
+++ b/test/unit/osquery-pipeline-audit.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# pipeline_audit_scan (dot_local/libexec/osquery/pipeline-audit.sh) is the
+# PERIODIC CONTENT AUDIT seam: it reads the root-owned pipeline-integrity
+# manifest, hashes every path the manifest lists, and reports each path whose
+# CURRENT state disagrees with its recorded tuple.
+#
+# Why it exists. The manifest was enforced only by osquery file_events, and
+# osquery watches PATHS. An attacker who hard-links a manifested script to a
+# writable path outside the pipeline home and overwrites the alias mutates the
+# SAME INODE while the filesystem event names the outside path: no event ever
+# reaches the watched path, no verdict runs, and the tampered script executes with
+# nothing paged. This audit is the answer, because it compares bytes on a
+# schedule and never depends on an event having fired.
+#
+# Contract:
+#   return 0 = the scan COMPLETED. Every divergence is one stdout line,
+#              "<kind> <path>"; no output means the deployed tree matches.
+#   return 1 = the scan could NOT be completed, and stdout is a single reason
+#              TOKEN from a fixed vocabulary (missing, untrustworthy, malformed,
+#              overlong, budget). A caller that cannot verify must page: this is
+#              a monitor, so a broken input is a loud condition, never a quiet
+#              all-clear.
+#
+# The completion/return split is the fail-safe hinge: "no output" alone would
+# read identically for "nothing diverged" and "the scan died before it started".
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AUDIT_HELPER="$REPO_ROOT/dot_local/libexec/osquery/executable_pipeline-audit.sh"
+VERDICT_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
+fails=0
+fail() {
+  printf 'osquery-pipeline-audit: FAIL -- %s\n' "$*" >&2
+  fails=$((fails + 1))
+}
+
+[[ -f $AUDIT_HELPER ]] || {
+  printf 'osquery-pipeline-audit: FAIL -- missing helper: %s\n' "$AUDIT_HELPER" >&2
+  exit 1
+}
+[[ -f $VERDICT_HELPER ]] || {
+  printf 'osquery-pipeline-audit: FAIL -- missing helper: %s\n' "$VERDICT_HELPER" >&2
+  exit 1
+}
+command -v shasum >/dev/null 2>&1 || {
+  printf 'osquery-pipeline-audit: FAIL -- shasum is required for this test\n' >&2
+  exit 1
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+pipeline="$home/.local/libexec/osquery"
+mkdir -p "$pipeline/results-alerter"
+
+# The helpers are installed at the SAME relative paths the deploy uses, because the
+# audit sources the verdict helper from the pipeline home (it reuses the manifest
+# constant and the root-ownership check rather than keeping a second copy).
+cp "$AUDIT_HELPER" "$pipeline/pipeline-audit.sh"
+cp "$VERDICT_HELPER" "$pipeline/results-alerter/pipeline-verdict.sh"
+
+sha_of() { shasum -a 256 -- "$1" | awk '{print $1}'; }
+
+# The manifested fixture set: an ordinary script, a second script whose name holds
+# a SPACE (the manifest binds one path per line, so a space in a path must not be
+# read as a field separator), and a plist.
+good_script="$pipeline/digest.sh"
+spaced_script="$pipeline/two words.sh"
+plist="$home/Library/LaunchAgents/com.webdavis.osquery-digest.plist"
+mkdir -p "$home/Library/LaunchAgents"
+printf 'echo digest\n' >"$good_script"
+printf 'echo spaced\n' >"$spaced_script"
+printf '<plist/>\n' >"$plist"
+
+manifest="$work/pipeline-known-good.sha256"
+write_manifest() {
+  {
+    printf '%s  %s\n' "$(sha_of "$good_script")" "$good_script"
+    printf '%s  %s\n' "$(sha_of "$spaced_script")" "$spaced_script"
+    printf '%s  %s\n' "$(sha_of "$plist")" "$plist"
+  } >"$manifest"
+}
+write_manifest
+
+# run_scan [VAR=value ...] -- run the audit in a fresh shell against the fixture
+# manifest. SCAN_RC is the return code, SCAN_OUT the stdout.
+SCAN_RC=0
+SCAN_OUT=""
+run_scan() {
+  SCAN_RC=0
+  # The child script is single-quoted on purpose: $1 must be expanded by the CHILD
+  # shell, not by this one. `env` hides the bash -c from shellcheck's nested-script
+  # analysis, hence the explicit directive.
+  # shellcheck disable=SC2016
+  SCAN_OUT="$(env HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" "$@" \
+    bash -c 'source "$1"
+      pipeline_audit_scan' _ "$pipeline/pipeline-audit.sh")" || SCAN_RC=$?
+}
+
+# expect_rc <label> <want> / expect_out <label> <want-exact-stdout>
+expect_rc() {
+  [[ $SCAN_RC -eq $2 ]] || fail "$1: expected return $2, got $SCAN_RC (stdout: $SCAN_OUT)"
+}
+expect_out() {
+  [[ $SCAN_OUT == "$2" ]] || fail "$1: expected stdout [$2], got [$SCAN_OUT]"
+}
+
+# --- a deployed tree that matches the manifest is clean -----------------------
+run_scan
+expect_rc "an untampered tree completes" 0
+expect_out "an untampered tree reports no divergence" ""
+
+# --- the headline: content that diverges is reported, with NO event involved ---
+printf 'echo tampered\n' >>"$good_script"
+run_scan
+expect_rc "a tampered file still completes the scan" 0
+expect_out "tampered content is reported" "content $good_script"
+printf 'echo digest\n' >"$good_script" # restore
+
+# --- a path whose file is GONE ------------------------------------------------
+mv "$plist" "$work/plist.stashed"
+run_scan
+expect_rc "a missing manifested path still completes the scan" 0
+expect_out "a missing manifested path is reported" "missing $plist"
+mv "$work/plist.stashed" "$plist"
+
+# --- a symlink standing where a manifested regular file belongs ---------------
+# The referent holds the EXACT bytes the manifest vouches for, so an audit that
+# followed the link would call this clean. It must not: the manifest binds a
+# regular file at that path, and the executed bytes now live somewhere the
+# manifest does not cover and nothing watches.
+mv "$good_script" "$work/relocated-payload.sh"
+ln -s "$work/relocated-payload.sh" "$good_script"
+run_scan
+expect_rc "a symlinked manifested path still completes the scan" 0
+expect_out "a symlink at a manifested path is reported even when its referent matches" \
+  "irregular $good_script"
+rm -f "$good_script"
+mv "$work/relocated-payload.sh" "$good_script"
+
+# --- a non-regular file (a directory) standing at a manifested path -----------
+rm -f "$good_script"
+mkdir -p "$good_script"
+run_scan
+expect_rc "a non-regular manifested path still completes the scan" 0
+expect_out "a directory at a manifested path is reported" "irregular $good_script"
+rmdir "$good_script"
+printf 'echo digest\n' >"$good_script"
+
+# --- a path with a SPACE is one manifest entry, not two fields ----------------
+printf 'echo tampered\n' >>"$spaced_script"
+run_scan
+expect_rc "a spaced path completes the scan" 0
+expect_out "a manifested path containing a space is read whole and judged" \
+  "content $spaced_script"
+printf 'echo spaced\n' >"$spaced_script" # restore
+run_scan
+expect_out "a restored spaced path is clean (the space is not a false divergence)" ""
+
+# --- every divergence in one pass, in manifest order --------------------------
+printf 'echo tampered\n' >>"$good_script"
+mv "$plist" "$work/plist.stashed"
+run_scan
+expect_rc "a multi-divergence scan completes" 0
+expect_out "every diverging path is reported, not just the first" \
+  "content $good_script
+missing $plist"
+printf 'echo digest\n' >"$good_script"
+mv "$work/plist.stashed" "$plist"
+
+# --- the scan is BOUNDED, and every bound fails toward a page -----------------
+# A manifested file larger than the per-file cap is not hashed at all (hashing an
+# attacker-grown file is the only unbounded work in the tick) and is itself a
+# divergence: our pipeline files are a few kilobytes.
+run_scan OSQUERY_PIPELINE_AUDIT_MAX_BYTES=1
+expect_rc "an over-cap file does not abort the scan" 0
+[[ $SCAN_OUT == *"oversize $good_script"* ]] ||
+  fail "an over-cap manifested file must be reported, got [$SCAN_OUT]"
+
+run_scan OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES=2
+expect_rc "a manifest with more entries than the audit will examine refuses" 1
+expect_out "an over-long manifest reports the overlong token" "overlong"
+
+run_scan OSQUERY_PIPELINE_AUDIT_BUDGET_SECONDS=0
+expect_rc "an exhausted time budget refuses" 1
+expect_out "an exhausted time budget reports the budget token" "budget"
+
+# --- an unusable manifest is a LOUD failure, never a quiet all-clear ----------
+run_scan OSQUERY_PIPELINE_MANIFEST="$work/no-such-manifest.sha256"
+expect_rc "an absent manifest refuses" 1
+expect_out "an absent manifest reports the missing token" "missing"
+
+empty_manifest="$work/empty.sha256"
+: >"$empty_manifest"
+run_scan OSQUERY_PIPELINE_MANIFEST="$empty_manifest"
+expect_rc "an empty manifest refuses" 1
+expect_out "an empty manifest reports the missing token" "missing"
+
+bad_manifest="$work/malformed.sha256"
+printf 'not-a-hash  /some/path\n' >"$bad_manifest"
+run_scan OSQUERY_PIPELINE_MANIFEST="$bad_manifest"
+expect_rc "a malformed manifest line refuses" 1
+expect_out "a malformed manifest reports the malformed token" "malformed"
+
+# A manifest whose paths are RELATIVE is malformed too: the audit resolves nothing
+# itself, so a relative path would be read against whatever directory launchd
+# happened to start the watchdog in.
+rel_manifest="$work/relative.sha256"
+printf '%s  digest.sh\n' "$(sha_of "$good_script")" >"$rel_manifest"
+run_scan OSQUERY_PIPELINE_MANIFEST="$rel_manifest"
+expect_rc "a relative manifested path refuses" 1
+expect_out "a relative manifested path reports the malformed token" "malformed"
+
+# --- the manifest must be root-owned before its verdict means anything --------
+# Driven with the OSQUERY_PIPELINE_MANIFEST override UNSET, because that override
+# is the test seam that skips the ownership check for fixture manifests (the same
+# seam the verdict helper uses). A manifest anyone can write could vouch for bytes
+# an attacker just planted, so an untrusted manifest is refused rather than obeyed.
+trust_rc=0
+# shellcheck disable=SC2016 # $1/$2 are expanded by the child shell, as above
+trust_out="$(env HOME="$home" bash -c '
+  source "$1"
+  unset OSQUERY_PIPELINE_MANIFEST
+  PIPELINE_MANIFEST="$2"
+  pipeline_audit_scan' _ "$pipeline/pipeline-audit.sh" "$manifest")" || trust_rc=$?
+[[ $trust_rc -eq 1 ]] ||
+  fail "a manifest that is not root-owned must be refused, got return $trust_rc"
+[[ $trust_out == "untrustworthy" ]] ||
+  fail "a non-root-owned manifest must report the untrustworthy token, got [$trust_out]"
+
+if [[ $fails -gt 0 ]]; then
+  printf '%d check(s) failed\n' "$fails" >&2
+  exit 1
+fi
+printf 'osquery-pipeline-audit: OK (a matching tree is clean; tampered content, a missing path, a symlink whose referent matches, a directory, and an over-cap file are each reported without any file event; spaced paths are read whole; an absent, empty, malformed, relative-path, over-long, or non-root-owned manifest and an exhausted budget all refuse LOUDLY)\n'


### PR DESCRIPTION
## Context

The osquery pipeline protects its own scripts with a root-owned manifest of known-good hashes, enforced
when the operating system reports a file change. That enforcement is driven entirely by filesystem events,
and those events are reported per path. An attacker who creates a hard link to a protected script somewhere
writable and then overwrites the link changes the same file on disk, but the event names the other path, so
nothing is ever checked.

This adds a periodic audit that re-reads the manifest and re-hashes every file it lists, catching
divergence whether or not an event ever fired. It runs as a fifth probe inside the existing uptime
watchdog, which already checks the pipeline every fifteen minutes.

## Summary

- The watchdog now re-hashes every manifested file on each run and pages if any has diverged.
- Catches tampering that produces no filesystem event at all, including through hard links and symlinks.
- Refuses loudly when it cannot scan, so a broken audit is never mistaken for a clean one.
- A divergence must persist across two runs before paging, so a legitimate apply does not raise a false alarm.
- Fixes a pre-existing flaky test that could reject an unrelated push.

Key files: `dot_local/libexec/osquery/executable_pipeline-audit.sh` (new),
`executable_uptime-watchdog.sh`, `test/integration/osquery-pipeline-manifest-agreement.sh`.

## Why a separate helper

The scan lives in its own sourced file rather than inline in the watchdog, for three reasons. It gets a
fast unit-test surface, and the commit gate runs the unit suite. It keeps the watchdog's probe section
readable. And because it sits in the pipeline directory, the manifest generator covers it automatically, so
the audit is itself audited.

It reuses the manifest path and the trust rule from the verdict helper rather than copying them, so there
is no second definition of either to drift.

## The contract

A completed scan returns success and prints one line per divergence. A refusal returns failure and prints a
single reason. That split is the point: without it, no output would mean both "nothing diverged" and "the
scan never ran", and a monitor that cannot tell those apart is worse than none.

Everything the scan cannot do resolves toward paging: a missing manifest, an untrustworthy one, a
malformed line, a file it cannot read, one that is not a regular file, one that is too large, or a scan
that exceeds its time budget.

## Cost and bounds

Twenty five files, about 230 KiB, takes six to eight tenths of a second per run, nearly all of it process
startup for the hashing tool. At one scan every fifteen minutes that is under a tenth of a percent duty
cycle, and the probe runs last so it delays nothing else. The scan is bounded on entry count, file size and
wall clock, each validated and each failing toward a page.

Hashing every file in a single batched call would be roughly ten times faster and was deliberately not
done: the results have to be matched back by path, a file that vanishes mid-scan simply omits its line, and
some implementations escape unusual names. That trades an obviously correct loop for a false-alarm vector.

## Not paging on a legitimate apply

An apply writes the deployed files and then regenerates the manifest, so a run landing between the two sees
a divergence that is gone moments later. The audit therefore requires the same divergence on two
consecutive runs before paging, and remembers what it already reported so a persistent problem does not
page every fifteen minutes forever. It re-runs on its own schedule, so waiting costs nothing, unlike the
event-driven path which judges each finding exactly once and has to decide in line.

The audit remembers a fingerprint of the finding rather than the finding itself, which keeps
attacker-influenceable paths out of its state file. The honest limit, recorded in the code, is that the
fingerprint covers which paths disagree rather than what they now contain, so re-tampering an
already-reported file does not raise a second page.

## Two failures found by running it for real

Smoke-running against this machine, which does not have the unshipped helper deployed, revealed that both
helpers were sourced unconditionally. Under the shell settings every caller uses, a partial deployment
aborted the watchdog mid-run and paged nothing at all, which is exactly the silent-monitor failure the
audit exists to prevent. Both are now conditional and surface as their own alert.

## The flaky test

`osquery-pipeline-manifest-agreement.sh` failed roughly one run in four, at the base commit and on main,
and had already rejected an unrelated push. The cause is a correct production behavior meeting a wrong test
assumption: the settle budget is deliberately shared across one alerter run, but the test drives every
scenario through a single shell, so an earlier scenario could spend the budget and a later one would
resolve immediately and report the opposite result. Whether it happened at all depended on filesystem
timestamp granularity.

Every scenario now runs through one helper that invokes the verdict in a subshell, so isolation holds by
construction and a scenario added later cannot inherit a spent budget by forgetting a line. The one
scenario that deliberately asserts the budget is shared keeps its own process, with a comment saying why.
Verified by forcing the failing condition (three of three runs failed before, three of three passed after)
and by eight consecutive full-suite runs with no failures.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover.
