### PR TITLE
feat(osquery): bind mode and owner in the pipeline-integrity manifest

### DIFF
--- a/.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh
+++ b/.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 #
 # run_after_05-osquery-pipeline-manifest.sh
-# Refresh the root-owned pipeline-integrity manifest: the known-good sha256 of the
-# osquery alerting pipeline's own scripts and plists. osqueryd (root) hashes those
-# files; the alerter PAGES a file_events change whose (path, hash) is not in this
-# manifest (tamper) and stays silent when it matches (a legitimate apply).
+# Refresh the root-owned pipeline-integrity manifest: the known-good sha256, mode
+# and owner of the osquery alerting pipeline's own scripts and plists. osqueryd
+# (root) watches those files; the alerter PAGES a file_events change whose
+# (path, hash, mode, uid) tuple is not in this manifest (tamper) and stays silent
+# when it matches (a legitimate apply).
+#
+# Format, one whitespace-separated tuple per line with the PATH LAST so a path
+# containing spaces is still read whole by `read -r hash mode uid path`:
+#
+#   <sha256> <mode> <uid> <path>
+#
+# mode is exactly four octal digits (0755); uid is decimal.
 #
 # NOT a template, deliberately. The mandated agent apply is
 # `chezmoi apply --exclude=templates`, which skips template scripts but still
@@ -24,7 +32,24 @@
 #     manifest, and therefore pages forever - which is correct;
 #   - each file's CONTENT hash comes from `chezmoi cat` (the source state rendered
 #     as chezmoi would write it), so a managed file tampered on disk is signed with
-#     its INTENDED hash and the tampered bytes then fail the tuple check and page.
+#     its INTENDED hash and the tampered bytes then fail the tuple check and page;
+#   - each file's MODE comes from `chezmoi dump` (the same source state, reported as
+#     the perm chezmoi would apply), so it is the mode encoded by the source
+#     attributes - the executable_ and private_ prefixes - and NOT the mode the file
+#     currently carries. A file an attacker chmod-ed on disk is therefore signed
+#     with its intended mode, and the drifted mode then fails the tuple check, for
+#     exactly the reason the content hash is taken from intent rather than a disk
+#     hash. This was verified empirically: chezmoi deploys a file at the perm dump
+#     reports (0755 for executable_, 0644 plain, 0700 for private_executable_),
+#     unclamped by umask, so intent and a clean deployment agree. `dump` needs a
+#     throwaway --persistent-state to run nested; see the call site.
+#   - each file's OWNER is the uid this apply is running as. chezmoi has no owner
+#     attribute; it writes every target file as the invoking user, so the uid that
+#     is running is BY DEFINITION the intended owner. That is process identity, not
+#     a property read out of the protected tree, so an attacker who has already
+#     chown-ed a pipeline file cannot influence it. (If an operator ever applied as
+#     root, the files really would be root-owned and the manifest would record that,
+#     so the derivation stays self-consistent.)
 # Nothing here reads or executes a user-writable DEPLOYED file.
 # (`chezmoi status`/`verify` are not usable for this: nested inside an apply they
 # fail with "timeout obtaining persistent state lock". `managed` and `cat` read the
@@ -53,10 +78,11 @@
 # is recorded rather than closed: root ownership buys a higher bar and a loud
 # failure mode, not integrity against a determined user-level attacker.
 #
-# Blind spot, recorded honestly: the manifest binds CONTENT only. An
-# ATTRIBUTES_MODIFIED event (for example `chmod g+w` on a pipeline script) carries
-# the unchanged hash, matches its tuple, and stays silent. A mode/owner column is a
-# follow-up, not part of this change.
+# Blind spot, recorded honestly: the owning GROUP is not bound. chezmoi has no
+# group intent to derive it from, and a chgrp alone cannot make a file writable
+# that the bound mode does not already grant group write to, so the only case a
+# group column would add on its own is chgrp plus chmod - which the mode column
+# already pages.
 set -euo pipefail
 
 [[ "$(uname)" == Darwin ]] || exit 0
@@ -89,7 +115,11 @@ chezmoi_args=()
 # change to a dropped file page forever.
 managed_list="$(mktemp)"
 sorted_list="$(mktemp)"
-trap 'rm -f "$managed_list" "$sorted_list" "${fresh:-}"' EXIT
+dump_json="$(mktemp)"
+# A THROWAWAY persistent state for the nested `chezmoi dump` below; see the comment
+# at that call for why it cannot share the apply's.
+dump_state_dir="$(mktemp -d)"
+trap 'rm -f "$managed_list" "$sorted_list" "$dump_json" "${fresh:-}"; rm -rf "$dump_state_dir"' EXIT
 
 if ! chezmoi "${chezmoi_args[@]}" managed --path-style=absolute --include=files >"$managed_list"; then
   printf 'osquery pipeline manifest: could not list managed files, refusing to rewrite the manifest\n' >&2
@@ -108,9 +138,78 @@ while IFS= read -r target; do
   esac
 done <"$sorted_list"
 
