### PR TITLE
feat(osquery): compare mode and owner in the periodic manifest audit

### DIFF
--- a/dot_local/libexec/osquery/executable_pipeline-audit.sh
+++ b/dot_local/libexec/osquery/executable_pipeline-audit.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# pipeline-audit.sh, sourced helper, not run directly. The PERIODIC CONTENT AUDIT
-# of the osquery pipeline: it reads the root-owned pipeline-integrity manifest,
-# hashes every path the manifest lists, and reports each path whose CURRENT state
-# disagrees with its recorded tuple. Sourced by the uptime watchdog, which runs it
-# once per 15-minute tick.
+# pipeline-audit.sh, sourced helper, not run directly. The PERIODIC MANIFEST AUDIT
+# of the osquery pipeline: it reads the root-owned pipeline-integrity manifest and
+# reports each path whose CURRENT content, mode or owner disagrees with the tuple
+# recorded for it. Sourced by the uptime watchdog, which runs it once per 15-minute
+# tick.
 #
 # WHY A SCHEDULED AUDIT AND NOT ANOTHER EVENT CHECK. Until this existed, the
 # manifest was enforced only through osquery file_events, and osquery watches
@@ -12,9 +12,10 @@
 # the pipeline home and then overwrites the outside alias mutates the SAME INODE:
 # the filesystem event names the attacker's path, nothing fires for the watched
 # path, no verdict runs, and the tampered script executes with nothing paged. A
-# symlink referent gives the same blind spot. That is a gap in EVENT GENERATION,
-# not in the verdict, so no amount of judging events can close it. Comparing bytes
-# on a schedule can, because it never depends on an event having fired.
+# chmod or chown through that same alias does it without changing a byte. A symlink
+# referent gives the same blind spot. That is a gap in EVENT GENERATION, not in the
+# verdict, so no amount of judging events can close it. Re-reading the files on a
+# schedule can, because it never depends on an event having fired.
 #
 # Usage (from a sourcing script):
 #   source "$HOME/.local/libexec/osquery/pipeline-audit.sh"
@@ -39,14 +40,25 @@ fi
 
 # COST, measured rather than assumed. The real manifest lists 25 files totalling
 # about 230 KiB, and a full scan of them takes 0.6 to 0.8s wall clock on this host:
-# one stat (~4ms) and one shasum (~28ms) fork per file, with the hashing itself lost
-# in the noise. shasum is a Perl script, so its startup, not the SHA-256, is nearly
-# all of that. A single batched shasum over every path would cut it to ~0.05s, and is
-# deliberately not done: it would have to be parsed back by path (an output line is
-# absent for a file that vanished mid-scan, and some implementations escape unusual
-# filenames), which trades an obviously-correct loop for a false-page vector. At one
-# scan per 15-minute tick this is a 0.08% duty cycle, and the audit runs LAST, so it
-# delays none of the other probes.
+# a size stat, a mode read, an owner read (~4ms each) and one shasum (~28ms) fork per
+# file, with the hashing itself lost in the noise. shasum is a Perl script, so its
+# startup, not the SHA-256, is nearly all of that. A single batched shasum over every
+# path would cut it to ~0.05s, and is deliberately not done: it would have to be
+# parsed back by path (an output line is absent for a file that vanished mid-scan,
+# and some implementations escape unusual filenames), which trades an
+# obviously-correct loop for a false-page vector. At one scan per 15-minute tick this
+# is a 0.09% duty cycle, and the audit runs LAST, so it delays none of the other
+# probes.
+#
+# Comparing the two ATTRIBUTE columns is what the mode and owner reads cost, measured
+# side by side over a 25-file fixture on this host: 0.70 to 0.73s, against 0.46 to
+# 0.48s for the same scan comparing content alone. Each read is a fork, and on BSD
+# each pays a failed GNU-stat attempt before the BSD form answers. Folding all three
+# values into one stat call would recover most of that quarter-second and is not
+# done: the mode reader exists because BSD `stat -f '%Lp'` prints only the low NINE
+# permission bits, so a hand-rolled stat here would read a setuid bit back as an
+# ordinary mode and compare EQUAL. A quarter-second per 15-minute tick is not worth
+# re-introducing that.
 #
 # Bounds, so one tick cannot become a long-running process. Every one of them
 # fails toward a page, never toward a quiet skip:
