### PR TITLE
feat(osquery): bind the page allowlist so a tampered one cannot suppress

### DIFF
--- a/.chezmoiscripts/run_after_05-osquery-known-good-manifests.sh
+++ b/.chezmoiscripts/run_after_05-osquery-known-good-manifests.sh
@@ -172,7 +172,11 @@ fi
 # These filters are one leg of the three-way agreement: the others are the
 # osquery.conf WATCH set and _pipeline_is_tracked in pipeline-verdict.sh, and an
 # integration test drives all three against one fixture so they cannot drift apart
-# silently.
+# silently. The WATCH leg is the loosest of the three: osquery watches directories,
+# so it reports neighbors of the covered files too, and _pipeline_is_tracked is what
+# classifies those as untracked. What must match exactly is this filter and the
+# tracked set, or a watched-and-tracked file the manifest can never contain pages
+# forever and a manifested file nothing watches is never checked.
 #
 # The bin arm is NON-RECURSIVE on purpose: ~/.local/bin holds tools, and a managed
 # file in a SUBDIRECTORY of it would be a different kind of thing that nothing has
@@ -184,6 +188,16 @@ while IFS= read -r target; do
   case "$target" in
     "$home"/.local/libexec/osquery/*) pipeline_paths+=("$target") ;;
     "$home"/Library/LaunchAgents/com.webdavis.osquery-*.plist) pipeline_paths+=("$target") ;;
+    # The page-launchd allowlist joins the PIPELINE arm, named as ONE EXACT FILE
+    # rather than by its directory. It decides whether an unknown user LaunchAgent
+    # pages, so it is infrastructure the alerter judges, and the verdict routes any
+    # path outside ~/.local/bin to the pipeline manifest, so this is the only arm
+    # that can vouch for it. The exact path matters: ~/.config/osquery also holds
+    # webhook-secret, the daemon config, packs/ and the allowlist writer's lock
+    # file, and a directory pattern would bind a secret's digest into this
+    # world-readable root-owned manifest and sign a lock file that is recreated on
+    # every curation run.
+    "$home"/.config/osquery/page-launchd-allowlist.txt) pipeline_paths+=("$target") ;;
     "$home"/.local/bin/*/*) : ;; # a managed file in a subdirectory: not covered
     "$home"/.local/bin/*) managed_bin_paths+=("$target") ;;
   esac

--- a/docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md
@@ -1,0 +1,294 @@
+# Design: making the page-launchd allowlist a real boundary
+
+Branch: `feat/osquery-allowlist-boundary`. Base: `51539ea` (`origin/main`, fetched over HTTPS; SSH to
+GitHub times out in this environment). Status: design only, no implementation.
+
+## Context
+
+The osquery alerting pipeline pages the operator when a new user LaunchAgent appears. Under the
+slice-6 default-deny ruling, an agent that is not in the page-launchd allowlist pages, and one that is
+in it stays quiet. That single file therefore decides whether persistence alerts fire at all.
+
+It is deployed at `~/.config/osquery/page-launchd-allowlist.txt`, owned and writable by the operator.
+It is not listed in the root-owned pipeline-integrity manifest, so neither of the two manifest layers
+ever looks at it. A change to it is routed to the daily digest, never to a page.
+
+The attack: a process running as the operator appends a tuple naming its own LaunchAgent with an empty
+`sha256` (the own-agent convention that skips the hash check), then installs that agent.
+`allowlist_verdict` returns 0, the persistence finding is dropped, and the allowlist edit surfaces at
+most once, the next day, inside a grouped digest. The component that decides whether to alert is
+neither protected nor watched.
+
+## What I verified before designing
+
+Everything below was checked against the tree or run on this host, not recalled.
+
+1. **The allowlist is user-writable and unmanifested.** The manifest runner
+   (`.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh`) filters `chezmoi managed` down to two
+   patterns: `$HOME/.local/libexec/osquery/*` and
+   `$HOME/Library/LaunchAgents/com.webdavis.osquery-*.plist`. The allowlist matches neither.
+   `_pipeline_is_tracked` in `results-alerter/pipeline-verdict.sh` uses the identical two patterns, and
+   `.chezmoitemplates/osquery/osquery.conf` watches the same two path sets under the
+   `pipeline_integrity` and `launch_agents` categories. All three agree, and all three exclude the
+   allowlist.
+
+1. **Its mutation only digests.** `results-alerter/route.sh` line 283 onward: the `allowlist_file`
+   category matches basename `page-launchd-allowlist.txt` and calls `digest_append`, then `continue`.
+   The digest is a once-daily grouped summary
+   (`Library/LaunchAgents/com.webdavis.osquery-digest.plist.tmpl` uses `StartCalendarInterval`), so
+   worst-case notice is roughly 24 hours, in a low-salience channel.
+
+1. **`file_paths_hashes` does not cover `~/.config/osquery`.** The `allowlist_file` category appears in
+   `file_paths` but not in `file_paths_hashes`, so allowlist events carry no `sha256` column at all.
+
+1. **Passwordless sudo is real on this host.** `sudo -n true` succeeds.
+
+1. **`chezmoi apply` destroys out-of-band writes to this file.** Verified empirically with a throwaway
+   source, destination and persistent state on chezmoi v2.71.0: a plain (not `modify_`, not `create_`)
+   managed file is rewritten from source on every apply. An appended line was gone after the next
+   apply.
+
+1. **A targeted apply does not run `run_after` scripts.** Same throwaway setup: a full
+   `chezmoi apply --force` fired `run_after_05`; `chezmoi apply --force <one-target>` restored the file
+   and fired nothing.
+
+1. **No third-party seed has ever been added.** Across the full history of both
+   `dot_config/osquery/private_page-launchd-allowlist.txt` and its predecessor
+   `dot_config/osquery/launch-allowlist.txt`, every entry ever added is a `com.webdavis.osquery-*`
+   own-agent, and every one landed as a source commit (`46a99cb`, `d0d4dae`, `1320d3c`, `a121b65`).
+   `allowlist.sh -a` has produced zero committed entries.
+
+## The reframe that facts 5 and 7 force
+
+The brief describes the blocker as: the slice-5 writer updates the deployed allowlist outside a chezmoi
+apply, so manifesting the file would page on every legitimate seed.
+
+That workflow does not survive contact with chezmoi. A tuple written by `allowlist.sh -a` lives until
+the next `chezmoi apply` and is then silently erased, along with the suppression it bought. The operator
+would find the agent paging again with no explanation. So the out-of-band seed is not a working
+workflow that a manifest would break. It is a latent bug, and the history confirms nobody has relied on
+it: every entry that exists got there by editing the source and committing.
+
+This changes the shape of the decision. Option B is not a workflow migration with a cost. It is the
+repair of a workflow that is already broken, and the boundary fix falls out of it.
+
+## Options
+
+Each option is judged on five questions: does it stop the attack, does it survive passwordless sudo,
+what happens to the seed workflow, what machinery it costs, and how it interacts with the existing two
+layers (event-time verdict, 15-minute scheduled audit).
+
+### A. Root-own the allowlist with a privileged update path
+
+Deploy the file `root:wheel 0644` and give the writer a `sudo` update path, mirroring how the manifest
+itself is installed.
+
+- **Stops the attack?** Only the literal write. A user process can no longer append directly.
+- **Survives passwordless sudo?** No. `sudo tee` is one command away, with no prompt. This is the same
+  limit both `_pipeline_manifest_is_trustworthy` and the manifest runner already record about the
+  manifest itself. Say it plainly: on this host root ownership is a raised bar and a loud failure mode,
+  not a boundary.
+- **Seed workflow?** Worse. Seeding now needs a privileged write, and the file still gets clobbered by
+  the next apply, because chezmoi writes every target as the invoking user and would fight the root
+  ownership on every run. Option A and chezmoi management are close to incompatible.
+- **Machinery?** A privileged write path in a user-facing curation tool, plus an exception to chezmoi's
+  ownership model.
+- **Two-layer interaction?** None gained. A root-owned file that is still unmanifested is still invisible
+  to both layers. The edit would go on digesting.
+
+**Verdict: weak.** It buys the least of any option here and costs the most in ownership complexity. It
+is also the only option that makes the file harder to manage rather than easier. Reject.
+
+### B. Manifest the allowlist and route the writer through chezmoi
+
+Add `~/.config/osquery/page-launchd-allowlist.txt` to the manifest's path filter, to
+`_pipeline_is_tracked`, and to the `allowlist_file` routing arm. Change `allowlist.sh` so `-a` and `-d`
+edit the chezmoi **source** file, apply that one target, and then refresh the manifest.
+
+- **Stops the attack?** It detects it, within seconds. The deployed bytes no longer match the manifest
+  tuple derived from chezmoi intent, so `pipeline_verdict` pages a CRIT for the allowlist file. The
+  suppression of the persistence finding still happens on that pass, so this is detection, not
+  prevention, unless it is paired with the verdict hardening described below.
+- **Survives passwordless sudo?** No, and nothing does. An attacker who escalates rewrites the manifest
+  and both layers then bless whatever they wrote. What B buys is that the allowlist stops being a
+  *softer* target than the alerter's own scripts: it inherits exactly their trust properties, no better
+  and no worse.
+- **Seed workflow?** It gets fixed. A seed becomes a source edit plus an apply, which is what every
+  existing entry already is, and the tuple now survives future applies instead of being erased. The
+  manifest regenerates from the same source in the same flow, so a legitimate seed is silent by
+  construction. Zero false pages.
+- **Machinery?** Moderate and mostly reuse. Three path filters gain one entry each, one routing arm
+  changes from `digest_append` to `pipeline_verdict`, and `allowlist.sh` gains source resolution
+  (`chezmoi source-path`), a targeted apply and a manifest refresh. Because a targeted apply does not
+  run `run_after` scripts (fact 6), the writer must invoke
+  `.chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh` itself; that script is deliberately not a
+  template and already handles a direct invocation with `CHEZMOI_SOURCE_DIR` unset.
+- **Two-layer interaction?** Both layers pick it up for free. Layer 1 judges any event on the path
+  against the full content, mode and owner tuple. Layer 2 re-reads it every 15 minutes, which covers the
+  hard-link and symlink-referent shapes that generate no event on the watched path. Binding mode and
+  owner also means a `chmod 0666` on the allowlist now pages, which nothing catches today.
+
+### C. Page on any allowlist mutation
+
+Leave the file where it is and change the `allowlist_file` arm from `digest_append` to `sev="CRIT"`.
+
+- **Stops the attack?** It makes it loud within seconds. It does not stop the suppression.
+- **Survives passwordless sudo?** No. The decision lives in `route.sh`, which an escalated attacker can
+  rewrite; they would have to also rewrite the manifest to stay quiet about it, which passwordless sudo
+  permits.
+- **Seed workflow?** Every legitimate seed pages and needs an operator dismissal. The noise cost is
+  empirically near zero right now (fact 7: no third-party seed has ever happened), but it is noise on
+  exactly the workflow that is meant to become easier, and it trains the operator to dismiss
+  allowlist pages, which is the failure mode this whole subsystem exists to avoid.
+- **Machinery?** Trivial. One line.
+- **Two-layer interaction?** Layer 1 only, and only on the event path. An attacker who edits the
+  allowlist through a hard link outside `~/.config/osquery` fires no event on the watched path and pages
+  nothing. Layer 2 cannot help, because layer 2 walks the manifest and the file is not in it.
+
+**Verdict: strictly dominated by B.** B is louder (both layers, including the no-event shapes), quieter
+on legitimate work (zero false pages instead of one per seed), and fixes the clobber bug as a side
+effect. C survives only as a fallback if B is judged too much machinery.
+
+### D. Bind the allowlist's content to something the attacker cannot also edit
+
+The brief asks whether the manifest's intent-derived trick applies here. It does, and that is precisely
+what B does: the manifest never reads the protected tree, it derives content from `chezmoi cat`, mode
+from `chezmoi dump` and owner from the running uid, then installs the result root-owned. Applying that
+to the allowlist requires the source to be the authority for the file's content, which is the writer
+change in B. So D is not a separate option. It is B's mechanism, and B is D's prerequisite.
+
+There is one genuinely separate idea in this family, and it is worth calling out because it converts B
+from detection into prevention:
+
+**D-prime, the verdict consults the manifest for its own input.** Make `allowlist_verdict` refuse to
+suppress anything when the deployed allowlist's current content, mode and owner are not the manifest's
+tuple for that path. It already has the seam: `results-alerter.sh` sources both
+`allowlist-verdict.sh` and `pipeline-verdict.sh` into the same shell, so
+`_pipeline_deployed_state_is_known_good` is callable, guarded by a `declare -F` check the way
+`pipeline-audit.sh` guards its own reuse.
+
+- **Stops the attack?** Yes, in the sense that matters: the appended tuple buys no suppression. The
+  attacker's LaunchAgent pages on the persistence detector, and the allowlist tamper pages separately.
+  Two independent signals from one edit.
+- **Survives passwordless sudo?** No. Same manifest, same escalation.
+- **Seed workflow?** Unaffected once B is in place, because after a seed the deployed file matches the
+  manifest again.
+- **Machinery?** Small, and no new file or dependency. The real cost is the failure mode: during the
+  sub-second window between an apply writing the file and `run_after_05` reinstalling the manifest, an
+  unbound allowlist suppresses nothing, so a persistence finding judged in that window pages for an own
+  agent. `_pipeline_tuple_settles` already implements exactly the bounded wait for that shape and should
+  be reused rather than reinvented.
+- **Two-layer interaction?** It adds a third consumer of the same manifest, which is the point: one
+  root-owned known-good list, three enforcers.
+
+### E. Suppress own agents by manifest membership instead of by allowlist entry
+
+All seven current entries are `com.webdavis.osquery-*` agents whose plists are already in the manifest.
+They carry an empty `sha256` only because their plists change with the dotfiles. If the verdict
+suppressed a user LaunchAgent whose plist path is manifested and currently matches its tuple, those
+seven entries would not need to exist, and the empty-`sha256` convention could be deleted outright.
+`allowlist.sh` already refuses to write an unpinned tuple, so after E every allowlist entry would carry
+a real hash.
+
+- **Stops the attack?** It kills the attack *as described*, because there is no longer an
+  empty-`sha256` convention to abuse. It does not stop the general attack: the attacker pins their own
+  plist's hash instead, which costs them one `shasum`. Do not let this option's elegance be mistaken for
+  a fix.
+- **Survives passwordless sudo?** No.
+- **Seed workflow?** Improves it. The seven own-agent entries stop needing hand maintenance, and the
+  completeness guard in `test/integration/osquery-page-allowlist-seed.sh` (which already caught one
+  missing tuple) becomes unnecessary for own agents.
+- **Machinery?** Moderate, and it touches the detector's semantics rather than only its inputs.
+- **Two-layer interaction?** It routes own-agent trust through the manifest, which is the same
+  consolidation D-prime performs.
+
+**Verdict: a good follow-on, not the fix.** It removes a convention that exists only as an exception,
+and it composes cleanly with B. It should not be bundled into the same change as the boundary work.
+
+## Recommendation
+
+**Do B, with D-prime, as one change. Defer E to a follow-up. Reject A. Keep C only as the fallback if
+the writer change is judged too invasive.**
+
+The reasoning in three lines:
+
+1. B is the only option that makes a legitimate seed *cheaper* rather than more expensive, because the
+   workflow it supposedly breaks is already broken and B repairs it.
+1. B reuses the manifest machinery whole. No new trust root, no new file format, no new privileged
+   path. The allowlist simply joins the set of files the pipeline already protects, and inherits both
+   enforcement layers, including the scheduled audit that covers the no-event shapes.
+1. D-prime is what turns B from "you find out afterwards" into "the tampered entry does not work," and
+   it costs one guarded function call because both helpers are already sourced into the same shell.
+
+Sequencing, so no step leaves the host in a paging state:
+
+1. Add the allowlist path to the manifest filter, `_pipeline_is_tracked`, and the routing arm, in one
+   change. Match the **exact path**, never the directory: `~/.config/osquery` also holds
+   `webhook-secret`, `osquery.conf`, `packs/` and the writer's `.lock` file, and every one of those must
+   stay a log-only neighbor.
+1. Change `allowlist.sh` to write the source, apply that one target, then invoke the manifest runner.
+   Apply first and refresh the manifest second, matching the order a real apply uses, so the brief
+   mismatch is the shape `_pipeline_tuple_settles` already waits out. The write lock moves to the source
+   file, which also gets the `.lock` out of the watched directory.
+1. Add D-prime to `allowlist_verdict`, guarded by `declare -F` and reusing `_pipeline_tuple_settles`.
+1. Fail closed everywhere a new failure is possible: a writer that cannot resolve the chezmoi source, or
+   cannot refresh the manifest, must refuse to claim it seeded anything.
+
+Optional, low value: adding the allowlist to `file_paths_hashes` in `osquery.conf`. `pipeline_verdict`
+re-hashes from disk and uses the event digest only to recognize the atomic-rename shape, so without it
+every allowlist event simply takes the 0.3 second rename path. If it is added, scope it to the single
+file, not to `~/.config/osquery/%%`, so `webhook-secret` does not get its digest recorded into
+`file_events`.
+
+## What this does not defend against
+
+In the style of the coverage map at the top of `pipeline-verdict.sh`.
+
+- **A USER-LEVEL ATTACKER ON A PASSWORDLESS-SUDO HOST. No option in this document closes that, and
+  none can.** Every proposal here roots trust in the manifest at
+  `/var/osquery/pipeline-known-good.sha256`, which is root-owned `0644`. A process running as the
+  operator escalates with no prompt, rewrites the manifest to bless whatever it just wrote, and both
+  layers go quiet. That is the same limit already recorded in `_pipeline_manifest_is_trustworthy` and in
+  the manifest runner's docblock, and it applies unchanged to the allowlist once the allowlist joins the
+  manifest. The honest claim for the recommendation is: the allowlist stops being the softest component
+  in the pipeline and becomes exactly as hard as the alerter's own scripts. It is not a boundary that
+  survives sudo. Requiring a sudo password is the only thing that would change that, and every
+  unattended chezmoi script on this host depends on the current configuration.
+
+- **SOURCE COMPROMISE.** Under the recommendation the chezmoi source becomes the authority for the
+  allowlist's content, and the source is user-writable. An attacker who edits
+  `dot_config/osquery/private_page-launchd-allowlist.txt` and then waits for, or races, a legitimate
+  apply gets their tuple both deployed and manifested, signed as known-good by all three enforcers. This
+  is not a regression; it is the identical exposure the alerter's own scripts already carry, and the
+  manifest runner's docblock already records it. Worth stating explicitly here so the allowlist's
+  posture is not read as stronger than the scripts it governs.
+
+- **PREVENTION AGAINST AN ATTACKER WHO PINS A HASH.** Option E deletes the empty-`sha256` convention,
+  which is the specific mechanism this report's attack uses. It does not stop an attacker from computing
+  the hash of their own plist and writing a fully pinned tuple. Any allowlist whose contents an attacker
+  can influence remains an allowlist an attacker can extend. The value of the recommendation is that the
+  influence now requires either a source edit or a manifest rewrite, both of which have their own
+  recorded exposures, rather than a bare append to a user-writable file that nothing reads.
+
+- **THE WINDOW BETWEEN APPLY AND MANIFEST REFRESH.** D-prime makes an unbound allowlist vouch for
+  nothing, so during the sub-second gap between the file landing and the manifest being reinstalled,
+  a persistence finding judged in that window pages for an agent that is in fact known-good. This fails
+  in the safe direction and `_pipeline_tuple_settles` bounds it, but it is a real false-page shape and
+  should be tested rather than assumed away.
+
+- **RE-TAMPERING WITHIN THE SAME DIVERGENCE SET.** Inherited unchanged from layer 2. Once the allowlist
+  is reported as a content divergence, a second edit to it does not page again until the divergence kind
+  set changes. Documented in `pipeline-verdict.sh`; it now applies to the allowlist too.
+
+## Open question for adjudication
+
+One, and it is the only thing I would hold implementation on: **should `allowlist.sh -a` run
+`chezmoi apply` on the operator's behalf, or stop after editing the source and print the apply command?**
+
+Auto-applying makes the tool a one-step seed and keeps the manifest consistent without operator
+discipline, at the cost of a curation tool that mutates the home directory and calls `sudo` through the
+manifest runner. Printing the command keeps the tool inert and makes the operator the one who deploys,
+at the cost of a window in which the source and the deployed file disagree and the seed silently does
+not work yet. My recommendation is auto-apply, because the alternative reintroduces exactly the
+"seed does not take effect" confusion that the current clobber bug already produces. Confirm before
+implementation.

--- a/dot_config/osquery/private_page-launchd-allowlist.txt
+++ b/dot_config/osquery/private_page-launchd-allowlist.txt
@@ -20,14 +20,21 @@
 # System daemons (/Library/LaunchDaemons) page by path regardless and are NOT allowlistable
 # here; Apple/system (com.apple.*) labels are refused by the writer. This file is mode 0600.
 #
-# KNOWN GAP (filed as a follow-up, not covered by this file's own rules). Under the
-# default-deny ruling this allowlist IS a security boundary: an entry suppresses a
-# persistence page. But the file is user-writable, it is NOT in the pipeline-integrity
-# manifest, and a change to it only DIGESTS rather than pages, so an attacker running as
-# the operator can append a tuple with an empty sha256 and silence the page for their own
-# LaunchAgent. Closing it needs design work rather than a one-line fix: the writer
-# (allowlist.sh) legitimately rewrites this file outside a chezmoi apply, so simply adding
-# it to the manifest would page on every legitimate seed.
+# DO NOT EDIT THE DEPLOYED COPY. This is the chezmoi SOURCE; the deployed file at
+# ~/.config/osquery/page-launchd-allowlist.txt is rewritten from here on every apply, so a
+# tuple added there directly is erased by the next one. The writer edits this source, applies
+# that one target, and refreshes the pipeline-integrity manifest, in that order.
+#
+# THIS FILE IS A SECURITY BOUNDARY, and is protected like one. Under the default-deny ruling
+# an entry here SUPPRESSES a persistence page, so the file is covered by the root-owned
+# pipeline-integrity manifest (both the event-time verdict and the 15-minute audit judge it),
+# and allowlist_verdict refuses to honor an allowlist the manifest cannot vouch for. A tuple
+# appended out of band therefore suppresses nothing and pages twice over: once as a tamper of
+# this file, once as the unallowlisted agent it was meant to hide.
+#
+# What that is NOT: a boundary that survives this host's passwordless sudo. The manifest is
+# root-owned, and a process running as the operator escalates with no prompt and rewrites it.
+# See the coverage map in results-alerter/pipeline-verdict.sh.
 
 {"label":"com.webdavis.osquery-results-alerter","path":"~/Library/LaunchAgents/com.webdavis.osquery-results-alerter.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/results-alerter.sh","sha256":""}
 {"label":"com.webdavis.osquery-firewall-gatekeeper-monitor","path":"~/Library/LaunchAgents/com.webdavis.osquery-firewall-gatekeeper-monitor.plist","program":"/opt/homebrew/bin/bash ~/.local/libexec/osquery/firewall-gatekeeper-monitor.sh","sha256":""}

--- a/dot_local/libexec/osquery/executable_allowlist.sh
+++ b/dot_local/libexec/osquery/executable_allowlist.sh
@@ -9,6 +9,11 @@
 #   allowlist.sh -d <label>   # deny: remove the entry for <label>
 #   allowlist.sh -l           # list the current allowlist
 #
+# -a and -d curate the CHEZMOI SOURCE and then deploy: edit the source, apply that one
+# target, refresh the pipeline-integrity manifest. See publish_allowlist for why all
+# three steps are required and what each failure leaves behind. -l reads the DEPLOYED
+# file, because that is the one the alerter actually consults.
+#
 # R2-1: an entry is a TUPLE, not a bare label. Suppressing on the label alone let an attacker
 # reuse an allowlisted label but point the plist at a malicious program and be silently
 # suppressed. `-a` captures the label's KNOWN-GOOD identity (canonical plist path + program +
@@ -22,6 +27,11 @@ set -euo pipefail
 
 ALLOWLIST="${OSQUERY_LAUNCHD_ALLOWLIST:-$HOME/.config/osquery/page-launchd-allowlist.txt}"
 OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
+CHEZMOI="${CHEZMOI:-$(command -v chezmoi || echo chezmoi)}"
+
+# The manifest runner, which is a chezmoi SOURCE script and is therefore never
+# deployed into $HOME; it is located inside the source tree. Overridable for tests.
+MANIFEST_RUNNER_REL=".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh"
 
 usage() {
   printf 'usage: %s -a <label> | -d <label> | -l\n' "${0##*/}" >&2