+# Resolve the SET before anything else consults it. `chezmoi dump` with NO target
+# arguments dumps the ENTIRE target state, which would render every managed
+# template - including the ones that call keepassxc - from an unattended apply. An
+# empty path list must therefore abort here, before the dump, not only at the
+# empty-manifest guard further down.
+if [[ ${#paths[@]} -eq 0 ]]; then
+  printf 'osquery pipeline manifest: no managed pipeline files resolved, refusing to rewrite the manifest\n' >&2
+  exit 1
+fi
+
+# The INTENDED mode of every pipeline file, in one dump of the same source state.
+# `chezmoi dump --format=json` reports each target as chezmoi would write it,
+# including the perm its source attributes (executable_, private_) encode, so the
+# mode column is intent for the same reason the hash column is.
+#
+# --persistent-state IS REQUIRED AND MUST NOT BE REMOVED. Unlike `managed` and
+# `cat`, `dump` opens chezmoi's persistent state, and this script runs NESTED
+# inside the apply that already holds that lock, so a plain `chezmoi dump` here
+# fails with "timeout obtaining persistent state lock" on every real apply
+# (verified empirically; the same trap the docblock records for `status`/`verify`).
+# Pointing it at a throwaway state file gives the dump its own uncontended lock.
+# The persistent state holds entry and script bookkeeping, not the source state, so
+# a fresh one does not change the perm or contents reported for a file target.
+#
+# Materialized under an explicit status check for the same reason the managed
+# listing is: a dump that emitted some entries and then failed must abort, never
+# leave a path silently without a mode.
+if ! chezmoi "${chezmoi_args[@]}" --persistent-state "$dump_state_dir/state.boltdb" \
+  dump --format=json "${paths[@]}" >"$dump_json"; then
+  printf 'osquery pipeline manifest: could not dump the managed pipeline files, refusing to rewrite the manifest\n' >&2
+  exit 1
+fi
+
+# jq, not a hand-rolled parse: the dump is JSON, and jq is already a hard runtime
+# dependency of the alerter this manifest protects. The perm is emitted FIRST and
+# the (destination-relative) name LAST, so `read -r perm rel` reads a name
+# containing spaces whole, the same discipline the manifest itself uses.
+#
+# Materialized to a file rather than read through a process substitution, for the
+# reason recorded above the managed listing: a process substitution discards the
+# producer's exit status, so a jq that emitted some pairs and then failed would
+# hand the loop a partial map and the tuples it could not answer for would be
+# silently missing their mode.
+perm_pairs="$(mktemp)"
+trap 'rm -f "$managed_list" "$sorted_list" "$dump_json" "$perm_pairs" "${fresh:-}"; rm -rf "$dump_state_dir"' EXIT
+if ! jq -r 'to_entries[] | "\(.value.perm) \(.key)"' "$dump_json" >"$perm_pairs"; then
+  printf 'osquery pipeline manifest: could not read the intended modes out of the dump, refusing to rewrite the manifest\n' >&2
+  exit 1
+fi
+
+declare -A intended_perm=()
+while read -r perm rel; do
+  [[ -n $perm && -n $rel ]] || continue
+  intended_perm["$home/$rel"]="$perm"
+done <"$perm_pairs"
+if [[ ${#intended_perm[@]} -eq 0 ]]; then
+  printf 'osquery pipeline manifest: the dump yielded no modes, refusing to rewrite the manifest\n' >&2
+  exit 1
+fi
+
+# The OWNER column: the uid this apply is running as, which is the uid chezmoi
+# writes every target file as. Validated as digits so a surprising `id` can never
+# put a non-numeric token in a security-critical column.
+owner_uid="$(id -u)"
+if [[ ! $owner_uid =~ ^[0-9]{1,10}$ ]]; then
+  printf 'osquery pipeline manifest: id -u did not report a numeric uid, refusing to rewrite the manifest\n' >&2
+  exit 1
+fi
+
 fresh="$(mktemp)"
 
-# shasum format ("<sha256>  <path>"), path-sorted above for a byte-reproducible
+# "<sha256> <mode> <uid> <path>", path-sorted above for a byte-reproducible
 # manifest. The hash is captured into a VARIABLE first, deliberately: a command
 # substitution used directly as a printf argument would discard a failing
 # `chezmoi cat` (printf itself still succeeds) and emit a tuple with an empty hash,
@@ -122,7 +221,18 @@ for target in "${paths[@]}"; do
     printf 'osquery pipeline manifest: could not hash %s, refusing to rewrite the manifest\n' "$target" >&2
     exit 1
   fi
-  printf '%s  %s\n' "$file_hash" "$target"
+  # chezmoi reports perm as a DECIMAL integer (493 for 0755). Validated as digits
+  # and range-bound to the twelve permission bits BEFORE the octal conversion, so a
+  # value that is not a mode aborts instead of being formatted into something that
+  # looks like one. `10#` forces base ten on both uses: a leading zero would
+  # otherwise make bash read the digits as octal.
+  target_perm="${intended_perm["$target"]:-}"
+  if [[ ! $target_perm =~ ^[0-9]{1,4}$ ]] || ((10#$target_perm > 4095)); then
+    printf 'osquery pipeline manifest: no usable intended mode for %s, refusing to rewrite the manifest\n' "$target" >&2
+    exit 1
+  fi
+  printf -v file_mode '%04o' "$((10#$target_perm))"
+  printf '%s %s %s %s\n' "$file_hash" "$file_mode" "$owner_uid" "$target"
 done >"$fresh"
 
 # Never let an empty render overwrite a good manifest.

--- a/dot_local/libexec/osquery/executable_pipeline-audit.sh
+++ b/dot_local/libexec/osquery/executable_pipeline-audit.sh
@@ -108,7 +108,8 @@ _pipeline_audit_size() {
 #              TOKEN: missing (absent, unreadable, or empty manifest),
 #              unavailable (the verdict helper it reuses is not installed),
 #              untrustworthy (not root-owned, or group/world-writable),
-#              malformed (a line that is not "<sha256>  <absolute-path>"),
+#              malformed (a line that is not
+#              "<sha256> <mode> <uid> <absolute-path>"),
 #              overlong (more entries than the audit will examine), budget (the
 #              wall-clock ceiling was reached first).
 #
@@ -117,9 +118,18 @@ _pipeline_audit_size() {
 # monitor that goes quiet when its own input breaks is the failure mode this whole
 # subsystem exists to avoid. Every refusal is the caller's cue to page.
 #
-# SCOPE, recorded honestly: this audits MANIFEST -> DISK. A file planted under the
-# pipeline home that the manifest does not list is not found here; that direction
-# is the alerter's, which pages any tracked path whose tuple it cannot confirm.
+# SCOPE, recorded honestly. This audits MANIFEST -> DISK, and only the CONTENT
+# column of it. Two consequences, both real:
+#   - A file planted under the pipeline home that the manifest does not list is not
+#     found here; that direction is the alerter's, which pages any tracked path
+#     whose tuple it cannot confirm.
+#   - The manifest also binds MODE and OWNER, and this scan does not compare them.
+#     Attribute drift on a watched path is caught at EVENT time by the verdict, so
+#     the residue is attribute drift that fires no event at all: a chmod or chown
+#     applied through a hard-link alias outside the pipeline home changes the shared
+#     inode while the event names the outside path. Comparing the two columns here
+#     would close that; it is deliberately left to the owner of this scan rather
+#     than bolted on by the change that added the columns.
 pipeline_audit_scan() {
   # The reused seam has to actually be here. Checked by NAME rather than assumed,
   # so a partial deploy reports a broken audit instead of an all-clear.
@@ -148,13 +158,20 @@ pipeline_audit_scan() {
     return 1
   }
 
-  # The manifest is shasum format, "<sha256>  <path>" with exactly two spaces. The
-  # line is matched WHOLE rather than split into fields: a path may contain spaces,
-  # and word-splitting would silently truncate it into a path that exists nowhere
-  # (which would then report as a bogus divergence forever). The path must be
-  # absolute, because the audit resolves nothing itself and a relative path would be
-  # read against whatever directory launchd happened to start the caller in.
-  local line_pattern='^([0-9a-fA-F]{64}) {2}(/.+)$'
+  # The manifest is "<sha256> <mode> <uid> <path>", single-space separated with the
+  # PATH LAST. The line is matched WHOLE rather than split into fields: a path may
+  # contain spaces, and word-splitting would silently truncate it into a path that
+  # exists nowhere (which would then report as a bogus divergence forever). The path
+  # must be absolute, because the audit resolves nothing itself and a relative path
+  # would be read against whatever directory launchd happened to start the caller
+  # in.
+  #
+  # The mode and owner columns are MATCHED but not compared here; see the scope note
+  # in this function's docblock for which layer covers attribute drift. Requiring
+  # them to be present and well-formed is what keeps this fail-closed: a manifest in
+  # the older content-only format does not match, so it reports malformed and the
+  # caller pages, rather than being read as if the missing columns did not matter.
+  local line_pattern='^([0-9a-fA-F]{64}) ([0-7]{4}) ([0-9]{1,10}) (/.+)$'
   local deadline entries=0 line want_hash target size disk_hash
   deadline=$(($(_pipeline_audit_now) + budget))
 
@@ -177,7 +194,7 @@ pipeline_audit_scan() {
     # Lower-cased on both sides: shasum and osquery both emit lowercase, so this is
     # documented defense in depth against a future producer, and it costs nothing.
     want_hash="${BASH_REMATCH[1],,}"
-    target="${BASH_REMATCH[2]}"
+    target="${BASH_REMATCH[4]}"
     # A manifested path must hold a REGULAR FILE, and links are never followed. A
     # symlink standing where a pipeline script belongs would otherwise be hashed
     # THROUGH to content the manifest vouches for, while the bytes that actually

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -88,6 +88,19 @@ _pipeline_mtime() {
   stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null
 }
 
+# _pipeline_change_time <path>: epoch inode CHANGE time, or empty when it cannot be
+# read. Same portable order as _pipeline_mtime.
+#
+# This, not mtime, is what "when did this file last change" means once mode and
+# owner are part of the tuple: a chmod or a chown moves ctime and leaves mtime
+# alone, while a content write moves both. Asking for mtime would make an
+# attribute-only apply look older than the manifest and skip the settle window
+# entirely, which the alerter cannot recover from - it judges each finding exactly
+# once, so the false CRIT would never be reconsidered.
+_pipeline_change_time() {
+  stat -c '%Z' "$1" 2>/dev/null || stat -f '%c' "$1" 2>/dev/null
+}
+
 # _pipeline_file_mode <path>: the file's permission bits as EXACTLY four octal
 # digits (0755, or 4755 for a setuid file), non-zero and empty output when they
 # cannot be read.
@@ -220,23 +233,28 @@ _pipeline_deployed_state_is_known_good() {
   _pipeline_manifest_has_tuple "$target" "$disk_hash" "$disk_mode" "$disk_uid"
 }
 
-# _pipeline_tuple_settles <path>: the current-content check, plus a bounded wait for
-# an in-flight manifest regeneration. It waits only when the manifest EXISTS but is
-# OLDER than the file that changed, which is exactly the apply-race shape (the file
+# _pipeline_tuple_settles <path>: the current-state check, plus a bounded wait for
+# an in-flight manifest regeneration. It waits only when the manifest EXISTS but
+# PREDATES the change to the file, which is exactly the apply-race shape (the file
 # landed, the manifest has not been reinstalled yet). A missing manifest pages
-# immediately, and a manifest newer than the target is already the final word. The
-# content is re-read on every retry, so a file still settling is judged on what it
+# immediately, and a manifest newer than the change is already the final word. The
+# state is re-read on every retry, so a file still settling is judged on what it
 # finally holds, not on a mid-write snapshot.
+#
+# The target side is its CHANGE time, not its modification time, because a chmod or
+# a chown moves only the former and both are now part of the tuple. The manifest
+# side stays mtime: the runner installs a fresh file, so its mtime is the moment
+# that manifest became current.
 _pipeline_tuple_settles() {
   local target="$1"
   _pipeline_deployed_state_is_known_good "$target" && return 0
   local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
   [[ -r $manifest ]] || return 1
-  local manifest_mtime target_mtime
+  local manifest_mtime target_ctime
   manifest_mtime=$(_pipeline_mtime "$manifest") || true
-  target_mtime=$(_pipeline_mtime "$target") || true
-  [[ -n $manifest_mtime && -n $target_mtime ]] || return 1
-  ((manifest_mtime < target_mtime)) || return 1
+  target_ctime=$(_pipeline_change_time "$target") || true
+  [[ -n $manifest_mtime && -n $target_ctime ]] || return 1
+  ((manifest_mtime < target_ctime)) || return 1
   # Open the shared window on the first miss of this invocation; a later miss
   # inherits whatever is left of it, and answers at once when it is spent.
   [[ -n $_pipeline_settle_deadline ]] ||

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -25,28 +25,46 @@
 # without a manifest tuple to justify it, and a missing/empty/mismatched hash pages
 # too.
 #
-# Blind spots, recorded honestly. This check judges EVENTS about the deployed tree,
-# so it is bounded by what generates events and by what the manifest binds:
+# COVERAGE MAP. Two layers now enforce the manifest, and they cover DIFFERENT
+# things. For any given tamper, this says which one is supposed to catch it.
 #
-#   - NO GROUP COLUMN. Content, mode and owner are bound; the owning GROUP is not.
+#   LAYER 1, this file, at EVENT time. Judges a filesystem event against the full
+#   tuple, so it catches CONTENT, PERMISSION and OWNERSHIP drift, but only on a
+#   change that produces an event on a watched path. It is the fast answer:
+#   whatever fires an event is judged within seconds.
+#
+#   LAYER 2, the PERIODIC CONTENT AUDIT in ../pipeline-audit.sh, which the uptime
+#   watchdog runs every 15 minutes. Re-hashes every manifested path on a schedule,
+#   so it catches drift that produces NO EVENT AT ALL and that layer 1 therefore
+#   never sees. The two shapes that matters for are hard links and symlink
+#   referents: the watch is path-based, so an attacker who hard-links a manifested
+#   script to a writable path outside the pipeline home overwrites the SAME INODE
+#   through the outside alias, the event names that path, and nothing fires for the
+#   watched one. That is a property of path-based file-integrity monitoring, not of
+#   the judgment below. The symlink and regular-file checks below remain the
+#   immediate answer on the event path.
+#
+# WHAT NEITHER LAYER COVERS, recorded honestly:
+#
+#   - GROUP OWNERSHIP. Content, mode and owner are bound; the owning GROUP is not.
 #     chezmoi has no group intent to derive one from, and a chgrp alone cannot make
 #     a file writable that the bound mode does not already grant group write to (a
 #     bound 0755 or 0644 grants none), so the case a group column would add on its
 #     own is chgrp plus chmod, which the mode column already pages.
-#   - HARD LINKS / EVENT GENERATION. The watch is path-based, so an attacker who
-#     hard-links a manifested script to a writable path outside the pipeline home
-#     can overwrite the SAME INODE through the outside alias: the filesystem event
-#     names that path, nothing fires for the watched one, and no verdict runs at
-#     all. This is a property of path-based file-integrity monitoring, not of the
-#     judgment below (before the manifest existed, no event meant no page either).
-#     Now covered by the PERIODIC CONTENT AUDIT in ../pipeline-audit.sh, which the
-#     uptime watchdog runs every 15 minutes: it hashes every manifested path and
-#     pages on a divergence, needing no event to have fired. The symlink and
-#     regular-file checks below remain the immediate answer on the event path.
+#   - ATTRIBUTE DRIFT THAT FIRES NO EVENT. The two layers overlap on content but not
+#     on attributes: layer 2 compares only the content column. So a chmod or chown
+#     applied through a hard-link alias outside the pipeline home lands in the gap
+#     between them - layer 1 sees no event, layer 2 does not look at those columns.
+#     Closing it means comparing mode and owner in the audit as well.
+#   - RE-TAMPERING AN ALREADY-REPORTED FILE. Layer 2 dedupes on a fingerprint of
+#     WHICH paths disagree and HOW, not of the bytes they now hold, so a path already
+#     reported as a content divergence can be rewritten again with different content
+#     without paging a second time. Deliberate (it is what stops a persistent
+#     divergence paging every 15 minutes forever), and worth knowing.
 #   - SOURCE COMPROMISE. The manifest is generated from chezmoi's source state,
 #     which is user-writable, so tampering with a managed file's SOURCE and letting
-#     a legitimate apply deploy it is signed as known-good. See the runner's
-#     docblock: this layer buys post-deployment integrity, not source integrity.
+#     a legitimate apply deploy it is signed as known-good by BOTH layers. See the
+#     runner's docblock: this buys post-deployment integrity, not source integrity.
 #
 # Return-code contract (from c69baab _pipeline_verdict):
 #   0 = PAGE   (tamper / cannot confirm legit / no manifest / delete)

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -5,11 +5,19 @@
 # directories: is this a tamper to PAGE, a known-good apply to stay SILENT, or an
 # untracked neighbor to log only?
 #
-# The pipeline-integrity manifest is a root-owned sha256 list of the alerter's own
-# scripts and plists (shasum format: "<sha256>  <path>"), regenerated on every
-# apply from chezmoi's managed intent. A change is legitimate only when its EXACT
-# (path, sha256) tuple is in the manifest, so a deployed known-good file matches
-# and stays silent while a tampered one does not.
+# The pipeline-integrity manifest is a root-owned list of the alerter's own scripts
+# and plists, regenerated on every apply from chezmoi's managed intent. One
+# whitespace-separated tuple per line, PATH LAST so a path containing spaces is
+# still read whole:
+#
+#   <sha256> <mode> <uid> <path>
+#
+# A change is legitimate only when the file's CURRENT content hash, mode AND owner
+# all equal the columns bound to its exact path, so a deployed known-good file
+# matches and stays silent while a tampered one does not. Binding mode and owner is
+# what makes a `chmod g+w` or a chown page: osquery reports those as
+# ATTRIBUTES_MODIFIED events carrying the file's unchanged digest, which a
+# content-only manifest matched and suppressed.
 #
 # Fail-safe (criterion 6): a missing, unreadable, or untrustworthy manifest makes
 # _pipeline_manifest_has_tuple return not-found, so a tracked change that cannot be
@@ -20,9 +28,11 @@
 # Blind spots, recorded honestly. This check judges EVENTS about the deployed tree,
 # so it is bounded by what generates events and by what the manifest binds:
 #
-#   - CONTENT ONLY. An ATTRIBUTES_MODIFIED event (for example `chmod g+w` on a
-#     pipeline script) carries unchanged content, matches its tuple, and stays
-#     silent. A mode/owner column is a follow-up.
+#   - NO GROUP COLUMN. Content, mode and owner are bound; the owning GROUP is not.
+#     chezmoi has no group intent to derive one from, and a chgrp alone cannot make
+#     a file writable that the bound mode does not already grant group write to (a
+#     bound 0755 or 0644 grants none), so the case a group column would add on its
+#     own is chgrp plus chmod, which the mode column already pages.
 #   - HARD LINKS / EVENT GENERATION. The watch is path-based, so an attacker who
 #     hard-links a manifested script to a writable path outside the pipeline home
 #     can overwrite the SAME INODE through the outside alias: the filesystem event
@@ -40,7 +50,8 @@
 #
 # Return-code contract (from c69baab _pipeline_verdict):
 #   0 = PAGE   (tamper / cannot confirm legit / no manifest / delete)
-#   1 = SILENT (an untracked neighbor, or an exact (path, sha256) manifest match)
+#   1 = SILENT (an untracked neighbor, or an exact (path, sha256, mode, uid)
+#               manifest match)
 
 # Keep this default in sync with the manifest path in
 # .chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh (the producer). A test
@@ -142,39 +153,71 @@ _pipeline_manifest_is_trustworthy() {
   return 0
 }
 
-# _pipeline_manifest_has_tuple <path> <hash>: 0 when the manifest holds a line
-# binding exactly this hash to exactly this path, else 1. Legitimacy is the EXACT
-# (path, sha256) tuple, not the hash alone: binding the hash to ITS path defeats a
-# swap-in-place (a valid hash lifted onto a different tracked path). Hashes are
-# compared case-insensitively via bash case-folding (no forks): shasum and osquery
-# both emit lowercase, so this is documented defense-in-depth against a future
-# producer, kept because it now costs nothing. A missing, unreadable, or
-# untrustworthy manifest returns 1 - the fail-safe hinge.
+# _pipeline_manifest_has_tuple <path> <hash> <mode> <uid>: 0 when the manifest
+# holds a line binding exactly this content hash, mode and owner to exactly this
+# path, else 1. Legitimacy is the EXACT tuple, not any one column:
+#
+#   - binding the hash to ITS path defeats a swap-in-place (a valid hash lifted
+#     onto a different tracked path);
+#   - binding MODE and OWNER alongside the content defeats an attribute-only
+#     change. osquery reports a chmod or a chown as an ATTRIBUTES_MODIFIED event
+#     carrying the file's UNCHANGED digest, so a content-only manifest matched it
+#     and stayed silent. Making a pipeline script group-writable now, to modify it
+#     later from a less privileged context, was therefore invisible.
+#
+# Manifest line shape, four whitespace-separated fields with the PATH LAST:
+#
+#   <sha256> <mode> <uid> <path>
+#
+# Path last is load-bearing: `read -r` assigns the remainder of the line to the
+# final variable, so a path containing spaces is still read whole. It also makes a
+# SHORT line inert rather than dangerous - a two-column line (the shape this
+# manifest had before mode and owner were bound) leaves uid and path empty, and an
+# empty path can never equal a real target, so the line vouches for nothing and
+# the change pages. The non-empty guard below states that explicitly rather than
+# leaving it to fall out of the comparison.
+#
+# Hashes are compared case-insensitively via bash case-folding (no forks): shasum
+# and osquery both emit lowercase, so this is documented defense-in-depth against a
+# future producer, kept because it now costs nothing. Mode and uid are compared
+# verbatim: the producer writes mode as exactly four octal digits and uid in
+# decimal, and _pipeline_file_mode / _pipeline_file_uid normalize the observed
+# values to the same form. A missing, unreadable, or untrustworthy manifest
+# returns 1 - the fail-safe hinge.
 _pipeline_manifest_has_tuple() {
   local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
   [[ -r $manifest ]] || return 1
   _pipeline_manifest_is_trustworthy "$manifest" || return 1
-  local want_path="$1" want_hash="${2,,}" h p
+  local want_path="$1" want_hash="${2,,}" want_mode="$3" want_uid="$4" h m u p
+  # An observed column that could not be read must never be matched against, or an
+  # equally empty manifest column would vouch for a file nothing was learned about.
+  [[ -n $want_hash && -n $want_mode && -n $want_uid && -n $want_path ]] || return 1
   # `|| [[ -n $h ]]` so a final line with no trailing newline is still examined.
-  while read -r h p || [[ -n $h ]]; do
-    [[ ${h,,} == "$want_hash" && $p == "$want_path" ]] && return 0
+  while read -r h m u p || [[ -n $h ]]; do
+    [[ -n $h && -n $m && -n $u && -n $p ]] || continue
+    [[ ${h,,} == "$want_hash" && $m == "$want_mode" &&
+      $u == "$want_uid" && $p == "$want_path" ]] && return 0
   done <"$manifest"
   return 1
 }
 
-# _pipeline_content_is_known_good <path>: hash the file AS IT IS NOW and require
-# that current content to be the manifest's tuple for this exact path. Re-reading
-# here (rather than trusting the digest osquery recorded when the event fired) is
-# what closes the swap-after-the-event race: an attacker could otherwise let a
-# known-good event be recorded, replace the file, run it, and restore it before the
-# next collection, and the stale digest would have vouched for bytes that were not
-# on disk when the decision was made. A file that cannot be hashed returns 1, so it
+# _pipeline_deployed_state_is_known_good <path>: read the file's content hash, mode
+# and owner AS THEY ARE NOW and require that state to be the manifest's tuple for
+# this exact path. Re-reading here (rather than trusting what osquery recorded when
+# the event fired) is what closes the swap-after-the-event race: an attacker could
+# otherwise let a known-good event be recorded, replace the file, run it, and
+# restore it before the next collection, and the stale digest would have vouched
+# for bytes that were not on disk when the decision was made. The same argument
+# applies to the attributes, which is why they are stat-ed here and not taken from
+# the event. A file whose hash, mode or owner cannot be read returns 1, so it
 # pages.
-_pipeline_content_is_known_good() {
-  local target="$1" disk_hash
+_pipeline_deployed_state_is_known_good() {
+  local target="$1" disk_hash disk_mode disk_uid
   disk_hash=$(shasum -a 256 "$target" 2>/dev/null | awk '{print $1}')
   [[ -n $disk_hash ]] || return 1
-  _pipeline_manifest_has_tuple "$target" "$disk_hash"
+  disk_mode=$(_pipeline_file_mode "$target") || return 1
+  disk_uid=$(_pipeline_file_uid "$target") || return 1
+  _pipeline_manifest_has_tuple "$target" "$disk_hash" "$disk_mode" "$disk_uid"
 }
 
 # _pipeline_tuple_settles <path>: the current-content check, plus a bounded wait for
@@ -186,7 +229,7 @@ _pipeline_content_is_known_good() {
 # finally holds, not on a mid-write snapshot.
 _pipeline_tuple_settles() {
   local target="$1"
-  _pipeline_content_is_known_good "$target" && return 0
+  _pipeline_deployed_state_is_known_good "$target" && return 0
   local manifest="${OSQUERY_PIPELINE_MANIFEST:-$PIPELINE_MANIFEST}"
   [[ -r $manifest ]] || return 1
   local manifest_mtime target_mtime
@@ -200,7 +243,7 @@ _pipeline_tuple_settles() {
     _pipeline_settle_deadline=$(($(_pipeline_now) + OSQUERY_PIPELINE_SETTLE_SECONDS))
   while (($(_pipeline_now) < _pipeline_settle_deadline)); do
     sleep 1
-    _pipeline_content_is_known_good "$target" && return 0
+    _pipeline_deployed_state_is_known_good "$target" && return 0
   done
   return 1
 }

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -77,6 +77,38 @@ _pipeline_mtime() {
   stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null
 }
 
+# _pipeline_file_mode <path>: the file's permission bits as EXACTLY four octal
+# digits (0755, or 4755 for a setuid file), non-zero and empty output when they
+# cannot be read.
+#
+# The two platforms are deliberately asked for DIFFERENT fields. GNU %a already
+# prints all twelve permission bits. BSD has no equivalent: %Lp prints only the
+# low NINE, so a setuid, setgid or sticky bit set on a pipeline script would read
+# back as an ordinary mode. %p prints the full mode including the file type
+# (100755), so the low four octal digits are taken from whichever form answered
+# and both platforms yield the same string for the same file.
+#
+# The value is range-bound by a regex BEFORE it is sliced, so a stat that printed
+# something unexpected fails the read instead of producing a plausible-looking
+# mode.
+_pipeline_file_mode() {
+  local raw
+  raw=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%p' "$1" 2>/dev/null) || return 1
+  [[ $raw =~ ^[0-7]{1,7}$ ]] || return 1
+  raw="000$raw"
+  printf '%s' "${raw: -4}"
+}
+
+# _pipeline_file_uid <path>: the file's owner uid in decimal, non-zero and empty
+# output when it cannot be read. Validated as digits so a caller never compares
+# against a stat error string.
+_pipeline_file_uid() {
+  local raw
+  raw=$(stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1" 2>/dev/null) || return 1
+  [[ $raw =~ ^[0-9]{1,10}$ ]] || return 1
+  printf '%s' "$raw"
+}
+
 # _pipeline_manifest_is_trustworthy <path>: 0 when the manifest may be trusted to
 # SUPPRESS a page. Whoever can write the manifest can self-whitelist a file they
 # just tampered, so root ownership and a not-group/world-writable mode are VERIFIED
@@ -101,12 +133,12 @@ _pipeline_mtime() {
 _pipeline_manifest_is_trustworthy() {
   [[ -n ${OSQUERY_PIPELINE_MANIFEST:-} ]] && return 0
   local owner mode
-  owner=$(stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1" 2>/dev/null) || true
-  mode=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null) || true
+  owner=$(_pipeline_file_uid "$1") || true
+  mode=$(_pipeline_file_mode "$1") || true
   [[ $owner == 0 ]] || return 1
   # Refuse a group- or world-writable manifest. The mode is OCTAL, so both operands
-  # are read base 8; an unreadable mode defaults to 777 and is refused.
-  ((8#${mode:-777} & 8#22)) && return 1
+  # are read base 8; an unreadable mode defaults to 7777 and is refused.
+  ((8#${mode:-7777} & 8#22)) && return 1
   return 0
 }
 

--- a/test/fixtures/osquery-manifest-lib.bash
+++ b/test/fixtures/osquery-manifest-lib.bash
@@ -102,9 +102,24 @@ manifest_fixture_run_runner() {
 # manifest_fixture_installed: did this run perform a privileged install?
 manifest_fixture_installed() { [[ -s $MF_SUDO_LOG ]]; }
 
+# The manifest is "<sha256> <mode> <uid> <path>", path LAST. awk splits on runs of
+# whitespace, so field 4 is the path only while the path itself has no spaces; the
+# fixture never creates one, and the runner's own reader takes the remainder of the
+# line rather than a fixed field.
+
 # manifest_hash_of <target-path>: the manifest's recorded hash for a path, or empty.
 manifest_hash_of() {
-  awk -v p="$1" '$2 == p {print $1}' "$MF_MANIFEST" 2>/dev/null
+  awk -v p="$1" '$4 == p {print $1}' "$MF_MANIFEST" 2>/dev/null
+}
+
+# manifest_mode_of <target-path>: the manifest's recorded mode (four octal digits).
+manifest_mode_of() {
+  awk -v p="$1" '$4 == p {print $2}' "$MF_MANIFEST" 2>/dev/null
+}
+
+# manifest_uid_of <target-path>: the manifest's recorded owner uid (decimal).
+manifest_uid_of() {
+  awk -v p="$1" '$4 == p {print $3}' "$MF_MANIFEST" 2>/dev/null
 }
 
 # verdict_says_page <target> [verdict-helper]: run the REAL pipeline_verdict over

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -292,13 +292,17 @@ seed_raw_canary() {
 # status: a `find` that failed midway would otherwise yield a short manifest and a
 # green audit over an unexamined tail.
 regenerate_pipeline_manifest() {
-  local listing target file_hash
+  local listing target file_hash file_mode file_uid
   listing="$WD_HOME/manifest-listing"
   find "$WD_HOME/.local/libexec/osquery" -type f | LC_ALL=C sort >"$listing" || return 1
   : >"$OSQUERY_PIPELINE_MANIFEST"
   while IFS= read -r target; do
     file_hash="$(shasum -a 256 -- "$target")"
-    printf '%s  %s\n' "${file_hash%% *}" "$target" >>"$OSQUERY_PIPELINE_MANIFEST"
+    file_mode="$(stat -c '%a' "$target" 2>/dev/null || stat -f '%p' "$target")" || return 1
+    file_mode="000$file_mode"
+    file_uid="$(stat -c '%u' "$target" 2>/dev/null || stat -f '%u' "$target")" || return 1
+    printf '%s %s %s %s\n' "${file_hash%% *}" "${file_mode: -4}" "$file_uid" "$target" \
+      >>"$OSQUERY_PIPELINE_MANIFEST"
   done <"$listing"
 }
 

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -203,6 +203,36 @@ elapsed=$(($(date +%s) - start))
 [[ $got -eq 0 ]] || fail "a tuple that never arrives must still PAGE (got rc $got)"
 ((elapsed <= 6)) || fail "the settle wait is not bounded (${elapsed}s for a 2s window)"
 
+# --- an ATTRIBUTE-only apply can settle too ----------------------------------
+# A chmod moves a file's inode CHANGE time, not its modification time. Keying the
+# settle guard on mtime therefore made an attribute-only apply skip the window
+# outright: the file lands, the manifest has not been reinstalled yet, and the
+# alerter judges that finding exactly once, so the false CRIT is never
+# reconsidered. Now that mode is part of the tuple, that race is reachable
+# whenever a source attribute changes without the bytes changing.
+#
+# The fixture back-dates the target's mtime and leaves its ctime at now, which is
+# the shape a chmod produces. The filesystem state is set up BEFORE the call, so
+# run_verdict's subshell sees it: a subshell inherits the filesystem and isolates
+# only shell state, which is exactly the split this case needs.
+chmod_settle_target="$MF_HOME/.local/libexec/osquery/chmod-settle.sh"
+printf 'echo chmod settle\n' >"$chmod_settle_target"
+chmod 755 "$chmod_settle_target"
+touch -t 200001010000 "$chmod_settle_target"
+chmod_settle_hash="$(hash_of "$chmod_settle_target")"
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$MF_MANIFEST"
+touch -t 200001010000 "$MF_MANIFEST"
+(
+  sleep 1
+  printf '%s 0755 %s %s\n' "$chmod_settle_hash" "$(id -u)" "$chmod_settle_target" >"$MF_MANIFEST"
+) &
+chmod_settle_pid=$!
+got=0
+run_verdict "$chmod_settle_target" "$chmod_settle_hash" ATTRIBUTES_MODIFIED 5 || got=$?
+wait "$chmod_settle_pid"
+[[ $got -eq 1 ]] ||
+  fail "an attribute-only change whose manifest lands inside the settle window must resolve to SILENT (got rc $got)"
+
 # --- the settle budget is per ALERTER RUN, not per finding -------------------
 # route_findings judges findings sequentially while the alerter holds its
 # single-instance lock, and a contended WatchPaths invocation exits without
@@ -242,4 +272,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree, including a chmod on unchanged content; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration, stays bounded, and spends ONE budget per alerter run across many misses)\n'
+printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree, including a chmod on unchanged content; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses)\n'

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -7,6 +7,12 @@
 #   TRACKED  (results-alerter/pipeline-verdict.sh _pipeline_is_tracked) what the alerter judges
 #   MANIFEST (.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh) what can be vouched for
 #
+# The manifest has a SECOND consumer, the periodic audit (pipeline-audit.sh), which
+# parses the file directly instead of going through the verdict. It is driven here
+# against the real generated manifest for the same reason: a format change that only
+# the hand-built fixtures in its own suite kept up with would leave it refusing every
+# real manifest.
+#
 # A watched-and-tracked file the manifest can never contain pages FOREVER; a
 # manifested file nothing watches is never checked at all. This test drives all
 # three against the same fixture and pins their agreement, including the launch
@@ -93,6 +99,8 @@ hash_of() { shasum -a 256 "$1" | awk '{print $1}'; }
 run_verdict() {
   local target="$1" hash_value="$2" verb="$3" settle="${4:-$OSQUERY_PIPELINE_SETTLE_SECONDS}"
   (
+    # Subshell-local by design; run_audit below scopes HOME the same way.
+    # shellcheck disable=SC2030
     export HOME="$MF_HOME" OSQUERY_PIPELINE_SETTLE_SECONDS="$settle"
     pipeline_verdict "$target" "$hash_value" "$verb"
   )
@@ -119,6 +127,61 @@ chmod g+w "$script_target"
 expect_verdict 0 "a chmod g+w on a manifested script PAGES" "$script_target" "$(hash_of "$script_target")" ATTRIBUTES_MODIFIED
 chmod 755 "$script_target"
 expect_verdict 1 "restoring the intended mode is SILENT again" "$script_target" "$(hash_of "$script_target")" ATTRIBUTES_MODIFIED
+
+# --- THE PERIODIC AUDIT READS THE SAME GENERATED MANIFEST --------------------
+# The audit is the manifest's OTHER consumer, and it parses the file itself rather
+# than going through the verdict. Its own suite builds fixture manifests by hand, so
+# it stayed green through a producer format change that left it reporting
+# "malformed" against every real manifest: a loud break, but a permanent one. This
+# drives the REAL scan over the REAL generated manifest, which is the only check
+# that fails when producer and consumer drift apart.
+AUDIT="$REPO_ROOT/dot_local/libexec/osquery/executable_pipeline-audit.sh"
+[[ -f $AUDIT ]] || fail "missing the periodic audit: $AUDIT"
+
+# run_audit -- one scan, in a subshell, for the same reason run_verdict uses one.
+# Prints the scan return code on the first line, then the scan's stdout.
+run_audit() {
+  (
+    # HOME is meant to be subshell-local here, exactly as it is in run_verdict:
+    # that scoping is the isolation, not an accident of it.
+    # shellcheck disable=SC2030,SC2031
+    export HOME="$MF_HOME"
+    # shellcheck source=/dev/null
+    source "$AUDIT"
+    local rc=0 out
+    out="$(pipeline_audit_scan)" || rc=$?
+    printf '%s\n%s' "$rc" "$out"
+  )
+}
+
+# A plain refute helper. `! grep` inside a test body is a silent no-op under set -e,
+# so absence is asserted with an explicit case instead.
+refute_line() { # <haystack> <needle> <label>
+  case "$1" in
+    *"$2"*) fail "$3" ;;
+  esac
+}
+
+audit_out="$(run_audit)"
+audit_rc="${audit_out%%$'\n'*}"
+audit_body="${audit_out#*$'\n'}"
+[[ $audit_rc == 0 ]] ||
+  fail "the audit could not complete against the generated manifest (reason token: $audit_body)"
+refute_line "$audit_body" "$script_target" \
+  "the audit reported a divergence for an untampered manifested script: $audit_body"
+
+# ...and it actually LOOKS at the file, rather than passing everything by default.
+printf 'echo audit tamper\n' >>"$script_target"
+audit_out="$(run_audit)"
+audit_rc="${audit_out%%$'\n'*}"
+audit_body="${audit_out#*$'\n'}"
+[[ $audit_rc == 0 ]] ||
+  fail "the audit could not complete over a tampered tree (reason token: $audit_body)"
+case "$audit_body" in
+  *"content $script_target"*) ;;
+  *) fail "the audit did not report the tampered script as a content divergence: $audit_body" ;;
+esac
+manifest_fixture_apply # restore
 
 # --- THE THREE-WAY AGREEMENT, across BOTH launch agent watch roots ------------
 # Every launch-agent path the WATCH reports is classified, and the TRACKED verdict
@@ -272,4 +335,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree, including a chmod on unchanged content; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses)\n'
+printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree, including a chmod on unchanged content; the periodic audit parses the same generated manifest and reports a real tamper; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses)\n'

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -17,8 +17,8 @@
 # earlier revision matched that basename anywhere and had exactly this divergence.
 #
 # It also pins the end-to-end agreement between the real generated manifest and the
-# real verdict (unchanged is SILENT, a one-byte tamper PAGES) and the bounded
-# apply-race settle window.
+# real verdict (unchanged is SILENT, a one-byte tamper PAGES, and a chmod on
+# otherwise unchanged content PAGES) and the bounded apply-race settle window.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -110,6 +110,15 @@ expect_verdict 1 "an unchanged pipeline script is SILENT" "$script_target" "$(ha
 printf 'echo tampered\n' >>"$script_target"
 expect_verdict 0 "a one-byte tamper PAGES" "$script_target" "$(hash_of "$script_target")" UPDATED
 manifest_fixture_apply # restore
+expect_verdict 1 "the restored script is SILENT again" "$script_target" "$(hash_of "$script_target")" UPDATED
+
+# A chmod PAGES end to end, against the REAL generated manifest. osquery reports
+# this as ATTRIBUTES_MODIFIED carrying the file's UNCHANGED digest, which is why
+# the event hash below is the same one that was just SILENT: only the mode moved.
+chmod g+w "$script_target"
+expect_verdict 0 "a chmod g+w on a manifested script PAGES" "$script_target" "$(hash_of "$script_target")" ATTRIBUTES_MODIFIED
+chmod 755 "$script_target"
+expect_verdict 1 "restoring the intended mode is SILENT again" "$script_target" "$(hash_of "$script_target")" ATTRIBUTES_MODIFIED
 
 # --- THE THREE-WAY AGREEMENT, across BOTH launch agent watch roots ------------
 # Every launch-agent path the WATCH reports is classified, and the TRACKED verdict
@@ -153,7 +162,7 @@ done <<<"$watch_roots"
 
 # Every path the manifest holds must be one the verdict tracks (no manifested-but-
 # unchecked file).
-while read -r _ manifested_path; do
+while read -r _ _ _ manifested_path; do
   [[ -n $manifested_path ]] || continue
   t=0
   HOME="$MF_HOME" _pipeline_is_tracked "$manifested_path" || t=$?
@@ -165,13 +174,17 @@ done <"$MF_MANIFEST"
 # is reinstalled must not page a false CRIT that is never reconsidered.
 settle_target="$script_target"
 settle_hash="$(hash_of "$settle_target")"
+settle_mode="$(manifest_mode_of "$settle_target")"
+settle_uid="$(manifest_uid_of "$settle_target")"
+[[ -n $settle_mode && -n $settle_uid ]] ||
+  fail "the settle fixture could not read the generated mode/owner columns"
 # A manifest that PREDATES the target and lacks the tuple: the verdict waits, and
 # goes SILENT when the regeneration lands inside the window.
-printf 'deadbeef  /nowhere\n' >"$MF_MANIFEST"
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$MF_MANIFEST"
 touch -t 200001010000 "$MF_MANIFEST"
 (
   sleep 1
-  printf '%s  %s\n' "$settle_hash" "$settle_target" >"$MF_MANIFEST"
+  printf '%s %s %s %s\n' "$settle_hash" "$settle_mode" "$settle_uid" "$settle_target" >"$MF_MANIFEST"
 ) &
 settle_pid=$!
 got=0
@@ -181,7 +194,7 @@ wait "$settle_pid"
   fail "a manifest that lands during the settle window must resolve to SILENT (got rc $got)"
 
 # ...but the wait is BOUNDED: a tuple that never arrives still PAGES.
-printf 'deadbeef  /nowhere\n' >"$MF_MANIFEST"
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$MF_MANIFEST"
 touch -t 200001010000 "$MF_MANIFEST"
 start=$(date +%s)
 got=0
@@ -203,7 +216,7 @@ elapsed=$(($(date +%s) - start))
 # land in a single invocation. run_verdict isolates CASES from each other; this
 # asserts what happens WITHIN one case. The two are the same rule from both sides.
 miss_manifest="$MF_ROOT/miss.sha256"
-printf 'deadbeef  /nowhere\n' >"$miss_manifest"
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$miss_manifest"
 touch -t 200001010000 "$miss_manifest"
 # The targets must EXIST and post-date the manifest, or the mtime guard short
 # circuits and nothing settles (the shape a real apply produces).
@@ -229,4 +242,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration, stays bounded, and spends ONE budget per alerter run across many misses)\n'
+printf 'osquery-pipeline-manifest-agreement: OK (generated manifest and real verdict agree, including a chmod on unchanged content; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the settle window resolves a live regeneration, stays bounded, and spends ONE budget per alerter run across many misses)\n'

--- a/test/integration/osquery-pipeline-manifest-generation.sh
+++ b/test/integration/osquery-pipeline-manifest-generation.sh
@@ -11,7 +11,12 @@
 #     as known-good permanently);
 #   - each file's CONTENT hash comes from `chezmoi cat` (the source state as
 #     chezmoi would write it), so a managed file TAMPERED on disk is recorded with
-#     its INTENDED hash and the tampered bytes then fail the tuple check and page.
+#     its INTENDED hash and the tampered bytes then fail the tuple check and page;
+#   - each file's MODE comes from `chezmoi dump` (the perm the source attributes
+#     encode), so a managed file CHMOD-ed on disk is recorded with its INTENDED
+#     mode and the drifted mode then fails the tuple check and pages;
+#   - each file's OWNER is the uid the apply runs as, which is the uid chezmoi
+#     writes target files as.
 #
 # Also pinned here: the manifest is path-sorted and byte-stable, covers the
 # recursive results-alerter/ helpers, excludes a non-osquery LaunchAgent and
@@ -80,8 +85,22 @@ want="$(manifest_fixture_chezmoi cat "$script_target" | shasum -a 256 | awk '{pr
 [[ "$(manifest_hash_of "$script_target")" == "$want" ]] ||
   fail "the manifest hash for $script_target is not the chezmoi-rendered (intent) hash"
 
+# 2a. MODE is INTENT too, and it is the mode the source ATTRIBUTES encode, not a
+#     policy this test and the runner both guess at. The fixture adds scripts with
+#     chezmoi's executable_ prefix (0755) and the plists as plain templates (0644),
+#     so the two literals below are the attribute semantics, asserted independently
+#     of however the runner obtains them.
+[[ "$(manifest_mode_of "$script_target")" == 0755 ]] ||
+  fail "an executable_ pipeline script must be manifested 0755, got '$(manifest_mode_of "$script_target")'"
+[[ "$(manifest_mode_of "$plist_target")" == 0644 ]] ||
+  fail "a plain managed plist must be manifested 0644, got '$(manifest_mode_of "$plist_target")'"
+
+# 2b. OWNER is the uid this apply runs as: the uid chezmoi writes target files as.
+[[ "$(manifest_uid_of "$script_target")" == "$(id -u)" ]] ||
+  fail "the manifest owner column is not the uid the apply runs as"
+
 # 3. Path-sorted and byte-stable across runs.
-LC_ALL=C sort -c <(awk '{print $2}' "$MF_MANIFEST") 2>/dev/null ||
+LC_ALL=C sort -c <(awk '{print $4}' "$MF_MANIFEST") 2>/dev/null ||
   fail "the manifest is not sorted by path"
 before="$(cat "$MF_MANIFEST")"
 manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero on the second run"
@@ -116,6 +135,21 @@ verdict_says_page "$script_target" "$VERDICT" ||
   fail "a tampered managed pipeline file must PAGE"
 manifest_fixture_apply # restore the intended bytes
 
+# 6a. THE CHMOD-ED FILE PIN, the mode-column twin of 6: a managed file whose mode
+#     was changed on disk is still recorded with its INTENDED mode, so the drifted
+#     mode fails the tuple check and pages. Deriving the mode column from the
+#     DEPLOYED file would bless the chmod instead - the exact flaw taking the
+#     content hash from disk would have.
+chmod g+w "$script_target"
+manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero with a chmod-ed file present"
+[[ "$(manifest_mode_of "$script_target")" == 0755 ]] ||
+  fail "SECURITY: the manifest recorded the CHMOD-ed mode instead of chezmoi's intent"
+verdict_says_page "$script_target" "$VERDICT" ||
+  fail "a chmod-ed managed pipeline file must PAGE (its content is unchanged)"
+chmod 755 "$script_target"
+verdict_says_page "$script_target" "$VERDICT" &&
+  fail "restoring the intended mode must return the file to SILENT"
+
 # 7. No drift: a newly-added managed file is covered with no change to the runner.
 manifest_fixture_add_script heartbeat.sh 'echo heartbeat'
 manifest_fixture_apply
@@ -127,4 +161,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-generation: OK (set and content from chezmoi intent; a PLANTED file is never blessed and pages; a TAMPERED managed file is signed with its intended hash and pages; sorted, stable, exclusions honored, new file auto-covered)\n'
+printf 'osquery-pipeline-manifest-generation: OK (set, content and mode from chezmoi intent, owner from the applying uid; a PLANTED file is never blessed and pages; a TAMPERED managed file is signed with its intended hash and pages; a CHMOD-ed one is signed with its intended mode and pages; sorted, stable, exclusions honored, new file auto-covered)\n'

--- a/test/integration/osquery-pipeline-manifest-install.sh
+++ b/test/integration/osquery-pipeline-manifest-install.sh
@@ -12,6 +12,12 @@
 # interactive apply. Pinned end to end below: the runner is dropped into a fixture
 # chezmoi source and must actually execute under --exclude=templates.
 #
+# That end-to-end step is also the only place a NESTED chezmoi call runs under a
+# real apply, which is where the persistent state lock is already held. `chezmoi
+# dump` takes that lock and fails without a throwaway --persistent-state; every
+# other check here invokes the runner directly, so none of them would notice. It
+# caught exactly that, so do not weaken it to a direct invocation.
+#
 # Also pinned: root:wheel 0644, the diff-guard (no privileged write when nothing
 # changed), re-install after a real change, refusal to install an empty manifest,
 # a generation failure leaving the previous manifest intact, and that the producer

--- a/test/unit/osquery-pipeline-audit.sh
+++ b/test/unit/osquery-pipeline-audit.sh
@@ -74,12 +74,18 @@ printf 'echo digest\n' >"$good_script"
 printf 'echo spaced\n' >"$spaced_script"
 printf '<plist/>\n' >"$plist"
 
+# The manifest binds content, mode and owner: "<sha256> <mode> <uid> <path>", path
+# LAST so a path containing spaces is still read whole. The audit compares only the
+# content column, but it REQUIRES all four to be present and well-formed, so these
+# fixtures carry the real shape rather than the content-only one they had before.
 manifest="$work/pipeline-known-good.sha256"
+manifest_uid="$(id -u)"
+[[ $manifest_uid =~ ^[0-9]+$ ]] || fail "id -u did not report a numeric uid: $manifest_uid"
 write_manifest() {
   {
-    printf '%s  %s\n' "$(sha_of "$good_script")" "$good_script"
-    printf '%s  %s\n' "$(sha_of "$spaced_script")" "$spaced_script"
-    printf '%s  %s\n' "$(sha_of "$plist")" "$plist"
+    printf '%s 0755 %s %s\n' "$(sha_of "$good_script")" "$manifest_uid" "$good_script"
+    printf '%s 0755 %s %s\n' "$(sha_of "$spaced_script")" "$manifest_uid" "$spaced_script"
+    printf '%s 0644 %s %s\n' "$(sha_of "$plist")" "$manifest_uid" "$plist"
   } >"$manifest"
 }
 write_manifest
@@ -200,7 +206,7 @@ expect_rc "an empty manifest refuses" 1
 expect_out "an empty manifest reports the missing token" "missing"
 
 bad_manifest="$work/malformed.sha256"
-printf 'not-a-hash  /some/path\n' >"$bad_manifest"
+printf 'not-a-hash 0755 %s /some/path\n' "$manifest_uid" >"$bad_manifest"
 run_scan OSQUERY_PIPELINE_MANIFEST="$bad_manifest"
 expect_rc "a malformed manifest line refuses" 1
 expect_out "a malformed manifest reports the malformed token" "malformed"
@@ -209,7 +215,7 @@ expect_out "a malformed manifest reports the malformed token" "malformed"
 # itself, so a relative path would be read against whatever directory launchd
 # happened to start the watchdog in.
 rel_manifest="$work/relative.sha256"
-printf '%s  digest.sh\n' "$(sha_of "$good_script")" >"$rel_manifest"
+printf '%s 0755 %s digest.sh\n' "$(sha_of "$good_script")" "$manifest_uid" >"$rel_manifest"
 run_scan OSQUERY_PIPELINE_MANIFEST="$rel_manifest"
 expect_rc "a relative manifested path refuses" 1
 expect_out "a relative manifested path reports the malformed token" "malformed"

--- a/test/unit/osquery-pipeline-verdict.sh
+++ b/test/unit/osquery-pipeline-verdict.sh
@@ -3,15 +3,17 @@
 # pipeline_verdict (results-alerter/pipeline-verdict.sh) decides whether a file
 # change under the watched pipeline directories is a tamper to PAGE, a known-good
 # apply to stay SILENT, or an untracked neighbor to log only. It checks the
-# change against the pipeline-integrity manifest, a root-owned sha256 list of the
-# alerter's own scripts/plists.
+# change against the pipeline-integrity manifest, a root-owned list of the
+# alerter's own scripts/plists binding each path to its content hash, mode and
+# owner ("<sha256> <mode> <uid> <path>", path last).
 #
 # Return-code contract (from c69baab _pipeline_verdict), inverted vs the
 # allowlist verdict on purpose:
 #   0 = PAGE   - a tracked file changed and we cannot confirm it legitimate
-#                (tamper, a delete, an empty/mismatched hash, or NO manifest).
+#                (tamper, a chmod, a chown, a delete, an empty/mismatched hash, a
+#                manifest line that is not a full tuple, or NO manifest).
 #   1 = SILENT - an untracked neighbor in a watched dir, OR a tracked change whose
-#                exact (path, sha256) tuple is present in the manifest.
+#                exact (path, sha256, mode, uid) tuple is present in the manifest.
 #
 # Criterion 6, the headline this behavior pins: with NO manifest present (a missing
 # or unreadable manifest), a change to a tracked pipeline file PAGES. That is the
@@ -44,8 +46,17 @@ home="$work/home"
 mkdir -p "$home/.local/libexec/osquery/results-alerter" "$home/.local/bin" "$home/Library/LaunchAgents"
 
 # REAL files with REAL hashes: the verdict rehashes the target at judgment time,
-# so a fixture manifest has to bind the content that is actually on disk.
+# so a fixture manifest has to bind the content that is actually on disk. Mode and
+# owner are re-read at judgment time for the same reason.
 sha_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+uid_self="$(id -u)"
+[[ $uid_self =~ ^[0-9]+$ ]] || fail "id -u did not report a numeric uid: $uid_self"
+# A uid this fixture's files provably do NOT have. Tests cannot chown without
+# privilege, so an ownership change is simulated from the manifest side: a tuple
+# that names an owner the deployed file does not have is exactly the state a chown
+# produces, and it is the state the verdict has to refuse.
+foreign_uid=$((uid_self + 1))
 
 libexec_script="$home/.local/libexec/osquery/results-alerter.sh"
 bin_script="$home/.local/bin/relay.sh"
@@ -59,6 +70,14 @@ stale_script="$home/.local/libexec/osquery/stale.sh"
 # that WOULD match the manifest if the verdict followed it.
 symlink_path="$home/.local/libexec/osquery/linked.sh"
 symlink_data="$work/outside-payload.sh"
+# Attribute probes: content matches the manifest exactly, only mode or owner drift.
+chmod_script="$home/.local/libexec/osquery/chmod-probe.sh"
+setuid_script="$home/.local/libexec/osquery/setuid-probe.sh"
+chown_script="$home/.local/libexec/osquery/chown-probe.sh"
+# Malformed-manifest probes: content, mode and owner on disk are all fine, but the
+# manifest line that would vouch for them is not parseable as a full tuple.
+legacy_script="$home/.local/libexec/osquery/legacy-line.sh"
+garbage_script="$home/.local/libexec/osquery/garbage-line.sh"
 
 printf 'echo libexec\n' >"$libexec_script"
 printf 'echo bin\n' >"$bin_script"
@@ -66,24 +85,66 @@ printf 'echo libexec\n' >"$twin_script" # same bytes as libexec_script
 printf 'echo original\n' >"$stale_script"
 printf 'echo linked\n' >"$symlink_data"
 ln -s "$symlink_data" "$symlink_path"
+printf 'echo chmod probe\n' >"$chmod_script"
+printf 'echo setuid probe\n' >"$setuid_script"
+printf 'echo chown probe\n' >"$chown_script"
+printf 'echo legacy line\n' >"$legacy_script"
+printf 'echo garbage line\n' >"$garbage_script"
+
+# Every manifested regular file is deployed 0755, which is what the manifest lines
+# below record LITERALLY. The literal is deliberate: deriving the expected column
+# from the same reader the implementation uses would make the mode comparison
+# vacuous.
+chmod 755 "$libexec_script" "$twin_script" "$stale_script" \
+  "$chmod_script" "$setuid_script" "$chown_script" "$legacy_script" "$garbage_script"
+chmod 755 "$bin_script"
 
 hash_libexec="$(sha_of "$libexec_script")"
 hash_bin="$(sha_of "$bin_script")"
 hash_stale_original="$(sha_of "$stale_script")"
 hash_linked="$(sha_of "$symlink_data")"
+hash_chmod="$(sha_of "$chmod_script")"
+hash_setuid="$(sha_of "$setuid_script")"
+hash_chown="$(sha_of "$chown_script")"
+hash_legacy="$(sha_of "$legacy_script")"
+hash_garbage="$(sha_of "$garbage_script")"
 hash_wrong="0000000000000000000000000000000000000000000000000000000000000000"
 
-# The manifest binds each hash to ITS path (shasum format: "<hash>  <path>").
+# The manifest binds content, mode AND owner to ITS path, one space-separated
+# tuple per line: "<sha256> <mode> <uid> <path>". The path stays LAST so a path
+# containing spaces is still read whole by `read -r hash mode uid path`.
+#
 # twin_script is deliberately ABSENT: its content hash exists in the manifest, but
 # bound to libexec_script, so a hash-only check would wrongly bless it.
 manifest="$work/pipeline-known-good.sha256"
 {
-  printf '%s  %s\n' "$hash_libexec" "$libexec_script"
-  printf '%s  %s\n' "$hash_bin" "$bin_script"
-  printf '%s  %s\n' "$hash_stale_original" "$stale_script"
-  printf '%s  %s\n' "$hash_linked" "$symlink_path"
+  printf '%s 0755 %s %s\n' "$hash_libexec" "$uid_self" "$libexec_script"
+  printf '%s 0755 %s %s\n' "$hash_bin" "$uid_self" "$bin_script"
+  printf '%s 0755 %s %s\n' "$hash_stale_original" "$uid_self" "$stale_script"
+  printf '%s 0755 %s %s\n' "$hash_linked" "$uid_self" "$symlink_path"
+  printf '%s 0755 %s %s\n' "$hash_chmod" "$uid_self" "$chmod_script"
+  printf '%s 0755 %s %s\n' "$hash_setuid" "$uid_self" "$setuid_script"
+  # The chown probe: a correct content hash and mode, bound to an owner the
+  # deployed file does not have.
+  printf '%s 0755 %s %s\n' "$hash_chown" "$foreign_uid" "$chown_script"
+  # The OLD two-column shape. A manifest left over from before mode and owner were
+  # bound must not be honored as a match, in either direction.
+  printf '%s  %s\n' "$hash_legacy" "$legacy_script"
+  # A line that is not a tuple at all.
+  printf '%s\n' "$hash_garbage"
 } >"$manifest"
 absent_manifest="$work/no-such-manifest.sha256"
+
+# Now drift the two attribute probes AWAY from the mode their tuple records. Their
+# CONTENT still matches, which is precisely the ATTRIBUTES_MODIFIED shape: osquery
+# reports the change carrying the file's unchanged digest.
+chmod 775 "$chmod_script"   # group-writable: the documented setup-for-later-tamper
+chmod 4755 "$setuid_script" # setuid: only the low nine bits would miss this one
+# GNU stat prints 4755 and BSD stat prints 104755 (the file type is included), so
+# the suffix match accepts either. GNU first, BSD as the fallback, the portable
+# order this repository requires.
+[[ "$(stat -c '%a' "$setuid_script" 2>/dev/null || stat -f '%p' "$setuid_script")" == *4755 ]] ||
+  fail "the fixture could not set the setuid bit, so that probe would pass vacuously"
 
 # Now replace the stale file's content. The manifest still records its ORIGINAL
 # hash, and the event below still carries that original (known-good) digest, but
@@ -133,6 +194,24 @@ cases=(
   #    twin has the same bytes as libexec_script, so a hash-only check would bless
   #    it; the (path, hash) binding is what refuses it. --
   "0|$manifest|$twin_script|$hash_libexec|UPDATED|swap-in-place (real content whose tuple is bound to another path) -> PAGE (tuple binding)"
+  # -- ATTRIBUTES: a chmod on a manifested file PAGES. The content is byte-for-byte
+  #    what the manifest records and the event carries that unchanged digest, so a
+  #    content-only manifest returns SILENT here. Making a pipeline script
+  #    group-writable is a plausible setup step for a later tamper from a less
+  #    privileged context, so it has to page on its own. --
+  "0|$manifest|$chmod_script|$hash_chmod|ATTRIBUTES_MODIFIED|a chmod g+w on a manifested file -> PAGE (mode is bound, not just content)"
+  # -- ATTRIBUTES: the setuid bit is inside the bound mode. It lives above the low
+  #    nine permission bits, so a mode reader that keeps only those (BSD stat %Lp)
+  #    reads 4755 back as 0755 and blesses it. --
+  "0|$manifest|$setuid_script|$hash_setuid|ATTRIBUTES_MODIFIED|a setuid bit set on a manifested file -> PAGE (all twelve mode bits are bound)"
+  # -- OWNERSHIP: a file whose owner is not the one its tuple records PAGES, with
+  #    content and mode both matching. --
+  "0|$manifest|$chown_script|$hash_chown|ATTRIBUTES_MODIFIED|a manifested file owned by someone other than its tuple records -> PAGE (owner is bound)"
+  # -- MALFORMED MANIFEST LINES resolve to PAGE, never to silence. Both probes have
+  #    correct content, mode and owner on disk; only the line that would vouch for
+  #    them is short. A pre-mode/owner manifest is exactly the two-column case. --
+  "0|$manifest|$legacy_script|$hash_legacy|UPDATED|a two-column (pre mode/owner) manifest line -> PAGE (a short line never vouches)"
+  "0|$manifest|$garbage_script|$hash_garbage|UPDATED|a one-field manifest line -> PAGE (an unparseable line never vouches)"
 )
 
 expected=()
@@ -187,4 +266,4 @@ HOME="$home" bash -c '
 [[ $trust_rc -ne 0 ]] ||
   fail "a manifest that is not root-owned must not be trusted to suppress a page"
 
-printf 'osquery-pipeline-verdict: OK (fail-safe PAGE for a tracked libexec file without a manifest; a ~/.local/bin neighbor and a /Library plist twin are SILENT; delete PAGES; manifest tuple match SILENT, mismatch/swap-in-place PAGE; a non-root-owned manifest is refused)\n'
+printf 'osquery-pipeline-verdict: OK (fail-safe PAGE for a tracked libexec file without a manifest; a ~/.local/bin neighbor and a /Library plist twin are SILENT; delete PAGES; manifest tuple match SILENT, mismatch/swap-in-place PAGE; chmod, setuid and a foreign owner PAGE on unchanged content; short and unparseable manifest lines PAGE; a non-root-owned manifest is refused)\n'

--- a/test/unit/osquery-route-pipeline.sh
+++ b/test/unit/osquery-route-pipeline.sh
@@ -79,15 +79,16 @@ in_a TAG03 || fail "our own osquery LaunchAgent change must PAGE (fail-safe)"
 in_a TAG04 && fail "an untracked neighbor plist must be SILENT (the verdict is consulted, not page-always)"
 in_a TAG07 && fail "a com.webdavis.osquery-*.plist under /Library must NOT be tracked (the manifest can never cover it; persistence default-deny owns it)"
 
-# ---- Pass B: a stubbed manifest with an exact (path, sha256) match. That event
-#      is confirmed known-good and stays silent; a DELETE still pages. ----
-# The verdict rehashes the target at judgment time, so the known-good file has to
-# actually exist and the manifest has to bind its REAL content hash.
+# ---- Pass B: a stubbed manifest with an exact (path, sha256, mode, uid) match.
+#      That event is confirmed known-good and stays silent; a DELETE still pages. --
+# The verdict re-reads the target at judgment time, so the known-good file has to
+# actually exist and the manifest has to bind its REAL content hash, mode and owner.
 known_target="$home/.local/libexec/osquery/knownTAG05.sh"
 printf 'echo known-good\n' >"$known_target"
+chmod 755 "$known_target"
 known_hash="$(shasum -a 256 "$known_target" | awk '{print $1}')"
 manifest="$work/pipeline-known-good.sha256"
-printf '%s  %s\n' "$known_hash" "$known_target" >"$manifest"
+printf '%s 0755 %s %s\n' "$known_hash" "$(id -u)" "$known_target" >"$manifest"
 
 page_b="$(run_gate "$manifest" \
   "$(fe pipeline_integrity "$known_target" "$known_hash" UPDATED)" \


### PR DESCRIPTION
## Context

The osquery pipeline protects its own scripts with a root-owned manifest of known-good file hashes. Because
it recorded only content, a permission or ownership change was invisible: the change event carries the
file's unchanged hash, the hash matches, and the check stays silent. Making a protected script
group-writable was therefore undetectable, which is a plausible first step before tampering with it from
somewhere less privileged.

This binds mode and owner alongside content, so a permissions or ownership change on a protected file
pages.

## Summary

- The manifest now records each file's intended permissions and owner, not just its content.
- A permission or ownership change on a protected file now pages instead of passing silently.
- Expected permissions come from what chezmoi intends to deploy, never from the file on disk.
- Documents which of the two enforcement layers catches which kind of tampering, and what neither covers.

Key files: `.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh`,
`dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh`.

## Where the expected permissions come from

This is the load-bearing decision. Reading the deployed file's current permissions would have been simplest
and is wrong for the same reason reading its current content was wrong: an attacker who changes a file
before an apply would have that change recorded as the new expected value, and the manifest would launder
the tampering into policy.

The expected mode therefore comes from what chezmoi intends to deploy, derived from the source attributes
that already encode it. A file made group-writable on disk is signed with its intended mode, and the drift
then fails the check. A test asserts this directly: a generator that reads mode from disk fails with a
message naming it as a security regression.

The expected owner is the user the apply runs as. chezmoi has no owner attribute and writes every file as
the invoking user, so that identity is the intended owner by definition. It comes from the process rather
than from anything inside the protected directory, so an attacker who has already changed a file's owner
cannot influence what gets recorded.

Group ownership is deliberately not bound, and that is stated in the code: chezmoi expresses no group
intent, and changing only the group cannot grant write access that the bound mode does not already grant.

## A constraint worth recording

The command that reports intended permissions opens chezmoi's persistent state, and this runner executes
inside an apply that already holds that lock, so the obvious call fails on every real apply. The fix is to
give it a throwaway state file of its own. That state holds bookkeeping rather than source data, so a fresh
one reports the same permissions.

This was caught by the end-to-end test that runs a real apply. Every isolated test passed without it.

## A regression this change introduced, and closed

Binding permissions meant a permissions-only apply became a thing that could happen, and the existing grace
window did not cover it. That window opened only when the manifest predated the file's modification time,
but changing permissions updates a different timestamp and leaves modification time alone. A legitimate
permissions-only apply would therefore have skipped the window and raised a false alarm that the alerting
path never reconsiders. The window now consults the timestamp that actually moves.

## The coverage map

Two layers now enforce the manifest and they cover different things, so the code states which catches what:
the event-driven check judges content, permissions and owner but only when a change produces an event on a
watched path; the periodic audit re-hashes on a schedule and so catches changes that produce no event at
all. What neither covers is recorded too, including one gap the two layers create between them, filed as
follow-up work rather than papered over.

## How it was reviewed

The gap was reproduced against `main` first: making a protected file group-writable returned silent. Every
new behavior has a test confirmed to fail before the change. Six mutations were run, each killing exactly
the test that should catch it, including reverting the expected-mode source to disk and reverting the
timestamp fix.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover, at which point the next apply rewrites the manifest in the new format.