@@ -98,12 +110,17 @@ _pipeline_audit_size() {
 #
 #   return 0 - the scan COMPLETED. Each divergence is one stdout line,
 #              "<kind> <path>", in manifest order; no output means the deployed
-#              tree matches the manifest exactly. Kinds:
+#              tree matches the manifest exactly. One line PER DIVERGING COLUMN, so
+#              a path that drifted on two of them is reported twice, under two
+#              kinds. Kinds:
 #                content     the bytes on disk differ from the recorded hash
+#                mode        the permission bits differ from the recorded mode
+#                owner       the owning uid differs from the recorded one
 #                missing     nothing exists at the manifested path
 #                irregular   a symlink or a non-regular file stands there
 #                oversize    too large to hash within the tick's bound
-#                unreadable  present and regular, but its size or hash failed
+#                unreadable  present and regular, but its size, mode, owner or
+#                            hash could not be read
 #   return 1 - the scan could NOT be completed, and stdout is a single reason
 #              TOKEN: missing (absent, unreadable, or empty manifest),
 #              unavailable (the verdict helper it reuses is not installed),
@@ -118,18 +135,20 @@ _pipeline_audit_size() {
 # monitor that goes quiet when its own input breaks is the failure mode this whole
 # subsystem exists to avoid. Every refusal is the caller's cue to page.
 #
-# SCOPE, recorded honestly. This audits MANIFEST -> DISK, and only the CONTENT
-# column of it. Two consequences, both real:
+# SCOPE, recorded honestly. This audits MANIFEST -> DISK, across ALL THREE bound
+# columns: content, mode and owner. What that does and does not reach:
 #   - A file planted under the pipeline home that the manifest does not list is not
 #     found here; that direction is the alerter's, which pages any tracked path
 #     whose tuple it cannot confirm.
-#   - The manifest also binds MODE and OWNER, and this scan does not compare them.
-#     Attribute drift on a watched path is caught at EVENT time by the verdict, so
-#     the residue is attribute drift that fires no event at all: a chmod or chown
-#     applied through a hard-link alias outside the pipeline home changes the shared
-#     inode while the event names the outside path. Comparing the two columns here
-#     would close that; it is deliberately left to the owner of this scan rather
-#     than bolted on by the change that added the columns.
+#   - Comparing mode and owner here is what covers ATTRIBUTE DRIFT THAT FIRES NO
+#     EVENT: a chmod or chown applied through a hard-link alias outside the pipeline
+#     home changes the shared inode while the event names the outside path, so the
+#     event-time verdict never judges it and no byte of content moves for a
+#     content-only comparison to notice. It is now a divergence here, within one
+#     tick of the change.
+#   - GROUP OWNERSHIP is still not compared, because the manifest does not bind it.
+#     See the coverage map in results-alerter/pipeline-verdict.sh for why, and for
+#     what remains uncovered across both layers.
 pipeline_audit_scan() {
   # The reused seam has to actually be here. Checked by NAME rather than assumed,
   # so a partial deploy reports a broken audit instead of an all-clear.
@@ -166,13 +185,15 @@ pipeline_audit_scan() {
   # would be read against whatever directory launchd happened to start the caller
   # in.
   #
-  # The mode and owner columns are MATCHED but not compared here; see the scope note
-  # in this function's docblock for which layer covers attribute drift. Requiring
-  # them to be present and well-formed is what keeps this fail-closed: a manifest in
-  # the older content-only format does not match, so it reports malformed and the
-  # caller pages, rather than being read as if the missing columns did not matter.
+  # All four columns are matched, and all four are compared below. Requiring the
+  # attribute columns to be present and well-formed is what keeps this fail-closed:
+  # a manifest in the older content-only format does not match, so it reports
+  # malformed and the caller pages, rather than being read as if the missing columns
+  # did not matter. The pattern is also what BOUNDS the two attribute columns, so
+  # the comparisons below are string equalities over already-constrained values.
   local line_pattern='^([0-9a-fA-F]{64}) ([0-7]{4}) ([0-9]{1,10}) (/.+)$'
-  local deadline entries=0 line want_hash target size disk_hash
+  local deadline entries=0 line want_hash want_mode want_uid target
+  local size disk_hash disk_mode disk_uid
   deadline=$(($(_pipeline_audit_now) + budget))
 
   # `|| [[ -n $line ]]` so a final line with no trailing newline is still examined
@@ -193,7 +214,13 @@ pipeline_audit_scan() {
     fi
     # Lower-cased on both sides: shasum and osquery both emit lowercase, so this is
     # documented defense in depth against a future producer, and it costs nothing.
+    #
+    # All four columns are captured HERE, in one go. BASH_REMATCH is global and is
+    # overwritten by the next [[ =~ ]] anywhere in this loop, so reading a column
+    # later would read whatever pattern matched most recently.
     want_hash="${BASH_REMATCH[1],,}"
+    want_mode="${BASH_REMATCH[2]}"
+    want_uid="${BASH_REMATCH[3]}"
     target="${BASH_REMATCH[4]}"
     # A manifested path must hold a REGULAR FILE, and links are never followed. A
     # symlink standing where a pipeline script belongs would otherwise be hashed
@@ -207,24 +234,48 @@ pipeline_audit_scan() {
     elif [[ ! -f $target ]]; then
       printf 'irregular %s\n' "$target"
     else
+      # The three columns are read BEFORE anything is judged, so an attribute that
+      # cannot be read reports unreadable ONCE for the path rather than once per
+      # failing reader. The mode and owner come from the verdict helper's readers,
+      # never from a stat here: BSD `stat -f '%Lp'` prints only the low NINE
+      # permission bits, so a setuid, setgid or sticky bit added to a pipeline
+      # script would read back as an ordinary mode and compare equal. The helpers
+      # ask each platform for a field that carries all twelve.
       size="$(_pipeline_audit_size "$target")"
-      if [[ ! $size =~ ^(0|[1-9][0-9]{0,18})$ ]]; then
+      disk_mode="$(_pipeline_file_mode "$target")" || disk_mode=""
+      disk_uid="$(_pipeline_file_uid "$target")" || disk_uid=""
+      if [[ ! $size =~ ^(0|[1-9][0-9]{0,18})$ ]] ||
+        [[ ! $disk_mode =~ ^[0-7]{4}$ ]] || [[ ! $disk_uid =~ ^[0-9]{1,10}$ ]]; then
         printf 'unreadable %s\n' "$target"
-      elif ((size > max_bytes)); then
-        printf 'oversize %s\n' "$target"
       else
-        # The hash is cut with parameter expansion rather than piped through awk:
-        # the audit runs this once per manifested file, and a saved fork per file is
-        # most of the tick's cost. shasum prints "<hash>  <path>", so everything from
-        # the first space on is dropped.
-        disk_hash="$(shasum -a 256 -- "$target" 2>/dev/null)"
-        disk_hash="${disk_hash%% *}"
-        disk_hash="${disk_hash,,}"
-        if [[ ! $disk_hash =~ ^[0-9a-f]{64}$ ]]; then
-          printf 'unreadable %s\n' "$target"
-        elif [[ $disk_hash != "$want_hash" ]]; then
-          printf 'content %s\n' "$target"
+        if ((size > max_bytes)); then
+          printf 'oversize %s\n' "$target"
+        else
+          # The hash is cut with parameter expansion rather than piped through awk:
+          # the audit runs this once per manifested file, and a saved fork per file is
+          # most of the tick's cost. shasum prints "<hash>  <path>", so everything from
+          # the first space on is dropped.
+          disk_hash="$(shasum -a 256 -- "$target" 2>/dev/null)"
+          disk_hash="${disk_hash%% *}"
+          disk_hash="${disk_hash,,}"
+          if [[ ! $disk_hash =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'unreadable %s\n' "$target"
+          elif [[ $disk_hash != "$want_hash" ]]; then
+            printf 'content %s\n' "$target"
+          fi
         fi
+        # Mode and owner are compared for every readable regular file, INCLUDING one
+        # too large to hash: the size bound caps hashing, and an attacker who grows a
+        # manifested file must not buy silence on its permissions with it. Both are
+        # STRING equalities against columns the line pattern already constrained
+        # (four octal digits, up to ten decimal digits), so neither side reaches
+        # arithmetic and a manifest value that is merely unusual cannot be read as
+        # octal or overflow. A divergence per COLUMN, each with its own kind: the
+        # watchdog dedupes on a fingerprint of this report, and folding both into one
+        # per-path line would make an escalation from mode drift to content tamper
+        # look like the condition already reported.
+        [[ $disk_mode == "$want_mode" ]] || printf 'mode %s\n' "$target"
+        [[ $disk_uid == "$want_uid" ]] || printf 'owner %s\n' "$target"
       fi
     fi
   done <"$manifest"

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -11,9 +11,9 @@
 # It also carries the pipeline's only SCHEDULED integrity check. The rest of the
 # pipeline-integrity manifest is enforced through osquery file_events, and osquery
 # watches PATHS, so tampering that generates no event on a watched path (a hard link
-# or a symlink pointing the executed bytes somewhere else) is invisible to it. The
-# content audit below hashes every manifested path on each tick, which needs no
-# event to have fired.
+# or a symlink pointing the executed bytes somewhere else, or a chmod through either)
+# is invisible to it. The manifest audit below re-reads every manifested path on each
+# tick and compares content, mode and owner, which needs no event to have fired.
 #
 # Cardinal invariant: FAIL-SAFE toward paging. Any ambiguous or failed check (an
 # unloaded or unknown-state agent, a wedged osqueryd, an unhealthy route, an
@@ -63,7 +63,7 @@ source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # daemon's scheduled canary), never a blind osqueryi one-shot.
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/canary-freshness.sh"
-# The periodic content audit of the pipeline-integrity manifest (probe 5). It also
+# The periodic manifest audit of the pipeline-integrity manifest (probe 5). It also
 # pulls in the verdict helper, which owns the manifest path and the root-ownership
 # check both consumers share.
 #
@@ -271,17 +271,19 @@ else
   growth_streak=0
 fi
 
-# 5) Periodic CONTENT AUDIT of the pipeline-integrity manifest. Every other check
+# 5) Periodic MANIFEST AUDIT of the pipeline-integrity manifest. Every other check
 #    of that manifest hangs off osquery file_events, and osquery watches PATHS: an
 #    attacker who hard-links a manifested pipeline script to a writable path outside
 #    the pipeline home and overwrites the outside alias mutates the SAME INODE, so
 #    the event names their path, nothing fires for the watched one, no verdict runs,
-#    and the tampered script executes with nothing paged. A symlink referent is the
-#    same blind spot in a second shape. That gap is in event GENERATION, so it can
-#    only be closed by comparing bytes on a SCHEDULE. The seam hashes every
-#    manifested path and reports what disagrees; it refuses (nonzero, with a reason
-#    token) rather than report a false all-clear when the manifest itself cannot be
-#    used, and it is bounded on entries, per-file bytes, and wall clock.
+#    and the tampered script executes with nothing paged. A chmod or chown through
+#    that alias does it without moving a byte, and a symlink referent is the same
+#    blind spot in a third shape. That gap is in event GENERATION, so it can only be
+#    closed by re-reading the files on a SCHEDULE. The seam compares each manifested
+#    path's content, mode and owner and reports what disagrees; it refuses (nonzero,
+#    with a reason token) rather than report a false all-clear when the manifest
+#    itself cannot be used, and it is bounded on entries, per-file bytes, and wall
+#    clock.
 audit_rc=0
 if declare -F pipeline_audit_scan >/dev/null 2>&1; then
   audit_report="$(pipeline_audit_scan 2>/dev/null)" || audit_rc=$?
@@ -291,12 +293,15 @@ else
 fi
 audit_reason=""
 audit_divergence_count=0
+audit_kind_text=""
 if [[ $audit_rc -ne 0 ]]; then
   # A refusal token, validated against the shape of the fixed vocabulary before it
   # can select a message; anything unexpected still pages, via the default arm.
   audit_reason="$audit_report"
   [[ $audit_reason =~ ^[a-z]{1,32}$ ]] || audit_reason="unknown"
 elif [[ -n $audit_report ]]; then
+  # One report line per diverging COLUMN, so this counts DIVERGENCES, not files: a
+  # path whose mode and content both drifted is two of them, under two kinds.
   audit_divergence_count="$(printf '%s\n' "$audit_report" | wc -l | tr -d '[:space:]')"
   # A count that cannot be read must not read as ZERO (that would silently discard a
   # real divergence): fall back to the refusal path, which pages.
@@ -304,6 +309,29 @@ elif [[ -n $audit_report ]]; then
     audit_reason="unknown"
     audit_divergence_count=0
   fi
+  # WHICH KINDS the report holds, as this watchdog's own static labels. The loop
+  # walks a FIXED vocabulary and asks whether each kind appears as a line PREFIX
+  # (the leading newline anchors the match to a line start, and a manifested path
+  # cannot contain one because the audit reads the manifest line by line). So what
+  # reaches a page body is one of seven literals written here, never a token lifted
+  # out of the report, and the paths beside them stay unrendered exactly as before.
+  # Naming the kinds is worth this much because the operator's next move differs by
+  # kind: a permission or ownership change is the step BEFORE a rewrite, and it is
+  # reversible; a content change means the script already executes attacker bytes.
+  for audit_kind in content mode owner missing irregular oversize unreadable; do
+    [[ $'\n'$audit_report == *$'\n'"$audit_kind "* ]] || continue
+    case "$audit_kind" in
+      content) audit_kind_label="content changed" ;;
+      mode) audit_kind_label="permissions changed" ;;
+      owner) audit_kind_label="ownership changed" ;;
+      missing) audit_kind_label="file missing" ;;
+      irregular) audit_kind_label="not a regular file" ;;
+      oversize) audit_kind_label="too large to hash" ;;
+      unreadable) audit_kind_label="unreadable" ;;
+      *) continue ;;
+    esac
+    audit_kind_text+="${audit_kind_text:+, }$audit_kind_label"
+  done
 fi
 
 # Page-once discipline, on the watchdog's existing streak conventions. The audit is
