### PR TITLE
fix(macos-defaults): share one library and resolve the source directory per worktree

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -56,4 +56,5 @@ Library
 .local/bin/macos-defaults-drift.sh
 .local/bin/macos-defaults-apply.sh
 .local/bin/macos-defaults-capture.sh
+.local/bin/macos-defaults-lib.sh
 {{- end -}}

--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -9,18 +9,17 @@ set -euo pipefail
 # Note: no `shopt -s lastpipe` here, the while loops below don't mutate
 # outer-scope state (no counter to preserve, unlike drift.sh).
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
-  exit 2
-fi
+DATA_FILE="$(macos_defaults_data_file)" || exit $?
+require_readable_data_file "$DATA_FILE" || exit $?
 
 # Pre-flight: close System Settings if open (same reason as runner).
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
 # Main loop: one `defaults write` per record.
-yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$DATA_FILE" |
+defaults_records_tsv "$DATA_FILE" |
   while IFS=$'\t' read -r domain key type value host; do
     [[ -z $domain ]] && continue
     if [[ -n $host ]]; then

--- a/dot_local/bin/executable_macos-defaults-capture.sh
+++ b/dot_local/bin/executable_macos-defaults-capture.sh
@@ -18,7 +18,8 @@
 
 set -euo pipefail
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
 usage() {
   printf 'usage: macos-defaults-capture <domain> <key> [--host current]\n' >&2
@@ -65,10 +66,10 @@ done
   exit 3
 }
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
-  exit 2
-fi
+# Resolved after argument validation so a malformed invocation still exits 3, not
+# 2, whatever state the chezmoi source directory is in.
+DATA_FILE="$(macos_defaults_data_file)" || exit $?
+require_readable_data_file "$DATA_FILE" || exit $?
 
 # Read live type. `defaults read-type` outputs e.g. "Type is boolean".
 host_flag=()

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -13,12 +13,11 @@
 set -euo pipefail
 shopt -s lastpipe
 
-DATA_FILE="${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+# shellcheck source=dot_local/bin/macos-defaults-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
-if [[ ! -r $DATA_FILE ]]; then
-  printf 'error: cannot read %s\n' "$DATA_FILE" >&2
-  exit 2
-fi
+DATA_FILE="$(macos_defaults_data_file)" || exit $?
+require_readable_data_file "$DATA_FILE" || exit $?
 
 # Normalize a value for comparison. macOS stores bools as 0/1; YAML ships them
 # as true/false. Strings/ints/floats compare directly.
@@ -45,10 +44,10 @@ print_header() {
   fi
 }
 
-# yq -r outputs each record as a single TSV line: domain<TAB>key<TAB>type<TAB>value<TAB>host
+# Each record arrives as one TSV line: domain<TAB>key<TAB>type<TAB>value<TAB>host.
 # Note: yq emits a single newline for an empty array; the inline guard below
 # skips that empty row so the script exits 0 cleanly when nothing is tracked.
-yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$DATA_FILE" |
+defaults_records_tsv "$DATA_FILE" |
   while IFS=$'\t' read -r domain key type value host; do
     [[ -z $domain ]] && continue
     expected="$(normalize "$type" "$value")"

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -12,25 +12,52 @@
 # resolve_source_dir, print the chezmoi source directory for the CURRENT context.
 #
 # Resolution order, most specific first:
-#   1. $MACOS_DEFAULTS_SOURCE_DIR when set, an explicit caller override.
-#   2. The current git worktree's top level, when that top level carries a
-#      .chezmoidata/macos_defaults.yaml, so a run from a secondary worktree targets
-#      THAT worktree rather than the primary checkout. It is routed through
-#      `chezmoi --source=<top> source-path` so chezmoi normalizes the path.
+#   1. $MACOS_DEFAULTS_SOURCE_DIR when SET, an explicit caller override. Set but
+#      empty is a caller error, not "unset", so it is rejected rather than skipped.
+#   2. The chezmoi source tree containing the current directory, so a run from a
+#      secondary worktree targets THAT worktree rather than the primary checkout.
+#      It is routed through `chezmoi --source=<top> source-path` so chezmoi
+#      normalizes the path.
 #   3. Otherwise chezmoi's configured source directory.
 #
 # Every failure returns nonzero with a message rather than falling through to the
 # next rule: falling back after a failed chezmoi call would silently retarget a
 # different checkout, which is the class of bug this resolver exists to end.
