### PR TITLE
fix(brew): declare the two endpoint-security casks so cleanup cannot remove them

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -181,6 +181,7 @@ packages:
         - google-chrome
         - karabiner-elements
         - keepassxc
+        - lulu
         - lunar
         - mediosz/tap/swipeaerospace
         - microsoft-auto-update
@@ -191,6 +192,7 @@ packages:
         - obsidian
         - openemu
         - osquery
+        - oversight
         - proton-drive
         - proton-mail
         - proton-mail-bridge


### PR DESCRIPTION
## Context

Package installation on this machine is declarative. A data file lists every formula and cask that should
be present, and the install step runs the package manager's bundle command with cleanup enabled, which
removes anything installed that the list does not name.

Two endpoint-security applications are installed and running on this machine but appear nowhere in that
list on this branch: an outbound traffic filter and a camera and microphone monitor. Nothing is wrong today
because the live machine applies from a different branch that does declare them. The moment the machine is
pointed at this one, the cleanup step would uninstall both.

## Summary

- Declares the outbound traffic filter and the camera and microphone monitor as casks.
- Removes the only path by which the branch cutover would uninstall two running security tools.
- Two lines in one data file, no behavior change on any machine today.

Key files: `.chezmoidata/system_packages_autoinstall.yaml`.

## Why this ships on its own

It is a live hazard rather than a dependency. Nothing later in the project waits on it, and it waits on
nothing, so holding it inside a larger change would only extend the window in which the cutover is unsafe.
Configuring these two applications is separate work with its own slices; this change only ensures they
survive.

Both entries were placed in alphabetical order, which puts one of them in a different position than the
branch the live machine currently follows. That branch has it out of order. This one is correct, and the
list is otherwise strictly sorted.

## Verified rather than assumed

Both applications were confirmed installed through the package manager and present on disk, using
read-only commands only. No package was installed, removed, or upgraded to produce this change. The
uninstall risk was confirmed by reading the install script's own description of its cleanup behavior
rather than inferred from the flag name.

No test asserts anything about the contents of this data file. The nearest existing coverage validates that
the file parses and exercises the runner's logic rather than its data, so a two-line data addition gets no
new harness.

## Found while verifying, not fixed here

Five more packages are installed on this machine and undeclared on this branch, carrying the same
uninstall risk: three casks and two formulae, one of which also needs its source repository added to two
separate trust lists before it would install at all, and another of which is an upstream rename of a
package the list still declares under its old name. Each needs different handling, so they are tracked
separately rather than folded in here.

## Effect of merging

No machine changes. The live machine follows another branch and already has both applications declared.
This removes a hazard that would otherwise appear at cutover.