@@ -367,38 +395,41 @@ else
   fi
 fi
 
-# The rendered problem carries a VALIDATED COUNT and static text only. The
-# manifested paths are deliberately not rendered: in the very scenario this audit
-# exists to catch they are attacker-influenceable, and the operator's next step is
-# the same either way. That keeps this watchdog's rule intact - known labels,
-# validated numerics, and static text reach a page body, nothing else.
+# The rendered problem carries a VALIDATED COUNT, KNOWN LABELS, and static text
+# only. The manifested paths are deliberately not rendered: in the very scenario
+# this audit exists to catch they are attacker-influenceable, and knowing WHICH
+# pipeline file is compromised does not change the first move (stop trusting the
+# pipeline, then read the manifest by hand). The kind labels are not the paths -
+# each is a literal chosen above from a closed vocabulary - so this keeps the
+# watchdog's rule intact: known labels, validated numerics, and static text reach a
+# page body, nothing else.
 if [[ $audit_should_page -eq 1 ]]; then
   if [[ -n $audit_reason ]]; then
     case "$audit_reason" in
       missing)
-        problems+=("the pipeline-integrity manifest is missing or unreadable, so the periodic content audit cannot verify the deployed pipeline; tampering would go unseen until it is restored")
+        problems+=("the pipeline-integrity manifest is missing or unreadable, so the periodic manifest audit cannot verify the deployed pipeline; tampering would go unseen until it is restored")
         ;;
       unavailable)