+#
+# Two rules keep that promise, and both close a way an earlier version broke it:
+#
+#   The source tree is identified by its .chezmoiversion marker, NOT by the data
+#   file. Those are different questions. A source tree whose macos_defaults.yaml is
+#   absent is STILL this tree, and must report a missing data file for the tree the
+#   caller is standing in. Keying on the data file made an absent file look like
+#   "some unrelated directory" and silently resolved whichever other checkout did
+#   have one, reintroducing the exact bug this resolver exists to end.
+#
+#   The worktree is resolved with git's context variables SCRUBBED. `git rev-parse`
+#   honors $GIT_DIR and $GIT_WORK_TREE, so an exported value from a git hook or a
+#   wrapper made the resolver describe a checkout the caller was not in. Unsetting
+#   them inside the command substitution binds the answer to the physical directory.
+#
+# Residual, stated rather than hidden: if git fails for a reason OTHER than an
+# inherited context variable, a corrupt repository being the realistic one, the
+# tree cannot be identified and resolution falls to chezmoi's configured source.
+# That case is not reproduced here and is left as the documented limit.
 resolve_source_dir() {
-  if [[ -n ${MACOS_DEFAULTS_SOURCE_DIR:-} ]]; then
+  if [[ -n ${MACOS_DEFAULTS_SOURCE_DIR+x} ]]; then
+    if [[ -z $MACOS_DEFAULTS_SOURCE_DIR ]]; then
+      printf 'error: MACOS_DEFAULTS_SOURCE_DIR is set but empty; refusing to resolve another checkout\n' >&2
+      return 1
+    fi
     printf '%s\n' "$MACOS_DEFAULTS_SOURCE_DIR"
     return 0
   fi
 
   local worktree_top resolved
-  if worktree_top="$(git rev-parse --show-toplevel 2>/dev/null)" &&
-    [[ -f "$worktree_top/.chezmoidata/macos_defaults.yaml" ]]; then
+  worktree_top="$(
+    unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+    git rev-parse --show-toplevel 2>/dev/null
+  )"
+  if [[ -n $worktree_top && -f "$worktree_top/.chezmoiversion" ]]; then
     if ! resolved="$(chezmoi --source="$worktree_top" source-path)"; then
       printf 'error: chezmoi --source=%s source-path failed; refusing to fall back to another checkout\n' \
         "$worktree_top" >&2

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -1,0 +1,82 @@
+# shellcheck shell=bash
+# macos-defaults-lib.sh, shared helpers for the macos-defaults-{apply,capture,
+# drift} tools. Sourced, never executed, so it carries no shebang and no
+# executable bit.
+#
+# Each tool sources it as
+#   source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
+# which resolves in BOTH the chezmoi source tree (dot_local/bin/) and the applied
+# ~/.local/bin/ layout: this file carries no executable_ or dot_ prefix, so chezmoi
+# deploys it under the same basename its siblings are deployed beside.
+
+# resolve_source_dir, print the chezmoi source directory for the CURRENT context.
+#
+# Resolution order, most specific first:
+#   1. $MACOS_DEFAULTS_SOURCE_DIR when set, an explicit caller override.
+#   2. The current git worktree's top level, when that top level carries a
+#      .chezmoidata/macos_defaults.yaml, so a run from a secondary worktree targets
+#      THAT worktree rather than the primary checkout. It is routed through
+#      `chezmoi --source=<top> source-path` so chezmoi normalizes the path.
+#   3. Otherwise chezmoi's configured source directory.
+#
+# Every failure returns nonzero with a message rather than falling through to the
+# next rule: falling back after a failed chezmoi call would silently retarget a
+# different checkout, which is the class of bug this resolver exists to end.
+resolve_source_dir() {
+  if [[ -n ${MACOS_DEFAULTS_SOURCE_DIR:-} ]]; then
+    printf '%s\n' "$MACOS_DEFAULTS_SOURCE_DIR"
+    return 0
+  fi
+
+  local worktree_top resolved
+  if worktree_top="$(git rev-parse --show-toplevel 2>/dev/null)" &&
+    [[ -f "$worktree_top/.chezmoidata/macos_defaults.yaml" ]]; then
+    if ! resolved="$(chezmoi --source="$worktree_top" source-path)"; then
+      printf 'error: chezmoi --source=%s source-path failed; refusing to fall back to another checkout\n' \
+        "$worktree_top" >&2
+      return 1
+    fi
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  if ! resolved="$(chezmoi source-path)"; then
+    printf 'error: chezmoi source-path failed; the chezmoi source directory is unknown\n' >&2
+    return 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+# macos_defaults_data_file, print the resolved path to macos_defaults.yaml.
+# Returns 2, the tools' shared "data file missing or unreadable" status, when the
+# source directory cannot be resolved. An empty resolution is a failure too: it
+# would otherwise compose into a plausible-looking /.chezmoidata/... path.
+macos_defaults_data_file() {
+  local source_dir
+  source_dir="$(resolve_source_dir)" || return 2
+  if [[ -z $source_dir ]]; then
+    printf 'error: resolved an empty chezmoi source directory for macos_defaults.yaml\n' >&2
+    return 2
+  fi
+  printf '%s/.chezmoidata/macos_defaults.yaml\n' "$source_dir"
+}
+
+# require_readable_data_file <path>, the shared readable-data-file guard. Returns
+# 2 with a message naming the file, so the caller's exit status matches the "data
+# file missing or unreadable" contract documented in each tool's header.
+require_readable_data_file() { # <path>
+  local data_file="$1"
+  if [[ ! -r $data_file ]]; then
+    printf 'error: cannot read %s\n' "$data_file" >&2
+    return 2
+  fi
+}
+
+# defaults_records_tsv <path>, emit each tracked record as one tab-separated line:
+#   domain<TAB>key<TAB>type<TAB>value<TAB>host    (host empty when global).
+# Callers read it with IFS=$'\t' so the trailing empty host field survives. yq
+# emits a single blank line for an empty array, which callers skip.
+defaults_records_tsv() { # <path>
+  local data_file="$1"
+  yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$data_file"
+}

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -74,8 +74,17 @@ require_readable_data_file() { # <path>
 
 # defaults_records_tsv <path>, emit each tracked record as one tab-separated line:
 #   domain<TAB>key<TAB>type<TAB>value<TAB>host    (host empty when global).
-# Callers read it with IFS=$'\t' so the trailing empty host field survives. yq
-# emits a single blank line for an empty array, which callers skip.
+# yq emits a single blank line for an empty array, which callers skip.
+#
+# KNOWN LIMITATION, carried unchanged from the pre-extraction code so this
+# refactor stays behavior-preserving. Callers read with IFS=$'\t', and tab is IFS
+# *whitespace*, so bash collapses runs of tabs. Only a TRAILING empty field
+# survives: an empty host reads back empty as intended. An empty INTERIOR field
+# does not. A record with an empty value would collapse its two adjacent tabs and
+# shift host left into value, applying the host string as the setting's value
+# against the global domain. No tracked record has an empty value today, so this
+# is latent rather than live. The fix is a non-whitespace delimiter and is its own
+# slice, which now changes this one function instead of every caller.
 defaults_records_tsv() { # <path>
   local data_file="$1"
   yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$data_file"

--- a/test/integration/macos-defaults-source-path.sh
+++ b/test/integration/macos-defaults-source-path.sh
@@ -92,10 +92,13 @@ hardcoded_primary="$sandbox/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_
 seed_data_file "$hardcoded_primary" "$PRIMARY_DOMAIN"
 
 # The secondary worktree the operator is standing in: a real git repo carrying its
-# own macos_defaults.yaml.
+# own macos_defaults.yaml and the .chezmoiversion marker that identifies a chezmoi
+# source tree. The marker, not the data file, is what the resolver keys on, so the
+# unreadable-file cases below still resolve THIS tree rather than falling through.
 worktree="$sandbox/wt"
 worktree_data_file="$worktree/.chezmoidata/macos_defaults.yaml"
 seed_data_file "$worktree_data_file" "$WORKTREE_DOMAIN"
+printf '2.62.3\n' >"$worktree/.chezmoiversion"
 git -C "$worktree" init -q
 # Pre-flight: the worktree branch of resolution fires only when git reports this
 # directory as its own top level. Assert it, so a green pass cannot hide a silent
@@ -133,10 +136,16 @@ chmod +x "$stub_bin/defaults" "$stub_bin/osascript" "$stub_bin/killall"
 
 # run_from_worktree <script> [args...] -- run a tool with the operator standing in
 # the worktree, against the sandbox HOME and the stub PATH.
+# The caller's own environment is scrubbed. This suite runs on developer machines
+# where the very override the library invites, and git's context variables, may
+# already be exported; inheriting any of them resolves a different tree and fails
+# the run for a reason that has nothing to do with the code. That is a false RED,
+# so the sandbox is made explicit rather than assumed.
 run_from_worktree() { # <script> [args...]
   (
     cd "$worktree" || exit 1
-    HOME="$sandbox" PATH="$stub_bin:$PATH" bash "$@"
+    unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+    HOME="$sandbox" XDG_CONFIG_HOME="$sandbox/.config" PATH="$stub_bin:$PATH" bash "$@"
   )
 }
 
@@ -174,4 +183,27 @@ chmod u+rw "$worktree_data_file"
 assert_file_contains "$drift_stderr" "$worktree_data_file" \
   "drift's exit-2 message must name the WORKTREE yaml, proving it resolved the worktree (stderr: $(cat "$drift_stderr"))"
 
-printf 'macos-defaults-source-path: OK (apply, capture and drift all resolve the worktree; both decoy primaries untouched)\n'
+# ---- apply and capture, unreadable data file --------------------------------
+# require_readable_data_file RETURNS its status rather than exiting, so each call
+# site has to propagate it. Only drift's site was exercised above; a site that
+# dropped the propagation would degrade a clean exit 2 into yq's own failure with
+# a different status and message, and nothing would have noticed. Every tool gets
+# the same assertion so this stays a property of the set, not of one member.
+assert_unreadable_exits_two() { # <label> <script> [args...]
+  local label="$1" script="$2"
+  shift 2
+  local err="$sandbox/$label.err" status=0
+  chmod 000 "$worktree_data_file"
+  run_from_worktree "$script" "$@" 2>"$err" || status=$?
+  chmod u+rw "$worktree_data_file"
+
+  [[ $status -eq 2 ]] ||
+    fail "$label with an unreadable worktree yaml must exit 2, the documented status (got $status, stderr: $(cat "$err"))"
+  assert_file_contains "$err" "$worktree_data_file" \
+    "$label's exit-2 message must name the WORKTREE yaml (stderr: $(cat "$err"))"
+}
+
+assert_unreadable_exits_two apply "$APPLY"
+assert_unreadable_exits_two capture "$CAPTURE" "$CAPTURED_DOMAIN" s10flag
+
+printf 'macos-defaults-source-path: OK (apply, capture and drift all resolve the worktree; both decoy primaries untouched; all three exit 2 naming the worktree yaml when it is unreadable)\n'

--- a/test/integration/macos-defaults-source-path.sh
+++ b/test/integration/macos-defaults-source-path.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# macos-defaults-source-path.sh -- all three macos-defaults tools must resolve
+# .chezmoidata/macos_defaults.yaml for the CURRENT context, never a hardcoded
+# primary checkout.
+#
+# The bug this pins: apply, capture and drift each hardcoded
+# "${HOME}/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml", so a
+# run from a SECONDARY git worktree read (or wrote) the PRIMARY tree instead of the
+# worktree the operator was standing in. The shared library now resolves the source
+# directory from the current git worktree, routed through chezmoi, and falls back to
+# chezmoi's configured source directory.
+#
+# Everything lives under one sandbox temp dir. HOME points there and a throwaway
+# chezmoi config points sourceDir at a sandbox "primary", so NEITHER the operator's
+# real checkout NOR the buggy hardcoded ${HOME}/workspaces/... path can be touched:
+# a red run mutates only the sandbox.
+#
+# Two decoy primaries are seeded, one per wrong answer the old code could give, and
+# each of the three tools is asserted to have consulted the WORKTREE and not either
+# decoy. That is a completeness check on the set of consumers: a tool that kept a
+# private copy of the hardcoded path fails here rather than passing by association.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
+CAPTURE="$REPO_ROOT/dot_local/bin/executable_macos-defaults-capture.sh"
+DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# refute_file_contains <file> <fixed-string> <message> -- the explicit negative
+# assertion. A bare `! grep` is dead under `set -e` unless it happens to be the
+# last statement, so every negative below goes through this helper.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+# Host-tool guard: a suite *.sh runs with host tools. The de-homebrewed
+# CI-faithful run has no chezmoi/yq/git on PATH, and this test cannot exercise
+# source-directory resolution without them.
+for tool in chezmoi yq git; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise source-directory resolution\n' "$tool"
+    exit 0
+  }
+done
+for script in "$APPLY" "$CAPTURE" "$DRIFT"; do
+  [[ -f $script ]] || fail "missing script: $script"
+done
+
+# Canonicalize away macOS's /var -> /private/var symlink so these paths match what
+# `git rev-parse --show-toplevel` (used by the resolver under test) reports.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'chmod -R u+rwX "$sandbox" 2>/dev/null; rm -rf "$sandbox"' EXIT
+
+WORKTREE_DOMAIN="com.example.s10worktree"
+PRIMARY_DOMAIN="com.example.s10primary"
+CAPTURED_DOMAIN="com.example.s10captured"
+
+# seed_data_file <path> <domain> -- one tracked bool record under <domain>.
+seed_data_file() { # <path> <domain>
+  mkdir -p "$(dirname "$1")"
+  cat >"$1" <<EOF
+macos:
+  defaults:
+    - domain: $2
+      key: s10flag
+      type: bool
+      value: true
+  killall: []
+EOF
+}
+
+# Decoy 1: chezmoi's configured source directory.
+mkdir -p "$sandbox/.config/chezmoi"
+printf 'sourceDir = "%s/primary-src"\n' "$sandbox" >"$sandbox/.config/chezmoi/chezmoi.toml"
+configured_primary="$sandbox/primary-src/.chezmoidata/macos_defaults.yaml"
+seed_data_file "$configured_primary" "$PRIMARY_DOMAIN"
+
+# Decoy 2: the path the buggy tools hardcoded. With HOME=sandbox it lands here, so
+# a red run has a readable target and still mutates only the sandbox.
+hardcoded_primary="$sandbox/workspaces/Ivy/webdavis/dotfiles/.chezmoidata/macos_defaults.yaml"
+seed_data_file "$hardcoded_primary" "$PRIMARY_DOMAIN"
+
+# The secondary worktree the operator is standing in: a real git repo carrying its
+# own macos_defaults.yaml.
+worktree="$sandbox/wt"
+worktree_data_file="$worktree/.chezmoidata/macos_defaults.yaml"
+seed_data_file "$worktree_data_file" "$WORKTREE_DOMAIN"
+git -C "$worktree" init -q
+# Pre-flight: the worktree branch of resolution fires only when git reports this
+# directory as its own top level. Assert it, so a green pass cannot hide a silent
+# fallback to a primary.
+[[ "$(git -C "$worktree" rev-parse --show-toplevel)" == "$worktree" ]] ||
+  fail "test setup: $worktree is not its own git top level"
+
+# Stubs. `defaults` logs every invocation so the apply assertions can read which
+# record was written; osascript and killall are stubbed so apply cannot reach the
+# operator's real System Settings or processes.
+stub_bin="$sandbox/bin"
+defaults_log="$sandbox/defaults.log"
+: >"$defaults_log"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/defaults" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>"$defaults_log"
+for arg in "\$@"; do
+  case "\$arg" in
+    read-type)
+      printf 'Type is boolean\n'
+      exit 0
+      ;;
+    read)
+      printf '1\n'
+      exit 0
+      ;;
+  esac
+done
+exit 0
+STUB
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/osascript"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/killall"
+chmod +x "$stub_bin/defaults" "$stub_bin/osascript" "$stub_bin/killall"
+
+# run_from_worktree <script> [args...] -- run a tool with the operator standing in
+# the worktree, against the sandbox HOME and the stub PATH.
+run_from_worktree() { # <script> [args...]
+  (
+    cd "$worktree" || exit 1
+    HOME="$sandbox" PATH="$stub_bin:$PATH" bash "$@"
+  )
+}
+
+# ---- apply (read path, whole record) ---------------------------------------
+# apply must write the WORKTREE's record and never the decoys' record.
+run_from_worktree "$APPLY" || fail "apply exited non-zero from the worktree"
+
+assert_file_contains "$defaults_log" "$WORKTREE_DOMAIN" \
+  "apply did not write the worktree's record; it read a primary instead of the worktree"
+refute_file_contains "$defaults_log" "$PRIMARY_DOMAIN" \
+  "apply wrote a primary checkout's record instead of the worktree's"
+
+# ---- capture (write path, the strongest proof) -------------------------------
+run_from_worktree "$CAPTURE" "$CAPTURED_DOMAIN" s10flag ||
+  fail "capture exited non-zero from the worktree"
+
+assert_file_contains "$worktree_data_file" "$CAPTURED_DOMAIN" \
+  "capture did not write the worktree yaml; the record went to a primary"
+refute_file_contains "$hardcoded_primary" "$CAPTURED_DOMAIN" \
+  "capture wrote the hardcoded ~/workspaces/... primary instead of the worktree"
+refute_file_contains "$configured_primary" "$CAPTURED_DOMAIN" \
+  "capture wrote the chezmoi-configured primary instead of the worktree"
+
+# ---- drift (read path, unreadable data file) ---------------------------------
+# An unreadable WORKTREE yaml must exit 2 naming that file. Both decoys stay
+# readable, so a tool still reading a primary exits 0 or 1 here and fails.
+chmod 000 "$worktree_data_file"
+drift_stderr="$sandbox/drift.err"
+drift_status=0
+run_from_worktree "$DRIFT" 2>"$drift_stderr" || drift_status=$?
+chmod u+rw "$worktree_data_file"
+
+[[ $drift_status -eq 2 ]] ||
+  fail "drift from the worktree with an unreadable yaml must exit 2 (got $drift_status); it read a primary, not the worktree"
+assert_file_contains "$drift_stderr" "$worktree_data_file" \
+  "drift's exit-2 message must name the WORKTREE yaml, proving it resolved the worktree (stderr: $(cat "$drift_stderr"))"
+
+printf 'macos-defaults-source-path: OK (apply, capture and drift all resolve the worktree; both decoy primaries untouched)\n'