@@ -62,11 +72,11 @@ take_allowlist_write_lock() {
 # fd-inheritance note on take_allowlist_write_lock.
 entry_label() { jq -r '.label // empty' 9>&- <<<"$1" 2>/dev/null || true; }
 
-# Rewrite the allowlist, preserving comment/blank lines and dropping any tuple for <label>.
-# Reads $ALLOWLIST, writes the filtered result to stdout (a no-op if the file is absent).
+# Rewrite an allowlist file, preserving comment/blank lines and dropping any tuple for
+# <label>. Reads <file>, writes the filtered result to stdout (a no-op if it is absent).
 _without_label() {
-  local drop="$1" line
-  [[ -f $ALLOWLIST ]] || return 0
+  local drop="$1" file="$2" line
+  [[ -f $file ]] || return 0
   while IFS= read -r line || [[ -n $line ]]; do
     case "$line" in
       '' | '#'*)
@@ -76,7 +86,101 @@ _without_label() {
     esac
     [[ "$(entry_label "$line")" == "$drop" ]] && continue
     printf '%s\n' "$line"
-  done <"$ALLOWLIST"
+  done <"$file"
+}
+
+# THE DEPLOY PATH, and why curation goes through chezmoi rather than writing the
+# deployed file.
+#
+# The allowlist is a chezmoi-managed plain file, so an apply rewrites it from source
+# every time (verified empirically). A tuple written straight to
+# ~/.config/osquery/page-launchd-allowlist.txt therefore survives only until the next
+# apply and then vanishes, taking its suppression with it and leaving the operator
+# with an agent that pages again for no visible reason. The file is also covered by
+# the pipeline-integrity manifest now, and allowlist_verdict refuses to honor an
+# allowlist the manifest cannot vouch for, so an out-of-band write suppresses nothing
+# even before the next apply erases it.
+#
+# So a seed is a SOURCE change: edit the source, apply that one target, refresh the
+# manifest. That order is the one a real apply uses (files land, then the run_after
+# runner signs them), so the brief disagreement in between is exactly the shape
+# _pipeline_tuple_settles already waits out.
+#
+# The runner is invoked DIRECTLY rather than left to the apply, because a targeted
+# `chezmoi apply <one-file>` does NOT run run_after scripts (verified empirically:
+# a full apply fires the runner, a single-target apply does not). Without this call
+# the deployed allowlist would sit ahead of the manifest, and the verdict would then
+# refuse to honor it - the seed would appear to do nothing.
+
+# allowlist_source_path: the chezmoi SOURCE file backing the deployed allowlist.
+# Fails closed: a target chezmoi does not manage, or an unavailable chezmoi, must
+# stop the run rather than silently fall back to writing the deployed file.
+allowlist_source_path() { "$CHEZMOI" source-path "$ALLOWLIST" 9>&-; }
+
+# manifest_runner_path: the known-good-manifests runner inside the chezmoi source
+# tree. It refreshes BOTH arms (pipeline and managed-bin) from one managed listing;
+# the allowlist rides in the pipeline arm, which is the one that has to be current
+# before the deployed allowlist can be honored again.
+manifest_runner_path() {
+  if [[ -n ${OSQUERY_PIPELINE_MANIFEST_RUNNER:-} ]]; then
+    printf '%s' "$OSQUERY_PIPELINE_MANIFEST_RUNNER"
+    return 0
+  fi
+  local source_dir
+  source_dir="$("$CHEZMOI" source-path 9>&-)" || return 1
+  printf '%s/%s' "$source_dir" "$MANIFEST_RUNNER_REL"
+}
+
+# publish_allowlist <staged-file> <source-file>: install the staged content as the
+# new source, deploy it, and refresh the manifest. All-or-nothing as far as it can
+# be, and loud where it cannot.
+#
+# A FAILED APPLY is fully recoverable, so it is rolled back: the source returns to
+# its previous bytes and nothing was deployed, which is indistinguishable from the
+# command never having run.
+#
+# A FAILED MANIFEST REFRESH is not recoverable that way, and it is the one outcome
+# that matters most to say out loud. The source and the deployed file are updated
+# but the manifest still describes the old bytes, so until it is refreshed the
+# deployed allowlist is unbound and the verdict refuses to honor it: every user
+# LaunchAgent pages. That fails in the SAFE direction, which is why it is reported
+# rather than papered over, and the exit status is non-zero so no caller can mistake
+# it for a completed seed. The runner's own stderr (sudo's, usually) is deliberately
+# NOT redirected: it is the only thing that says why.
+publish_allowlist() {
+  local staged="$1" source_file="$2" backup runner
+  backup="$(mktemp 9>&-)" || {
+    printf 'refused: could not stage a rollback copy of the allowlist source\n' >&2
+    return 1
+  }
+  cp "$source_file" "$backup" 9>&- 2>/dev/null || : >"$backup"
+  if ! mv -f "$staged" "$source_file" 9>&-; then
+    printf 'refused: could not write the allowlist source at %s\n' "$source_file" >&2
+    rm -f "$backup" 9>&-
+    return 1
+  fi
+  if ! "$CHEZMOI" apply --force "$ALLOWLIST" 9>&-; then
+    cp "$backup" "$source_file" 9>&-
+    rm -f "$backup" 9>&-
+    printf 'FAILED: chezmoi apply of %s did not succeed. The allowlist source has been rolled back and nothing was deployed.\n' \
+      "$ALLOWLIST" >&2
+    return 1
+  fi
+  rm -f "$backup" 9>&-
+  if ! runner="$(manifest_runner_path)" || [[ ! -f $runner ]]; then
+    printf 'FAILED: the allowlist was deployed but the known-good-manifests runner could not be located (%s). The manifest is now STALE: until it is refreshed the deployed allowlist is unbound and every user LaunchAgent will page. Run a full chezmoi apply to refresh it.\n' \
+      "${runner:-unresolved}" >&2
+    return 1
+  fi
+  # No CHEZMOI_SOURCE_DIR is set: the runner treats an absent one as a direct
+  # invocation and resolves the configured source itself, which is the same source
+  # the apply above just used.
+  if ! bash "$runner" 9>&-; then
+    printf 'FAILED: the allowlist was deployed but refreshing the known-good manifests failed (%s). The manifest is now STALE: until it is refreshed the deployed allowlist is unbound and every user LaunchAgent will page. Re-run this command, or run a full chezmoi apply.\n' \
+      "$runner" >&2
+    return 1
+  fi
+  return 0
 }
 
 # A real launchd label starts alphanumeric, then allows . _ @ - (so
@@ -128,15 +232,22 @@ allow_label() {
   rel_prog="${abs_prog//"$HOME"\//\~/}"
   # Refresh in place: drop any existing tuple for this label (preserving every other line
   # and all comments/blanks), then append the freshly captured tuple, so re-adding a label
-  # updates its identity and never duplicates it.
-  mkdir -p "$(dirname "$ALLOWLIST" 9>&-)" 9>&-
-  touch "$ALLOWLIST" 9>&-
+  # updates its identity and never duplicates it. An unchanged identity therefore
+  # reproduces the source byte for byte, which makes a repeated -a a true no-op: the
+  # apply writes identical bytes and the manifest runner compares equal and installs
+  # nothing.
+  local source_file
+  if ! source_file="$(allowlist_source_path)" || [[ -z $source_file ]]; then
+    printf 'refused: could not resolve the chezmoi source for %s; the allowlist is chezmoi-managed and must be curated through its source\n' \
+      "$ALLOWLIST" >&2
+    exit 1
+  fi
   local temp
   temp=$(mktemp 9>&-)
-  _without_label "$label" >"$temp"
+  _without_label "$label" "$source_file" >"$temp"
   jq -cn --arg label "$label" --arg path "$rel_path" --arg program "$rel_prog" --arg sha256 "$sha" \
     '{label:$label, path:$path, program:$program, sha256:$sha256}' 9>&- >>"$temp"
-  mv -f "$temp" "$ALLOWLIST" 9>&-
+  publish_allowlist "$temp" "$source_file" || exit 1
   printf 'allowed: %s -> %s\n' "$label" "$abs_prog"
 }
 
@@ -146,16 +257,24 @@ deny_label() {
     printf 'refused (invalid or system label): %s\n' "$label" >&2
     exit 1
   fi
-  # Removing a label that was never allowed is a clean no-op: exit 0, file untouched,
-  # a note on stdout (nothing on stderr), so a caller can deny unconditionally.
-  if [[ ! -f $ALLOWLIST ]] || ! grep -qF "\"label\":\"$label\"" "$ALLOWLIST" 9>&- 2>/dev/null; then
+  local source_file
+  if ! source_file="$(allowlist_source_path)" || [[ -z $source_file ]]; then
+    printf 'refused: could not resolve the chezmoi source for %s; the allowlist is chezmoi-managed and must be curated through its source\n' \
+      "$ALLOWLIST" >&2
+    exit 1
+  fi
+  # Removing a label that was never allowed is a clean no-op: exit 0, nothing
+  # deployed, no manifest refresh, a note on stdout (nothing on stderr), so a caller
+  # can deny unconditionally. The SOURCE is what is consulted, because the source is
+  # the authority an apply deploys from.
+  if [[ ! -f $source_file ]] || ! grep -qF "\"label\":\"$label\"" "$source_file" 9>&- 2>/dev/null; then
     printf 'not present: %s\n' "$label"
     return 0
   fi
   local temp
   temp=$(mktemp 9>&-)
-  _without_label "$label" >"$temp"
-  mv -f "$temp" "$ALLOWLIST" 9>&-
+  _without_label "$label" "$source_file" >"$temp"
+  publish_allowlist "$temp" "$source_file" || exit 1
   printf 'denied: %s\n' "$label"
 }
 

--- a/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh
@@ -22,13 +22,44 @@
 # Namespaced so it does not collide with the other sourced helpers.
 _allowlist_verdict_expand_home() { printf '%s' "${1//\~\//$HOME/}"; }
 
+# _allowlist_is_manifest_bound <allowlist-file>: 0 when the root-owned
+# pipeline-integrity manifest vouches for THIS allowlist file as it stands right
+# now (content, mode and owner), else 1.
+#
+# WHY THE VERDICT ASKS THIS AT ALL. The allowlist is deployed user-writable, and
+# under default-deny an entry in it SUPPRESSES a persistence page. A process
+# running as the operator could therefore append a tuple naming its own
+# LaunchAgent and silence the page for it. Manifesting the file makes that edit
+# page, but a page after the fact is nearly worthless for a component whose whole
+# job is to suppress: by the time the alert lands the attacker has already had the
+# silent window they wanted. Refusing to honor an allowlist nothing can vouch for
+# is what turns detection into prevention - the appended tuple simply does not
+# work, and the agent it was meant to hide pages on its own merits.
+#
+# The check is reused, never reimplemented: _pipeline_tuple_settles is the same
+# comparison the file_events verdict makes, including the bounded wait for an
+# in-flight manifest regeneration. That wait is what keeps a legitimate apply from
+# false-paging in the window between the new allowlist landing and the manifest
+# being reinstalled a moment later.
+#
+# Checked by NAME rather than assumed. results-alerter.sh sources both helpers, so
+# a missing pipeline verdict aborts the alerter and this branch is unreachable in
+# production; a partial install must still fail toward paging rather than toward a
+# quiet suppression nobody can account for.
+_allowlist_is_manifest_bound() {
+  declare -F _pipeline_tuple_settles >/dev/null 2>&1 || return 1
+  _pipeline_tuple_settles "$1"
+}
+
 # allowlist_verdict <label> <path> <program>:
-#   0 = suppress (full tuple match; an empty stored sha256 skips only the hash
+#   0 = suppress (full tuple match, FROM AN ALLOWLIST THE PIPELINE-INTEGRITY
+#       MANIFEST VOUCHES FOR; an empty stored sha256 skips only the hash
 #       dimension, the own-agent seed entries)
 #   2 = reused label -> page (the label is allowlisted but path/program diverges,
 #       or the pinned hash no longer matches the on-disk plist)
 #   1 = not allowlisted (no label match, a degraded label-only entry that cannot
-#       vouch, or a missing/unreadable allowlist file)
+#       vouch, a missing/unreadable allowlist file, or an allowlist the manifest
+#       cannot vouch for - see _allowlist_is_manifest_bound)
 allowlist_verdict() {
   local want_label="$1" want_path="$2" want_program="$3"
   local file="${OSQUERY_LAUNCHD_ALLOWLIST:-$HOME/.config/osquery/page-launchd-allowlist.txt}"
@@ -62,5 +93,15 @@ allowlist_verdict() {
     disk_hash=$(shasum -a 256 "$want_path" 2>/dev/null | awk '{print $1}')
     [[ $disk_hash == "$jhash" ]] || return 2
   fi
-  return 0 # full tuple match -> known-good, suppress
+  # LAST GATE, and only on the suppress path. Everything above has agreed this
+  # entry vouches for the finding; what is left is whether the FILE that entry came
+  # from is itself accounted for. An allowlist the root-owned manifest cannot
+  # confirm is treated as not-allowlisted (1), so the finding pages.
+  #
+  # Placed here rather than at the top of the function on purpose. It is the only
+  # outcome the binding can change: a reused label (2) and a miss (1) both page
+  # already, and gating them too would spend a hash and a stat on every finding to
+  # reach an answer that was never in doubt.
+  _allowlist_is_manifest_bound "$file" || return 1
+  return 0 # full tuple match, from an allowlist the manifest vouches for -> suppress
 }

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -355,11 +355,21 @@ _pipeline_tuple_settles() {
 # osquery.conf watch on the identical file set.
 #
 # ~/.local/bin is tracked on a DIFFERENT rule: see _managed_bin_is_tracked below.
+#
+# The page-launchd allowlist is tracked as ONE EXACT FILE, never by its directory.
+# It decides whether an unknown user LaunchAgent pages, so it is infrastructure and
+# belongs here; but the watch on ~/.config/osquery is a DIRECTORY watch, and that
+# directory also holds webhook-secret, the daemon config, packs/, and the lock file
+# the allowlist writer recreates on every -a/-d. None of those is manifested, so a
+# directory pattern here would page on each of them forever and would route a
+# secret's every touch through the pipeline. It is judged against the PIPELINE
+# manifest, which is what _pipeline_manifest_for routes every non-bin path to.
 _pipeline_is_tracked() {
   local target="$1"
   case "$target" in
     "$HOME"/.local/libexec/osquery/*) return 0 ;;
     "$HOME"/Library/LaunchAgents/com.webdavis.osquery-*.plist) return 0 ;;
+    "$HOME"/.config/osquery/page-launchd-allowlist.txt) return 0 ;;
     "$HOME"/.local/bin/*) _managed_bin_is_tracked "$target" ;;
     *) return 1 ;;
   esac

--- a/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
+++ b/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh
@@ -100,6 +100,19 @@
 #     which is user-writable, so tampering with a managed file's SOURCE and letting
 #     a legitimate apply deploy it is signed as known-good by BOTH layers. See the
 #     runner's docblock: this buys post-deployment integrity, not source integrity.
+#   - A USER-LEVEL ATTACKER, INCLUDING AGAINST THE PAGE-LAUNCHD ALLOWLIST. The
+#     allowlist is covered here now, and allowlist_verdict additionally refuses to
+#     suppress anything when this manifest cannot vouch for it, so a tuple appended
+#     out of band neither silences a persistence page nor passes unnoticed. What
+#     that is worth, stated narrowly: the allowlist stops being the softest
+#     component and becomes exactly as hard as the alerter's own scripts,
+#     inheriting their recorded exposures rather than adding a bare user-writable
+#     append that nothing reads. It is NOT a boundary that survives this host's
+#     passwordless sudo. Every layer here roots trust in a root-owned manifest, and
+#     a process running as the operator escalates with no prompt and rewrites it,
+#     blessing whatever it just wrote. Requiring a sudo password is the only thing
+#     that would change that, and every unattended chezmoi script depends on the
+#     current configuration, so this is a recorded limit rather than a defect.
 #
 # Return-code contract (from c69baab _pipeline_verdict):
 #   0 = PAGE   (tamper / cannot confirm legit / no manifest / delete)

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -266,11 +266,12 @@ route_findings() {
             ;;
           sshd_config) sev="CRIT" ;; # remote-auth policy pages
           # The alerter's own scripts/plists (pipeline_integrity), the managed
-          # scripts in ~/.local/bin (managed_bin) and our own LaunchAgents
-          # (launch_agents/launch_daemons) consult pipeline_verdict:
+          # scripts in ~/.local/bin (managed_bin), our own LaunchAgents
+          # (launch_agents/launch_daemons) and the page-launchd allowlist
+          # (allowlist_file) consult pipeline_verdict:
           # 0 = page (tamper / cannot confirm / no manifest -> fail-safe), 1 = silent
-          # (an untracked neighbor, or an exact (path, sha256) manifest match). Never
-          # digests - page or silent.
+          # (an untracked neighbor, or an exact (path, sha256, mode, uid) manifest
+          # match). Never digests - page or silent.
           #
           # managed_bin shares this arm rather than getting its own because the
           # decision is identical; what differs is WHICH manifest vouches for the
@@ -280,7 +281,17 @@ route_findings() {
           # hash hundreds of megabytes of third-party binaries), which the verdict
           # already handles: an absent event digest is the atomic-rename shape, and
           # it re-reads the file's current bytes either way.
-          pipeline_integrity | managed_bin | launch_agents | launch_daemons)
+          #
+          # allowlist_file joins them for the same reason. The page-launchd allowlist
+          # DECIDES whether an unknown user LaunchAgent pages, so an edit to it that
+          # the manifest cannot vouch for is a tamper of the deciding component, not
+          # a line for tomorrow's digest. Routing it here leaves _pipeline_is_tracked
+          # the single authority on which files in the watched directories are ours:
+          # its neighbors (webhook-secret, the daemon config, packs/, the writer's
+          # lock) are untracked and come back SILENT, so no second copy of the
+          # allowlist's basename lives in this file. Its events carry no sha256
+          # either, for the same reason managed_bin's do not.
+          pipeline_integrity | managed_bin | launch_agents | launch_daemons | allowlist_file)
             hash=$(jq -r '.cols.sha256 // ""' <<<"$obj")
             verb=$(jq -r '.cols.action // ""' <<<"$obj")
             if pipeline_verdict "$target" "$hash" "$verb"; then sev="CRIT"; else continue; fi
@@ -288,15 +299,6 @@ route_findings() {
           sudoers)
             digest_append "$obj"
             continue
-            ;;
-          allowlist_file)
-            case "$base" in
-              page-launchd-allowlist.txt)
-                digest_append "$obj" # the page-suppressor edit itself digests
-                continue
-                ;;
-              *) continue ;; # other ~/.config/osquery neighbors, log-only
-            esac
             ;;
           *) continue ;;
         esac

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -234,6 +234,10 @@ route_findings() {
             # reverted #52 (c69baab), which silently digested an unknown agent.
             # allowlist_verdict: 0 = full-tuple match (known-good) -> suppress;
             # 2 = reused label (identity diverges) -> page; 1 = not-found -> page.
+            # A suppress verdict additionally requires the allowlist FILE to be
+            # vouched for by the root-owned pipeline-integrity manifest, so a tuple
+            # appended to it out of band silences nothing; that case arrives here
+            # as 1 and pages under the same default-deny branch as an unknown.
             label=$(jq -r '.cols.label // ""' <<<"$obj")
             program=$(jq -r '.cols.program // ""' <<<"$obj")
             av=0

--- a/test/e2e/osquery-alerter-criteria.bats
+++ b/test/e2e/osquery-alerter-criteria.bats
@@ -52,6 +52,23 @@ STUB
 {"label":"com.evil","path":"~/Library/LaunchAgents/com.evilUNTRUSTED.plist","program":"~/bin/evil","sha256":""}
 EOF
 
+  # The allowlist decides whether an unknown user LaunchAgent pages, so the verdict
+  # refuses to suppress unless the root-owned pipeline-integrity manifest vouches
+  # for the file it just read. bind_allowlist writes the tuple a real apply's
+  # manifest refresh leaves behind, for whichever allowlist a test points the
+  # alerter at; the seeded default is bound here so the suppression criteria are
+  # exercised in the state production is actually in. The manifest never names the
+  # pipeline scripts, so criterion 6 still sees no tuple for them and pages.
+  export OSQUERY_PIPELINE_MANIFEST="$HOME/pipeline-known-good.sha256"
+  export OSQUERY_PIPELINE_SETTLE_SECONDS=0
+  bind_allowlist() {
+    chmod 600 "$1"
+    printf '%s 0600 %s %s\n' \
+      "$(shasum -a 256 "$1" | awk '{print $1}')" "$(id -u)" "$1" \
+      >"$OSQUERY_PIPELINE_MANIFEST"
+  }
+  bind_allowlist "$HOME/.config/osquery/page-launchd-allowlist.txt"
+
   export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
   export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
   export OSQUERY_DIGEST_STORE="$HOME/.local/state/osquery-digest-spool/digest.ndjson"
@@ -157,6 +174,7 @@ EOF
 {"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
 EOF
   export OSQUERY_LAUNCHD_ALLOWLIST="$custom"
+  bind_allowlist "$custom" # the verdict only honors an allowlist the manifest vouches for
   feed "{\"name\":\"pack_intrusion-detection_persistence_launchd\",\"action\":\"added\",\"columns\":{\"label\":\"com.good\",\"path\":\"$HOME/Library/LaunchAgents/com.good.plist\",\"program\":\"$HOME/bin/good\"}}"
   assert_no_page   # suppressed via the env-var path
 }

--- a/test/fixtures/osquery-allowlist-lib.bash
+++ b/test/fixtures/osquery-allowlist-lib.bash
@@ -21,6 +21,7 @@ setup_allowlist_harness() {
   ALLOWLIST_HOME="$(mktemp -d)"
   export OSQUERY_LAUNCHD_ALLOWLIST="$ALLOWLIST_HOME/.config/osquery/page-launchd-allowlist.txt"
   mkdir -p "$ALLOWLIST_HOME/bin"
+  setup_allowlist_chezmoi
   cat >"$ALLOWLIST_HOME/bin/osqueryi" <<'SHIM'
 #!/usr/bin/env bash
 # Concurrency knobs: the sentinel tells a test the capture has STARTED (so it can
@@ -44,6 +45,56 @@ SHIM
   export ALLOWLIST_OSQUERYI="$ALLOWLIST_HOME/bin/osqueryi"
 }
 
+# The writer edits the chezmoi SOURCE and deploys with an apply, so the harness needs
+# a REAL (tiny) chezmoi source and its own config, isolated from the operator's. A
+# stub would only prove the writer calls something named chezmoi; the real binary is
+# what proves the target is actually MANAGED (so `source-path` resolves) and that the
+# apply really lands the source bytes at the deployed path.
+#
+# Two more seams the writer needs, both recorded rather than hidden:
+#   ALLOWLIST_CHEZMOI          - a wrapper pinning source/dest/config/state, so nested
+#                                calls can never touch the operator's real chezmoi.
+#   ALLOWLIST_MANIFEST_RUNNER  - a spy for the pipeline-manifest runner. It records
+#                                that it ran and exits ALLOWLIST_MANIFEST_RC, so the
+#                                loud-failure paths are exercised without sudo. The
+#                                real runner has its own suites; what belongs here is
+#                                whether the writer invokes it and how it reacts.
+setup_allowlist_chezmoi() {
+  export ALLOWLIST_SRC="$ALLOWLIST_HOME/chezmoi-src"
+  export ALLOWLIST_SOURCE_FILE="$ALLOWLIST_SRC/dot_config/osquery/private_page-launchd-allowlist.txt"
+  mkdir -p "$ALLOWLIST_SRC/dot_config/osquery" "$ALLOWLIST_HOME/.config/chezmoi"
+  printf 'sourceDir = "%s"\ndestDir = "%s"\n' "$ALLOWLIST_SRC" "$ALLOWLIST_HOME" \
+    >"$ALLOWLIST_HOME/.config/chezmoi/chezmoi.toml"
+  # The target must exist in the source, or it is not managed and source-path fails.
+  : >"$ALLOWLIST_SOURCE_FILE"
+
+  cat >"$ALLOWLIST_HOME/bin/chezmoi" <<EOF
+#!/usr/bin/env bash
+exec env -u XDG_CONFIG_HOME -u XDG_DATA_HOME chezmoi \\
+  --config "$ALLOWLIST_HOME/.config/chezmoi/chezmoi.toml" \\
+  --source "$ALLOWLIST_SRC" --destination "$ALLOWLIST_HOME" \\
+  --persistent-state "$ALLOWLIST_HOME/chezmoi-state.boltdb" "\$@"
+EOF
+  chmod +x "$ALLOWLIST_HOME/bin/chezmoi"
+  export ALLOWLIST_CHEZMOI="$ALLOWLIST_HOME/bin/chezmoi"
+
+  export ALLOWLIST_MANIFEST_LOG="$ALLOWLIST_HOME/manifest-runner.log"
+  : >"$ALLOWLIST_MANIFEST_LOG"
+  cat >"$ALLOWLIST_HOME/bin/manifest-runner" <<'SPY'
+#!/usr/bin/env bash
+printf 'RAN source=%s\n' "${CHEZMOI_SOURCE_DIR:-}" >>"$ALLOWLIST_MANIFEST_LOG"
+if [[ -n ${ALLOWLIST_MANIFEST_RC:-} ]] && [[ $ALLOWLIST_MANIFEST_RC -ne 0 ]]; then
+  printf 'sudo: a password is required\n' >&2
+  exit "$ALLOWLIST_MANIFEST_RC"
+fi
+SPY
+  chmod +x "$ALLOWLIST_HOME/bin/manifest-runner"
+  export ALLOWLIST_MANIFEST_RUNNER="$ALLOWLIST_HOME/bin/manifest-runner"
+
+  # Deploy the (empty) source so the harness starts from an applied, consistent state.
+  "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1 || true
+}
+
 teardown_allowlist_harness() { [[ -n ${ALLOWLIST_HOME:-} ]] && rm -rf "$ALLOWLIST_HOME"; }
 
 # Run the writer with the harness env (args passed verbatim). HOME is the temp harness
@@ -53,15 +104,44 @@ run_allowlist() {
   HOME="$ALLOWLIST_HOME" \
     OSQUERY_LAUNCHD_ALLOWLIST="$OSQUERY_LAUNCHD_ALLOWLIST" \
     OSQUERYI="$ALLOWLIST_OSQUERYI" \
+    CHEZMOI="$ALLOWLIST_CHEZMOI" \
+    OSQUERY_PIPELINE_MANIFEST_RUNNER="$ALLOWLIST_MANIFEST_RUNNER" \
+    ALLOWLIST_MANIFEST_LOG="$ALLOWLIST_MANIFEST_LOG" \
+    ALLOWLIST_MANIFEST_RC="${ALLOWLIST_MANIFEST_RC:-0}" \
     bash "$ALLOWLIST_TOOL" "$@"
 }
 
-# Seed one NDJSON tuple line into the allowlist directly (bypassing capture), so a
-# deny/list test starts from a known store: seed_allowlist_tuple <label> <path> <program> [sha256].
+# The chezmoi SOURCE file's entry lines: what the writer must actually be editing.
+source_entry_lines() {
+  grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST_SOURCE_FILE" 2>/dev/null || true
+}
+
+# Did this run invoke the pipeline-manifest runner?
+assert_manifest_refreshed() {
+  if ! grep -q '^RAN' "$ALLOWLIST_MANIFEST_LOG" 2>/dev/null; then
+    echo "expected the writer to refresh the pipeline manifest; runner log: $(cat "$ALLOWLIST_MANIFEST_LOG" 2>/dev/null || echo '(none)')" >&2
+    return 1
+  fi
+}
+
+refute_manifest_refreshed() {
+  if grep -q '^RAN' "$ALLOWLIST_MANIFEST_LOG" 2>/dev/null; then
+    echo "expected NO manifest refresh, but the runner ran: $(cat "$ALLOWLIST_MANIFEST_LOG")" >&2
+    return 1
+  fi
+}
+
+# Seed one NDJSON tuple line into the allowlist (bypassing capture), so a deny/list
+# test starts from a known store: seed_allowlist_tuple <label> <path> <program> [sha256].
+#
+# The tuple goes into the chezmoi SOURCE and is then applied, because the source is
+# the authority the deployed file is rewritten from on every apply. Seeding the
+# deployed file alone would build a state chezmoi erases and the writer does not
+# consider present, which is precisely the shape this design removed.
 seed_allowlist_tuple() {
-  mkdir -p "$(dirname "$OSQUERY_LAUNCHD_ALLOWLIST")"
   jq -cn --arg label "$1" --arg path "$2" --arg program "$3" --arg sha256 "${4:-}" \
-    '{label:$label, path:$path, program:$program, sha256:$sha256}' >>"$OSQUERY_LAUNCHD_ALLOWLIST"
+    '{label:$label, path:$path, program:$program, sha256:$sha256}' >>"$ALLOWLIST_SOURCE_FILE"
+  "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1
 }
 
 # Membership by the JSON .label field (the file is NDJSON tuples now, R2-1).

--- a/test/fixtures/osquery-manifest-lib.bash
+++ b/test/fixtures/osquery-manifest-lib.bash
@@ -27,6 +27,7 @@ manifest_fixture_setup() {
   mkdir -p "$MF_SRC/dot_local/libexec/osquery/results-alerter" \
     "$MF_SRC/dot_local/bin" \
     "$MF_SRC/Library/LaunchAgents" \
+    "$MF_SRC/dot_config/osquery" \
     "$MF_HOME/.config/chezmoi" \
     "$MF_ROOT/bin"
   printf 'sourceDir = "%s"\ndestDir = "%s"\n' "$MF_SRC" "$MF_HOME" \
@@ -76,6 +77,14 @@ manifest_fixture_add_bin_script() {
 # (the real plists are templates, so the fixture mirrors that shape).
 manifest_fixture_add_plist() {
   printf '%s\n' "$2" >"$MF_SRC/Library/LaunchAgents/$1.plist.tmpl"
+}
+
+# manifest_fixture_add_config <source-basename> <content>: add a MANAGED file under
+# ~/.config/osquery. The basename is passed with its chezmoi attribute prefix
+# intact (private_ for the 0600 files), because the mode those prefixes encode is
+# exactly what the manifest's mode column has to come from.
+manifest_fixture_add_config() {
+  printf '%s\n' "$2" >"$MF_SRC/dot_config/osquery/$1"
 }
 
 # manifest_fixture_chezmoi <args...>: run chezmoi against the fixture, isolated.

--- a/test/integration/osquery-allowlist.bats
+++ b/test/integration/osquery-allowlist.bats
@@ -387,3 +387,173 @@ stub_launchd() {
   }
   assert_not_allowlisted 'homebrew.mxcl.postgresql@17'
 }
+
+# --- The writer deploys through chezmoi, not by hand -------------------------
+# The allowlist is chezmoi-managed, so a tuple written straight to the deployed
+# file is erased by the next apply (verified: a plain managed file is rewritten
+# from source every time) and the seed silently stops working. It is also
+# manifest-covered now, so an out-of-band write no longer suppresses anything
+# even before that. The writer therefore edits the SOURCE, applies that one
+# target, and refreshes the manifest, in that order.
+
+@test "-a writes the chezmoi SOURCE and deploys it, so the seed survives a later apply" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+
+  run run_allowlist -a com.foo.agent
+  [ "$status" -eq 0 ] || {
+    echo "expected exit 0, got $status: $output"
+    false
+  }
+
+  # The SOURCE holds the tuple (this is the authority the manifest is derived from).
+  run grep -qF '"label":"com.foo.agent"' "$ALLOWLIST_SOURCE_FILE"
+  [ "$status" -eq 0 ] || {
+    echo "the tuple is not in the chezmoi source: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+  # ...and the deployed file matches it, so the alerter sees the seed immediately.
+  assert_allowlisted com.foo.agent
+
+  # THE HEADLINE: an independent apply does not undo the seed. Writing the deployed
+  # file directly would lose it here, which is the bug this shape removes.
+  "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1
+  assert_allowlisted com.foo.agent
+}
+
+@test "-a refreshes the pipeline manifest after the apply, so the deployed allowlist is bound and can still suppress" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+
+  run run_allowlist -a com.foo.agent
+  [ "$status" -eq 0 ]
+  assert_manifest_refreshed
+}
+
+@test "-d removes from the SOURCE and refreshes the manifest, so the removal survives an apply" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+  run run_allowlist -a com.foo.agent
+  [ "$status" -eq 0 ]
+
+  : >"$ALLOWLIST_MANIFEST_LOG"
+  run run_allowlist -d com.foo.agent
+  [ "$status" -eq 0 ] || {
+    echo "expected exit 0 on deny, got $status: $output"
+    false
+  }
+  assert_not_allowlisted com.foo.agent
+  assert_manifest_refreshed
+  "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1
+  assert_not_allowlisted com.foo.agent
+}
+
+@test "-a is idempotent: re-adding an unchanged identity leaves the source byte-identical and adds no duplicate" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+
+  run run_allowlist -a com.foo.agent
+  [ "$status" -eq 0 ]
+  local first
+  first="$(cat "$ALLOWLIST_SOURCE_FILE")"
+
+  run run_allowlist -a com.foo.agent
+  [ "$status" -eq 0 ] || {
+    echo "a repeated -a must succeed, got $status: $output"
+    false
+  }
+  [ "$(cat "$ALLOWLIST_SOURCE_FILE")" = "$first" ] || {
+    echo "a repeated -a changed the source; before: $first  after: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+  assert_allowlist_label_count 1
+  [ "$(source_entry_lines | grep -cF '"label":"com.foo.agent"')" -eq 1 ] || {
+    echo "the source gained a duplicate tuple: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+}
+
+@test "a failed apply rolls the source back and reports non-zero, leaving no half-applied state" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+
+  local before
+  before="$(cat "$ALLOWLIST_SOURCE_FILE")"
+
+  # A chezmoi that resolves the source path but fails the apply.
+  cat >"$ALLOWLIST_HOME/bin/chezmoi-badapply" <<EOF
+#!/usr/bin/env bash
+[[ \$1 == apply ]] && { printf 'chezmoi: apply exploded\n' >&2; exit 1; }
+exec "$ALLOWLIST_CHEZMOI" "\$@"
+EOF
+  chmod +x "$ALLOWLIST_HOME/bin/chezmoi-badapply"
+
+  run env HOME="$ALLOWLIST_HOME" OSQUERY_LAUNCHD_ALLOWLIST="$OSQUERY_LAUNCHD_ALLOWLIST" \
+    OSQUERYI="$ALLOWLIST_OSQUERYI" CHEZMOI="$ALLOWLIST_HOME/bin/chezmoi-badapply" \
+    OSQUERY_PIPELINE_MANIFEST_RUNNER="$ALLOWLIST_MANIFEST_RUNNER" \
+    ALLOWLIST_MANIFEST_LOG="$ALLOWLIST_MANIFEST_LOG" \
+    bash "$ALLOWLIST_TOOL" -a com.foo.agent
+  [ "$status" -ne 0 ] || {
+    echo "a failed apply must exit non-zero, got 0: $output"
+    false
+  }
+  [[ $output == *"apply"* ]] || {
+    echo "the failure must name the failed step; got: $output"
+    false
+  }
+  [ "$(cat "$ALLOWLIST_SOURCE_FILE")" = "$before" ] || {
+    echo "the source was left edited after a failed apply: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+  # A manifest refresh over a source that was rolled back would sign a state the
+  # operator never asked for, so the step must not have run at all.
+  refute_manifest_refreshed
+}
+
+@test "a failed manifest refresh is LOUD and non-zero, names the stale manifest, and does not swallow sudo's message" {
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" "$ALLOWLIST_HOME/bin/foo.sh"
+
+  ALLOWLIST_MANIFEST_RC=1 run run_allowlist -a com.foo.agent
+  [ "$status" -ne 0 ] || {
+    echo "a failed manifest refresh must exit non-zero, got 0: $output"
+    false
+  }
+  # The runner's own stderr (here sudo's) must reach the operator, not /dev/null.
+  [[ $output == *"password is required"* ]] || {
+    echo "the manifest runner's stderr was swallowed; got: $output"
+    false
+  }
+  # ...and the message has to say what state the host is in, because this is the
+  # one failure that leaves the deployed allowlist ahead of the manifest.
+  [[ $output == *manifest* ]] || {
+    echo "the failure must name the manifest as the stale component; got: $output"
+    false
+  }
+}
+
+@test "the default manifest runner is the real known-good-manifests script inside the chezmoi source" {
+  # The seam above is a test double. Pin the DEFAULT so it cannot drift from the
+  # runner that actually exists in the source tree.
+  run grep -qF 'run_after_05-osquery-known-good-manifests.sh' "$ALLOWLIST_TOOL"
+  [ "$status" -eq 0 ] || {
+    echo "the writer does not name the real manifest runner as its default"
+    false
+  }
+  [ -f "${BATS_TEST_DIRNAME}/../../.chezmoiscripts/run_after_05-osquery-known-good-manifests.sh" ] || {
+    echo "the runner the writer names does not exist in the source tree"
+    false
+  }
+}

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -443,8 +443,75 @@ elapsed=$(($(date +%s) - start))
 ((elapsed <= 8)) ||
   fail "$misses misses took ${elapsed}s: the settle budget is per finding, not per alerter run (a stall vector)"
 
+# --- THE ALLOWLIST BINDING SURVIVES THE SAME APPLY RACE ----------------------
+# allowlist_verdict refuses to suppress unless the manifest vouches for the
+# allowlist it just read, so it inherits the apply race the settle window exists
+# for: the new allowlist lands, the manifest is reinstalled a moment later, and a
+# persistence finding judged in between would otherwise be told the allowlist
+# cannot be trusted and would page for a known-good own agent. The alerter judges
+# each finding exactly once, so that false CRIT would never be reconsidered.
+#
+# The binding reuses _pipeline_tuple_settles rather than waiting its own way, and
+# this is what pins that: the same back-dated-manifest fixture that resolves for a
+# pipeline script has to resolve for the allowlist.
+ALLOWLIST_VERDICT="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+[[ -f $ALLOWLIST_VERDICT ]] || fail "missing the allowlist verdict: $ALLOWLIST_VERDICT"
+# The settle sections above deliberately leave $MF_MANIFEST holding a back-dated
+# stub, so regenerate it here rather than reading columns out of that wreckage.
+manifest_fixture_apply
+manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero before the allowlist race case"
+allowlist_target="$MF_HOME/.config/osquery/page-launchd-allowlist.txt"
+[[ -r $allowlist_target ]] || fail "the fixture apply did not deploy the allowlist to $allowlist_target"
+
+# run_allowlist_verdict <settle-seconds> -- one verdict for the fixture's com.seed
+# tuple, in a SUBSHELL for the reason run_verdict uses one: the settle budget is
+# one per alerter run, and a case that spends it must not answer for the next.
+run_allowlist_verdict() {
+  (
+    # shellcheck disable=SC2030,SC2031
+    export HOME="$MF_HOME" OSQUERY_PIPELINE_SETTLE_SECONDS="$1"
+    export OSQUERY_LAUNCHD_ALLOWLIST="$allowlist_target"
+    # shellcheck source=/dev/null
+    source "$ALLOWLIST_VERDICT"
+    allowlist_verdict com.seed "$MF_HOME/x.plist" "$MF_HOME/x"
+  )
+}
+
+allowlist_hash="$(hash_of "$allowlist_target")"
+allowlist_mode="$(manifest_mode_of "$allowlist_target")"
+allowlist_uid="$(manifest_uid_of "$allowlist_target")"
+[[ $allowlist_mode == 0600 ]] ||
+  fail "the generated manifest records the allowlist at '$allowlist_mode', expected 0600 (its private_ prefix)"
+
+# A manifest that PREDATES the allowlist and does not yet name it: the verdict
+# waits, and suppresses once the regeneration lands inside the window.
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$MF_MANIFEST"
+touch -t 200001010000 "$MF_MANIFEST"
+(
+  sleep 1
+  printf '%s %s %s %s\n' "$allowlist_hash" "$allowlist_mode" "$allowlist_uid" "$allowlist_target" >"$MF_MANIFEST"
+) &
+allowlist_settle_pid=$!
+got=0
+run_allowlist_verdict 4 || got=$?
+wait "$allowlist_settle_pid"
+[[ $got -eq 0 ]] ||
+  fail "a legitimate apply must NOT false-page: the allowlist binding has to settle when the manifest lands (got rc $got)"
+
+# ...and the wait is bounded the same way: a binding that never arrives refuses to
+# suppress, so the finding pages rather than trusting an unaccountable allowlist.
+printf 'deadbeef 0755 %s /nowhere\n' "$(id -u)" >"$MF_MANIFEST"
+touch -t 200001010000 "$MF_MANIFEST"
+start=$(date +%s)
+got=0
+run_allowlist_verdict 2 || got=$?
+elapsed=$(($(date +%s) - start))
+[[ $got -eq 1 ]] ||
+  fail "an allowlist the manifest never vouches for must not suppress (got rc $got)"
+((elapsed <= 6)) || fail "the allowlist binding wait is not bounded (${elapsed}s for a 2s window)"
+
 if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-agreement: OK (both generated manifests and the real verdict agree, including a chmod on unchanged content; the periodic audit parses the same generated manifests and reports a real tamper; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the managed-bin arm is contained by its watch root, tracks exactly what it manifests, stays disjoint from the pipeline manifest, and pages a tamper and a chmod while an unmanaged neighbor is silent; producer and consumer name both default paths; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses)\n'
+printf 'osquery-pipeline-manifest-agreement: OK (both generated manifests and the real verdict agree, including a chmod on unchanged content; the periodic audit parses the same generated manifests and reports a real tamper; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the managed-bin arm is contained by its watch root, tracks exactly what it manifests, stays disjoint from the pipeline manifest, and pages a tamper and a chmod while an unmanaged neighbor is silent; producer and consumer name both default paths; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses; the allowlist binding settles through the same apply race and stays bounded)\n'

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -212,6 +212,33 @@ case "$audit_body" in
 esac
 manifest_fixture_apply # restore
 
+# ...and the PAGE-LAUNCHD ALLOWLIST is audited on the same tick, because it rides in
+# the pipeline manifest and the audit is a driver over every manifested path. That
+# matters beyond tidiness: the event-time verdict is path-based, so an attacker who
+# edits the allowlist through a hard link outside ~/.config/osquery fires no event on
+# the watched path and layer 1 never runs. This is the layer that still finds it,
+# within two ticks, and it reports content and mode as SEPARATE kinds, so an edit
+# that later widens the file's permissions is a new fingerprint rather than a
+# condition already reported.
+allowlist_audit_target="$MF_HOME/.config/osquery/page-launchd-allowlist.txt"
+[[ -r $allowlist_audit_target ]] || fail "the fixture did not deploy an allowlist to audit"
+printf '{"label":"com.evil","path":"~/e.plist","program":"~/e","sha256":""}\n' >>"$allowlist_audit_target"
+chmod 644 "$allowlist_audit_target"
+audit_out="$(run_audit)"
+audit_rc="${audit_out%%$'\n'*}"
+audit_body="${audit_out#*$'\n'}"
+[[ $audit_rc == 0 ]] ||
+  fail "the audit could not complete over a tampered allowlist (reason token: $audit_body)"
+case "$audit_body" in
+  *"content $allowlist_audit_target"*) ;;
+  *) fail "the periodic audit does not cover the page-launchd allowlist: $audit_body" ;;
+esac
+case "$audit_body" in
+  *"mode $allowlist_audit_target"*) ;;
+  *) fail "the audit did not report the widened allowlist mode as its own divergence kind: $audit_body" ;;
+esac
+manifest_fixture_apply # restore
+
 # --- THE THREE-WAY AGREEMENT, across BOTH launch agent watch roots ------------
 # Every launch-agent path the WATCH reports is classified, and the TRACKED verdict
 # must say yes exactly when the MANIFEST can contain it.
@@ -514,4 +541,4 @@ if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2
   exit 1
 fi
-printf 'osquery-pipeline-manifest-agreement: OK (both generated manifests and the real verdict agree, including a chmod on unchanged content; the periodic audit parses the same generated manifests and reports a real tamper; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the managed-bin arm is contained by its watch root, tracks exactly what it manifests, stays disjoint from the pipeline manifest, and pages a tamper and a chmod while an unmanaged neighbor is silent; producer and consumer name both default paths; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses; the allowlist binding settles through the same apply race and stays bounded)\n'
+printf 'osquery-pipeline-manifest-agreement: OK (both generated manifests and the real verdict agree, including a chmod on unchanged content; the periodic audit parses the same generated manifests and reports a real tamper; watch/tracked/manifest cover the identical set across BOTH launch agent roots; a /Library twin is untracked; the managed-bin arm is contained by its watch root, tracks exactly what it manifests, stays disjoint from the pipeline manifest, and pages a tamper and a chmod while an unmanaged neighbor is silent; producer and consumer name both default paths; the settle window resolves a live regeneration for a content AND an attribute-only change, stays bounded, and spends ONE budget per alerter run across many misses; the allowlist binding settles through the same apply race and stays bounded; the periodic audit covers the allowlist and reports its content and mode divergences as separate kinds)\n'

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -75,6 +75,10 @@ manifest_fixture_add_plist com.webdavis.osquery-digest '<plist>{{ .chezmoi.os }}
 # manifest (it refuses to install an EMPTY manifest) and so the agreement checks
 # below can drive that arm too.
 manifest_fixture_add_bin_script update-skills.sh 'echo update-skills'
+# The page-launchd allowlist, so the manifested-implies-tracked sweep below covers
+# the one manifested file that lives outside both the pipeline home and bin.
+manifest_fixture_add_config private_page-launchd-allowlist.txt \
+  '{"label":"com.seed","path":"~/x.plist","program":"~/x","sha256":""}'
 manifest_fixture_apply
 manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero"
 

--- a/test/integration/osquery-pipeline-manifest-generation.sh
+++ b/test/integration/osquery-pipeline-manifest-generation.sh
@@ -61,8 +61,16 @@ manifest_fixture_add_script digest.sh 'echo digest'
 manifest_fixture_add_script results-alerter.sh 'echo entry'
 manifest_fixture_add_script results-alerter/normalize.sh 'true'
 manifest_fixture_add_plist com.webdavis.osquery-digest '<plist>{{ .chezmoi.os }}</plist>'
+# The page-launchd allowlist: managed, 0600 via the private_ prefix, and covered
+# because it decides whether an unknown user LaunchAgent pages.
+manifest_fixture_add_config private_page-launchd-allowlist.txt \
+  '{"label":"com.seed","path":"~/x.plist","program":"~/x","sha256":""}'
 # Decoys the manifest must never cover.
 manifest_fixture_add_plist com.webdavis.atuin-daemon '<plist>atuin</plist>'
+# A MANAGED neighbour of the allowlist, in the same watched directory. Covering the
+# directory rather than the one file would manifest a secret, and every touch of it
+# would then be judged by the alerter.
+manifest_fixture_add_config private_webhook-secret 'hunter2'
 mkdir -p "$MF_SRC/dot_local/bin"
 printf 'echo relay\n' >"$MF_SRC/dot_local/bin/executable_relay.sh"
 
@@ -72,6 +80,9 @@ manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero on a c
 script_target="$MF_HOME/.local/libexec/osquery/digest.sh"
 helper_target="$MF_HOME/.local/libexec/osquery/results-alerter/normalize.sh"
 plist_target="$MF_HOME/Library/LaunchAgents/com.webdavis.osquery-digest.plist"
+allowlist_target="$MF_HOME/.config/osquery/page-launchd-allowlist.txt"
+secret_target="$MF_HOME/.config/osquery/webhook-secret"
+lock_target="$MF_HOME/.config/osquery/page-launchd-allowlist.txt.lock"
 
 # 1. Every managed pipeline file is covered, including the recursive helper and the
 #    plist (a TEMPLATE, excluded from this apply, so it is covered from intent even
@@ -79,6 +90,26 @@ plist_target="$MF_HOME/Library/LaunchAgents/com.webdavis.osquery-digest.plist"
 for t in "$script_target" "$helper_target" "$plist_target"; do
   [[ -n "$(manifest_hash_of "$t")" ]] || fail "no manifest tuple for $t"
 done
+
+# 1a. THE ALLOWLIST IS COVERED, at the 0600 its private_ prefix encodes. It decides
+#     whether an unknown user LaunchAgent pages, so leaving it out of the manifest
+#     leaves the deciding component the only unwatched part of the pipeline.
+[[ -n "$(manifest_hash_of "$allowlist_target")" ]] ||
+  fail "no manifest tuple for the page-launchd allowlist ($allowlist_target)"
+[[ "$(manifest_mode_of "$allowlist_target")" == 0600 ]] ||
+  fail "the allowlist must be manifested 0600 (its private_ prefix), got '$(manifest_mode_of "$allowlist_target")'"
+
+# 1b. ITS NEIGHBOURS ARE NOT. The alerter watches the whole ~/.config/osquery
+#     directory, so the manifest has to name the ONE file rather than the directory:
+#     manifesting webhook-secret would bind a secret's digest into a world-readable
+#     root file, and manifesting the writer's lock would page on every -a/-d.
+[[ -z "$(manifest_hash_of "$secret_target")" ]] ||
+  fail "SECURITY: the webhook-secret neighbour leaked into the manifest (cover the file, never the directory)"
+printf 'lock\n' >"$lock_target"
+manifest_fixture_run_runner "$RUNNER" || fail "the runner exited non-zero with the writer's lock present"
+[[ -z "$(manifest_hash_of "$lock_target")" ]] ||
+  fail "the writer's .lock neighbour leaked into the manifest"
+rm -f "$lock_target"
 
 # 2. Content is INTENT: the recorded hash equals chezmoi's rendered bytes.
 want="$(manifest_fixture_chezmoi cat "$script_target" | shasum -a 256 | awk '{print $1}')"

--- a/test/unit/osquery-allowlist-verdict.sh
+++ b/test/unit/osquery-allowlist-verdict.sh
@@ -30,6 +30,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 
 fail() {
   printf 'osquery-allowlist-verdict: FAIL -- %s\n' "$*" >&2
@@ -37,6 +38,7 @@ fail() {
 }
 
 [[ -f $HELPER ]] || fail "missing helper: $HELPER"
+[[ -f $PIPELINE_HELPER ]] || fail "missing helper: $PIPELINE_HELPER"
 command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
 
 work="$(mktemp -d)"
@@ -66,55 +68,89 @@ allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
   printf '{"label":"com.seed","path":"~/Library/LaunchAgents/com.seed.plist","program":"~/bin/seed","sha256":""}\n'
   printf '{"label":"com.degraded","path":"","program":"","sha256":""}\n'
 } >"$allowlist"
+# The allowlist deploys 0600 (chezmoi's private_ prefix).
+chmod 600 "$allowlist"
 
-# Each case: <expected-rc> <TAB> <allowlist-file> <TAB> <label> <TAB> <path>
-# <TAB> <program> <TAB> <behavior label>. Every case runs in ONE sourcing subshell
-# (below) instead of a subshell per case, so the suite stays under the fast unit
-# bar while the live on-disk re-hash is still exercised for real.
+# THE MANIFEST BINDING (D-prime). The allowlist decides whether an unknown user
+# LaunchAgent pages, so an allowlist the root-owned pipeline-integrity manifest
+# cannot vouch for may not suppress ANYTHING. This is the fixture for the bound
+# (post-apply) state: a manifest tuple naming the allowlist's current content, its
+# 0600 mode and its owner.
+bound_manifest="$work/pipeline-known-good.sha256"
+write_bound_manifest() {
+  printf '%s 0600 %s %s\n' \
+    "$(shasum -a 256 "$allowlist" | awk '{print $1}')" "$(id -u)" "$allowlist" \
+    >"$bound_manifest"
+}
+write_bound_manifest
+absent_manifest="$work/no-such-manifest.sha256"
+
+# Each case: <expected-rc> <TAB> <manifest> <TAB> <allowlist-file> <TAB> <label>
+# <TAB> <path> <TAB> <program> <TAB> <behavior label>. Every case runs in ONE
+# sourcing subshell (below) instead of a subshell per case, so the suite stays under
+# the fast unit bar while the live on-disk re-hash is still exercised for real.
+#
+# The manifest column is what pins D-prime: a suppress verdict is only reachable
+# when the root-owned manifest vouches for the allowlist the verdict just read.
 missing="$work/does-not-exist.txt"
 cases=(
   # (a) full tuple match, on-disk hash matches the pin -> suppress.
-  $'0\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\tfull tuple match (label+path+program+matching on-disk hash) suppresses'
+  $'0\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\tfull tuple match (label+path+program+matching on-disk hash) suppresses'
   # (b) same label, different program -> reused-label page (diverges before the hash check).
-  $'2\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/EVIL"$'\tan allowlisted label with a different program pages (reused label)'
+  $'2\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/EVIL"$'\tan allowlisted label with a different program pages (reused label)'
   # (b2) same label, same program, different path -> reused-label page.
-  $'2\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/EVIL.plist"$'\t'"$home/bin/full"$'\tan allowlisted label with a different path pages (reused label)'
+  $'2\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/EVIL.plist"$'\t'"$home/bin/full"$'\tan allowlisted label with a different path pages (reused label)'
   # (c) same label/path/program but the on-disk plist no longer matches the pin -> page.
-  $'2\t'"$allowlist"$'\tcom.hashpin\t'"$home/Library/LaunchAgents/com.hashpin.plist"$'\t'"$home/bin/hp"$'\ta pinned-hash entry whose on-disk plist was rewritten pages (hash mismatch)'
+  $'2\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.hashpin\t'"$home/Library/LaunchAgents/com.hashpin.plist"$'\t'"$home/bin/hp"$'\ta pinned-hash entry whose on-disk plist was rewritten pages (hash mismatch)'
   # (d) unknown label -> not allowlisted.
-  $'1\t'"$allowlist"$'\tcom.unknown\t'"$home/Library/LaunchAgents/com.unknown.plist"$'\t'"$home/bin/unknown"$'\tan unknown label is not allowlisted'
+  $'1\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.unknown\t'"$home/Library/LaunchAgents/com.unknown.plist"$'\t'"$home/bin/unknown"$'\tan unknown label is not allowlisted'
   # (e) empty-sha256 seed entry -> suppress on label+path+program, skipping the hash dimension
   #     (the seed plist need not even exist).
-  $'0\t'"$allowlist"$'\tcom.seed\t'"$home/Library/LaunchAgents/com.seed.plist"$'\t'"$home/bin/seed"$'\tan empty-sha256 seed entry suppresses on label+path+program, skipping the hash dimension'
+  $'0\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.seed\t'"$home/Library/LaunchAgents/com.seed.plist"$'\t'"$home/bin/seed"$'\tan empty-sha256 seed entry suppresses on label+path+program, skipping the hash dimension'
   # (f) degraded label-only entry (no path/program) cannot vouch -> not allowlisted (fail-safe).
-  $'1\t'"$allowlist"$'\tcom.degraded\t'"$home/Library/LaunchAgents/com.degraded.plist"$'\t'"$home/bin/degraded"$'\ta degraded label-only entry cannot vouch and does not suppress (fail-safe)'
+  $'1\t'"$bound_manifest"$'\t'"$allowlist"$'\tcom.degraded\t'"$home/Library/LaunchAgents/com.degraded.plist"$'\t'"$home/bin/degraded"$'\ta degraded label-only entry cannot vouch and does not suppress (fail-safe)'
   # (g) missing allowlist file -> not allowlisted, cleanly, no error.
-  $'1\t'"$missing"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\ta missing allowlist file yields not-allowlisted for everything, no error'
+  $'1\t'"$bound_manifest"$'\t'"$missing"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\ta missing allowlist file yields not-allowlisted for everything, no error'
+  # -- D-PRIME: an allowlist the manifest cannot vouch for suppresses NOTHING. --
+  # (h) NO MANIFEST. Detection after the fact is nearly worthless for a component
+  #     whose whole job is to suppress, so an unbindable allowlist fails toward
+  #     paging instead of quietly vouching for its entries.
+  $'1\t'"$absent_manifest"$'\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/full"$'\ta full tuple match with NO manifest does not suppress (an unbound allowlist vouches for nothing)'
+  $'1\t'"$absent_manifest"$'\t'"$allowlist"$'\tcom.seed\t'"$home/Library/LaunchAgents/com.seed.plist"$'\t'"$home/bin/seed"$'\tan own-agent seed entry with NO manifest does not suppress'
+  # (i) A reused label still pages with no manifest: the gate is on the SUPPRESS
+  #     path only, so the louder verdict is never softened into a quieter one.
+  $'2\t'"$absent_manifest"$'\t'"$allowlist"$'\tcom.full\t'"$home/Library/LaunchAgents/com.full.plist"$'\t'"$home/bin/EVIL"$'\ta reused label still pages when the manifest is absent (the gate only blocks suppression)'
 )
 
-# Split into parallel arrays and feed the (file, label, path, program) tuples
-# through ONE sourcing subshell that prints a return code per line, in order.
+# Split into parallel arrays and feed the (manifest, file, label, path, program)
+# tuples through ONE sourcing subshell that prints a return code per line, in order.
 expected=()
 labels=()
 feed=""
 for row in "${cases[@]}"; do
-  IFS=$'\t' read -r rc file label path program label_text <<<"$row"
+  IFS=$'\t' read -r rc case_manifest file label path program label_text <<<"$row"
   expected+=("$rc")
   labels+=("$label_text")
-  feed+="$file"$'\t'"$label"$'\t'"$path"$'\t'"$program"$'\n'
+  feed+="$case_manifest"$'\t'"$file"$'\t'"$label"$'\t'"$path"$'\t'"$program"$'\n'
 done
 
+# Both helpers are sourced, in the order results-alerter.sh sources them, because
+# the manifest binding is a real dependency of the verdict and not a test fixture.
+# The settle window is zeroed so a miss answers immediately: the window's own
+# behavior belongs to the manifest-agreement suite, and a unit test must not sleep.
 got=()
 mapfile -t got < <(
-  printf '%s' "$feed" | HOME="$home" bash -c '
+  printf '%s' "$feed" | HOME="$home" OSQUERY_PIPELINE_SETTLE_SECONDS=0 bash -c '
     source "$1"
-    while IFS="$(printf "\t")" read -r file label path program; do
+    source "$2"
+    while IFS="$(printf "\t")" read -r case_manifest file label path program; do
       OSQUERY_LAUNCHD_ALLOWLIST="$file"
+      OSQUERY_PIPELINE_MANIFEST="$case_manifest"
       rc=0
       allowlist_verdict "$label" "$path" "$program" || rc=$?
       printf "%s\n" "$rc"
     done
-  ' _ "$HELPER"
+  ' _ "$HELPER" "$PIPELINE_HELPER"
 )
 
 [[ ${#got[@]} -eq ${#expected[@]} ]] ||
@@ -125,4 +161,58 @@ for i in "${!expected[@]}"; do
     fail "${labels[i]}: expected return ${expected[i]}, got ${got[i]}"
 done
 
-printf 'osquery-allowlist-verdict: OK (full-tuple suppress, reused-label page on path/program/hash divergence, empty-sha256 seed suppress, unknown/degraded/missing not-allowlisted)\n'
+# --- THE ATTACK THIS EXISTS TO STOP ------------------------------------------
+# A process running as the operator appends a tuple naming its own LaunchAgent,
+# with the empty sha256 that skips the hash dimension, and installs that agent.
+# Before D-prime the verdict returned suppress, the persistence finding was
+# dropped, and the edit itself only reached the next day's digest.
+#
+# Appending changes the allowlist's bytes, so it no longer matches the tuple the
+# root-owned manifest holds for it, and an allowlist nothing can vouch for
+# suppresses NOTHING: not the attacker's freshly added entry, and not the
+# legitimate entry that was suppressing a moment ago. The manifest is NOT
+# regenerated here, which is the whole point: regenerating it is an apply, and an
+# apply is the operator's authority, not the attacker's.
+verdict_with() { # <label> <path> <program> -> prints the return code
+  local rc=0
+  HOME="$home" OSQUERY_PIPELINE_SETTLE_SECONDS=0 \
+    OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" OSQUERY_PIPELINE_MANIFEST="$bound_manifest" \
+    bash -c 'source "$1"; source "$2"; allowlist_verdict "$3" "$4" "$5"' \
+    _ "$HELPER" "$PIPELINE_HELPER" "$1" "$2" "$3" || rc=$?
+  printf '%s' "$rc"
+}
+
+# Baseline: bound allowlist, the legitimate entry suppresses.
+[[ "$(verdict_with com.full "$home/Library/LaunchAgents/com.full.plist" "$home/bin/full")" == 0 ]] ||
+  fail "the bound-allowlist baseline does not suppress, so the attack pin below would pass vacuously"
+
+printf '{"label":"com.evil","path":"~/Library/LaunchAgents/com.evil.plist","program":"~/bin/evil","sha256":""}\n' \
+  >>"$allowlist"
+
+[[ "$(verdict_with com.evil "$home/Library/LaunchAgents/com.evil.plist" "$home/bin/evil")" == 1 ]] ||
+  fail "SECURITY: a tuple appended to the allowlist out of band SUPPRESSED its own agent (D-prime is not enforcing)"
+[[ "$(verdict_with com.full "$home/Library/LaunchAgents/com.full.plist" "$home/bin/full")" == 1 ]] ||
+  fail "SECURITY: a tampered allowlist still vouched for its pre-existing entries"
+
+# ...and a legitimate apply restores suppression: the operator's edit regenerates
+# the manifest in the same flow, so the file is bound again and nothing false-pages.
+write_bound_manifest
+[[ "$(verdict_with com.full "$home/Library/LaunchAgents/com.full.plist" "$home/bin/full")" == 0 ]] ||
+  fail "a legitimate apply (allowlist edited, manifest regenerated) must restore suppression, not false-page"
+[[ "$(verdict_with com.evil "$home/Library/LaunchAgents/com.evil.plist" "$home/bin/evil")" == 0 ]] ||
+  fail "an entry seeded through the writer (source edit + apply + manifest refresh) must suppress"
+
+# --- A PARTIAL INSTALL FAILS TOWARD PAGING -----------------------------------
+# results-alerter.sh sources both helpers, so a missing pipeline verdict aborts the
+# alerter outright and this state is not reachable in production. It is checked by
+# NAME anyway, for the reason the periodic audit checks its own reused seam: a
+# monitor that goes quiet when its own dependency is absent is the failure mode
+# this whole subsystem exists to avoid.
+rc=0
+HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" OSQUERY_PIPELINE_MANIFEST="$bound_manifest" \
+  bash -c 'source "$1"; allowlist_verdict "$2" "$3" "$4"' \
+  _ "$HELPER" com.full "$home/Library/LaunchAgents/com.full.plist" "$home/bin/full" || rc=$?
+[[ $rc == 1 ]] ||
+  fail "SECURITY: with the pipeline verdict helper absent the allowlist still suppressed (expected 1, got $rc)"
+
+printf 'osquery-allowlist-verdict: OK (full-tuple suppress, reused-label page on path/program/hash divergence, empty-sha256 seed suppress, unknown/degraded/missing not-allowlisted; D-prime: an allowlist the manifest cannot vouch for suppresses nothing, an out-of-band appended tuple never silences its own agent, a legitimate apply restores suppression, and a missing verdict helper fails toward paging)\n'

--- a/test/unit/osquery-pipeline-verdict.sh
+++ b/test/unit/osquery-pipeline-verdict.sh
@@ -56,7 +56,8 @@ command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 home="$work/home"
-mkdir -p "$home/.local/libexec/osquery/results-alerter" "$home/.local/bin" "$home/Library/LaunchAgents"
+mkdir -p "$home/.local/libexec/osquery/results-alerter" "$home/.local/bin" \
+  "$home/Library/LaunchAgents" "$home/.config/osquery/packs"
 
 # REAL files with REAL hashes: the verdict rehashes the target at judgment time,
 # so a fixture manifest has to bind the content that is actually on disk. Mode and
@@ -101,6 +102,17 @@ chown_script="$home/.local/libexec/osquery/chown-probe.sh"
 # manifest line that would vouch for them is not parseable as a full tuple.
 legacy_script="$home/.local/libexec/osquery/legacy-line.sh"
 garbage_script="$home/.local/libexec/osquery/garbage-line.sh"
+# The page-launchd allowlist. It DECIDES whether an unknown user LaunchAgent pages,
+# so it is pipeline infrastructure and joins the tracked set at its EXACT path.
+# Its neighbors in the same watched directory must stay untracked: the watch is a
+# directory watch, and tracking the directory would put webhook-secret (a secret)
+# and the writer's own lock file into the manifest's coverage, where neither can
+# ever be confirmed and both would page forever.
+allowlist_file="$home/.config/osquery/page-launchd-allowlist.txt"
+allowlist_lock="$home/.config/osquery/page-launchd-allowlist.txt.lock"
+neighbor_secret="$home/.config/osquery/webhook-secret"
+neighbor_conf="$home/.config/osquery/osquery.conf"
+neighbor_pack="$home/.config/osquery/packs/intrusion-detection.conf"
 
 printf 'echo libexec\n' >"$libexec_script"
 printf 'echo bin\n' >"$bin_script"
@@ -117,6 +129,14 @@ printf 'echo setuid probe\n' >"$setuid_script"
 printf 'echo chown probe\n' >"$chown_script"
 printf 'echo legacy line\n' >"$legacy_script"
 printf 'echo garbage line\n' >"$garbage_script"
+printf '{"label":"com.seed","path":"~/x.plist","program":"~/x","sha256":""}\n' >"$allowlist_file"
+printf 'lock\n' >"$allowlist_lock"
+printf 'hunter2\n' >"$neighbor_secret"
+printf '{}\n' >"$neighbor_conf"
+printf '{}\n' >"$neighbor_pack"
+# The allowlist deploys 0600 (chezmoi's private_ prefix), which is what its
+# manifest tuple below records literally.
+chmod 600 "$allowlist_file"
 
 # Every manifested regular file is deployed 0755, which is what the manifest lines
 # below record LITERALLY. The literal is deliberate: deriving the expected column
@@ -138,6 +158,7 @@ hash_setuid="$(sha_of "$setuid_script")"
 hash_chown="$(sha_of "$chown_script")"
 hash_legacy="$(sha_of "$legacy_script")"
 hash_garbage="$(sha_of "$garbage_script")"
+hash_allowlist="$(sha_of "$allowlist_file")"
 hash_wrong="0000000000000000000000000000000000000000000000000000000000000000"
 
 # The manifest binds content, mode AND owner to ITS path, one space-separated
@@ -156,6 +177,8 @@ manifest="$work/pipeline-known-good.sha256"
   # The chown probe: a correct content hash and mode, bound to an owner the
   # deployed file does not have.
   printf '%s 0755 %s %s\n' "$hash_chown" "$foreign_uid" "$chown_script"
+  # The allowlist, at the 0600 its private_ source prefix deploys.
+  printf '%s 0600 %s %s\n' "$hash_allowlist" "$uid_self" "$allowlist_file"
   # The OLD two-column shape. A manifest left over from before mode and owner were
   # bound must not be honored as a match, in either direction.
   printf '%s  %s\n' "$hash_legacy" "$legacy_script"
@@ -174,6 +197,14 @@ bin_manifest="$work/managed-bin-known-good.sha256"
   printf '%s 0755 %s %s\n' "$hash_bin_linked" "$uid_self" "$bin_symlink"
 } >"$bin_manifest"
 absent_bin_manifest="$work/no-such-bin-manifest.sha256"
+
+# A bin manifest that DOES hold a correct tuple for the allowlist. It must still
+# vouch for nothing: _pipeline_manifest_for sends every non-bin path to the pipeline
+# manifest, so the two lists can never bless each other's files. Without this fixture
+# the allowlist cases would pass even if the routing were removed.
+allowlist_in_bin_manifest="$work/allowlist-in-bin-manifest.sha256"
+printf '%s 0600 %s %s\n' "$hash_allowlist" "$uid_self" "$allowlist_file" \
+  >"$allowlist_in_bin_manifest"
 
 # Now drift the two attribute probes AWAY from the mode their tuple records. Their
 # CONTENT still matches, which is precisely the ATTRIBUTES_MODIFIED shape: osquery
@@ -211,8 +242,26 @@ cases=(
   #    would be a watched-but-unmanifested file that pages forever. It falls through
   #    to the persistence detector, which default-denies it. --
   "1|$absent_manifest|$bin_manifest|/Library/LaunchAgents/com.webdavis.osquery-uptime-watchdog.plist|$hash_libexec|UPDATED|a com.webdavis.osquery-*.plist under /Library is NOT tracked -> SILENT (tracked set == manifest set)"
+  # -- THE PAGE-LAUNCHD ALLOWLIST is tracked at its EXACT path. It decides whether
+  #    an unknown user LaunchAgent pages, so an edit nobody can confirm is a tamper
+  #    of the deciding component, not a note for tomorrow's digest. It is judged
+  #    against the PIPELINE manifest, which is where every non-bin path routes. --
+  "0|$absent_manifest|$bin_manifest|$allowlist_file|$hash_allowlist|UPDATED|the page-launchd allowlist, no pipeline manifest -> PAGE (it decides whether persistence pages)"
+  "1|$manifest|$bin_manifest|$allowlist_file|$hash_allowlist|UPDATED|the allowlist at its manifested content, mode and owner -> SILENT (a legitimate apply)"
+  # -- ...and the BIN manifest can never vouch for it. One target is judged against
+  #    exactly one manifest, so a tuple in the wrong list blesses nothing. --
+  "0|$absent_manifest|$allowlist_in_bin_manifest|$allowlist_file|$hash_allowlist|UPDATED|an allowlist tuple sitting in the BIN manifest does not vouch for it -> PAGE (one target, one manifest)"
+  # -- ITS NEIGHBOURS in the same watched directory stay untracked. The watch is a
+  #    DIRECTORY watch, so tracking the directory rather than the one file would pull
+  #    in webhook-secret and the writer's own lock: neither is manifested, so both
+  #    would page forever, and the secret's every touch would become a CRIT. --
+  "1|$absent_manifest|$bin_manifest|$neighbor_secret|$hash_allowlist|UPDATED|the webhook-secret neighbor is untracked -> SILENT (never manifested, and not ours to judge)"
+  "1|$absent_manifest|$bin_manifest|$allowlist_lock|$hash_allowlist|UPDATED|the writer's own .lock neighbor is untracked -> SILENT (it is created on every -a/-d)"
+  "1|$absent_manifest|$bin_manifest|$neighbor_conf|$hash_allowlist|UPDATED|the osquery.conf neighbor is untracked -> SILENT (root serves the daemon config from /var)"
+  "1|$absent_manifest|$bin_manifest|$neighbor_pack|$hash_allowlist|UPDATED|a packs/ neighbor is untracked -> SILENT"
   # -- A DELETE of a tracked file always PAGES, even with a manifest present --
   "0|$manifest|$bin_manifest|$libexec_script||DELETED|a delete of a tracked file -> PAGE (destructive, manifest cannot vouch)"
+  "0|$manifest|$bin_manifest|$allowlist_file||DELETED|a delete of the allowlist -> PAGE (the deciding component vanished)"
   # -- Empty event hash (atomic-rename shape): debounce, rehash disk; no manifest -> PAGE --
   "0|$absent_manifest|$bin_manifest|$libexec_script||MOVED_TO|atomic-rename empty-hash event, no manifest -> PAGE after rehash"
   # -- Manifest present: the file's CURRENT content is known-good -> SILENT --

--- a/test/unit/osquery-route-enrichment.sh
+++ b/test/unit/osquery-route-enrichment.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
 ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 
 fail() {
   printf 'osquery-route-enrichment: FAIL -- %s\n' "$*" >&2
@@ -26,6 +27,7 @@ fail() {
 
 [[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
 [[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+[[ -f $PIPELINE_HELPER ]] || fail "missing helper: $PIPELINE_HELPER"
 command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
 
 work="$(mktemp -d)"
@@ -62,6 +64,15 @@ allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
   printf '{"label":"com.evil","path":"~/Library/LaunchAgents/com.evilUNTRUSTED.plist","program":"~/bin/evil","sha256":"%s"}\n' "$untrusted_hash"
   printf '{"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":"%s"}\n' "$trusted_hash"
 } >"$allowlist"
+chmod 600 "$allowlist"
+
+# The allowlist is pipeline infrastructure, so allowlist_verdict refuses to
+# suppress unless the root-owned manifest vouches for the file it just read. This
+# fixture is the state a legitimate apply leaves behind; without it the TAGB
+# suppression assertion would pass for the wrong reason.
+manifest="$work/pipeline-known-good.sha256"
+printf '%s 0600 %s %s\n' \
+  "$(shasum -a 256 "$allowlist" | awk '{print $1}')" "$(id -u)" "$allowlist" >"$manifest"
 
 findings=(
   # HEADLINE: fully allowlisted (label+path+program+hash all match) BUT the program
@@ -78,12 +89,14 @@ findings=(
 )
 
 page_out="$(printf '%s\n' "${findings[@]}" |
-  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" OSQUERY_ENRICH_SCRIPT="$enricher" DIGEST_SPY="$spy" bash -c '
+  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" OSQUERY_ENRICH_SCRIPT="$enricher" DIGEST_SPY="$spy" \
+    OSQUERY_PIPELINE_MANIFEST="$manifest" OSQUERY_PIPELINE_SETTLE_SECONDS=0 bash -c '
     source "$1"
     source "$2"
+    source "$3"
     digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
     route_findings
-  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER" "$PIPELINE_HELPER")"
 
 # signing_of <tag> -> the .signing value of the paged finding with that tag ("" if absent).
 signing_of() { jq -rs --arg t "$1" 'map(select(.cols.tag == $t)) | (.[0].signing // "")' <<<"$page_out"; }

--- a/test/unit/osquery-route-gate.sh
+++ b/test/unit/osquery-route-gate.sh
@@ -59,14 +59,22 @@ findings=(
   '{"q":"file_events_recent","act":"added","cols":{"category":"sshd_config","target_path":"/etc/ssh/sshd_configTAG07"},"ep":"/etc/ssh/sshd_configTAG07"}'
   '{"q":"file_events_recent","act":"added","cols":{"category":"ssh","target_path":"/Users/x/.ssh/authorized_keys","note":"TAG08"},"ep":"/Users/x/.ssh/authorized_keys"}'
   '{"q":"file_events_recent","act":"added","cols":{"category":"pipeline_integrity","target_path":"/Users/x/.local/libexec/osquery/results-alerterTAG09.sh","sha256":"abc","action":"UPDATED"},"ep":"/Users/x/.local/libexec/osquery/results-alerterTAG09.sh"}'
+  # The page-allowlist edit itself. It decides whether an unknown user LaunchAgent
+  # pages, so with no manifest to confirm the edit it PAGES like any other tracked
+  # pipeline file. The token rides in a note column because the path has to be the
+  # REAL tracked path for the tracked-set match to mean anything.
+  '{"q":"file_events_recent","act":"added","cols":{"category":"allowlist_file","target_path":"/Users/x/.config/osquery/page-launchd-allowlist.txt","sha256":"abc","action":"UPDATED","note":"TAG15"},"ep":""}'
   # -- DIGEST --
   '{"q":"agent_authfile_changed","act":"added","cols":{"path":"/Users/x/.codex/config.tomlTAG10"},"ep":""}'
   '{"q":"system_extensions_new","act":"added","cols":{"identifier":"com.ext.TAG11"},"ep":""}'
   '{"q":"listening_ports_non_loopback","act":"added","cols":{"name":"procTAG12","address":"0.0.0.0","port":"9999"},"ep":""}'
   '{"q":"file_events_recent","act":"added","cols":{"category":"ssh","target_path":"/Users/x/.ssh/id_rsaTAG13"},"ep":"/Users/x/.ssh/id_rsaTAG13"}'
   '{"q":"file_events_recent","act":"added","cols":{"category":"sudoers","target_path":"/etc/sudoersTAG14"},"ep":"/etc/sudoersTAG14"}'
-  '{"q":"file_events_recent","act":"added","cols":{"category":"allowlist_file","target_path":"/Users/x/.config/osquery-TAG15/page-launchd-allowlist.txt"},"ep":""}'
   # -- LOG-ONLY --
+  # A neighbour in the SAME watched directory as the allowlist. The watch is a
+  # directory watch, so this event really does arrive; the tracked set is what keeps
+  # a secret file from becoming a CRIT nobody can ever confirm.
+  '{"q":"file_events_recent","act":"added","cols":{"category":"allowlist_file","target_path":"/Users/x/.config/osquery/webhook-secret","sha256":"abc","action":"UPDATED","note":"TAG21"},"ep":""}'
   '{"q":"agent_exposure_changed","act":"removed","cols":{"name":"ncTAG16","address":"0.0.0.0","port":"4444"},"ep":""}'
   '{"q":"firewall_state","act":"added","cols":{"global_state":"0","note":"TAG17"},"ep":""}'
   '{"q":"homebrew_packages","act":"added","cols":{"name":"pkgTAG18"},"ep":""}'
@@ -112,6 +120,7 @@ classify TAG06 page # persistence_launchd added (unconditional now; TODO B11 all
 classify TAG07 page # file_events sshd_config
 classify TAG08 page # file_events ssh authorized_keys
 classify TAG09 page # file_events pipeline_integrity (unconditional now; TODO B12 pipeline)
+classify TAG15 page # file_events allowlist_file (the page-allowlist edit, no manifest to vouch)
 
 # -- DIGEST --
 classify TAG10 digest # agent_authfile_changed (criterion 3: the 3 non-secret configs)
@@ -119,9 +128,9 @@ classify TAG11 digest # system_extensions_new
 classify TAG12 digest # listening_ports_non_loopback added
 classify TAG13 digest # file_events ssh (a non-authorized_keys file)
 classify TAG14 digest # file_events sudoers
-classify TAG15 digest # file_events allowlist_file (the page-allowlist edit itself)
 
 # -- LOG-ONLY --
+classify TAG21 logonly # an allowlist_file neighbour (webhook-secret) is untracked
 classify TAG16 logonly # agent_exposure_changed removed (the exposure being fixed)
 classify TAG17 logonly # firewall_state (poller-owned; routing here would double-page)
 classify TAG18 logonly # homebrew_packages (INFO drift)
@@ -130,10 +139,10 @@ classify TAG20 logonly # filevault_off removed (encryption restored)
 
 # -- Contract: every paged line is exactly one CRIT finding; counts add up. --
 page_count="$(grep -c . <<<"$page_out" || true)"
-[[ $page_count -eq 9 ]] || fail "expected 9 page-candidates, got $page_count"
+[[ $page_count -eq 10 ]] || fail "expected 10 page-candidates, got $page_count"
 [[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$page_out")" == true ]] ||
   fail "every page-candidate must carry .sev == CRIT"
 digest_count="$(grep -c . "$spool" 2>/dev/null || true)"
-[[ $digest_count -eq 6 ]] || fail "expected 6 digested findings, got $digest_count"
+[[ $digest_count -eq 5 ]] || fail "expected 5 digested findings, got $digest_count"
 
-printf 'osquery-route-gate: OK (9 page-candidates all CRIT, 6 digested, 5 log-only; criteria 1-3 tiers pinned; poller-owned + drift are log-only)\n'
+printf 'osquery-route-gate: OK (10 page-candidates all CRIT, 5 digested, 6 log-only; criteria 1-3 tiers pinned; the page-allowlist edit pages and its neighbours stay log-only)\n'

--- a/test/unit/osquery-route-persistence-allowlist.sh
+++ b/test/unit/osquery-route-persistence-allowlist.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
 ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 
 fail() {
   printf 'osquery-route-persistence-allowlist: FAIL -- %s\n' "$*" >&2
@@ -30,6 +31,7 @@ fail() {
 
 [[ -f $ROUTE ]] || fail "missing helper: $ROUTE"
 [[ -f $ALLOWLIST_HELPER ]] || fail "missing helper: $ALLOWLIST_HELPER"
+[[ -f $PIPELINE_HELPER ]] || fail "missing helper: $PIPELINE_HELPER"
 command -v shasum >/dev/null 2>&1 || fail "shasum is required for this test"
 
 work="$(mktemp -d)"
@@ -46,6 +48,16 @@ known_hash="$(shasum -a 256 "$home/Library/LaunchAgents/com.known.plist" | awk '
 allowlist="$home/.config/osquery/page-launchd-allowlist.txt"
 printf '{"label":"com.known","path":"~/Library/LaunchAgents/com.known.plist","program":"~/bin/known","sha256":"%s"}\n' \
   "$known_hash" >"$allowlist"
+chmod 600 "$allowlist"
+
+# The allowlist is pipeline infrastructure, so allowlist_verdict refuses to
+# suppress unless the root-owned manifest vouches for the file it just read. This
+# fixture is the state a legitimate apply leaves behind: the allowlist bound to its
+# own content, its 0600 mode and its owner. Without it every case below would page
+# for the wrong reason and the suppression assertions would pass vacuously.
+manifest="$work/pipeline-known-good.sha256"
+printf '%s 0600 %s %s\n' \
+  "$(shasum -a 256 "$allowlist" | awk '{print $1}')" "$(id -u)" "$allowlist" >"$manifest"
 
 # Fixture persistence_launchd findings. Each carries a unique tag in .cols.tag,
 # which allowlist_verdict ignores (it reads only label/path/program).
@@ -63,12 +75,14 @@ findings=(
 )
 
 page_out="$(printf '%s\n' "${findings[@]}" |
-  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" DIGEST_SPY="$spy" bash -c '
+  HOME="$home" OSQUERY_LAUNCHD_ALLOWLIST="$allowlist" DIGEST_SPY="$spy" \
+    OSQUERY_PIPELINE_MANIFEST="$manifest" OSQUERY_PIPELINE_SETTLE_SECONDS=0 bash -c '
     source "$1"
     source "$2"
+    source "$3"
     digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
     route_findings
-  ' _ "$ROUTE" "$ALLOWLIST_HELPER")"
+  ' _ "$ROUTE" "$ALLOWLIST_HELPER" "$PIPELINE_HELPER")"
 
 in_page() { grep -qF "$1" <<<"$page_out"; }
 


### PR DESCRIPTION
## Context

The osquery alerter pages when an unknown user LaunchAgent appears. An allowlist decides which agents are
known and therefore silent, which makes that file a security boundary: whatever it says, the alerter obeys.

It was deployed writable by the user, it was not covered by the integrity manifest, and changes to it were
only recorded in the daily digest rather than paged. So a process running as the operator could add an entry
naming its own agent, install that agent, and be silently exempted, with the edit itself surfacing at most
once a day in a low-attention channel.

## Summary

- The allowlist is now signed into the known-good manifest, so an out-of-band edit is detectable.
- More importantly, a modified allowlist can no longer silence anything at all.
- The tool that adds an entry now edits the source, deploys it, and refreshes the signature in one step.
- The scheduled audit covers the file too, so an edit that produces no filesystem event is still caught.
- Neighbouring files in the same directory, including the webhook secret, are proven to stay excluded.

Key files: `dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh`, the manifest runner, and the
allowlist writer.

## Why detection alone would not have been enough

Manifesting the file makes tampering visible, but the allowlist's job is to *suppress* alerts. An attacker
who edits it gets their silence immediately, and a tamper alert that arrives afterwards reports a failure
that already happened.

So the check gates the suppression itself: before any entry may silence a finding, the deployed allowlist's
content, permissions and owner must match its signature. An appended entry changes the file, so the file no
longer matches, so it vouches for nothing. The attacker's agent then pages on its own merits and the edit
pages separately as tampering. One write, two alerts.

The check runs only on the path that would suppress. The paths that already page are left alone, since
verifying a signature to confirm an answer that was never in doubt only costs time. An unverified allowlist
returns the same result as one that simply does not list the agent, so it flows through the existing
default-deny handling with no new branch.

## A premise that turned out to be false

The reason this was left open was a belief that binding the allowlist would break a real workflow: the
operator seeds a known-good agent by writing the deployed file directly, and a signed file would page on
every legitimate seed.

Neither half held up. Applying the dotfiles already overwrites that file from source, so a direct edit is
silently discarded on the next apply, which is a latent bug rather than a workflow. And in the entire
history of the file, every entry was added as a source change; the direct-write path has never produced a
committed entry. Binding the file is therefore the repair, not a migration.

The writer now edits the source, deploys that one file, and refreshes the signature, rolling back if the
deploy fails and failing loudly if the signature step does. It has to invoke the signing step itself,
because deploying a single file does not run the scripts that normally follow an apply.

## The honest limit

Recorded in the code in the same style as the existing coverage notes: this is not a boundary that survives
an attacker who can escalate privileges without a prompt, which on this machine is anyone running as the
operator. Every layer here roots its trust in a root-owned signature file that such a process can rewrite.

What it does buy is narrower and still worth having. The allowlist stops being the softest component in the
pipeline and becomes exactly as hard as the alerter's own scripts, inheriting their already-documented
exposures instead of offering a bare user-writable append that nothing was reading.

## How it was reviewed

Ten mutations were confirmed to fail the tests meant to catch them, including removing the suppression gate,
covering the directory instead of the exact file, and each way the writer could leave the deployed file and
its signature disagreeing. The timing window where a legitimate apply has deployed the file but not yet
refreshed the signature is pinned in both directions: a signature that lands late must not raise a false
alert, and one that never arrives must refuse to suppress within a bound.

## Effect of merging

Merging advances `main` only. The live machine tracks `integration/modernization`, so its behavior does not
change until a later cutover.