-        problems+=("the periodic content audit is not installed completely (a helper it needs is missing), so the deployed pipeline is unverified against the pipeline-integrity manifest")
+        problems+=("the periodic manifest audit is not installed completely (a helper it needs is missing), so the deployed pipeline is unverified against the pipeline-integrity manifest")
         ;;
       untrustworthy)
         problems+=("the pipeline-integrity manifest is no longer root-owned (or is group/world-writable), so it can no longer vouch for the deployed pipeline")
         ;;
       malformed)
-        problems+=("the pipeline-integrity manifest holds a malformed entry, so the periodic content audit cannot verify the deployed pipeline")
+        problems+=("the pipeline-integrity manifest holds a malformed entry, so the periodic manifest audit cannot verify the deployed pipeline")
         ;;
       overlong)
         problems+=("the pipeline-integrity manifest lists more files than one audit tick will examine, so the deployed pipeline cannot be fully verified")
         ;;
       budget)
-        problems+=("the periodic content audit ran out of its time budget before checking every file in the pipeline-integrity manifest, so the deployed pipeline cannot be fully verified")
+        problems+=("the periodic manifest audit ran out of its time budget before checking every file in the pipeline-integrity manifest, so the deployed pipeline cannot be fully verified")
         ;;
       *)
-        problems+=("the periodic content audit could not verify the deployed pipeline against the pipeline-integrity manifest")
+        problems+=("the periodic manifest audit could not verify the deployed pipeline against the pipeline-integrity manifest")
         ;;
     esac
   else
-    problems+=("$audit_divergence_count file(s) in the pipeline-integrity manifest no longer match it (content changed, missing, or not a regular file); no file event reported this, which is what a hard-linked or relocated pipeline script looks like")
+    problems+=("$audit_divergence_count divergence(s) from the pipeline-integrity manifest${audit_kind_text:+ ($audit_kind_text)}; no file event reported this, which is what a hard-linked or relocated pipeline script, or a chmod through such an alias, looks like")
   fi
 fi
 

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -349,10 +349,14 @@ fi
 #   - a CHANGED fingerprint restarts the confirmation, so new tampering is reported;
 #   - a clean audit forgets both, so a recurrence pages again.
 #
-# The fingerprint covers WHICH paths disagree and HOW, not the bytes they now hold,
-# so re-tampering with an already-reported file does not page a second time. That is
-# deliberate: the operator has already been told that file is compromised, and the
-# alternative re-pages on every keystroke an attacker makes.
+# The fingerprint covers WHICH paths disagree and HOW (the divergence KIND per
+# path), not the bytes or the mode they now hold. So re-tampering an already-reported
+# file the SAME way does not page a second time, and that is deliberate: the operator
+# has already been told that file is compromised, and the alternative re-pages on
+# every keystroke an attacker makes. Escalating to a DIFFERENT kind does page again,
+# which is why the audit reports one line per diverging column: a file already
+# reported for its permissions and then rewritten gains a content divergence, the
+# report changes, and the confirmation starts over.
 audit_fingerprint=""
 audit_fingerprint_is_valid=1
 if [[ $audit_rc -ne 0 || -n $audit_report ]]; then

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -25,24 +25,33 @@
 # without a manifest tuple to justify it, and a missing/empty/mismatched hash pages
 # too.
 #