--- a/test/integration/macos-defaults-source-path.sh
+++ b/test/integration/macos-defaults-source-path.sh
@@ -21,6 +21,16 @@
 # private copy of the hardcoded path fails here rather than passing by association.
 set -euo pipefail
 
+# Scrubbed at SCRIPT scope, before any git call, not just around the tools under
+# test. Git exports GIT_DIR to every hook it runs, and this suite runs from the
+# pre-push hook. Under an inherited GIT_DIR the sandbox's `git init` silently
+# targets that directory instead, so the sandbox never becomes a repository at
+# all, resolution finds no worktree, and the run fails somewhere far from the
+# cause. Verified directly: `GIT_DIR=<repo>/.git git -C <tmp> init` leaves <tmp>
+# with no .git. The same applies to the library's own override, which a developer
+# machine may already export.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
 CAPTURE="$REPO_ROOT/dot_local/bin/executable_macos-defaults-capture.sh"

--- a/test/unit/macos-defaults-source-path-propagation.sh
+++ b/test/unit/macos-defaults-source-path-propagation.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# macos-defaults-source-path-propagation.sh -- resolve_source_dir must PROPAGATE a
+# failed `chezmoi source-path`, never mask it and never fall through to a different
+# checkout.
+#
+# The masking shape this pins: running `chezmoi --source=<top> source-path` on its
+# own line and then `return 0` unconditionally. Under `set -e` the mask is hidden
+# by the caller dying anyway, so every case below calls the function from a shell
+# WITHOUT `set -e`, which is the only context where a masked failure is observable.
+# Falling through to the next resolution rule is the same bug wearing a different
+# hat: it would silently retarget another checkout, which is exactly what this
+# resolver exists to prevent.
+#
+# Pure stubs, no real git and no real chezmoi, so this is a unit test. Case 1 is
+# the unmutated control: a green harness must be able to report success.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# refute_file_contains <file> <fixed-string> <message> -- explicit negative
+# assertion. A bare `! grep` is dead under `set -e`, so negatives go through here.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+[[ -f $LIB ]] || fail "missing lib: $LIB"
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# A fake worktree top carrying the data file, so the worktree branch of
+# resolve_source_dir is the branch under test.
+worktree_top="$work/top"
+mkdir -p "$worktree_top/.chezmoidata"
+: >"$worktree_top/.chezmoidata/macos_defaults.yaml"
+
+stub_bin="$work/bin"
+mkdir -p "$stub_bin"
+
+# write_git_stub <found|missing> -- `git rev-parse --show-toplevel` either reports
+# the fake worktree top or fails, selecting which resolution branch runs.
+write_git_stub() { # <found|missing>
+  if [[ $1 == found ]]; then
+    cat >"$stub_bin/git" <<EOF
+#!/bin/bash
+if [[ "\$1 \$2" == "rev-parse --show-toplevel" ]]; then
+  printf '%s\n' "$worktree_top"
+  exit 0
+fi
+exit 0
+EOF
+  else
+    cat >"$stub_bin/git" <<'EOF'
+#!/bin/bash
+if [[ "$1 $2" == "rev-parse --show-toplevel" ]]; then
+  printf 'fatal: not a git repository\n' >&2
+  exit 128
+fi
+exit 0
+EOF
+  fi
+  chmod +x "$stub_bin/git"
+}
+
+# write_chezmoi_stub <ok|fail|empty> -- how `chezmoi source-path` behaves.
+write_chezmoi_stub() { # <ok|fail|empty>
+  case "$1" in
+    ok)
+      cat >"$stub_bin/chezmoi" <<EOF
+#!/bin/bash
+printf '%s\n' "$worktree_top"
+exit 0
+EOF
+      ;;
+    fail)
+      cat >"$stub_bin/chezmoi" <<'EOF'
+#!/bin/bash
+printf 'chezmoi: source-path is unavailable\n' >&2
+exit 1
+EOF
+      ;;
+    empty)
+      cat >"$stub_bin/chezmoi" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+      ;;
+  esac
+  chmod +x "$stub_bin/chezmoi"
+}
+
+# call_lib <function> -- run one library function in a shell WITHOUT `set -e`,
+# with the stubs on PATH and no MACOS_DEFAULTS_SOURCE_DIR override. Prints the
+# function's stdout, writes its stderr to "$work/err", returns its status.
+call_lib() { # <function>
+  PATH="$stub_bin:$PATH" LIB="$LIB" FUNCTION="$1" bash -c '
+    unset MACOS_DEFAULTS_SOURCE_DIR
+    source "$LIB"
+    "$FUNCTION"
+  ' 2>"$work/err"
+}
+
+# call_lib_with_override <function> <dir> -- same, with the explicit override set.
+call_lib_with_override() { # <function> <dir>
+  PATH="$stub_bin:$PATH" LIB="$LIB" FUNCTION="$1" MACOS_DEFAULTS_SOURCE_DIR="$2" bash -c '
+    source "$LIB"
+    "$FUNCTION"
+  ' 2>"$work/err"
+}
+
+# ---- case 0: the explicit override wins and short-circuits ------------------
+# Both stubs fail hard, so a resolver that consulted git or chezmoi at all cannot
+# return the override's value.
+write_git_stub missing
+write_chezmoi_stub fail
+status=0
+output="$(call_lib_with_override resolve_source_dir "$work/override")" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "override: MACOS_DEFAULTS_SOURCE_DIR must win outright (got $status, stderr: $(cat "$work/err"))"
+[[ $output == "$work/override" ]] ||
+  fail "override: resolve_source_dir must print the override verbatim (got '$output')"
+
+# ---- case 1: control. A working chezmoi resolves cleanly. -------------------
+write_git_stub found
+write_chezmoi_stub ok
+control_status=0
+control_output="$(call_lib resolve_source_dir)" || control_status=$?
+[[ $control_status -eq 0 ]] ||
+  fail "control: resolve_source_dir must succeed when chezmoi succeeds (got $control_status, stderr: $(cat "$work/err"))"
+[[ $control_output == "$worktree_top" ]] ||
+  fail "control: resolve_source_dir must print the resolved dir (got '$control_output')"
+
+# ---- case 2: worktree branch, chezmoi source-path fails ---------------------
+write_git_stub found
+write_chezmoi_stub fail
+status=0
+output="$(call_lib resolve_source_dir)" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "worktree branch: a failed chezmoi source-path must propagate, not be masked by return 0 (got 0, stdout: '$output')"
+grep -qF 'source-path' "$work/err" ||
+  fail "worktree branch: the error must name source-path (stderr: $(cat "$work/err"))"
+[[ -z $output ]] ||
+  fail "worktree branch: a failed resolution must print no directory on stdout (got '$output')"
+
+# ---- case 3: fallback branch, chezmoi source-path fails ---------------------
+write_git_stub missing
+write_chezmoi_stub fail
+status=0
+output="$(call_lib resolve_source_dir)" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "fallback branch: a failed chezmoi source-path must propagate (got 0, stdout: '$output')"
+grep -qF 'source-path' "$work/err" ||
+  fail "fallback branch: the error must name source-path (stderr: $(cat "$work/err"))"
+
+# ---- case 4: an empty resolution is a failure, not a plausible path ---------
+# A chezmoi that exits 0 printing nothing would otherwise compose into
+# "/.chezmoidata/macos_defaults.yaml", a real path on the wrong tree.
+write_git_stub found
+write_chezmoi_stub empty
+status=0
+output="$(call_lib macos_defaults_data_file)" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "empty resolution: macos_defaults_data_file must fail rather than compose a rooted path (got 0, stdout: '$output')"
+printf '%s' "$output" >"$work/out"
+refute_file_contains "$work/out" '/.chezmoidata/macos_defaults.yaml' \
+  "empty resolution: macos_defaults_data_file must not emit a composed path when the source dir is empty"
+
+printf 'macos-defaults-source-path-propagation: OK (control resolves; both branches propagate a failed source-path; an empty resolution fails closed)\n'