-# COVERAGE MAP. Two layers now enforce the manifest, and they cover DIFFERENT
-# things. For any given tamper, this says which one is supposed to catch it.
+# COVERAGE MAP. Two layers enforce the manifest. They compare the SAME three
+# columns and differ in what TRIGGERS them, so for any given tamper this says which
+# one catches it, and how fast.
 #
 #   LAYER 1, this file, at EVENT time. Judges a filesystem event against the full
 #   tuple, so it catches CONTENT, PERMISSION and OWNERSHIP drift, but only on a
 #   change that produces an event on a watched path. It is the fast answer:
 #   whatever fires an event is judged within seconds.
 #
-#   LAYER 2, the PERIODIC CONTENT AUDIT in ../pipeline-audit.sh, which the uptime
-#   watchdog runs every 15 minutes. Re-hashes every manifested path on a schedule,
-#   so it catches drift that produces NO EVENT AT ALL and that layer 1 therefore
-#   never sees. The two shapes that matters for are hard links and symlink
-#   referents: the watch is path-based, so an attacker who hard-links a manifested
-#   script to a writable path outside the pipeline home overwrites the SAME INODE
-#   through the outside alias, the event names that path, and nothing fires for the
-#   watched one. That is a property of path-based file-integrity monitoring, not of
-#   the judgment below. The symlink and regular-file checks below remain the
-#   immediate answer on the event path.
+#   LAYER 2, the PERIODIC MANIFEST AUDIT in ../pipeline-audit.sh, which the uptime
+#   watchdog runs every 15 minutes. Re-reads every manifested path on a schedule and
+#   compares all three columns itself, so it catches drift that produces NO EVENT AT
+#   ALL and that layer 1 therefore never sees. The two shapes that matters for are
+#   hard links and symlink referents: the watch is path-based, so an attacker who
+#   hard-links a manifested script to a writable path outside the pipeline home acts
+#   on the SAME INODE through the outside alias, the event names that path, and
+#   nothing fires for the watched one. That covers both rewriting the file and
+#   merely chmod-ing or chown-ing it, which moves no bytes at all. It is a property
+#   of path-based file-integrity monitoring, not of the judgment below. Slower by
+#   design: a divergence must repeat on two consecutive ticks before it pages (so an
+#   in-flight apply cannot false-page), which puts detection at 15 to 30 minutes.
+#   The symlink and regular-file checks below remain the immediate answer on the
+#   event path.
+#
+# So: anything that fires an event on a watched path is judged in seconds by layer
+# 1, on all three columns; anything that fires no event is found within two ticks by
+# layer 2, on the same three columns.
 #
 # WHAT NEITHER LAYER COVERS, recorded honestly:
 #
@@ -51,16 +60,15 @@
 #     a file writable that the bound mode does not already grant group write to (a
 #     bound 0755 or 0644 grants none), so the case a group column would add on its
 #     own is chgrp plus chmod, which the mode column already pages.
-#   - ATTRIBUTE DRIFT THAT FIRES NO EVENT. The two layers overlap on content but not
-#     on attributes: layer 2 compares only the content column. So a chmod or chown
-#     applied through a hard-link alias outside the pipeline home lands in the gap
-#     between them - layer 1 sees no event, layer 2 does not look at those columns.
-#     Closing it means comparing mode and owner in the audit as well.
-#   - RE-TAMPERING AN ALREADY-REPORTED FILE. Layer 2 dedupes on a fingerprint of
-#     WHICH paths disagree and HOW, not of the bytes they now hold, so a path already
-#     reported as a content divergence can be rewritten again with different content
-#     without paging a second time. Deliberate (it is what stops a persistent
-#     divergence paging every 15 minutes forever), and worth knowing.
+#   - RE-TAMPERING WITHIN THE SAME SET OF DIVERGENCES. Layer 2 dedupes on a
+#     fingerprint of WHICH paths disagree and HOW (the divergence KIND per path), not
+#     of the bytes or the mode they now hold. So a path already reported as a content
+#     divergence can be rewritten again, with different content, without paging a
+#     second time, and a mode already reported as drifted can drift further. What
+#     DOES page again is any change to the kind set: a file reported for its mode and
+#     then rewritten adds a content divergence, which is a new fingerprint and a
+#     fresh confirmation. Deliberate (it is what stops one persistent divergence
+#     paging every 15 minutes forever), and worth knowing.
 #   - SOURCE COMPROMISE. The manifest is generated from chezmoi's source state,
 #     which is user-writable, so tampering with a managed file's SOURCE and letting
 #     a legitimate apply deploy it is signed as known-good by BOTH layers. See the

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -7,7 +7,7 @@
 # has five probes: osqueryd present-and-answering, every OTHER osquery LaunchAgent
 # loaded-and-not-crash-looping, the hermes #priority route reachable, the delivery
 # backlog (dead-letter count and a sustained pending-growth streak), and a periodic
-# content audit of the pipeline-integrity manifest (the backstop for tampering that
+# manifest audit of the pipeline-integrity manifest (the backstop for tampering that
 # generates no file event at all).
 #
 # This harness stands the watchdog up in isolation against recording spies, with
@@ -21,9 +21,9 @@
 #     as a stand-in dispatch library at the libexec path the watchdog sources.
 #     send_alert never delivers; it records each call's severity, sound, and argv,
 #     and the state file as it stood at call time (to prove notify-before-persist);
-#   - a fixture pipeline home with a real manifest over it, so the content audit
-#     runs against real files and real hashes. A test tampers with a deployed file,
-#     or the manifest, and the audit judges what is actually on disk.
+#   - a fixture pipeline home with a real manifest over it, so the manifest audit
+#     runs against real files, hashes, modes and owners. A test tampers with a
+#     deployed file, or the manifest, and the audit judges what is actually on disk.
 #
 # A fresh temp HOME keeps every run off the operator's real ~/.local/state and
 # ~/.local/libexec. Sourced by the watchdog suite; no main.
@@ -145,7 +145,7 @@ SHIM
   cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_canary-freshness.sh" \
     "$WD_HOME/.local/libexec/osquery/canary-freshness.sh"
 
-  # The periodic content audit and the verdict helper it reuses the manifest
+  # The periodic manifest audit and the verdict helper it reuses the manifest
   # constant and root-ownership check from, both at their deployed paths.
   mkdir -p "$WD_HOME/.local/libexec/osquery/results-alerter"
   cp "${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_pipeline-audit.sh" \

--- a/test/fixtures/osquery-watchdog-lib.bash
+++ b/test/fixtures/osquery-watchdog-lib.bash
@@ -320,6 +320,19 @@ tamper_second_manifested_file() {
   printf 'echo also-tampered\n' >"$WD_MANIFESTED_SCRIPT_ALT"
 }
 
+# chmod_manifested_file_through_hard_link -- make the stand-in pipeline script
+# group-writable by chmod-ing a HARD LINK to it, created OUTSIDE the pipeline home.
+# The two names are ONE INODE, so the watched path's mode changes while the change
+# is made to the attacker's path: no file event names the watched path, and not one
+# byte of content moves. This is the attribute half of the hard-link blind spot,
+# and the step an attacker takes before rewriting the script from a less
+# privileged context later.
+chmod_manifested_file_through_hard_link() {
+  local alias_path="$WD_HOME/attacker-alias.sh"
+  ln "$WD_MANIFESTED_SCRIPT" "$alias_path" || return 1
+  chmod g+w "$alias_path"
+}
+
 # restore_manifested_file -- put the known-good bytes back.
 restore_manifested_file() {
   printf 'echo digest\n' >"$WD_MANIFESTED_SCRIPT"

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -521,7 +521,7 @@ teardown() { teardown_watchdog_harness; }
   assert_no_page
 }
 
-# --- the periodic content audit: tamper that generates NO file event ------------
+# --- the periodic manifest audit: tamper that generates NO file event -----------
 #
 # osquery watches PATHS. An attacker who hard-links a manifested pipeline script to
 # a writable path outside the pipeline home and overwrites that alias mutates the

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -605,6 +605,56 @@ teardown() { teardown_watchdog_harness; }
   assert_page_body_has 'pipeline-integrity manifest'
 }
 