--- a/test/unit/macos-defaults-source-path-propagation.sh
+++ b/test/unit/macos-defaults-source-path-propagation.sh
@@ -36,23 +36,42 @@ refute_file_contains() { # <file> <fixed-string> <message>
 work="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$work"' EXIT
 
-# A fake worktree top carrying the data file, so the worktree branch of
-# resolve_source_dir is the branch under test.
+# A fake worktree top carrying the .chezmoiversion marker, so the worktree branch
+# of resolve_source_dir is the branch under test. The marker, NOT the data file,
+# is what identifies a chezmoi source tree: case 6 pins that a source tree whose
+# data file is absent still resolves to ITSELF.
 worktree_top="$work/top"
 mkdir -p "$worktree_top/.chezmoidata"
+: >"$worktree_top/.chezmoiversion"
 : >"$worktree_top/.chezmoidata/macos_defaults.yaml"
+
+# A second source tree, marked but with NO data file, for case 6.
+markerless_data="$work/marked-no-data"
+mkdir -p "$markerless_data"
+: >"$markerless_data/.chezmoiversion"
 
 stub_bin="$work/bin"
 mkdir -p "$stub_bin"
 
-# write_git_stub <found|missing> -- `git rev-parse --show-toplevel` either reports
-# the fake worktree top or fails, selecting which resolution branch runs.
-write_git_stub() { # <found|missing>
+# write_git_stub <found|missing> [top] -- `git rev-parse --show-toplevel` either
+# reports a worktree top or fails, selecting which resolution branch runs. [top]
+# defaults to the marked fake worktree.
+#
+# The found stub HONORS $GIT_WORK_TREE exactly as real git does, printing it in
+# preference to the physical top. That is what makes the scrub observable: if the
+# library ever stops unsetting the git context variables, this stub reports the
+# hijacked directory and case 5 fails.
+write_git_stub() { # <found|missing> [top]
+  local top="${2:-$worktree_top}"
   if [[ $1 == found ]]; then
     cat >"$stub_bin/git" <<EOF
 #!/bin/bash
 if [[ "\$1 \$2" == "rev-parse --show-toplevel" ]]; then
-  printf '%s\n' "$worktree_top"
+  if [[ -n \${GIT_WORK_TREE:-} ]]; then
+    printf '%s\n' "\$GIT_WORK_TREE"
+  else
+    printf '%s\n' "$top"
+  fi
   exit 0
 fi
 exit 0
@@ -74,8 +93,19 @@ EOF
 write_chezmoi_stub() { # <ok|fail|empty>
   case "$1" in
     ok)
+      # Echoes back whatever --source it was handed, as real chezmoi's
+      # `--source=<dir> source-path` does, so a test can tell WHICH tree the
+      # library asked about. Falls back to the marked fake worktree.
       cat >"$stub_bin/chezmoi" <<EOF
 #!/bin/bash
+for arg in "\$@"; do
+  case "\$arg" in
+    --source=*)
+      printf '%s\n' "\${arg#--source=}"
+      exit 0
+      ;;
+  esac
+done
 printf '%s\n' "$worktree_top"
 exit 0
 EOF
@@ -145,8 +175,11 @@ status=0
 output="$(call_lib resolve_source_dir)" || status=$?
 [[ $status -ne 0 ]] ||
   fail "worktree branch: a failed chezmoi source-path must propagate, not be masked by return 0 (got 0, stdout: '$output')"
-grep -qF 'source-path' "$work/err" ||
-  fail "worktree branch: the error must name source-path (stderr: $(cat "$work/err"))"
+# Assert on text only the LIBRARY emits. The chezmoi stub writes its own
+# "source-path is unavailable" to the same stderr, so grepping for 'source-path'
+# passed even with the library's whole diagnostic deleted.
+grep -qF 'refusing to fall back' "$work/err" ||
+  fail "worktree branch: the library must say it refuses to fall back (stderr: $(cat "$work/err"))"
 [[ -z $output ]] ||
   fail "worktree branch: a failed resolution must print no directory on stdout (got '$output')"
 
@@ -157,8 +190,9 @@ status=0
 output="$(call_lib resolve_source_dir)" || status=$?
 [[ $status -ne 0 ]] ||
   fail "fallback branch: a failed chezmoi source-path must propagate (got 0, stdout: '$output')"
-grep -qF 'source-path' "$work/err" ||
-  fail "fallback branch: the error must name source-path (stderr: $(cat "$work/err"))"
+# Library-unique text again, for the same reason as case 2.
+grep -qF 'source directory is unknown' "$work/err" ||
+  fail "fallback branch: the library must say the source directory is unknown (stderr: $(cat "$work/err"))"
 
 # ---- case 4: an empty resolution is a failure, not a plausible path ---------
 # A chezmoi that exits 0 printing nothing would otherwise compose into
@@ -169,8 +203,110 @@ status=0
 output="$(call_lib macos_defaults_data_file)" || status=$?
 [[ $status -ne 0 ]] ||
   fail "empty resolution: macos_defaults_data_file must fail rather than compose a rooted path (got 0, stdout: '$output')"
+# The EXACT status matters. The tools document 2 as "data file missing or
+# unreadable" and capture distinguishes 2 from 3, so asserting merely nonzero
+# left the documented contract free to drift to any other code.
+[[ $status -eq 2 ]] ||
+  fail "empty resolution: macos_defaults_data_file must return the documented status 2, not just nonzero (got $status)"
 printf '%s' "$output" >"$work/out"
 refute_file_contains "$work/out" '/.chezmoidata/macos_defaults.yaml' \
   "empty resolution: macos_defaults_data_file must not emit a composed path when the source dir is empty"
 
-printf 'macos-defaults-source-path-propagation: OK (control resolves; both branches propagate a failed source-path; an empty resolution fails closed)\n'
+# ---- case 5: an inherited git context must NOT retarget another checkout -----
+# `git rev-parse` honors $GIT_WORK_TREE and $GIT_DIR, so a value exported by a git
+# hook or a wrapper used to make the resolver describe a checkout the caller was
+# not standing in. The git stub honors GIT_WORK_TREE exactly as real git does, so
+# if the library stops scrubbing, the hijacked path surfaces here.
+write_git_stub found
+write_chezmoi_stub ok
+hijack="$work/hijacked-checkout"
+mkdir -p "$hijack"
+# The hijack target must itself look like a source tree. Without the marker, a
+# resolver that FAILED to scrub would reject the hijacked top, fall through to the
+# configured-source rule, and land back on the right answer by accident, so the
+# case would pass while pinning nothing. Verified: dropping the scrub in the
+# library fails this case only once the marker is here.
+: >"$hijack/.chezmoiversion"
+status=0
+output="$(
+  PATH="$stub_bin:$PATH" LIB="$LIB" GIT_WORK_TREE="$hijack" GIT_DIR="$hijack/.git" bash -c '
+    unset MACOS_DEFAULTS_SOURCE_DIR
+    source "$LIB"
+    resolve_source_dir
+  ' 2>"$work/err"
+)" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "git context: resolution must still succeed with GIT_WORK_TREE set (got $status, stderr: $(cat "$work/err"))"
+[[ $output == "$worktree_top" ]] ||
+  fail "git context: an inherited GIT_WORK_TREE must not retarget the resolver (got '$output', wanted '$worktree_top')"
+
+# ---- case 6: a source tree with NO data file resolves to ITSELF -------------
+# Identity and data-file presence are different questions. Keying identity on the
+# data file made an absent file look like "some unrelated directory", so the
+# resolver silently fell through to whichever other checkout did have one. The
+# tree must resolve to itself and let the readable-file guard report the miss.
+write_git_stub found "$markerless_data"
+write_chezmoi_stub ok
+status=0
+output="$(call_lib resolve_source_dir)" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "marked tree without data: resolution must succeed (got $status, stderr: $(cat "$work/err"))"
+[[ $output == "$markerless_data" ]] ||
+  fail "marked tree without data: must resolve to ITSELF, not fall through to another checkout (got '$output', wanted '$markerless_data')"
+
+# ---- case 7: an override that is SET BUT EMPTY is rejected ------------------
+# Treating set-but-empty as unset silently resolved a different checkout, which is
+# a fall-through the resolver's contract forbids.
+write_git_stub found
+write_chezmoi_stub ok
+status=0
+output="$(call_lib_with_override resolve_source_dir '')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "empty override: a set-but-empty MACOS_DEFAULTS_SOURCE_DIR must be rejected, not skipped (got 0, stdout: '$output')"
+grep -qF 'set but empty' "$work/err" ||
+  fail "empty override: the library must name the empty override (stderr: $(cat "$work/err"))"
+[[ -z $output ]] ||
+  fail "empty override: a rejected override must print no directory (got '$output')"
+
+# ---- case 8: every record field maps to its documented column ---------------
+# defaults_records_tsv is the one function all three tools share, so a field-order
+# or field-selection slip in its yq expression corrupts every tool at once. The
+# per-field assertions below fail on any swap; a whole-line substring match would
+# not, because a swapped domain and key still contain both strings.
+records_yaml="$work/records.yaml"
+cat >"$records_yaml" <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.alpha
+      key: AlphaKey
+      type: bool
+      value: "true"
+      host: currentHost
+    - domain: com.example.beta
+      key: BetaKey
+      type: string
+      value: BetaValue
+EOF
+status=0
+records="$(bash -c 'source "$1"; defaults_records_tsv "$2"' _ "$LIB" "$records_yaml" 2>"$work/err")" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "record shape: defaults_records_tsv must succeed on a well-formed file (got $status, stderr: $(cat "$work/err"))"
+
+line_one="$(printf '%s\n' "$records" | sed -n '1p')"
+IFS=$'\t' read -r got_domain got_key got_type got_value got_host <<<"$line_one"
+[[ $got_domain == com.example.alpha ]] || fail "record shape: column 1 must be the domain (got '$got_domain')"
+[[ $got_key == AlphaKey ]] || fail "record shape: column 2 must be the key (got '$got_key')"
+[[ $got_type == bool ]] || fail "record shape: column 3 must be the type (got '$got_type')"
+[[ $got_value == true ]] || fail "record shape: column 4 must be the value (got '$got_value')"
+[[ $got_host == currentHost ]] || fail "record shape: column 5 must be the host (got '$got_host')"
+
+# A record with no host must still yield the other four columns, with host empty.
+line_two="$(printf '%s\n' "$records" | sed -n '2p')"
+IFS=$'\t' read -r got_domain got_key got_type got_value got_host <<<"$line_two"
+[[ $got_domain == com.example.beta ]] || fail "record shape: hostless column 1 must be the domain (got '$got_domain')"
+[[ $got_key == BetaKey ]] || fail "record shape: hostless column 2 must be the key (got '$got_key')"
+[[ $got_type == string ]] || fail "record shape: hostless column 3 must be the type (got '$got_type')"
+[[ $got_value == BetaValue ]] || fail "record shape: hostless column 4 must be the value (got '$got_value')"
+[[ -z $got_host ]] || fail "record shape: an absent host must read back empty (got '$got_host')"
+
+printf 'macos-defaults-source-path-propagation: OK (control resolves; both branches propagate a failed source-path; an empty resolution fails closed with status 2; an inherited git context cannot retarget; a marked tree without data resolves to itself; a set-but-empty override is rejected; every record column maps to its documented field)\n'


### PR DESCRIPTION
## Context

Three scripts manage the tracked macOS settings: one applies them, one captures a setting into the
tracked data, and one reports drift. Each carried its own copy of the logic for finding the data file,
and each resolved it by hardcoding a path into the primary checkout.

That hardcoded path is wrong whenever the operator is standing somewhere else. Run any of the three from
a git worktree and it silently reads and writes the primary instead, so a capture lands in a file nobody
is looking at and a drift report describes settings from another branch. This shares the logic in one
library and resolves the directory from the current context instead.

## Summary

- The three tools share one library instead of three copies of the same logic.
- A run from any worktree now targets that worktree, not a hardcoded checkout.
- Closes four ways resolution could still silently land on the wrong checkout.
- Pins the exit status, error text and record shape that review proved were unpinned.
- The suite no longer inherits the caller's environment, which made it fail under the pre-push hook.

Key files: `dot_local/bin/macos-defaults-lib.sh` (new), the three `macos-defaults-*` tools,
`test/unit/macos-defaults-source-path-propagation.sh`, `test/integration/macos-defaults-source-path.sh`.

## The four ways resolution still went wrong

Found by adversarial review after the first version, each reproduced before being fixed. All four
contradicted the resolver's own comment, which promised that every failure returns an error rather than
falling through to the next rule.

The largest was a conflated question. Identity was decided by asking "does this directory have
macos_defaults.yaml?", which is not the same as "am I in the source tree?". A source tree whose data file
was missing therefore looked like an unrelated directory, so resolution fell through and landed on
whichever other checkout did have one. That is the exact bug this work exists to end, reintroduced
through the back door. Identity now comes from the `.chezmoiversion` marker, and a tree with no data file
resolves to itself and reports the missing file for the tree the caller is actually in.

Two more came from inherited state. `git rev-parse` honors `GIT_DIR` and `GIT_WORK_TREE`, so a value
exported by a git hook or a wrapper made the resolver describe a checkout the caller was not in, and an
invalid `GIT_DIR` made the lookup fail and fall through to the same wrong answer. Both are now unset at
the point of use, binding the answer to the physical directory.

The last: an override that was set but empty was treated as unset and skipped, quietly resolving another
checkout rather than rejecting a malformed configuration.

## What review proved the tests were not catching

Four separate mutations to the production code passed the suite before this round. Each is now caught.

The one that mattered most was the shared record reader, the single function all three tools depend on.
Swapping two fields in it went unnoticed, which means a typo there would have written every tracked
setting under the wrong domain, in all three tools at once. Consolidating three copies into one removed
duplication but concentrated the blast radius, and the concentrated version had no coverage of its own.

The others: two error-message assertions were satisfied by a stub's own output rather than the library's,
so deleting the library's diagnostic entirely still passed; the documented exit status was asserted as
merely nonzero and could drift to any value; and only one of the three call sites of the returning
readable-file guard was exercised, leaving the other two free to drop propagation.

## How it was reviewed

Two independent reviewers, one on resolution correctness and one on whether the tests could fail, then
every finding reproduced before being accepted. Every assertion added here was mutation-verified against
an unmutated control, so a dead harness could not be mistaken for a passing one.

That discipline caught a mistake in this change itself. The first regression test written for the
inherited-context fix passed against the deliberately broken library: the hijack target lacked the
marker, so a resolver that failed to scrub rejected it and fell through to the right answer by accident.
Green, and protecting nothing. The fixture was corrected and the case now fails as intended.

The pre-push gate then caught a second one that no local run reproduced. Git exports `GIT_DIR` to every
hook, and the sandbox setup inherited it, so `git init` targeted that directory and the sandbox never
became a repository at all. The environment is now scrubbed at script scope, before the first git call,
and the suite was confirmed against a plain run, a run with `GIT_DIR` set, and a run with `GIT_DIR`,
`GIT_WORK_TREE` and an inherited override set together.

## Carried unchanged, deliberately

The shared record reader splits fields on tab, and tab is treated as whitespace, so runs of tabs collapse
and only a trailing empty field survives. A record with an empty value would shift the following field
left. No tracked record has an empty value today, so this is latent rather than live, and it predates
this change. It is documented in the code and fixed in its own slice, where the extraction makes it a
one-place change rather than three.

## Effect of merging

Advances `main` only. The live machine follows another branch, so its behavior does not change until a
later cutover.