+@test "T-WATCH-audit-attr-hardlink-pages: a chmod made through a hard link outside the pipeline home pages, with no file event and no content change" {
+  # The attribute half of the same blind spot, and the one neither layer used to
+  # catch. The alias and the manifested script are one inode, so the watched path
+  # is now group-writable; the change was made to the attacker's path, so nothing
+  # fires for the watched one and the event layer never judges it; and no byte of
+  # content moved, so a content-only audit called it clean.
+  chmod_manifested_file_through_hard_link
+  run run_watchdog # tick 1: first observation, a transient is tolerated
+  [[ $status -eq 0 ]] || {
+    echo "tick1 status $status: $output"
+    false
+  }
+  assert_no_page
+
+  run run_watchdog # tick 2: the same divergence is still there
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_sound_nonempty
+  assert_page_body_has 'pipeline-integrity manifest'
+  # The path stays out of the body for an attribute divergence too: same rule, and
+  # the manifest is just as attacker-influenceable in this shape as in the others.
+  refute_file_contains "$WD_MANIFESTED_SCRIPT" "$WD_SEND_ALERT_LOG"
+}
+
+@test "T-WATCH-audit-attr-then-content-repages: a file already reported for its MODE pages again when its content is tampered too" {
+  # The escalation case. Page-once dedupes on a fingerprint of the report, so the
+  # second, more serious drift is suppressed unless the report itself changes. It
+  # changes only because mode and content are DISTINCT kinds, each on its own line:
+  # one generic per-path divergence line would be byte-identical before and after,
+  # and the content tamper would page nothing.
+  chmod_manifested_file_through_hard_link
+  run run_watchdog # tick 1: confirming
+  run run_watchdog # tick 2: pages for the mode drift
+  assert_page_count 1
+
+  tamper_manifested_file # the SAME file, now rewritten as well
+  run run_watchdog       # the divergence set changed: confirming again
+  assert_page_count 1
+  run run_watchdog # confirmed: a second page for the escalation
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 2
+}
+
 @test "T-WATCH-audit-manifest-missing-pages: an absent manifest pages instead of reading as all-clear" {
   # A monitor must not go quiet because its own input broke: with no known-good list
   # there is nothing to compare against, so tampering would pass unseen.

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -555,6 +555,8 @@ teardown() { teardown_watchdog_harness; }
   assert_page_severity_is CRIT
   assert_page_sound_nonempty
   assert_page_body_has 'pipeline-integrity manifest'
+  assert_page_body_has 'content changed'
+  refute_file_contains 'permissions changed' "$WD_SEND_ALERT_LOG"
 }
 
 @test "T-WATCH-audit-tamper-body-inert: the diverging PATH never reaches the page body" {
@@ -628,6 +630,12 @@ teardown() { teardown_watchdog_harness; }
   assert_page_severity_is CRIT
   assert_page_sound_nonempty
   assert_page_body_has 'pipeline-integrity manifest'
+  # The KIND is named, from the watchdog's own closed vocabulary, because the
+  # operator's next move differs: this is the step before a rewrite, and it is
+  # reversible. A body that said only "no longer matches" would read the same for a
+  # permission change and for a script already executing attacker bytes.
+  assert_page_body_has 'permissions changed'
+  refute_file_contains 'content changed' "$WD_SEND_ALERT_LOG"
   # The path stays out of the body for an attribute divergence too: same rule, and
   # the manifest is just as attacker-influenceable in this shape as in the others.
   refute_file_contains "$WD_MANIFESTED_SCRIPT" "$WD_SEND_ALERT_LOG"

--- a/test/unit/osquery-pipeline-audit.sh
+++ b/test/unit/osquery-pipeline-audit.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 #
 # pipeline_audit_scan (dot_local/libexec/osquery/pipeline-audit.sh) is the
-# PERIODIC CONTENT AUDIT seam: it reads the root-owned pipeline-integrity
-# manifest, hashes every path the manifest lists, and reports each path whose
-# CURRENT state disagrees with its recorded tuple.
+# PERIODIC MANIFEST AUDIT seam: it reads the root-owned pipeline-integrity
+# manifest and reports each path whose CURRENT content, mode or owner disagrees
+# with the tuple recorded for it.
 #
 # Why it exists. The manifest was enforced only by osquery file_events, and
 # osquery watches PATHS. An attacker who hard-links a manifested script to a
 # writable path outside the pipeline home and overwrites the alias mutates the
 # SAME INODE while the filesystem event names the outside path: no event ever
 # reaches the watched path, no verdict runs, and the tampered script executes with
-# nothing paged. This audit is the answer, because it compares bytes on a
+# nothing paged. A chmod or chown through that alias does it without moving a
+# byte. This audit is the answer to both, because it re-reads the files on a
 # schedule and never depends on an event having fired.
 #
 # Contract:
 #   return 0 = the scan COMPLETED. Every divergence is one stdout line,
-#              "<kind> <path>"; no output means the deployed tree matches.
+#              "<kind> <path>", one line per diverging COLUMN; no output means
+#              the deployed tree matches.
 #   return 1 = the scan could NOT be completed, and stdout is a single reason
 #              TOKEN from a fixed vocabulary (missing, untrustworthy, malformed,
 #              overlong, budget). A caller that cannot verify must page: this is
@@ -73,11 +75,16 @@ mkdir -p "$home/Library/LaunchAgents"
 printf 'echo digest\n' >"$good_script"
 printf 'echo spaced\n' >"$spaced_script"
 printf '<plist/>\n' >"$plist"
+# The modes are set EXPLICITLY to the ones the manifest below binds, rather than
+# left to whatever umask happened to apply. The audit compares the mode column, so
+# a fixture whose disk mode disagreed with its manifest line would report a mode
+# divergence in every single case and drown the case each one is actually pinning.
+chmod 0755 "$good_script" "$spaced_script"
+chmod 0644 "$plist"
 
 # The manifest binds content, mode and owner: "<sha256> <mode> <uid> <path>", path
-# LAST so a path containing spaces is still read whole. The audit compares only the
-# content column, but it REQUIRES all four to be present and well-formed, so these
-# fixtures carry the real shape rather than the content-only one they had before.
+# LAST so a path containing spaces is still read whole. All four columns are
+# compared, and all four are required to be present and well-formed.
 manifest="$work/pipeline-known-good.sha256"
 manifest_uid="$(id -u)"
 [[ $manifest_uid =~ ^[0-9]+$ ]] || fail "id -u did not report a numeric uid: $manifest_uid"
@@ -126,6 +133,57 @@ expect_rc "a tampered file still completes the scan" 0
 expect_out "tampered content is reported" "content $good_script"
 printf 'echo digest\n' >"$good_script" # restore
 
+# --- the headline for ATTRIBUTES: a chmod through a HARD LINK, with no event ---
+# The attribute half of the same blind spot. An attacker hard-links a manifested
+# script to a path OUTSIDE the pipeline home and chmods the alias: both names are
+# one inode, so the watched path becomes group-writable, while any filesystem
+# event names the attacker's path. The event layer never judges the watched path,
+# and an audit that compared only content reads this as clean, because not one
+# byte changed. The script can then be rewritten later from a less privileged
+# context.
+outside_alias="$work/attacker-alias.sh"
+ln "$good_script" "$outside_alias"
+chmod g+w "$outside_alias"
+[[ $(stat -c '%a' "$good_script" 2>/dev/null || stat -f '%Lp' "$good_script") == 775 ]] ||
+  fail "the fixture hard link did not carry the chmod onto the manifested path"
+run_scan
+expect_rc "an attribute-only divergence still completes the scan" 0
+expect_out "a mode changed through a hard-link alias outside the pipeline home is reported" \
+  "mode $good_script"
+chmod 0755 "$outside_alias"
+rm -f "$outside_alias"
+run_scan
+expect_out "the restored mode is clean again (an attribute check is not a false-page source)" ""
+
+# --- an OWNER that no longer matches its manifest line ------------------------
+# Driven from the manifest side because a test cannot chown (that needs root). The
+# comparison is a plain equality between the recorded uid and the current one, so a
+# manifest recorded while the file was root-owned and read after it was chowned away
+# is the same mismatch, in the direction a test can actually produce.
+owner_manifest="$work/owner-drift.sha256"
+printf '%s 0755 0 %s\n' "$(sha_of "$good_script")" "$good_script" >"$owner_manifest"
+run_scan OSQUERY_PIPELINE_MANIFEST="$owner_manifest"
+expect_rc "an owner divergence still completes the scan" 0
+expect_out "a file whose owner no longer matches the manifest is reported" "owner $good_script"
+
+# --- content, mode and owner are DISTINCT kinds -------------------------------
+# The watchdog dedupes on a fingerprint of this report, so an escalation from an
+# attribute change to a content change has to CHANGE the report or it is suppressed
+# as already-reported. It does, because each diverging column is its own line with
+# its own kind: one generic "diverged <path>" line would read identically before and
+# after, and the more serious drift would page nothing.
+chmod g+w "$good_script"
+printf 'echo tampered\n' >>"$good_script"
+run_scan
+expect_rc "a file diverging on two columns still completes the scan" 0
+expect_out "content and mode are reported as separate kinds for the same path" \
+  "content $good_script
+mode $good_script"
+printf 'echo digest\n' >"$good_script"
+chmod 0755 "$good_script"
+run_scan
+expect_out "restoring both columns is clean" ""
+
 # --- a path whose file is GONE ------------------------------------------------
 mv "$plist" "$work/plist.stashed"
 run_scan
@@ -155,6 +213,7 @@ expect_rc "a non-regular manifested path still completes the scan" 0
 expect_out "a directory at a manifested path is reported" "irregular $good_script"
 rmdir "$good_script"
 printf 'echo digest\n' >"$good_script"
+chmod 0755 "$good_script" # recreated from scratch, so the manifest's mode is restored too
 
 # --- a path with a SPACE is one manifest entry, not two fields ----------------
 printf 'echo tampered\n' >>"$spaced_script"
@@ -185,6 +244,16 @@ run_scan OSQUERY_PIPELINE_AUDIT_MAX_BYTES=1
 expect_rc "an over-cap file does not abort the scan" 0
 [[ $SCAN_OUT == *"oversize $good_script"* ]] ||
   fail "an over-cap manifested file must be reported, got [$SCAN_OUT]"
+
+# The size bound caps HASHING, and must not become an attribute blind spot: an
+# attacker who grows a manifested file past the cap would otherwise buy silence on
+# its permissions along with it.
+chmod g+w "$good_script"
+run_scan OSQUERY_PIPELINE_AUDIT_MAX_BYTES=1
+expect_rc "an over-cap file with an attribute divergence does not abort the scan" 0
+[[ $SCAN_OUT == *"mode $good_script"* ]] ||
+  fail "an over-cap file's mode must still be compared, got [$SCAN_OUT]"
+chmod 0755 "$good_script"
 
 run_scan OSQUERY_PIPELINE_AUDIT_MAX_ENTRIES=2
 expect_rc "a manifest with more entries than the audit will examine refuses" 1
@@ -253,4 +322,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-audit: OK (a matching tree is clean; tampered content, a missing path, a symlink whose referent matches, a directory, and an over-cap file are each reported without any file event; spaced paths are read whole; an absent, empty, malformed, relative-path, over-long, or non-root-owned manifest, an absent verdict helper, and an exhausted budget all refuse LOUDLY)\n'
+printf 'osquery-pipeline-audit: OK (a matching tree is clean; tampered content, a mode changed through a hard-link alias outside the pipeline home, a drifted owner, a missing path, a symlink whose referent matches, a directory, and an over-cap file are each reported without any file event; content and mode are distinct kinds on the same path; spaced paths are read whole; an absent, empty, malformed, relative-path, over-long, or non-root-owned manifest, an absent verdict helper, and an exhausted budget all refuse LOUDLY)\n'


### PR DESCRIPTION
## Context

The osquery pipeline protects its own scripts with a root-owned manifest, enforced by two layers. One
judges filesystem change events as they arrive and compares content, permissions and owner. The other
re-hashes every listed file on a schedule, which catches tampering that produces no event at all, such as a
change made through a hard link created elsewhere.

The scheduled layer compared only content. So a permissions or ownership change made through a hard link
fell between the two: no event for the first layer to judge, and columns the second layer never looked at.

## Summary

- The scheduled audit now compares permissions and owner as well as content.
- A permissions change made through a hard link, which fires no event at all, now pages.
- Each diverging attribute is reported separately, so a later, more serious change is never mistaken for one already reported.
- Both coverage notes are rewritten to match what the two layers now actually cover.

Key file: `dot_local/libexec/osquery/executable_pipeline-audit.sh`.

## The gap, reproduced first

Against the previous code, with a hard link to a protected script created outside the pipeline directory
and the permissions changed through that link: the protected file's permissions changed on disk, the event
named the outside path, and the audit reported nothing. An ownership change behaved the same way. A content
change through the same link was caught, because content was the only column compared.

## Why each attribute is reported on its own line

The audit avoids re-alerting every fifteen minutes by remembering a fingerprint of what it last reported.
That makes the report's shape part of the security model rather than a presentation detail.

Reporting one line per diverging file would have been enough to catch the gap, but it creates a worse
problem. An attacker who changes a file's permissions, waits for that to be reported and recorded, and then
replaces the file's contents produces an identical report: the same file, the same generic line. The
fingerprint would not move, and the more serious second change would be discarded as already known.

Reporting one line per diverging attribute means the report grows when a new kind of divergence appears, so
the fingerprint changes and it alerts again. A test covers exactly that sequence, and removing the
attribute name from the fingerprint fails that test and no other.

## Cost

Twenty five files went from about 0.47 to about 0.71 seconds per run, from two extra reads per file. At one
run every fifteen minutes that is under a tenth of a percent duty cycle, and the probe runs last so it
delays nothing else.

Combining those reads into a single call would be faster and is deliberately refused: the existing readers
exist because one platform's stat reports only the lower permission bits, so a hand-rolled call would read
an added setuid bit back as ordinary permissions.

## What still is not covered

Recorded in both notes rather than left implied: group ownership is not bound, because there is no
expressed intent for it and changing only the group cannot grant access the bound permissions do not
already grant. Re-tampering is now narrowed to repeating the same kind of change on a file already
reported, which stays deduplicated by design; introducing a different kind alerts again.

## How it was reviewed

Every behavior was confirmed failing before the change. Seven mutations were run, each killing exactly the
test meant to catch it, including removing each attribute comparison, skipping attributes on oversized
files, and fingerprinting paths without their attribute names.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover.
