### PR TITLE
feat(macos-defaults): support system-scope records in the defaults tooling

### DIFF
--- a/.chezmoidata/macos_defaults.yaml
+++ b/.chezmoidata/macos_defaults.yaml
@@ -9,6 +9,14 @@
 #     type:   bool|int|float|string
 #     value:  <scalar>   # must match `type`
 #     host:   current    # OPTIONAL, if set, runner uses `defaults -currentHost`
+#     scope:  user|system  # OPTIONAL, absent means user. A system record is
+#                          # written with sudo to a root-owned plist,
+#                          # /Library/Preferences/<domain> by default. Cannot
+#                          # be combined with `host` (ByHost is per-user).
+#     plist_path: <path>   # OPTIONAL, system scope only: an explicit ABSOLUTE
+#                          # plist path for a product that stores preferences
+#                          # outside /Library/Preferences (e.g. LuLu).
+#                          # Relative paths are rejected.
 #
 # Each entry in `killall:` runs after the defaults loop. cfprefsd is required
 # for changes to take effect immediately (long-standing macOS plist-cache

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -10,9 +10,45 @@ set -euo pipefail
 # Settings and writes them back on close, silently overwriting our writes.
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
+{{ $hasSystemScopeRecord := false -}}
+{{- /* Scope pass: validate every record's optional scope field and detect
+whether any record is system-scope. The field is read through hasKey/index,
+NEVER the bare dotted-field form: Go's text/template errors with `map has no
+entry for key "scope"` on that form when a record omits the key, which is the
+common case (same class of bug as the `index . "host"` guard below). An
+absent field means user scope; a present field must be exactly user or
+system, and system cannot pair with host (ByHost storage is per-user). */ -}}
+{{ range .macos.defaults -}}
+{{ $scope := "user" -}}
+{{ if hasKey . "scope" }}{{ $scope = index . "scope" }}{{ end -}}
+{{ if and (ne $scope "user") (ne $scope "system") -}}
+{{ fail (printf "macos_defaults.yaml: unknown scope %q on record %s %s (expected user or system)" $scope .domain .key) -}}
+{{ end -}}
+{{ if and (eq $scope "system") (index . "host") -}}
+{{ fail (printf "macos_defaults.yaml: record %s %s combines scope system with host; ByHost storage is per-user" .domain .key) -}}
+{{ end -}}
+{{ if eq $scope "system" }}{{ $hasSystemScopeRecord = true }}{{ end -}}
+{{ end -}}
+{{ if $hasSystemScopeRecord -}}
+# Sudo prelude: at least one record targets a root-owned system plist, so
+# validate sudo once, up front, before any write.
+sudo -v
+{{ end -}}
 # Main loop: one `defaults write` per record.
 {{ range .macos.defaults -}}
+{{ $scope := "user" -}}
+{{ if hasKey . "scope" }}{{ $scope = index . "scope" }}{{ end -}}
+{{ if eq $scope "system" -}}
+{{- /* An absent or empty plist_path means the default system location; a
+declared path must be absolute, never resolved against a working directory. */ -}}
+{{ $plistPath := index . "plist_path" | default (printf "/Library/Preferences/%s" .domain) -}}
+{{ if not (hasPrefix "/" $plistPath) -}}
+{{ fail (printf "macos_defaults.yaml: relative plist_path %q on record %s %s; an absolute path is required" $plistPath .domain .key) -}}
+{{ end -}}
+sudo defaults write {{ $plistPath | quote }} {{ .key | quote }} -{{ .type }} {{ .value | quote }}
+{{ else -}}
 defaults {{ if index . "host" }}-currentHost {{ end }}write {{ .domain | quote }} {{ .key | quote }} -{{ .type }} {{ .value | quote }}
+{{ end -}}
 {{ end -}}
 
 # Post-loop: restart user-facing processes so changes take effect immediately.

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -54,6 +54,31 @@ the only thing guarding the type. */ -}}
 {{ if not (has .type (list "array" "bool" "data" "date" "dict" "float" "int" "string")) -}}
 {{ fail (printf "macos_defaults.yaml: unsupported type %q on record %s %s; expected one of array bool data date dict float int string" .type .domain .key) -}}
 {{ end -}}
+{{- /* A blank YAML scalar parses as nil, and `toString nil` is the literal text
+"<nil>". Left alone, a mistyped `value:` would be WRITTEN, as root on a system
+record, as the four characters <nil>. The previous quoting happened to render
+nothing there, which made `defaults` reject the line and abort the run, so
+silently accepting it now would be a fail-open regression rather than a new
+convenience. Reject it instead, which is louder than either behavior and says
+which field is at fault. An empty STRING is still legitimate and unaffected: it
+is a value, not a missing one. */ -}}
+{{ $record := . -}}
+{{ range $blankField := list "domain" "key" "value" -}}
+{{ if kindIs "invalid" (index $record $blankField) -}}
+{{ fail (printf "macos_defaults.yaml: record %v %v has a blank %s; give it a value or remove the field" (index $record "domain") (index $record "key") $blankField) -}}
+{{ end -}}
+{{ end -}}
+{{- /* The shared library refuses a whole data file whose record stream would be
+ambiguous, because a newline or a unit separator inside a field can forge a
+second record. Without the same rule here, one file would RENDER cleanly and
+then make every tool refuse it, and the operator would learn about it from a
+broken `just D` rather than at apply time. Reject at the same boundary. */ -}}
+{{ range $streamField := list "domain" "key" "value" "plist_path" -}}
+{{ $streamValue := toString (index $record $streamField | default "") -}}
+{{ if or (contains "\n" $streamValue) (contains "\x1f" $streamValue) -}}
+{{ fail (printf "macos_defaults.yaml: record %v %v has a %s containing a newline or a unit separator, which the record stream cannot represent unambiguously" (index $record "domain") (index $record "key") $streamField) -}}
+{{ end -}}
+{{ end -}}
 {{- /* A plist_path is meaningful only for a system record. The shared tools
 reject the pairing already; without this the template would silently IGNORE the
 declared path and write the user domain, which is a malformed record producing a

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -27,6 +27,38 @@ system, and system cannot pair with host (ByHost storage is per-user). */ -}}
 {{ if and (eq $scope "system") (index . "host") -}}
 {{ fail (printf "macos_defaults.yaml: record %s %s combines scope system with host; ByHost storage is per-user" .domain .key) -}}
 {{ end -}}
+{{- /* The type is the ONE field rendered into shell source unquoted, because it
+becomes an option word (-bool, -int). Unquoted interpolation of data into shell
+syntax is command injection: a type of `bool true; some-command #` renders a
+valid write followed by an attacker's command, and on a system record that runs
+under the sudo credential the prelude just cached. Quoting is not the fix, since
+`defaults` needs a bare option word, so the type is constrained to a closed set
+instead. Everything else on these lines goes through `quote`. */ -}}
+{{ if not (has .type (list "array" "bool" "data" "date" "dict" "float" "int" "string")) -}}
+{{ fail (printf "macos_defaults.yaml: unsupported type %q on record %s %s; expected one of array bool data date dict float int string" .type .domain .key) -}}
+{{ end -}}
+{{- /* A plist_path is meaningful only for a system record. The shared tools
+reject the pairing already; without this the template would silently IGNORE the
+declared path and write the user domain, which is a malformed record producing a
+plausible-looking result. */ -}}
+{{ if and (ne $scope "system") (index . "plist_path") -}}
+{{ fail (printf "macos_defaults.yaml: record %s %s declares plist_path outside scope system" .domain .key) -}}
+{{ end -}}
+{{- /* Containment. `hasPrefix "/"` answers "does this start with a slash", which
+is a PROXY for the real question, "does this resolve where I intend to write".
+They diverge exactly where it matters: /Library/Preferences/../../etc/x starts
+with a slash and resolves to /etc/x, written as root. A defaults domain is
+reverse-DNS and never legitimately contains a slash, so rejecting one keeps the
+default construction contained by construction rather than by a later check. */ -}}
+{{ if eq $scope "system" -}}
+{{ if contains "/" .domain -}}
+{{ fail (printf "macos_defaults.yaml: system-scope domain %q on record %s contains a slash; it would escape the default plist directory" .domain .key) -}}
+{{ end -}}
+{{ $declaredPath := index . "plist_path" | default "" -}}
+{{ if or (hasPrefix "../" $declaredPath) (contains "/../" $declaredPath) (hasSuffix "/.." $declaredPath) -}}
+{{ fail (printf "macos_defaults.yaml: system-scope plist_path %q on record %s %s contains a parent-directory component" $declaredPath .domain .key) -}}
+{{ end -}}
+{{ end -}}
 {{ if eq $scope "system" }}{{ $hasSystemScopeRecord = true }}{{ end -}}
 {{ end -}}
 {{ if $hasSystemScopeRecord -}}

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -1,3 +1,16 @@
+{{- /* shellSingleQuoted, the one place a data field becomes a shell word. It
+wraps the value in POSIX single quotes and rewrites every embedded single quote
+as the four characters '\'' (close, escaped quote, reopen). Bash performs NO
+expansion of any kind inside single quotes, so a field carrying $(...), a
+backtick or $VAR arrives at `defaults` as literal text.
+Two near-misses this deliberately avoids. sprig's `quote` emits a Go %q
+DOUBLE-quoted string: it escapes " and \, so nothing can break OUT of the
+quotes, but bash still expands $(...), backticks and $VAR INSIDE them, so a
+value of $(id -un) executed. sprig's `squote` wraps in single quotes WITHOUT
+escaping embedded ones, so a value containing an apostrophe breaks out.
+Defined at file scope because Go's text/template only accepts {{ define }} at
+the top level of a file, never nested inside an action. */ -}}
+{{- define "shellSingleQuoted" }}{{ printf "'%s'" (replace "'" "'\\''" (toString .)) }}{{ end -}}
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # Tier 1, macOS user defaults runner.
@@ -33,7 +46,11 @@ syntax is command injection: a type of `bool true; some-command #` renders a
 valid write followed by an attacker's command, and on a system record that runs
 under the sudo credential the prelude just cached. Quoting is not the fix, since
 `defaults` needs a bare option word, so the type is constrained to a closed set
-instead. Everything else on these lines goes through `quote`. */ -}}
+instead. Every OTHER field goes through the shellSingleQuoted template defined
+at the top of this file, which stops bash from expanding anything inside it.
+What that does NOT promise: the field still reaches `defaults` as an argument,
+so it must still be a value `defaults` accepts, and the closed set above remains
+the only thing guarding the type. */ -}}
 {{ if not (has .type (list "array" "bool" "data" "date" "dict" "float" "int" "string")) -}}
 {{ fail (printf "macos_defaults.yaml: unsupported type %q on record %s %s; expected one of array bool data date dict float int string" .type .domain .key) -}}
 {{ end -}}
@@ -54,9 +71,20 @@ default construction contained by construction rather than by a later check. */ 
 {{ if contains "/" .domain -}}
 {{ fail (printf "macos_defaults.yaml: system-scope domain %q on record %s contains a slash; it would escape the default plist directory" .domain .key) -}}
 {{ end -}}
+{{- /* Degenerate targets. A domain that is empty or nothing but dots resolves
+to /Library/Preferences/, /Library/Preferences/. or /Library/Preferences/..,
+none of which escape the directory (`defaults` appends .plist) and none of which
+name a file anybody meant to write. Hygiene, not containment, but the stated
+rule is "does this resolve where I intend to write" and these do not. */ -}}
+{{ if eq (trimAll "." .domain) "" -}}
+{{ fail (printf "macos_defaults.yaml: system-scope domain %q on record %s is empty or nothing but dots; it names no plist" .domain .key) -}}
+{{ end -}}
 {{ $declaredPath := index . "plist_path" | default "" -}}
 {{ if or (hasPrefix "../" $declaredPath) (contains "/../" $declaredPath) (hasSuffix "/.." $declaredPath) -}}
 {{ fail (printf "macos_defaults.yaml: system-scope plist_path %q on record %s %s contains a parent-directory component" $declaredPath .domain .key) -}}
+{{ end -}}
+{{ if eq $declaredPath "/" -}}
+{{ fail (printf "macos_defaults.yaml: system-scope plist_path %q on record %s %s is the filesystem root; it names no plist" $declaredPath .domain .key) -}}
 {{ end -}}
 {{ end -}}
 {{ if eq $scope "system" }}{{ $hasSystemScopeRecord = true }}{{ end -}}
@@ -77,15 +105,15 @@ declared path must be absolute, never resolved against a working directory. */ -
 {{ if not (hasPrefix "/" $plistPath) -}}
 {{ fail (printf "macos_defaults.yaml: relative plist_path %q on record %s %s; an absolute path is required" $plistPath .domain .key) -}}
 {{ end -}}
-sudo defaults write {{ $plistPath | quote }} {{ .key | quote }} -{{ .type }} {{ .value | quote }}
+sudo defaults write {{ template "shellSingleQuoted" $plistPath }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
 {{ else -}}
-defaults {{ if index . "host" }}-currentHost {{ end }}write {{ .domain | quote }} {{ .key | quote }} -{{ .type }} {{ .value | quote }}
+defaults {{ if index . "host" }}-currentHost {{ end }}write {{ template "shellSingleQuoted" .domain }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
 {{ end -}}
 {{ end -}}
 
 # Post-loop: restart user-facing processes so changes take effect immediately.
 # cfprefsd kill is non-negotiable (caches plist values in memory).
 {{ range .macos.killall -}}
-killall {{ . | quote }} 2>/dev/null || true
+killall {{ template "shellSingleQuoted" . }} 2>/dev/null || true
 {{ end }}
 {{- end }}

--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -18,11 +18,19 @@ require_readable_data_file "$DATA_FILE" || exit $?
 # Pre-flight: close System Settings if open (same reason as runner).
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
-# Main loop: one `defaults write` per record.
-defaults_records_tsv "$DATA_FILE" |
-  while IFS=$'\t' read -r domain key type value host; do
+# Main loop: one `defaults write` per record. A system-scope record goes
+# through sudo to its resolved plist path; user-scope records write exactly as
+# before. A record that fails validation (unknown scope, a meaningless field
+# pairing, a relative plist_path) aborts the run with the data-file status 2
+# before anything is written for it.
+defaults_records_unit_separated "$DATA_FILE" |
+  while IFS=$'\x1f' read -r domain key type value host scope plist_path; do
     [[ -z $domain ]] && continue
-    if [[ -n $host ]]; then
+    scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
+    if [[ $scope == system ]]; then
+      resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2
+      system_defaults_write "$resolved_plist_path" "$key" "$type" "$value"
+    elif [[ -n $host ]]; then
       defaults -currentHost write "$domain" "$key" "-$type" "$value"
     else
       defaults write "$domain" "$key" "-$type" "$value"

--- a/dot_local/bin/executable_macos-defaults-capture.sh
+++ b/dot_local/bin/executable_macos-defaults-capture.sh
@@ -7,7 +7,11 @@
 # is already tracked but the live value DIVERGES: exit 4 (drift), resolve
 # via `just defaults-apply` (revert) or hand-edit YAML (capture intent).
 #
-# Usage: macos-defaults-capture.sh <domain> <key> [--host current]
+# Usage: macos-defaults-capture.sh <domain> <key> [--host current] [--scope user|system]
+#
+# --scope system captures from the record's system plist path
+# (/Library/Preferences/<domain>) and appends the record with `scope: system`.
+# It cannot be combined with --host current: ByHost storage is per-user.
 #
 # Exit codes:
 #   0: appended, or already in sync
@@ -22,11 +26,11 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
 
 usage() {
-  printf 'usage: macos-defaults-capture <domain> <key> [--host current]\n' >&2
+  printf 'usage: macos-defaults-capture <domain> <key> [--host current] [--scope user|system]\n' >&2
   exit 3
 }
 
-[[ $# -lt 2 || $# -gt 4 ]] && usage
+[[ $# -lt 2 || $# -gt 6 ]] && usage
 
 domain="$1"
 key="$2"
@@ -36,7 +40,11 @@ shift 2
 #   --host=current  (single token, what the justfile recipe emits)
 #   --host current  (two tokens, what a direct CLI invocation might use)
 #   (omitted)       (global storage, no -currentHost flag)
+# Optional scope argument, same two spellings, defaulting to user. The value
+# is validated below AFTER parsing, so a set-but-empty --scope '' is rejected
+# rather than silently treated as the default.
 host=""
+scope="user"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --host=current)
@@ -48,11 +56,29 @@ while [[ $# -gt 0 ]]; do
       host="current"
       shift 2
       ;;
+    --scope=*)
+      scope="${1#*=}"
+      shift
+      ;;
+    --scope)
+      [[ $# -lt 2 ]] && usage
+      scope="$2"
+      shift 2
+      ;;
     *)
       usage
       ;;
   esac
 done
+
+# Scope validation is the shared library's: the scope enum, and the rule that
+# system scope cannot pair with ByHost storage (per-user by definition). The
+# library prints the reason; any refusal is a malformed invocation here, so it
+# maps to exit 3.
+if ! validate_record_scope "$scope" "$host" "" >/dev/null; then
+  printf 'error: rejected --scope %s combined with --host %s\n' "${scope:-''}" "${host:-''}" >&2
+  exit 3
+fi
 
 # Reject domain/key with characters outside the reverse-DNS / identifier set.
 # Defends against yq-expression injection via crafted inputs even though
@@ -71,11 +97,17 @@ done
 DATA_FILE="$(macos_defaults_data_file)" || exit $?
 require_readable_data_file "$DATA_FILE" || exit $?
 
-# Read live type. `defaults read-type` outputs e.g. "Type is boolean".
+# Read live type. `defaults read-type` outputs e.g. "Type is boolean". A
+# system-scope capture reads from the record's resolved system plist path
+# (readable without sudo; /Library/Preferences is world-readable).
 host_flag=()
 [[ -n $host ]] && host_flag=(-currentHost)
+read_target="$domain"
+if [[ $scope == system ]]; then
+  read_target="$(resolve_system_plist_path "$domain" "")"
+fi
 
-if ! raw_type="$(defaults "${host_flag[@]}" read-type "$domain" "$key" 2>/dev/null)"; then
+if ! raw_type="$(defaults "${host_flag[@]}" read-type "$read_target" "$key" 2>/dev/null)"; then
   printf 'error: %s %s is not currently set on this Mac\n' "$domain" "$key" >&2
   exit 1
 fi
@@ -92,7 +124,7 @@ case "$raw_type" in
     ;;
 esac
 
-raw_value="$(defaults "${host_flag[@]}" read "$domain" "$key")"
+raw_value="$(defaults "${host_flag[@]}" read "$read_target" "$key")"
 
 # Normalize for YAML emission.
 case "$schema_type" in
@@ -112,9 +144,12 @@ case "$schema_type" in
     ;;
 esac
 
-# Check whether (domain, key, host) is already in the YAML.
+# Check whether (domain, key, host, scope) is already in the YAML. Scope is
+# part of the identity: the same domain/key may be tracked at user scope AND
+# at system scope, and a scope-blind match would answer "already tracked" and
+# silently skip the append.
 existing_value="$(yq eval -r \
-  ".macos.defaults[] | select(.domain == \"$domain\" and .key == \"$key\" and ((.host // \"\") == \"$host\")) | .value" \
+  ".macos.defaults[] | select(.domain == \"$domain\" and .key == \"$key\" and ((.host // \"\") == \"$host\") and ((.scope // \"user\") == \"$scope\")) | .value" \
   "$DATA_FILE")"
 
 if [[ -n $existing_value ]]; then
@@ -152,11 +187,12 @@ tmp="$(mktemp "${DATA_FILE}.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 
 yq eval \
-  ".macos.defaults += [{\"domain\": \"$domain\", \"key\": \"$key\", \"type\": \"$schema_type\", \"value\": $yaml_value$([[ -n $host ]] && printf ', "host": "%s"' "$host")}]" \
+  ".macos.defaults += [{\"domain\": \"$domain\", \"key\": \"$key\", \"type\": \"$schema_type\", \"value\": $yaml_value$([[ -n $host ]] && printf ', "host": "%s"' "$host")$([[ $scope == system ]] && printf ', "scope": "system"')}]" \
   "$DATA_FILE" >"$tmp"
 
 mv "$tmp" "$DATA_FILE"
 trap - EXIT
 
-printf 'captured: %s %s = %s (type=%s%s)\n' "$domain" "$key" "$raw_value" "$schema_type" \
-  "$([[ -n $host ]] && printf ' host=%s' "$host")"
+printf 'captured: %s %s = %s (type=%s%s%s)\n' "$domain" "$key" "$raw_value" "$schema_type" \
+  "$([[ -n $host ]] && printf ' host=%s' "$host")" \
+  "$([[ $scope == system ]] && printf ' scope=system')"

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -2,13 +2,17 @@
 # macos-defaults-drift.sh, read-only drift checker for tracked macOS defaults.
 #
 # Compares each record in .chezmoidata/macos_defaults.yaml against the live
-# value via `defaults [-currentHost] read`. Prints a tab-aligned table of
-# drifted rows only. Never writes.
+# value via `defaults [-currentHost] read` (user scope) or a read of the
+# record's resolved system plist path (system scope). Prints a tab-aligned
+# table of drifted rows, plus one row per INDETERMINATE system-scope record:
+# a plist this user cannot read gets the <unreadable> marker, distinct from
+# <unset>, and is counted separately, never as drift and never skipped.
+# Never writes.
 #
 # Exit codes:
-#   0: no drift
+#   0: no drift (indeterminate rows, if any, are reported but not counted)
 #   1: drift detected
-#   2: data file missing or unreadable
+#   2: data file missing or unreadable, or a record failed validation
 
 set -euo pipefail
 shopt -s lastpipe
@@ -35,7 +39,11 @@ normalize() {
   esac
 }
 
+# Both counters mutate inside the pipeline's while loop, which is why lastpipe
+# is required above: without it the loop runs in a subshell and both would
+# read 0 after the loop, a silent false negative.
 drift_count=0
+indeterminate_count=0
 header_printed=0
 print_header() {
   if ((header_printed == 0)); then
@@ -44,14 +52,30 @@ print_header() {
   fi
 }
 
-# Each record arrives as one TSV line: domain<TAB>key<TAB>type<TAB>value<TAB>host.
+# Each record arrives as one unit-separated line: domain, key, type, value,
+# host, scope, plist_path. A record that fails validation (unknown scope, a
+# meaningless field pairing, a relative plist_path) aborts with the data-file
+# status 2 rather than being misread. A system-scope record has THREE read
+# outcomes: the value, <unset> (genuinely not set, compared as drift like any
+# other value), and <unreadable> (indeterminate: reported as its own row,
+# counted separately, never as drift and never skipped).
 # Note: yq emits a single newline for an empty array; the inline guard below
 # skips that empty row so the script exits 0 cleanly when nothing is tracked.
-defaults_records_tsv "$DATA_FILE" |
-  while IFS=$'\t' read -r domain key type value host; do
+defaults_records_unit_separated "$DATA_FILE" |
+  while IFS=$'\x1f' read -r domain key type value host scope plist_path; do
     [[ -z $domain ]] && continue
+    scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
     expected="$(normalize "$type" "$value")"
-    if [[ -n $host ]]; then
+    if [[ $scope == system ]]; then
+      resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2
+      actual="$(system_defaults_read_actual "$resolved_plist_path" "$key")"
+      if [[ $actual == '<unreadable>' ]]; then
+        print_header
+        printf '%s\t%s\t%s\t%s\n' "$domain" "$key" "$expected" '<unreadable>'
+        indeterminate_count=$((indeterminate_count + 1))
+        continue
+      fi
+    elif [[ -n $host ]]; then
       actual="$(defaults -currentHost read "$domain" "$key" 2>/dev/null || printf '<unset>')"
     else
       actual="$(defaults read "$domain" "$key" 2>/dev/null || printf '<unset>')"
@@ -63,6 +87,9 @@ defaults_records_tsv "$DATA_FILE" |
     fi
   done
 
+if ((indeterminate_count > 0)); then
+  printf '\n%d indeterminate row(s): unreadable, not counted as drift.\n' "$indeterminate_count" >&2
+fi
 if ((drift_count > 0)); then
   printf '\n%d drift row(s) detected.\n' "$drift_count" >&2
   exit 1

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -68,12 +68,17 @@ defaults_records_unit_separated "$DATA_FILE" |
     expected="$(normalize "$type" "$value")"
     if [[ $scope == system ]]; then
       resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2
-      actual="$(system_defaults_read_actual "$resolved_plist_path" "$key")"
-      if [[ $actual == '<unreadable>' ]]; then
+      # The outcome arrives as a STATUS, so no live value can impersonate it.
+      read_status=0
+      actual="$(system_defaults_read_actual "$resolved_plist_path" "$key")" || read_status=$?
+      if [[ $read_status -eq $SYSTEM_READ_UNREADABLE ]]; then
         print_header
         printf '%s\t%s\t%s\t%s\n' "$domain" "$key" "$expected" '<unreadable>'
         indeterminate_count=$((indeterminate_count + 1))
         continue
+      fi
+      if [[ $read_status -eq $SYSTEM_READ_UNSET ]]; then
+        actual='<unset>'
       fi
     elif [[ -n $host ]]; then
       actual="$(defaults -currentHost read "$domain" "$key" 2>/dev/null || printf '<unset>')"

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -152,15 +152,6 @@ validate_record_scope() { # <scope> <host> <plist_path>
 # the default, /Library/Preferences/<domain>. A declared path must be
 # ABSOLUTE: a relative path would resolve against whatever directory the tool
 # happens to run from, so it is rejected, never resolved.
-# The three outcomes of reading a system-scope setting, carried as an exit STATUS
-# rather than a marker string. A string sentinel is representable as a real value:
-# a tracked setting whose live value happened to be the marker would be reported
-# indeterminate, hiding both a match and a genuine drift. A status cannot be
-# impersonated by any value, so the two channels stay separate.
-readonly SYSTEM_READ_OK=0
-readonly SYSTEM_READ_UNSET=1
-readonly SYSTEM_READ_UNREADABLE=2
-
 resolve_system_plist_path() { # <domain> <plist_path>
   local domain="$1" plist_path="$2"
   if [[ -z $plist_path ]]; then
@@ -193,6 +184,22 @@ resolve_system_plist_path() { # <domain> <plist_path>
   fi
   printf '%s\n' "$plist_path"
 }
+
+# The three outcomes of reading a system-scope setting, carried as an exit STATUS
+# rather than a marker string. A string sentinel is representable as a real value:
+# a tracked setting whose live value happened to be the marker would be reported
+# indeterminate, hiding both a match and a genuine drift. A status cannot be
+# impersonated by any value, so the two channels stay separate.
+#
+# NOT readonly, deliberately. This file is a library: sourcing it twice must be a
+# no-op, and `readonly` makes the second source's assignment fail. Every tool
+# runs under `set -euo pipefail`, so that failure does not just skip the
+# assignment, it kills the CALLER. Plain assignment also beats `readonly` on the
+# other axis that matters here: it OVERWRITES an inherited value, so a hostile
+# environment cannot hand the tools a different set of status codes.
+SYSTEM_READ_OK=0
+SYSTEM_READ_UNSET=1
+SYSTEM_READ_UNREADABLE=2
 
 # system_defaults_write <plist_path> <key> <type> <value>, one system-scope
 # write. /Library plists are root-owned, so the write goes through sudo;

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -99,6 +99,45 @@ require_readable_data_file() { # <path>
   fi
 }
 
+# defaults_records_join_expression <record-selector>, the yq expression that
+# joins one record selection into SEVEN fields separated by the ASCII unit
+# separator (0x1f): domain, key, type, value, host, scope, plist_path. Shared by
+# the stream below and by the per-record locator, so the two can never drift into
+# describing different records.
+defaults_records_join_expression() { # <record-selector>
+  local unit_separator=$'\x1f'
+  printf '%s | [.domain, .key, .type, .value, (.host // ""), (.scope // "user"), (.plist_path // "")] | join("%s")' \
+    "$1" "$unit_separator"
+}
+
+# defaults_records_field_count <line>, how many unit-separated fields one line
+# carries. Pure bash: the substitution keeps only the separators, so the field
+# count is one more than what is left.
+defaults_records_field_count() { # <line>
+  local unit_separator=$'\x1f'
+  local separators_only="${1//[!$unit_separator]/}"
+  printf '%s' "$((${#separators_only} + 1))"
+}
+
+# defaults_records_locate_malformed <path> <declared-count>, describe the FIRST
+# record that does not render as exactly one seven-field line. Only ever called
+# on the failure path, so its per-record yq calls cost nothing in the normal case.
+defaults_records_locate_malformed() { # <path> <declared-count>
+  local data_file="$1" declared_record_count="$2"
+  local index record_render line_count
+  for ((index = 0; index < declared_record_count; index++)); do
+    record_render="$(yq eval -r "$(defaults_records_join_expression ".macos.defaults[$index]")" "$data_file")" || continue
+    line_count="$(printf '%s\n' "$record_render" | wc -l | tr -d ' ')"
+    if [[ $line_count -ne 1 || $(defaults_records_field_count "$record_render") -ne 7 ]]; then
+      printf 'record %d (domain %s, key %s)' "$index" \
+        "$(yq eval -r ".macos.defaults[$index].domain" "$data_file" | head -1)" \
+        "$(yq eval -r ".macos.defaults[$index].key" "$data_file" | head -1)"
+      return 0
+    fi
+  done
+  printf 'a record this locator could not identify'
+}
+
 # defaults_records_unit_separated <path>, emit each tracked record as one line
 # of SEVEN fields joined by the ASCII unit separator (0x1f):
 #   domain, key, type, value, host, scope, plist_path
@@ -106,14 +145,63 @@ require_readable_data_file() { # <path>
 # "user" here, so a scope that reaches a caller empty was explicitly empty in
 # the record (a record error, rejected by validate_record_scope below). The
 # unit separator is not IFS whitespace, so an empty INTERIOR field survives
-# `IFS=$'\x1f' read` intact, unlike the tab-separated stream above, whose
-# collapse is exactly why the new optional columns do not extend it. A value
-# containing a literal 0x1f byte would still split; no macOS preference value
-# carries one.
+# `IFS=$'\x1f' read` intact, unlike a tab-separated stream, whose collapse is
+# exactly why the optional columns do not extend one.
+#
+# The stream is SELF-VALIDATING, because the separator on its own guarantees
+# nothing. A field value carrying a literal 0x1f byte, a NEWLINE, or both is not
+# a formatting nuisance, it is record forgery. One record whose value was
+#   v<0x1f><0x1f>system<0x1f>\nEVIL.DOMAIN<0x1f>EVILKEY<0x1f>bool<0x1f>true
+# emitted two well-formed-LOOKING lines and made apply perform TWO root writes,
+# the second fully attacker-controlled, while the template rendered only one.
+# Both halves of that payload carry exactly seven fields, so a per-line field
+# count does not catch it on its own. Two checks together do:
+#   - every line must carry exactly seven fields, which catches a separator
+#     injected without a newline;
+#   - the number of emitted lines must equal the number of DECLARED records,
+#     which catches a newline whether or not the halves are balanced.
+# A violation returns 2, the tools' shared "data file unusable" status, names the
+# offending record, and emits NOTHING: a caller must not act on part of a stream
+# it has just been told is malformed. A legitimate multi-line preference value is
+# therefore refused loudly rather than silently corrupted.
 defaults_records_unit_separated() { # <path>
   local data_file="$1"
-  local unit_separator=$'\x1f'
-  yq eval -r ".macos.defaults[] | [.domain, .key, .type, .value, (.host // \"\"), (.scope // \"user\"), (.plist_path // \"\")] | join(\"$unit_separator\")" "$data_file"
+  local declared_record_count raw_records
+  if ! declared_record_count="$(yq eval -r '(.macos.defaults // []) | length' "$data_file")"; then
+    printf 'error: cannot count the records in %s\n' "$data_file" >&2
+    return 2
+  fi
+  if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
+    printf 'error: cannot read the records in %s\n' "$data_file" >&2
+    return 2
+  fi
+
+  local line field_count emitted_line_count=0
+  local -a validated_lines=()
+  while IFS= read -r line; do
+    # yq prints a single empty line for an empty array; that is not a record.
+    [[ -z $line ]] && continue
+    field_count="$(defaults_records_field_count "$line")"
+    if [[ $field_count -ne 7 ]]; then
+      printf 'error: %s: %s renders %s fields, not 7; a field value contains a unit separator (0x1f) or a newline\n' \
+        "$data_file" "$(defaults_records_locate_malformed "$data_file" "$declared_record_count")" \
+        "$field_count" >&2
+      return 2
+    fi
+    validated_lines+=("$line")
+    emitted_line_count=$((emitted_line_count + 1))
+  done <<<"$raw_records"
+
+  if [[ $emitted_line_count -ne $declared_record_count ]]; then
+    printf 'error: %s declares %s record(s) but the record stream has %s line(s); %s contains a newline\n' \
+      "$data_file" "$declared_record_count" "$emitted_line_count" \
+      "$(defaults_records_locate_malformed "$data_file" "$declared_record_count")" >&2
+    return 2
+  fi
+
+  if [[ ${#validated_lines[@]} -gt 0 ]]; then
+    printf '%s\n' "${validated_lines[@]}"
+  fi
 }
 
 # validate_record_scope <scope> <host> <plist_path>, print the validated scope.

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -154,18 +154,39 @@ validate_record_scope() { # <scope> <host> <plist_path>
 # happens to run from, so it is rejected, never resolved.
 resolve_system_plist_path() { # <domain> <plist_path>
   local domain="$1" plist_path="$2"
+  # A defaults domain is reverse-DNS and never legitimately contains a slash.
+  # Rejecting one keeps the default construction inside /Library/Preferences BY
+  # CONSTRUCTION: without it, a domain of ../../tmp/owned resolves to
+  # /Library/Preferences/../../tmp/owned, which is /tmp/owned, written as root.
+  #
+  # Checked for EVERY system-scope record, not only the ones that omit
+  # plist_path. The domain rule is a property of the record, and the template
+  # rejects such a record outright: a library that only checked it on the
+  # default-path branch was the MORE PERMISSIVE of the two consumers, so the same
+  # YAML rendered one way and applied another.
+  if [[ $domain == */* ]]; then
+    printf 'error: system-scope domain %q contains a slash; it would escape %s\n' \
+      "$domain" '/Library/Preferences' >&2
+    return 1
+  fi
+  # Degenerate domains: "", ".", "..", and any run of nothing but dots. None of
+  # them escape a directory (`defaults` appends .plist), so this is hygiene
+  # rather than containment, but none of them name a plist anybody meant to write
+  # either, and the rule this function enforces is "does this resolve where I
+  # intend to write".
+  if [[ -z ${domain//./} ]]; then
+    printf 'error: system-scope domain %q is empty or nothing but dots; it names no plist\n' \
+      "$domain" >&2
+    return 1
+  fi
   if [[ -z $plist_path ]]; then
-    # A defaults domain is reverse-DNS and never legitimately contains a slash.
-    # Rejecting one keeps the default construction inside /Library/Preferences BY
-    # CONSTRUCTION: without it, a domain of ../../tmp/owned resolves to
-    # /Library/Preferences/../../tmp/owned, which is /tmp/owned, written as root.
-    if [[ $domain == */* ]]; then
-      printf 'error: system-scope domain %q contains a slash; it would escape %s\n' \
-        "$domain" '/Library/Preferences' >&2
-      return 1
-    fi
     printf '/Library/Preferences/%s\n' "$domain"
     return 0
+  fi
+  if [[ $plist_path == / ]]; then
+    printf 'error: plist_path %q (domain %s) is the filesystem root; it names no plist\n' \
+      "$plist_path" "$domain" >&2
+    return 1
   fi
   if [[ $plist_path != /* ]]; then
     printf 'error: relative plist_path %q (domain %s); an absolute path is required\n' \

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -208,19 +208,25 @@ system_defaults_write() { # <plist_path> <key> <type> <value>
   sudo defaults write "$1" "$2" "-$3" "$4"
 }
 
-# system_defaults_read_actual <plist_path> <key>, the three-outcome
-# system-scope read for drift. Prints exactly one of:
-#   - the live value, when `defaults read` succeeds;
-#   - "<unset>", ONLY when defaults itself reports the domain/default pair
-#     does not exist, the one failure that genuinely means "not set";
-#   - "<unreadable>", up front when the plist file exists but this user cannot
-#     read it (defaults would answer from a stale cache or misreport), and for
-#     every other read failure. Unknown failures land here, never in
-#     "<unset>": collapsing them would report drift against a value nobody
-#     actually read, and skipping them would hide the record entirely.
-# Always returns 0; the outcome is the printed marker. Documented limit: a
-# plist whose PARENT directory blocks traversal cannot be file-checked, so
-# that case rides on the stderr classification alone.
+# system_defaults_read_actual <plist_path> <key>, the three-outcome system-scope
+# read for drift. The outcome is the EXIT STATUS, named by the constants above,
+# and only ONE of the three prints anything:
+#   - SYSTEM_READ_OK (0): `defaults read` succeeded. The live value is printed on
+#     stdout, with no trailing newline.
+#   - SYSTEM_READ_UNSET (1): `defaults` itself reported the domain/default pair
+#     does not exist, the one failure that genuinely means "not set". Prints
+#     nothing.
+#   - SYSTEM_READ_UNREADABLE (2): indeterminate. Returned up front when the plist
+#     file exists but this user cannot read it (defaults would answer from a
+#     stale cache or misreport), when the temp file that captures defaults'
+#     stderr cannot be created, and for every OTHER read failure. Unknown
+#     failures land here, never in unset: collapsing them would report drift
+#     against a value nobody read, and skipping them would hide the record
+#     entirely. Prints nothing.
+# Turning the outcome into a display marker is the caller's job; that is the
+# whole point of using a status. Documented limit: a plist whose PARENT directory
+# blocks traversal cannot be file-checked, so that case rides on the stderr
+# classification alone.
 system_defaults_read_actual() { # <plist_path> <key>
   local plist_path="$1" key="$2"
   local file_candidate
@@ -231,8 +237,15 @@ system_defaults_read_actual() { # <plist_path> <key>
   done
   local value read_error_file read_status=0
   # A failed mktemp must not become an ambiguous redirect that silently loses the
-  # classifier's only input. Refuse toward indeterminate, the safe direction.
-  read_error_file="$(mktemp)" || return "$SYSTEM_READ_UNREADABLE"
+  # classifier's only input. Refuse toward indeterminate, the safe direction, and
+  # SAY SO: the ambiguous redirect ends at this same status by accident, so
+  # without the message the deliberate refusal and the accident are
+  # indistinguishable to a caller and to a test.
+  if ! read_error_file="$(mktemp)"; then
+    printf 'error: cannot classify the system read of %s %s; mktemp failed\n' \
+      "$plist_path" "$key" >&2
+    return "$SYSTEM_READ_UNREADABLE"
+  fi
   value="$(defaults read "$plist_path" "$key" 2>"$read_error_file")" || read_status=$?
   if [[ $read_status -eq 0 ]]; then
     rm -f "$read_error_file"

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -116,3 +116,116 @@ defaults_records_tsv() { # <path>
   local data_file="$1"
   yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$data_file"
 }
+
+# defaults_records_unit_separated <path>, emit each tracked record as one line
+# of SEVEN fields joined by the ASCII unit separator (0x1f):
+#   domain, key, type, value, host, scope, plist_path
+# host and plist_path are empty when absent; an ABSENT scope defaults to
+# "user" here, so a scope that reaches a caller empty was explicitly empty in
+# the record (a record error, rejected by validate_record_scope below). The
+# unit separator is not IFS whitespace, so an empty INTERIOR field survives
+# `IFS=$'\x1f' read` intact, unlike the tab-separated stream above, whose
+# collapse is exactly why the new optional columns do not extend it. A value
+# containing a literal 0x1f byte would still split; no macOS preference value
+# carries one.
+defaults_records_unit_separated() { # <path>
+  local data_file="$1"
+  local unit_separator=$'\x1f'
+  yq eval -r ".macos.defaults[] | [.domain, .key, .type, .value, (.host // \"\"), (.scope // \"user\"), (.plist_path // \"\")] | join(\"$unit_separator\")" "$data_file"
+}
+
+# validate_record_scope <scope> <host> <plist_path>, print the validated scope.
+# Rejects, with a message and nonzero status, every combination that would
+# otherwise be silently misapplied:
+#   - a scope other than user/system, including the set-but-empty scope ""
+#     (defaults_records_unit_separated already turned an ABSENT field into
+#     "user", so an empty scope here was explicitly empty in the record);
+#   - scope system with a host: ByHost storage is per-user, the pair is
+#     meaningless;
+#   - scope user with a plist_path: the path is only honored on system
+#     records, and accepting it would silently write the user domain instead
+#     of the named file.
+validate_record_scope() { # <scope> <host> <plist_path>
+  local scope="$1" host="$2" plist_path="$3"
+  case "$scope" in
+    user | system) ;;
+    *)
+      printf 'error: unknown scope %q (expected user or system)\n' "$scope" >&2
+      return 1
+      ;;
+  esac
+  if [[ $scope == system && -n $host ]]; then
+    printf 'error: scope system cannot be combined with host %q; ByHost storage is per-user\n' "$host" >&2
+    return 1
+  fi
+  if [[ $scope == user && -n $plist_path ]]; then
+    printf 'error: plist_path %q is only honored on scope system records\n' "$plist_path" >&2
+    return 1
+  fi
+  printf '%s\n' "$scope"
+}
+
+# resolve_system_plist_path <domain> <plist_path>, print the plist path a
+# system-scope record writes to and reads from. An empty declared path means
+# the default, /Library/Preferences/<domain>. A declared path must be
+# ABSOLUTE: a relative path would resolve against whatever directory the tool
+# happens to run from, so it is rejected, never resolved.
+resolve_system_plist_path() { # <domain> <plist_path>
+  local domain="$1" plist_path="$2"
+  if [[ -z $plist_path ]]; then
+    printf '/Library/Preferences/%s\n' "$domain"
+    return 0
+  fi
+  if [[ $plist_path != /* ]]; then
+    printf 'error: relative plist_path %q (domain %s); an absolute path is required\n' \
+      "$plist_path" "$domain" >&2
+    return 1
+  fi
+  printf '%s\n' "$plist_path"
+}
+
+# system_defaults_write <plist_path> <key> <type> <value>, one system-scope
+# write. /Library plists are root-owned, so the write goes through sudo;
+# keeping it here keeps apply and any future caller on one code path.
+system_defaults_write() { # <plist_path> <key> <type> <value>
+  sudo defaults write "$1" "$2" "-$3" "$4"
+}
+
+# system_defaults_read_actual <plist_path> <key>, the three-outcome
+# system-scope read for drift. Prints exactly one of:
+#   - the live value, when `defaults read` succeeds;
+#   - "<unset>", ONLY when defaults itself reports the domain/default pair
+#     does not exist, the one failure that genuinely means "not set";
+#   - "<unreadable>", up front when the plist file exists but this user cannot
+#     read it (defaults would answer from a stale cache or misreport), and for
+#     every other read failure. Unknown failures land here, never in
+#     "<unset>": collapsing them would report drift against a value nobody
+#     actually read, and skipping them would hide the record entirely.
+# Always returns 0; the outcome is the printed marker. Documented limit: a
+# plist whose PARENT directory blocks traversal cannot be file-checked, so
+# that case rides on the stderr classification alone.
+system_defaults_read_actual() { # <plist_path> <key>
+  local plist_path="$1" key="$2"
+  local file_candidate
+  for file_candidate in "$plist_path" "$plist_path.plist"; do
+    if [[ -e $file_candidate && ! -r $file_candidate ]]; then
+      printf '<unreadable>'
+      return 0
+    fi
+  done
+  local value read_error_file read_status=0
+  read_error_file="$(mktemp)"
+  value="$(defaults read "$plist_path" "$key" 2>"$read_error_file")" || read_status=$?
+  if [[ $read_status -eq 0 ]]; then
+    rm -f "$read_error_file"
+    printf '%s' "$value"
+    return 0
+  fi
+  if grep -q 'does not exist' "$read_error_file"; then
+    rm -f "$read_error_file"
+    printf '<unset>'
+    return 0
+  fi
+  rm -f "$read_error_file"
+  printf '<unreadable>'
+}

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -99,24 +99,6 @@ require_readable_data_file() { # <path>
   fi
 }
 
-# defaults_records_tsv <path>, emit each tracked record as one tab-separated line:
-#   domain<TAB>key<TAB>type<TAB>value<TAB>host    (host empty when global).
-# yq emits a single blank line for an empty array, which callers skip.
-#
-# KNOWN LIMITATION, carried unchanged from the pre-extraction code so this
-# refactor stays behavior-preserving. Callers read with IFS=$'\t', and tab is IFS
-# *whitespace*, so bash collapses runs of tabs. Only a TRAILING empty field
-# survives: an empty host reads back empty as intended. An empty INTERIOR field
-# does not. A record with an empty value would collapse its two adjacent tabs and
-# shift host left into value, applying the host string as the setting's value
-# against the global domain. No tracked record has an empty value today, so this
-# is latent rather than live. The fix is a non-whitespace delimiter and is its own
-# slice, which now changes this one function instead of every caller.
-defaults_records_tsv() { # <path>
-  local data_file="$1"
-  yq eval -r '.macos.defaults[] | [.domain, .key, .type, .value, (.host // "")] | @tsv' "$data_file"
-}
-
 # defaults_records_unit_separated <path>, emit each tracked record as one line
 # of SEVEN fields joined by the ASCII unit separator (0x1f):
 #   domain, key, type, value, host, scope, plist_path

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -171,6 +171,19 @@ defaults_records_unit_separated() { # <path>
     printf 'error: cannot count the records in %s\n' "$data_file" >&2
     return 2
   fi
+  # The count is a STRING from yq, and it is about to drive both `((...))` loop
+  # bounds and the `-ne` comparison that catches a forged record. Bash arithmetic
+  # on a non-numeric string raises a syntax error and evaluates FALSE, so the
+  # comparison would fall through and emit the very stream it exists to reject.
+  # A multi-document file is the one input observed to produce a multi-line count,
+  # and it is caught earlier only because yq also prints a separator line that
+  # trips the field-count check. That is the guard holding by accident of another
+  # tool's output format, so bound it here by construction instead.
+  if [[ ! $declared_record_count =~ ^(0|[1-9][0-9]{0,6})$ ]]; then
+    printf 'error: %s produced an unusable record count %q; refusing to emit a stream that cannot be checked\n' \
+      "$data_file" "$declared_record_count" >&2
+    return 2
+  fi
   if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -152,14 +152,42 @@ validate_record_scope() { # <scope> <host> <plist_path>
 # the default, /Library/Preferences/<domain>. A declared path must be
 # ABSOLUTE: a relative path would resolve against whatever directory the tool
 # happens to run from, so it is rejected, never resolved.
+# The three outcomes of reading a system-scope setting, carried as an exit STATUS
+# rather than a marker string. A string sentinel is representable as a real value:
+# a tracked setting whose live value happened to be the marker would be reported
+# indeterminate, hiding both a match and a genuine drift. A status cannot be
+# impersonated by any value, so the two channels stay separate.
+readonly SYSTEM_READ_OK=0
+readonly SYSTEM_READ_UNSET=1
+readonly SYSTEM_READ_UNREADABLE=2
+
 resolve_system_plist_path() { # <domain> <plist_path>
   local domain="$1" plist_path="$2"
   if [[ -z $plist_path ]]; then
+    # A defaults domain is reverse-DNS and never legitimately contains a slash.
+    # Rejecting one keeps the default construction inside /Library/Preferences BY
+    # CONSTRUCTION: without it, a domain of ../../tmp/owned resolves to
+    # /Library/Preferences/../../tmp/owned, which is /tmp/owned, written as root.
+    if [[ $domain == */* ]]; then
+      printf 'error: system-scope domain %q contains a slash; it would escape %s\n' \
+        "$domain" '/Library/Preferences' >&2
+      return 1
+    fi
     printf '/Library/Preferences/%s\n' "$domain"
     return 0
   fi
   if [[ $plist_path != /* ]]; then
     printf 'error: relative plist_path %q (domain %s); an absolute path is required\n' \
+      "$plist_path" "$domain" >&2
+    return 1
+  fi
+  # Leading-slash is a PROXY for "resolves where I intend", and the two diverge
+  # exactly where it matters: /Library/Preferences/../../etc/x passes the check
+  # above and resolves to /etc/x. Reject parent-directory components outright
+  # rather than canonicalizing, so the rejection does not depend on the path
+  # existing yet.
+  if [[ $plist_path == *"/../"* || $plist_path == *"/.." ]]; then
+    printf 'error: plist_path %q (domain %s) contains a parent-directory component\n' \
       "$plist_path" "$domain" >&2
     return 1
   fi
@@ -191,23 +219,27 @@ system_defaults_read_actual() { # <plist_path> <key>
   local file_candidate
   for file_candidate in "$plist_path" "$plist_path.plist"; do
     if [[ -e $file_candidate && ! -r $file_candidate ]]; then
-      printf '<unreadable>'
-      return 0
+      return "$SYSTEM_READ_UNREADABLE"
     fi
   done
   local value read_error_file read_status=0
-  read_error_file="$(mktemp)"
+  # A failed mktemp must not become an ambiguous redirect that silently loses the
+  # classifier's only input. Refuse toward indeterminate, the safe direction.
+  read_error_file="$(mktemp)" || return "$SYSTEM_READ_UNREADABLE"
   value="$(defaults read "$plist_path" "$key" 2>"$read_error_file")" || read_status=$?
   if [[ $read_status -eq 0 ]]; then
     rm -f "$read_error_file"
     printf '%s' "$value"
-    return 0
+    return "$SYSTEM_READ_OK"
   fi
+  # Only a genuinely absent domain or key is "unset". Every other failure, an
+  # unparseable plist, a traversal-blocked parent, a `defaults` that is missing or
+  # errors, or a message this does not recognize on a future macOS, stays
+  # indeterminate rather than being reported as a known state.
   if grep -q 'does not exist' "$read_error_file"; then
     rm -f "$read_error_file"
-    printf '<unset>'
-    return 0
+    return "$SYSTEM_READ_UNSET"
   fi
   rm -f "$read_error_file"
-  printf '<unreadable>'
+  return "$SYSTEM_READ_UNREADABLE"
 }

--- a/test/integration/macos-defaults-injection.sh
+++ b/test/integration/macos-defaults-injection.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# macos-defaults-injection.sh -- the macos_defaults.yaml data file is UNTRUSTED
+# input to two code generators: the Tier 1 runner template, which renders records
+# into shell source, and the shared library, which renders them into a
+# separator-joined record stream. This suite pins the properties that keep a
+# record from becoming code.
+#
+# Why it matters here specifically: a system-scope record makes the runner cache
+# a sudo credential in a `sudo -v` prelude that runs BEFORE any write, so
+# anything the runner is tricked into executing afterwards runs with a
+# passwordless root escalation already available.
+#
+# The properties pinned, each one previously unpinned:
+#
+#   A. A `type` outside the closed set fails the render on BOTH scopes, and no
+#      write line is emitted. The type is the one field rendered as a bare word,
+#      so the closed set is the only thing standing between it and shell syntax.
+#   B. Command substitution, backticks, and parameter expansion in `domain`,
+#      `key`, `value`, `plist_path`, and a killall entry never reach shell source
+#      as live syntax. Rendering is not enough evidence, so the render is EXECUTED
+#      under stubs: no marker file may appear, and every stub must have received
+#      the literal text.
+#   C. The template refuses the targets it cannot vouch for: a traversal domain,
+#      a traversal plist_path, a plist_path on a user-scope record, and the
+#      degenerate targets (empty/all-dot domain, a plist_path of exactly "/").
+#
+# Real chezmoi and yq; `defaults`, `sudo`, `osascript`, and `killall` are
+# stubbed. Never runs real sudo, never touches /Library.
+#
+# This test deals in LITERAL shell-injection payloads and stub-script bodies, so
+# `$(...)` / `$@` inside single quotes is deliberate (they must NOT expand here).
+# shellcheck disable=SC2016
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any git or chezmoi call. Git exports GIT_DIR
+# to every hook it runs and this suite runs from the pre-push hook; the
+# library's own override may be exported on a developer machine.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it happens to be the last
+# statement, so every negative below goes through this helper.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the data-file injection guards\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$TEMPLATE" "$LIB"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+render_home="$sandbox/render-home"
+mkdir -p "$render_home"
+
+make_source_dir() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_defaults.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+render_template() { # <source-dir> <out-file> <err-file>
+  HOME="$render_home" chezmoi --source "$1" execute-template --no-tty <"$TEMPLATE" >"$2" 2>"$3"
+}
+
+render_error="$sandbox/render.err"
+
+# Non-darwin hosts render an empty body, so there is nothing to exercise. Probed
+# once, with a minimal fixture, before any assertion depends on a real render.
+probe_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.probe
+      key: ProbeKey
+      type: bool
+      value: true
+  killall: []
+EOF
+)"
+render_template "$probe_src" "$sandbox/rendered-probe" "$render_error" ||
+  fail "the probe render must succeed (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$sandbox/rendered-probe")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# assert_render_rejects <label> <expected-stderr-fragment> -- feed a fixture on
+# stdin, require the render to FAIL, require the message to name the reason, and
+# require that no write line was emitted. The last part is what makes this an
+# injection assertion rather than a status check: a render that failed only
+# after emitting a write line has already written the attacker's script.
+assert_render_rejects() { # <label> <expected-stderr-fragment>   (fixture on stdin)
+  local label="$1" expected_fragment="$2"
+  local source_dir out_file status=0
+  source_dir="$(make_source_dir)"
+  out_file="$sandbox/rejected-render"
+  render_template "$source_dir" "$out_file" "$render_error" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "$label: the render must fail (got 0, render: $(cat "$out_file"))"
+  assert_file_contains "$render_error" "$expected_fragment" \
+    "$label: the failure must name the reason '$expected_fragment' (stderr: $(cat "$render_error"))"
+  if grep -qE '^(sudo )?defaults ' "$out_file"; then
+    fail "$label: a rejected render must emit no write line (got: $(grep -E '^(sudo )?defaults ' "$out_file"))"
+  fi
+}
+
+# ---- A: a hostile type fails the render on both scopes ----------------------
+
+# The payload is a valid `defaults` option word followed by a shell command
+# separator, so an unvalidated type renders a legitimate write and then the
+# attacker's command. Quoting cannot fix it: `defaults` needs a BARE option
+# word, which is why the closed set exists.
+assert_render_rejects 'hostile type, user scope' 'unsupported type' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.usertype
+      key: UserTypeKey
+      type: 'bool true; touch hostile-user-type-marker #'
+      value: true
+  killall: []
+EOF
+
+assert_render_rejects 'hostile type, system scope' 'unsupported type' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.systype
+      key: SysTypeKey
+      type: 'bool true; touch hostile-system-type-marker #'
+      value: true
+      scope: system
+  killall: []
+EOF
+
+# Control for A: the closed set still admits every supported type, so the
+# rejections above are not satisfied by a template that refuses all of them.
+every_type_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.t1
+      key: K1
+      type: array
+      value: v
+    - domain: com.example.t2
+      key: K2
+      type: bool
+      value: true
+    - domain: com.example.t3
+      key: K3
+      type: data
+      value: v
+    - domain: com.example.t4
+      key: K4
+      type: date
+      value: v
+    - domain: com.example.t5
+      key: K5
+      type: dict
+      value: v
+    - domain: com.example.t6
+      key: K6
+      type: float
+      value: 1.5
+    - domain: com.example.t7
+      key: K7
+      type: int
+      value: 7
+    - domain: com.example.t8
+      key: K8
+      type: string
+      value: v
+  killall: []
+EOF
+)"
+render_template "$every_type_src" "$sandbox/rendered-every-type" "$render_error" ||
+  fail "every supported type must still render (stderr: $(cat "$render_error"))"
+every_type_write_count="$(grep -cE '^defaults ' "$sandbox/rendered-every-type" || true)"
+[[ $every_type_write_count -eq 8 ]] ||
+  fail "the eight supported types must each render a write (got $every_type_write_count)"
+
+# ---- B: shell metacharacters never reach shell source as live syntax --------
+
+# Every data field carries a payload that WOULD run if the rendered field were
+# double-quoted (bash expands $(...), backticks and $VAR inside double quotes)
+# or unquoted. Each payload writes a distinctly named marker, so a failure names
+# the field that leaked.
+injection_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: "com.example.userdomain$(touch user-domain-marker)"
+      key: "UserKey$(touch user-key-marker)"
+      type: string
+      value: "$(touch user-value-marker)`touch user-tick-marker`$INJECTED_VARIABLE"
+    - domain: "com.example.sysdomain$(touch system-domain-marker)"
+      key: SysDomainKey
+      type: bool
+      value: true
+      scope: system
+    - domain: com.example.syspath
+      key: "SysPathKey$(touch system-key-marker)"
+      type: string
+      value: "$(touch system-value-marker)"
+      scope: system
+      plist_path: "/Library/Preferences/sys$(touch system-path-marker).plist"
+  killall:
+    - "Dock$(touch killall-marker)`touch killall-tick-marker`"
+EOF
+)"
+rendered_injection="$sandbox/rendered-injection"
+render_template "$injection_src" "$rendered_injection" "$render_error" ||
+  fail "the injection fixture must render (these are legal, if hostile, values; stderr: $(cat "$render_error"))"
+
+# The stubs record the argument vector they were handed and do nothing else.
+# `sudo` does NOT exec its argument list: nothing here should run for real.
+stub_bin="$sandbox/bin"
+mkdir -p "$stub_bin"
+stub_log="$sandbox/stub.log"
+for stubbed_command in defaults sudo osascript killall; do
+  cat >"$stub_bin/$stubbed_command" <<EOF
+#!/bin/bash
+{ printf '$stubbed_command'; printf ' [%s]' "\$@"; printf '\n'; } >>"$stub_log"
+exit 0
+EOF
+  chmod +x "$stub_bin/$stubbed_command"
+done
+
+# The rendered script runs with this directory as its working directory, so any
+# payload that executes lands here, observable and contained.
+marker_dir="$sandbox/markers"
+mkdir -p "$marker_dir"
+: >"$stub_log"
+(
+  cd "$marker_dir" || exit 1
+  PATH="$stub_bin:$PATH" INJECTED_VARIABLE=EXPANDED_VARIABLE_VALUE \
+    bash "$rendered_injection"
+) || fail "the rendered injection script must run cleanly under the stubs (log: $(cat "$stub_log"))"
+
+created_markers="$(find "$marker_dir" -mindepth 1 -print)"
+[[ -z $created_markers ]] ||
+  fail "no payload may execute; the rendered script created: $created_markers"
+
+# The stubs must have seen the LITERAL payload text. Without this the emptiness
+# check above is also satisfied by a template that dropped the fields entirely.
+assert_file_contains "$stub_log" 'com.example.userdomain$(touch user-domain-marker)' \
+  "the user domain must arrive as literal text (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" 'UserKey$(touch user-key-marker)' \
+  "the user key must arrive as literal text (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" '$(touch user-value-marker)`touch user-tick-marker`$INJECTED_VARIABLE' \
+  "the user value must arrive as literal text, backticks and $ included (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" '/Library/Preferences/com.example.sysdomain$(touch system-domain-marker)' \
+  "the system domain must arrive as literal text inside the resolved path (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" 'SysPathKey$(touch system-key-marker)' \
+  "the system key must arrive as literal text (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" '/Library/Preferences/sys$(touch system-path-marker).plist' \
+  "the declared plist_path must arrive as literal text (log: $(cat "$stub_log"))"
+assert_file_contains "$stub_log" 'Dock$(touch killall-marker)`touch killall-tick-marker`' \
+  "the killall entry must arrive as literal text (log: $(cat "$stub_log"))"
+refute_file_contains "$stub_log" 'EXPANDED_VARIABLE_VALUE' \
+  'a $VAR in a data field must never be expanded against the runner environment'
+
+# A value containing a single quote must survive the single-quoting intact.
+# `squote` would wrap without escaping, which BREAKS OUT of the quotes; this is
+# the case that separates correct escaping from the convenient-looking one.
+apostrophe_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.apostrophe
+      key: ApostropheKey
+      type: string
+      value: "it's $(touch apostrophe-marker) done"
+  killall: []
+EOF
+)"
+rendered_apostrophe="$sandbox/rendered-apostrophe"
+render_template "$apostrophe_src" "$rendered_apostrophe" "$render_error" ||
+  fail "the apostrophe fixture must render (stderr: $(cat "$render_error"))"
+: >"$stub_log"
+(
+  cd "$marker_dir" || exit 1
+  PATH="$stub_bin:$PATH" bash "$rendered_apostrophe"
+) || fail "the apostrophe render must run cleanly under the stubs (log: $(cat "$stub_log"))"
+created_markers="$(find "$marker_dir" -mindepth 1 -print)"
+[[ -z $created_markers ]] ||
+  fail "a value containing a single quote must not break out of its quoting; created: $created_markers"
+assert_file_contains "$stub_log" "it's \$(touch apostrophe-marker) done" \
+  "the apostrophe value must arrive intact and literal (log: $(cat "$stub_log"))"
+
+# ---- C: the template refuses targets it cannot vouch for --------------------
+
+assert_render_rejects 'traversal domain' 'contains a slash' <<'EOF'
+macos:
+  defaults:
+    - domain: ../../tmp/owned
+      key: OwnedKey
+      type: bool
+      value: true
+      scope: system
+  killall: []
+EOF
+
+assert_render_rejects 'traversal plist_path' 'parent-directory component' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.traverse
+      key: TraverseKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: /Library/Preferences/../../etc/owned.plist
+EOF
+
+assert_render_rejects 'plist_path on a user-scope record' 'outside scope system' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.userpath
+      key: UserPathKey
+      type: bool
+      value: true
+      plist_path: /Library/Preferences/com.example.userpath.plist
+  killall: []
+EOF
+
+assert_render_rejects 'empty domain' 'domain' <<'EOF'
+macos:
+  defaults:
+    - domain: ""
+      key: EmptyDomainKey
+      type: bool
+      value: true
+      scope: system
+  killall: []
+EOF
+
+assert_render_rejects 'dot domain' 'domain' <<'EOF'
+macos:
+  defaults:
+    - domain: "."
+      key: DotDomainKey
+      type: bool
+      value: true
+      scope: system
+  killall: []
+EOF
+
+assert_render_rejects 'dot-dot domain' 'domain' <<'EOF'
+macos:
+  defaults:
+    - domain: ".."
+      key: DotDotDomainKey
+      type: bool
+      value: true
+      scope: system
+  killall: []
+EOF
+
+assert_render_rejects 'root plist_path' 'plist_path' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.root
+      key: RootKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: "/"
+  killall: []
+EOF
+
+# Control for C: the real Objective-See path a later slice depends on stays
+# ACCEPTED, so none of the rejections above were bought with a blanket refusal.
+lulu_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.lulu
+      key: LuLuKey
+      type: string
+      value: block
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+  killall: []
+EOF
+)"
+render_template "$lulu_src" "$sandbox/rendered-lulu" "$render_error" ||
+  fail "the tracked Objective-See path must still render (stderr: $(cat "$render_error"))"
+assert_file_contains "$sandbox/rendered-lulu" '/Library/Objective-See/LuLu/preferences.plist' \
+  'the tracked Objective-See path must be the write target'
+
+printf 'macos-defaults-injection: OK (a hostile type fails the render on both scopes with no write emitted; command substitution, backticks and $VAR in every data field arrive as literal text and execute nothing; traversal, user-scope and degenerate targets are refused while the tracked Objective-See path still renders)
+'

--- a/test/integration/macos-defaults-injection.sh
+++ b/test/integration/macos-defaults-injection.sh
@@ -318,6 +318,62 @@ assert_file_contains "$stub_log" "it's \$(touch apostrophe-marker) done" \
 
 # ---- C: the template refuses targets it cannot vouch for --------------------
 
+# A blank YAML scalar parses as nil, and rendering it stringifies to the literal
+# text <nil>. That would be WRITTEN, as root on a system record. It is caught
+# here rather than left to look like a value, and each field is asserted
+# separately so a guard covering only one of them fails.
+assert_render_rejects 'blank value' 'has a blank value' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.blankvalue
+      key: BlankValueKey
+      type: string
+      value:
+      scope: system
+  killall: []
+EOF
+
+assert_render_rejects 'blank key' 'has a blank key' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.blankkey
+      key:
+      type: string
+      value: v
+  killall: []
+EOF
+
+assert_render_rejects 'blank domain' 'has a blank domain' <<'EOF'
+macos:
+  defaults:
+    - domain:
+      key: BlankDomainKey
+      type: string
+      value: v
+  killall: []
+EOF
+
+# The distinction the guard above must NOT lose: an empty STRING is a legitimate
+# value, not a missing one, and has to keep rendering. A guard written as a
+# plain truthiness test would reject both and this case is what catches that.
+empty_string_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.emptystring
+      key: EmptyStringKey
+      type: string
+      value: ""
+      scope: system
+  killall: []
+EOF
+)"
+rendered_empty_string="$sandbox/rendered-empty-string"
+render_template "$empty_string_src" "$rendered_empty_string" "$render_error" ||
+  fail "an empty-string value must still render (stderr: $(cat "$render_error"))"
+assert_file_contains "$rendered_empty_string" "-string ''" \
+  'an empty-string value must render as an empty quoted argument, not be rejected'
+
 assert_render_rejects 'traversal domain' 'contains a slash' <<'EOF'
 macos:
   defaults:
@@ -488,15 +544,20 @@ refute_file_contains "$stub_log" 'EVIL.DOMAIN' \
 refute_file_contains "$stub_log" '[write]' \
   'apply must perform NO write at all once the record stream is known to be malformed'
 
-# The template renders this same file as ONE write, which is exactly the
-# disagreement the check above removes: the tools now refuse rather than seeing
-# a record the template never rendered.
+# The template must refuse the same file, at the EARLIER boundary. It used to
+# render it as one write and leave the tools to refuse, which meant one data file
+# rendered cleanly and then made every tool fail; the operator met the problem
+# through a broken drift report rather than at apply time. Both consumers now
+# reject the same record, and this asserts the template is the one that says so
+# first.
 rendered_forging="$sandbox/rendered-forging"
-render_template "$forging_src" "$rendered_forging" "$render_error" ||
-  fail "the forging fixture still renders as one record (stderr: $(cat "$render_error"))"
-template_write_count="$(grep -cE '^(sudo )?defaults ' "$rendered_forging" || true)"
-[[ $template_write_count -eq 1 ]] ||
-  fail "the template must render exactly one write for one record (got $template_write_count)"
+if render_template "$forging_src" "$rendered_forging" "$render_error"; then
+  fail "the forging fixture must FAIL the render, not be left for the tools to catch"
+fi
+assert_file_contains "$render_error" 'newline or a unit separator' \
+  "the render's refusal must name the reason (stderr: $(cat "$render_error"))"
+refute_file_contains "$rendered_forging" 'EVIL' \
+  'a refused render must not leave the forged record in its output'
 
 # A lone unit separator, no newline, is caught by the field count rather than by
 # the line count, so both halves of the guard are exercised.

--- a/test/integration/macos-defaults-injection.sh
+++ b/test/integration/macos-defaults-injection.sh
@@ -23,6 +23,10 @@
 #   C. The template refuses the targets it cannot vouch for: a traversal domain,
 #      a traversal plist_path, a plist_path on a user-scope record, and the
 #      degenerate targets (empty/all-dot domain, a plist_path of exactly "/").
+#   D. One YAML record produces exactly one write. A record whose value carries
+#      unit separators and a newline can otherwise forge a SECOND, fully
+#      attacker-controlled root write that the template never renders, leaving
+#      the tools and the runner disagreeing about how many records exist.
 #
 # Real chezmoi and yq; `defaults`, `sudo`, `osascript`, and `killall` are
 # stubbed. Never runs real sudo, never touches /Library.
@@ -40,6 +44,7 @@ unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_F
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
 LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -64,7 +69,7 @@ for tool in chezmoi yq; do
     exit 0
   }
 done
-for required_file in "$TEMPLATE" "$LIB"; do
+for required_file in "$TEMPLATE" "$LIB" "$APPLY"; do
   [[ -f $required_file ]] || fail "missing file: $required_file"
 done
 
@@ -411,5 +416,108 @@ render_template "$lulu_src" "$sandbox/rendered-lulu" "$render_error" ||
 assert_file_contains "$sandbox/rendered-lulu" '/Library/Objective-See/LuLu/preferences.plist' \
   'the tracked Objective-See path must be the write target'
 
-printf 'macos-defaults-injection: OK (a hostile type fails the render on both scopes with no write emitted; command substitution, backticks and $VAR in every data field arrive as literal text and execute nothing; traversal, user-scope and degenerate targets are refused while the tracked Objective-See path still renders)
-'
+# ---- D: one record, one write ------------------------------------------------
+
+# run_apply <source-dir> <err-file> -- run apply with the stubs first on PATH,
+# from inside the sandbox so a path bug lands somewhere observable.
+run_apply() { # <source-dir> <err-file>
+  (
+    cd "$sandbox" || exit 1
+    MACOS_DEFAULTS_SOURCE_DIR="$1" HOME="$sandbox/apply-home" \
+      PATH="$stub_bin:$PATH" bash "$APPLY"
+  ) 2>"$2"
+}
+mkdir -p "$sandbox/apply-home"
+
+# Control: one benign system record yields exactly one write. Without this row
+# the rejection below is satisfied by an apply that writes nothing ever.
+one_record_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.sys
+      key: SysKey
+      type: string
+      value: v
+      scope: system
+  killall: []
+EOF
+)"
+: >"$stub_log"
+run_apply "$one_record_src" "$sandbox/apply-benign.err" ||
+  fail "apply must succeed on one benign system record (stderr: $(cat "$sandbox/apply-benign.err"))"
+benign_write_count="$(grep -cF 'sudo [defaults] [write]' "$stub_log" || true)"
+[[ $benign_write_count -eq 1 ]] ||
+  fail "one system record must produce exactly one root write (got $benign_write_count; log: $(cat "$stub_log"))"
+
+# The forging payload: unit separators plus a newline inside ONE record's value.
+# It is BALANCED on purpose, so both halves carry exactly seven fields and a
+# field-count check alone waves them through; only comparing the number of
+# emitted lines against the number of DECLARED records catches it.
+forging_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.sys
+      key: SysKey
+      type: string
+      value: "v\x1f\x1fsystem\x1f\nEVIL.DOMAIN\x1fEVILKEY\x1fbool\x1ftrue"
+      scope: system
+  killall: []
+EOF
+)"
+forging_data_file="$forging_src/.chezmoidata/macos_defaults.yaml"
+
+stream_status=0
+stream_output="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$forging_data_file" 2>"$sandbox/stream.err")" || stream_status=$?
+[[ $stream_status -ne 0 ]] ||
+  fail "the record stream must reject a forged record (got 0, stream: $(printf '%s' "$stream_output" | cat -v))"
+assert_file_contains "$sandbox/stream.err" 'com.example.sys' \
+  "the rejection must name the offending record (stderr: $(cat "$sandbox/stream.err"))"
+refute_file_contains "$sandbox/stream.err" 'EVIL.DOMAIN' \
+  'the rejection must name the real record, not the forged one it produced'
+
+: >"$stub_log"
+forging_status=0
+run_apply "$forging_src" "$sandbox/apply-forging.err" || forging_status=$?
+[[ $forging_status -ne 0 ]] ||
+  fail "apply must refuse a data file carrying a forged record (log: $(cat "$stub_log"))"
+refute_file_contains "$stub_log" 'EVIL.DOMAIN' \
+  'apply must never perform the forged root write'
+refute_file_contains "$stub_log" '[write]' \
+  'apply must perform NO write at all once the record stream is known to be malformed'
+
+# The template renders this same file as ONE write, which is exactly the
+# disagreement the check above removes: the tools now refuse rather than seeing
+# a record the template never rendered.
+rendered_forging="$sandbox/rendered-forging"
+render_template "$forging_src" "$rendered_forging" "$render_error" ||
+  fail "the forging fixture still renders as one record (stderr: $(cat "$render_error"))"
+template_write_count="$(grep -cE '^(sudo )?defaults ' "$rendered_forging" || true)"
+[[ $template_write_count -eq 1 ]] ||
+  fail "the template must render exactly one write for one record (got $template_write_count)"
+
+# A lone unit separator, no newline, is caught by the field count rather than by
+# the line count, so both halves of the guard are exercised.
+separator_only_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.sep
+      key: SepKey
+      type: string
+      value: "a\x1fb"
+  killall: []
+EOF
+)"
+stream_status=0
+bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$separator_only_src/.chezmoidata/macos_defaults.yaml" \
+  >/dev/null 2>"$sandbox/stream-separator.err" || stream_status=$?
+[[ $stream_status -ne 0 ]] ||
+  fail 'the record stream must reject a value containing a bare unit separator'
+assert_file_contains "$sandbox/stream-separator.err" 'com.example.sep' \
+  "the bare-separator rejection must name the record (stderr: $(cat "$sandbox/stream-separator.err"))"
+
+printf 'macos-defaults-injection: OK (a hostile type fails the render on both scopes with no write emitted; command substitution, backticks and $VAR in every data field arrive as literal text and execute nothing; traversal, user-scope and degenerate targets are refused while the tracked Objective-See path still renders; one record yields exactly one write and a separator/newline forgery is refused before anything is written)\n'

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -1,0 +1,696 @@
+#!/usr/bin/env bash
+# macos-defaults-system-scope.sh -- system-domain support across all four
+# consumers of macos_defaults.yaml: the Tier 1 runner template and the three
+# tools (apply, capture, drift), plus the shared library's record stream.
+#
+# A record may carry an optional `scope` field: `user` (the default, and the
+# meaning of an absent field) or `system` (a root-owned plist, written through
+# sudo). The properties pinned here, one per acceptance criterion:
+#
+#   1. With no system-scope record the rendered runner is byte-identical to the
+#      pre-slice render and contains no `sudo` (the golden below was rendered
+#      from main's template before this slice changed it).
+#   2. With a system-scope record the rendered runner contains exactly one
+#      `sudo -v`, before any write, and that record's write is `sudo defaults
+#      write "/Library/Preferences/<domain>" ...`.
+#   3. An explicit ABSOLUTE plist_path is written instead of the default.
+#   4. A RELATIVE plist_path is rejected (render fails; apply refuses), never
+#      resolved against the ambient working directory.
+#   5. drift reports an unreadable system-scope record as indeterminate, with a
+#      marker distinct from <unset>, and does NOT count it as drift.
+#   6. drift on a set-and-matching system-scope record reports no drift.
+#   7. capture --scope system appends a record carrying `scope: system`.
+#   8. capture rejects --scope system combined with --host current.
+#   9. The template's scope guard tolerates records WITHOUT the field (the
+#      `.scope` field form would abort the render of every existing record;
+#      criterion 1's golden render is the behavioral pin, the source grep the
+#      belt).
+#
+# Real chezmoi and yq; `defaults`, `sudo`, `osascript`, and `killall` are
+# stubbed. Never runs real sudo, never touches /Library.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any git or chezmoi call. Git exports GIT_DIR
+# to every hook it runs and this suite runs from the pre-push hook; the
+# library's own override may be exported on a developer machine.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
+CAPTURE="$REPO_ROOT/dot_local/bin/executable_macos-defaults-capture.sh"
+DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# refute_file_contains <file> <fixed-string> <message> -- the explicit negative
+# assertion. A bare `! grep` is dead under `set -e` unless it happens to be the
+# last statement, so every negative below goes through this helper.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+# Host-tool guard: the de-homebrewed CI-faithful run has no chezmoi/yq on PATH,
+# and this test cannot render templates or read records without them.
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise system-scope support\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$TEMPLATE" "$LIB" "$APPLY" "$CAPTURE" "$DRIFT"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'chmod -R u+rwX "$sandbox" 2>/dev/null; rm -rf "$sandbox"' EXIT
+mkdir -p "$sandbox/home"
+render_home="$sandbox/render-home"
+mkdir -p "$render_home"
+
+# make_source_dir -- create a chezmoi source tree whose macos_defaults.yaml is
+# read from stdin; prints the tree's path.
+make_source_dir() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_defaults.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+# render_template <source-dir> <out-file> <err-file> -- render the Tier 1
+# runner template against one source tree; returns chezmoi's status.
+render_template() { # <source-dir> <out-file> <err-file>
+  HOME="$render_home" chezmoi --source "$1" execute-template --no-tty <"$TEMPLATE" >"$2" 2>"$3"
+}
+
+# ---- criterion 1: user-only data renders byte-identical to main -------------
+
+user_only_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.alpha
+      key: AlphaKey
+      type: bool
+      value: true
+    - domain: com.example.beta
+      key: BetaKey
+      type: string
+      value: BetaValue
+      host: current
+  killall:
+    - Dock
+    - cfprefsd
+EOF
+)"
+
+# The golden render: main's template (pre-slice, commit 5d70c94) rendered
+# against the fixture above. Byte for byte, including the trailing blank line.
+golden="$sandbox/golden-user-only"
+cat >"$golden" <<'EOF'
+#!/bin/bash
+# Tier 1, macOS user defaults runner.
+# chezmoi hash-gates on the rendered template body; this script re-runs only
+# when .chezmoidata/macos_defaults.yaml changes.
+
+set -euo pipefail
+
+# Pre-flight: close System Settings if open. macOS caches plist values inside
+# Settings and writes them back on close, silently overwriting our writes.
+osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
+
+# Main loop: one `defaults write` per record.
+defaults write "com.example.alpha" "AlphaKey" -bool "true"
+defaults -currentHost write "com.example.beta" "BetaKey" -string "BetaValue"
+# Post-loop: restart user-facing processes so changes take effect immediately.
+# cfprefsd kill is non-negotiable (caches plist values in memory).
+killall "Dock" 2>/dev/null || true
+killall "cfprefsd" 2>/dev/null || true
+
+EOF
+
+rendered="$sandbox/rendered-user-only"
+render_error="$sandbox/render.err"
+render_template "$user_only_src" "$rendered" "$render_error" ||
+  fail "user-only render must succeed (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+cmp -s "$golden" "$rendered" ||
+  fail "user-only render must be byte-identical to the pre-slice render (diff: $(diff "$golden" "$rendered" | head -20))"
+refute_file_contains "$rendered" 'sudo' \
+  'user-only render must contain no sudo invocation'
+
+# The repo's REAL data file declares no system-scope record in this slice, so
+# the shipped render must contain no sudo either.
+rendered_real="$sandbox/rendered-real-data"
+render_template "$REPO_ROOT" "$rendered_real" "$render_error" ||
+  fail "render against the repo's real data must succeed (stderr: $(cat "$render_error"))"
+refute_file_contains "$rendered_real" 'sudo' \
+  "render against the repo's real data must contain no sudo invocation"
+
+# Criterion 9, source form: the guard reads the optional field through
+# `index . "scope"`; the `.scope` field form aborts on every record without
+# the field (the renders above already prove that behaviorally).
+assert_file_contains "$TEMPLATE" 'index . "scope"' \
+  'the template scope guard must read the field through index . "scope"'
+if grep -qE '\.scope' "$TEMPLATE"; then
+  fail 'the template must not use the .scope field form anywhere'
+fi
+
+# ---- criterion 2: a system record adds one sudo -v, before any write --------
+
+system_default_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.alpha
+      key: AlphaKey
+      type: bool
+      value: true
+    - domain: com.example.sys
+      key: SysKey
+      type: bool
+      value: false
+      scope: system
+  killall:
+    - cfprefsd
+EOF
+)"
+
+rendered_system="$sandbox/rendered-system"
+render_template "$system_default_src" "$rendered_system" "$render_error" ||
+  fail "system-record render must succeed (stderr: $(cat "$render_error"))"
+
+sudo_validate_count="$(grep -cxF 'sudo -v' "$rendered_system" || true)"
+[[ $sudo_validate_count -eq 1 ]] ||
+  fail "system-record render must contain exactly one 'sudo -v' (got $sudo_validate_count)"
+sudo_validate_line="$(grep -nxF 'sudo -v' "$rendered_system" | cut -d: -f1)"
+first_write_line="$(grep -nE '^(sudo )?defaults ' "$rendered_system" | head -1 | cut -d: -f1)"
+[[ -n $first_write_line ]] || fail 'system-record render must contain defaults writes'
+[[ $sudo_validate_line -lt $first_write_line ]] ||
+  fail "the sudo -v prelude must come before any write (sudo -v at line $sudo_validate_line, first write at line $first_write_line)"
+grep -qxF 'sudo defaults write "/Library/Preferences/com.example.sys" "SysKey" -bool "false"' "$rendered_system" ||
+  fail "the system record's write must be sudo-prefixed and target /Library/Preferences/<domain> (got: $(grep -F 'com.example.sys' "$rendered_system"))"
+grep -qxF 'defaults write "com.example.alpha" "AlphaKey" -bool "true"' "$rendered_system" ||
+  fail 'the user record must keep its plain, un-sudoed write'
+refute_file_contains "$rendered_system" 'sudo defaults write "com.example.alpha"' \
+  'the user record must not be written through sudo'
+
+# ---- criterion 3: an explicit absolute plist_path wins over the default -----
+
+explicit_path_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.lulu
+      key: LuLuKey
+      type: string
+      value: block
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+  killall: []
+EOF
+)"
+
+rendered_explicit="$sandbox/rendered-explicit"
+render_template "$explicit_path_src" "$rendered_explicit" "$render_error" ||
+  fail "explicit-path render must succeed (stderr: $(cat "$render_error"))"
+grep -qxF 'sudo defaults write "/Library/Objective-See/LuLu/preferences.plist" "LuLuKey" -string "block"' "$rendered_explicit" ||
+  fail "an explicit absolute plist_path must be the write target (got: $(grep -F LuLuKey "$rendered_explicit"))"
+refute_file_contains "$rendered_explicit" '/Library/Preferences/com.example.lulu' \
+  'an explicit plist_path must replace the /Library/Preferences default, not coexist with it'
+
+# ---- criterion 4: a relative plist_path fails the render --------------------
+
+relative_path_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.rel
+      key: RelKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: Library/Preferences/rel.plist
+  killall: []
+EOF
+)"
+
+relative_status=0
+render_template "$relative_path_src" "$sandbox/rendered-relative" "$render_error" || relative_status=$?
+[[ $relative_status -ne 0 ]] ||
+  fail 'a relative plist_path must fail the render, never resolve silently'
+assert_file_contains "$render_error" 'Library/Preferences/rel.plist' \
+  "the relative-path render failure must name the offending path (stderr: $(cat "$render_error"))"
+
+# A system record combined with host is meaningless (ByHost storage is
+# per-user) and must fail the render rather than render something half-right.
+system_host_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.syshost
+      key: SysHostKey
+      type: bool
+      value: true
+      scope: system
+      host: current
+  killall: []
+EOF
+)"
+system_host_status=0
+render_template "$system_host_src" "$sandbox/rendered-system-host" "$render_error" || system_host_status=$?
+[[ $system_host_status -ne 0 ]] ||
+  fail 'a system-scope record with a host must fail the render'
+
+# An unknown scope must fail the render, not silently fall back to user scope.
+bogus_scope_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.bogus
+      key: BogusKey
+      type: bool
+      value: true
+      scope: bogus
+  killall: []
+EOF
+)"
+bogus_scope_status=0
+render_template "$bogus_scope_src" "$sandbox/rendered-bogus" "$render_error" || bogus_scope_status=$?
+[[ $bogus_scope_status -ne 0 ]] ||
+  fail 'an unknown scope must fail the render'
+assert_file_contains "$render_error" 'unknown scope' \
+  "the unknown-scope render failure must say so (stderr: $(cat "$render_error"))"
+
+# ---- the shared record stream: one line, seven fields, empties survive ------
+
+# The unit separator (0x1f) is not IFS whitespace, so an empty INTERIOR field
+# (here: host absent while scope and plist_path follow it) must survive the
+# read intact. Under a tab-separated stream the empty host would collapse and
+# shift scope left into host, which is the regression this section pins.
+columns_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.full
+      key: FullKey
+      type: string
+      value: FullValue
+      scope: system
+      plist_path: /Library/Objective-See/full.plist
+    - domain: com.example.minimal
+      key: MinimalKey
+      type: bool
+      value: true
+    - domain: com.example.byhost
+      key: ByHostKey
+      type: int
+      value: 7
+      host: current
+  killall: []
+EOF
+)"
+record_stream="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$columns_src/.chezmoidata/macos_defaults.yaml")" ||
+  fail 'defaults_records_unit_separated must succeed on a well-formed file'
+
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+  <<<"$(printf '%s\n' "$record_stream" | sed -n '1p')"
+[[ $got_domain == com.example.full ]] || fail "record stream: field 1 must be the domain (got '$got_domain')"
+[[ $got_key == FullKey ]] || fail "record stream: field 2 must be the key (got '$got_key')"
+[[ $got_type == string ]] || fail "record stream: field 3 must be the type (got '$got_type')"
+[[ $got_value == FullValue ]] || fail "record stream: field 4 must be the value (got '$got_value')"
+[[ -z $got_host ]] ||
+  fail "record stream: an absent host must survive as an EMPTY interior field, not collapse (got '$got_host')"
+[[ $got_scope == system ]] || fail "record stream: field 6 must be the scope (got '$got_scope')"
+[[ $got_plist_path == /Library/Objective-See/full.plist ]] ||
+  fail "record stream: field 7 must be the plist path (got '$got_plist_path')"
+
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+  <<<"$(printf '%s\n' "$record_stream" | sed -n '2p')"
+[[ $got_domain == com.example.minimal ]] || fail "record stream: minimal field 1 must be the domain (got '$got_domain')"
+[[ -z $got_host ]] || fail "record stream: minimal host must be empty (got '$got_host')"
+[[ $got_scope == user ]] ||
+  fail "record stream: an ABSENT scope must default to user in the stream (got '$got_scope')"
+[[ -z $got_plist_path ]] || fail "record stream: minimal plist path must be empty (got '$got_plist_path')"
+
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+  <<<"$(printf '%s\n' "$record_stream" | sed -n '3p')"
+[[ $got_host == current ]] || fail "record stream: field 5 must be the host (got '$got_host')"
+[[ $got_scope == user ]] || fail "record stream: byhost scope must default to user (got '$got_scope')"
+
+# ---- tool stubs --------------------------------------------------------------
+
+stub_bin="$sandbox/bin"
+mkdir -p "$stub_bin"
+defaults_log="$sandbox/defaults.log"
+sudo_log="$sandbox/sudo.log"
+
+# sudo stub: records the space-joined invocation, then runs it (so the
+# defaults stub behind it still answers). Fixture values contain no spaces, so
+# the space-joined log parses back per field unambiguously.
+cat >"$stub_bin/sudo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$sudo_log"
+exec "\$@"
+EOF
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/osascript"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/killall"
+chmod +x "$stub_bin/sudo" "$stub_bin/osascript" "$stub_bin/killall"
+
+# write_defaults_stub <write-only|read-value|read-unset|read-denied|capture-bool>
+# -- the per-section behavior of the `defaults` stub. Every variant logs its
+# space-joined invocation first.
+# SC2016: the single-quoted $1 lines are stub SOURCE, expanded when the stub
+# runs, deliberately not here.
+# shellcheck disable=SC2016
+write_defaults_stub() {
+  local mode="$1"
+  {
+    printf '#!/bin/bash\n'
+    printf 'printf "%%s\\n" "$*" >>"%s"\n' "$defaults_log"
+    case "$mode" in
+      write-only)
+        printf 'exit 0\n'
+        ;;
+      read-value)
+        printf 'if [[ $1 == read ]]; then printf "1\\n"; exit 0; fi\nexit 0\n'
+        ;;
+      read-unset)
+        printf 'if [[ $1 == read ]]; then printf "does not exist\\n" >&2; exit 1; fi\nexit 0\n'
+        ;;
+      read-denied)
+        printf 'if [[ $1 == read ]]; then printf "Operation not permitted\\n" >&2; exit 1; fi\nexit 0\n'
+        ;;
+      capture-bool)
+        printf 'if [[ $1 == read-type ]]; then printf "Type is boolean\\n"; exit 0; fi\n'
+        printf 'if [[ $1 == read ]]; then printf "1\\n"; exit 0; fi\nexit 0\n'
+        ;;
+    esac
+  } >"$stub_bin/defaults"
+  chmod +x "$stub_bin/defaults"
+}
+
+# run_tool <source-dir> <script> [args...] -- run one tool against one source
+# tree, stubs first on PATH. Runs from inside the sandbox so a relative-path
+# bug that resolved against the working directory would land in the sandbox,
+# observable and contained.
+run_tool() { # <source-dir> <script> [args...]
+  local source_dir="$1"
+  shift
+  (
+    cd "$sandbox" || exit 1
+    MACOS_DEFAULTS_SOURCE_DIR="$source_dir" HOME="$sandbox/home" \
+      PATH="$stub_bin:$PATH" bash "$@"
+  )
+}
+
+# ---- apply: system records go through sudo to the resolved path -------------
+
+apply_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.alpha
+      key: AlphaKey
+      type: bool
+      value: true
+    - domain: com.example.sys
+      key: SysKey
+      type: bool
+      value: false
+      scope: system
+    - domain: com.example.lulu
+      key: LuLuKey
+      type: string
+      value: block
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+  killall: []
+EOF
+)"
+write_defaults_stub write-only
+: >"$defaults_log"
+: >"$sudo_log"
+run_tool "$apply_src" "$APPLY" || fail 'apply must succeed on a mixed user/system data file'
+
+system_write_line="$(grep -F 'com.example.sys' "$sudo_log" || true)"
+[[ -n $system_write_line ]] ||
+  fail "apply must route the system record's write through sudo (sudo log: $(cat "$sudo_log"))"
+read -r -a system_write_fields <<<"$system_write_line"
+[[ ${#system_write_fields[@]} -eq 6 ]] ||
+  fail "apply's sudo write must carry exactly 6 arguments (got: $system_write_line)"
+[[ ${system_write_fields[0]} == defaults ]] || fail "apply sudo write: field 1 must be 'defaults' (got '${system_write_fields[0]}')"
+[[ ${system_write_fields[1]} == write ]] || fail "apply sudo write: field 2 must be 'write' (got '${system_write_fields[1]}')"
+[[ ${system_write_fields[2]} == /Library/Preferences/com.example.sys ]] ||
+  fail "apply sudo write: field 3 must be the default plist path (got '${system_write_fields[2]}')"
+[[ ${system_write_fields[3]} == SysKey ]] || fail "apply sudo write: field 4 must be the key (got '${system_write_fields[3]}')"
+[[ ${system_write_fields[4]} == -bool ]] || fail "apply sudo write: field 5 must be the dashed type (got '${system_write_fields[4]}')"
+[[ ${system_write_fields[5]} == false ]] || fail "apply sudo write: field 6 must be the value (got '${system_write_fields[5]}')"
+
+assert_file_contains "$sudo_log" '/Library/Objective-See/LuLu/preferences.plist' \
+  "apply must write an explicit plist_path record to that path (sudo log: $(cat "$sudo_log"))"
+refute_file_contains "$sudo_log" '/Library/Preferences/com.example.lulu' \
+  'apply must not compose the default path for a record carrying an explicit plist_path'
+assert_file_contains "$defaults_log" 'write com.example.alpha AlphaKey -bool true' \
+  "apply must still write the user record (defaults log: $(cat "$defaults_log"))"
+refute_file_contains "$sudo_log" 'com.example.alpha' \
+  'apply must not route a user-scope write through sudo'
+
+# apply refuses a relative plist_path and never writes it.
+apply_relative_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.rel
+      key: RelKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: Library/Preferences/rel.plist
+  killall: []
+EOF
+)"
+: >"$defaults_log"
+: >"$sudo_log"
+apply_relative_status=0
+run_tool "$apply_relative_src" "$APPLY" 2>"$sandbox/apply-relative.err" || apply_relative_status=$?
+[[ $apply_relative_status -ne 0 ]] ||
+  fail 'apply must refuse a relative plist_path'
+assert_file_contains "$sandbox/apply-relative.err" 'absolute path is required' \
+  "apply's relative-path refusal must say an absolute path is required (stderr: $(cat "$sandbox/apply-relative.err"))"
+refute_file_contains "$defaults_log" 'rel.plist' \
+  'apply must not write a relative plist_path record at all'
+refute_file_contains "$sudo_log" 'rel.plist' \
+  'apply must not sudo-write a relative plist_path record at all'
+
+# apply refuses an unknown scope rather than guessing a write target.
+apply_bogus_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.bogus
+      key: BogusKey
+      type: bool
+      value: true
+      scope: bogus
+  killall: []
+EOF
+)"
+: >"$defaults_log"
+apply_bogus_status=0
+run_tool "$apply_bogus_src" "$APPLY" 2>"$sandbox/apply-bogus.err" || apply_bogus_status=$?
+[[ $apply_bogus_status -ne 0 ]] || fail 'apply must refuse an unknown scope'
+refute_file_contains "$defaults_log" 'com.example.bogus' \
+  'apply must not write a record whose scope it could not validate'
+
+# ---- drift: three outcomes for a system-scope record -------------------------
+
+drift_system_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.sys
+      key: SysKey
+      type: bool
+      value: true
+      scope: system
+  killall: []
+EOF
+)"
+
+# criterion 6: set and matching (the stub reads back 1, the normalized true).
+write_defaults_stub read-value
+drift_out="$sandbox/drift.out"
+drift_err="$sandbox/drift.err"
+run_tool "$drift_system_src" "$DRIFT" >"$drift_out" 2>"$drift_err" ||
+  fail "drift on a matching system record must exit 0 (stderr: $(cat "$drift_err"))"
+[[ ! -s $drift_out ]] ||
+  fail "drift on a matching system record must print no rows (got: $(cat "$drift_out"))"
+assert_file_contains "$defaults_log" 'read /Library/Preferences/com.example.sys SysKey' \
+  "drift must read the system record from its resolved plist path (defaults log: $(cat "$defaults_log"))"
+
+# criterion 5, defaults-failure route: an unknown read failure is indeterminate,
+# marked distinctly from <unset>, and NOT counted as drift.
+write_defaults_stub read-denied
+drift_status=0
+run_tool "$drift_system_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
+[[ $drift_status -eq 0 ]] ||
+  fail "an unreadable system record must not count as drift (got exit $drift_status, stderr: $(cat "$drift_err"))"
+indeterminate_row="$(grep -F 'com.example.sys' "$drift_out" || true)"
+[[ -n $indeterminate_row ]] ||
+  fail "an unreadable system record must be reported as its own row, not silently skipped (stdout: $(cat "$drift_out"))"
+IFS=$'\t' read -r row_domain row_key row_expected row_actual <<<"$indeterminate_row"
+[[ $row_domain == com.example.sys ]] || fail "indeterminate row: field 1 must be the domain (got '$row_domain')"
+[[ $row_key == SysKey ]] || fail "indeterminate row: field 2 must be the key (got '$row_key')"
+[[ $row_expected == 1 ]] || fail "indeterminate row: field 3 must be the normalized expected value (got '$row_expected')"
+[[ $row_actual == '<unreadable>' ]] ||
+  fail "indeterminate row: field 4 must be the <unreadable> marker, distinct from <unset> (got '$row_actual')"
+refute_file_contains "$drift_out" '<unset>' \
+  'an unreadable read must never collapse into <unset>'
+assert_file_contains "$drift_err" 'indeterminate' \
+  "drift must summarize indeterminate rows on stderr (stderr: $(cat "$drift_err"))"
+
+# criterion 5, unreadable-file route: the plist exists but cannot be read. The
+# stub would report a MATCHING value, so a drift that skipped the file check
+# would report all-clear here; the correct behavior is distinguishable.
+locked_plist="$sandbox/system-plists/locked.plist"
+mkdir -p "$(dirname "$locked_plist")"
+: >"$locked_plist"
+chmod 000 "$locked_plist"
+drift_locked_src="$(
+  make_source_dir <<EOF
+macos:
+  defaults:
+    - domain: com.example.locked
+      key: LockedKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: $locked_plist
+  killall: []
+EOF
+)"
+write_defaults_stub read-value
+drift_status=0
+run_tool "$drift_locked_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
+chmod u+rw "$locked_plist"
+[[ $drift_status -eq 0 ]] ||
+  fail "an unreadable plist file must not count as drift (got exit $drift_status, stderr: $(cat "$drift_err"))"
+assert_file_contains "$drift_out" '<unreadable>' \
+  "an existing-but-unreadable plist must be reported indeterminate even when a read would have answered (stdout: $(cat "$drift_out"))"
+
+# A genuinely unset system record IS drift, with the <unset> marker.
+write_defaults_stub read-unset
+drift_status=0
+run_tool "$drift_system_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
+[[ $drift_status -eq 1 ]] ||
+  fail "a genuinely unset system record must count as drift (got exit $drift_status)"
+unset_row="$(grep -F 'com.example.sys' "$drift_out" || true)"
+IFS=$'\t' read -r row_domain row_key row_expected row_actual <<<"$unset_row"
+[[ $row_actual == '<unset>' ]] ||
+  fail "an unset system record's row must carry the <unset> marker (got '$row_actual')"
+
+# drift refuses an unknown scope rather than misreading a record.
+drift_bogus_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.bogus
+      key: BogusKey
+      type: bool
+      value: true
+      scope: bogus
+  killall: []
+EOF
+)"
+write_defaults_stub read-value
+drift_status=0
+run_tool "$drift_bogus_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
+[[ $drift_status -eq 2 ]] ||
+  fail "drift must exit 2 on a record whose scope it cannot validate (got $drift_status)"
+
+# ---- capture: --scope system --------------------------------------------------
+
+# criterion 7. The fixture already tracks the SAME domain/key at user scope, so
+# a duplicate check that ignored scope would answer "already tracked" and skip
+# the append; the correct behavior appends a second, system-scope record.
+capture_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.cap
+      key: CapKey
+      type: bool
+      value: true
+  killall: []
+EOF
+)"
+capture_data_file="$capture_src/.chezmoidata/macos_defaults.yaml"
+write_defaults_stub capture-bool
+: >"$defaults_log"
+run_tool "$capture_src" "$CAPTURE" com.example.cap CapKey --scope system ||
+  fail 'capture --scope system must append alongside an existing user-scope record'
+captured_record="$(yq eval -r \
+  '.macos.defaults[] | select(.domain == "com.example.cap" and .key == "CapKey" and ((.scope // "user") == "system")) | [.domain, .key, .type, .value, .scope] | join("|")' \
+  "$capture_data_file")"
+[[ $captured_record == 'com.example.cap|CapKey|bool|true|system' ]] ||
+  fail "capture --scope system must append a record carrying scope: system (got '$captured_record')"
+user_record_count="$(yq eval -r \
+  '[.macos.defaults[] | select(.domain == "com.example.cap" and .key == "CapKey" and ((.scope // "user") == "user"))] | length' \
+  "$capture_data_file")"
+[[ $user_record_count -eq 1 ]] ||
+  fail "capture --scope system must leave the user-scope record in place (got $user_record_count)"
+assert_file_contains "$defaults_log" 'read-type /Library/Preferences/com.example.cap CapKey' \
+  "capture --scope system must read the live value from the system plist path (defaults log: $(cat "$defaults_log"))"
+
+# criterion 8: --scope system with --host current is rejected as malformed.
+capture_reject_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults: []
+  killall: []
+EOF
+)"
+capture_reject_data_file="$capture_reject_src/.chezmoidata/macos_defaults.yaml"
+cp "$capture_reject_data_file" "$sandbox/capture-reject.before"
+capture_status=0
+run_tool "$capture_reject_src" "$CAPTURE" com.example.cap CapKey --scope system --host current \
+  2>"$sandbox/capture-reject.err" || capture_status=$?
+[[ $capture_status -eq 3 ]] ||
+  fail "capture --scope system --host current must exit 3, the malformed-args status (got $capture_status)"
+assert_file_contains "$sandbox/capture-reject.err" '--scope system' \
+  "the rejection must name the conflicting flags (stderr: $(cat "$sandbox/capture-reject.err"))"
+cmp -s "$sandbox/capture-reject.before" "$capture_reject_data_file" ||
+  fail 'a rejected capture must leave the data file untouched'
+
+# A set-but-empty --scope is rejected, not treated as unset.
+capture_status=0
+run_tool "$capture_reject_src" "$CAPTURE" com.example.cap CapKey --scope '' \
+  2>"$sandbox/capture-empty.err" || capture_status=$?
+[[ $capture_status -eq 3 ]] ||
+  fail "capture --scope '' must exit 3 (got $capture_status)"
+
+# The single-token form is parsed too, and an unknown scope value is rejected.
+capture_status=0
+run_tool "$capture_reject_src" "$CAPTURE" com.example.cap CapKey --scope=bogus \
+  2>"$sandbox/capture-bogus.err" || capture_status=$?
+[[ $capture_status -eq 3 ]] ||
+  fail "capture --scope=bogus must exit 3 (got $capture_status)"
+
+printf 'macos-defaults-system-scope: OK (user-only render byte-identical with no sudo; one sudo -v before any write; explicit absolute plist_path honored, relative rejected everywhere; drift distinguishes value/<unset>/<unreadable> and never counts indeterminate as drift; capture appends scope: system and rejects the --host pairing)\n'

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -7,12 +7,17 @@
 # meaning of an absent field) or `system` (a root-owned plist, written through
 # sudo). The properties pinned here, one per acceptance criterion:
 #
-#   1. With no system-scope record the rendered runner is byte-identical to the
-#      pre-slice render and contains no `sudo` (the golden below was rendered
-#      from main's template before this slice changed it).
+#   1. With no system-scope record the rendered runner is SEMANTICALLY identical
+#      to the pre-slice render and contains no `sudo`. Byte-identity was the
+#      original claim and it no longer holds, deliberately: hardening every data
+#      field from Go's %q double-quoting to POSIX single-quoting changes the
+#      quote character on every write line. Both goldens are kept below, and the
+#      two are run under identical stubs so the argument vectors `defaults` and
+#      `killall` receive must match exactly. Argument vectors are what the claim
+#      was ever about; the quote characters are not.
 #   2. With a system-scope record the rendered runner contains exactly one
 #      `sudo -v`, before any write, and that record's write is `sudo defaults
-#      write "/Library/Preferences/<domain>" ...`.
+#      write '/Library/Preferences/<domain>' ...`.
 #   3. An explicit ABSOLUTE plist_path is written instead of the default.
 #   4. A RELATIVE plist_path is rejected (render fails; apply refuses), never
 #      resolved against the ambient working directory.
@@ -95,7 +100,7 @@ render_template() { # <source-dir> <out-file> <err-file>
   HOME="$render_home" chezmoi --source "$1" execute-template --no-tty <"$TEMPLATE" >"$2" 2>"$3"
 }
 
-# ---- criterion 1: user-only data renders byte-identical to main -------------
+# ---- criterion 1: user-only data renders with unchanged behavior ------------
 
 user_only_src="$(
   make_source_dir <<'EOF'
@@ -116,10 +121,13 @@ macos:
 EOF
 )"
 
-# The golden render: main's template (pre-slice, commit 5d70c94) rendered
-# against the fixture above. Byte for byte, including the trailing blank line.
-golden="$sandbox/golden-user-only"
-cat >"$golden" <<'EOF'
+# The PRE-SLICE golden: main's template (commit 5d70c94) rendered against the
+# fixture above, byte for byte including the trailing blank line. It is no
+# longer the byte-target, it is the BEHAVIORAL reference: the section below runs
+# it and the current render under the same stubs and compares what `defaults`
+# and `killall` actually receive.
+pre_slice_golden="$sandbox/golden-user-only-pre-slice"
+cat >"$pre_slice_golden" <<'EOF'
 #!/bin/bash
 # Tier 1, macOS user defaults runner.
 # chezmoi hash-gates on the rendered template body; this script re-runs only
@@ -141,6 +149,33 @@ killall "cfprefsd" 2>/dev/null || true
 
 EOF
 
+# The CURRENT golden: the same fixture through the hardened template. Every data
+# field is POSIX single-quoted, so bash performs no expansion inside it at all.
+# Keeping this as a byte pin means any future change to the quoting shows up as
+# a diff in this file rather than as a silent change in what gets executed.
+hardened_golden="$sandbox/golden-user-only-hardened"
+cat >"$hardened_golden" <<'EOF'
+#!/bin/bash
+# Tier 1, macOS user defaults runner.
+# chezmoi hash-gates on the rendered template body; this script re-runs only
+# when .chezmoidata/macos_defaults.yaml changes.
+
+set -euo pipefail
+
+# Pre-flight: close System Settings if open. macOS caches plist values inside
+# Settings and writes them back on close, silently overwriting our writes.
+osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
+
+# Main loop: one `defaults write` per record.
+defaults write 'com.example.alpha' 'AlphaKey' -bool 'true'
+defaults -currentHost write 'com.example.beta' 'BetaKey' -string 'BetaValue'
+# Post-loop: restart user-facing processes so changes take effect immediately.
+# cfprefsd kill is non-negotiable (caches plist values in memory).
+killall 'Dock' 2>/dev/null || true
+killall 'cfprefsd' 2>/dev/null || true
+
+EOF
+
 rendered="$sandbox/rendered-user-only"
 render_error="$sandbox/render.err"
 render_template "$user_only_src" "$rendered" "$render_error" ||
@@ -149,10 +184,42 @@ if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi
-cmp -s "$golden" "$rendered" ||
-  fail "user-only render must be byte-identical to the pre-slice render (diff: $(diff "$golden" "$rendered" | head -20))"
+cmp -s "$hardened_golden" "$rendered" ||
+  fail "user-only render must match the hardened golden (diff: $(diff "$hardened_golden" "$rendered" | head -20))"
 refute_file_contains "$rendered" 'sudo' \
   'user-only render must contain no sudo invocation'
+
+# Semantic identity with the pre-slice render, the claim byte-identity was
+# standing in for. Both scripts run under the same stubs and the recorded
+# argument vectors must be identical: same commands, same arguments, same order.
+# The fixture is benign, so a quoting change that altered ANY argument, or
+# reordered anything, shows up here.
+equivalence_bin="$sandbox/equivalence-bin"
+mkdir -p "$equivalence_bin"
+for stubbed_command in defaults killall osascript; do
+  cat >"$equivalence_bin/$stubbed_command" <<EOF
+#!/bin/bash
+printf '$stubbed_command'
+printf ' [%s]' "\$@"
+printf '\n'
+exit 0
+EOF
+  chmod +x "$equivalence_bin/$stubbed_command"
+done
+run_render_capturing_arguments() { # <script> <out-file>
+  (
+    cd "$sandbox" || exit 1
+    PATH="$equivalence_bin:$PATH" bash "$1"
+  ) >"$2" 2>&1
+}
+run_render_capturing_arguments "$pre_slice_golden" "$sandbox/argv-pre-slice" ||
+  fail 'the pre-slice golden must run cleanly under the stubs'
+run_render_capturing_arguments "$rendered" "$sandbox/argv-hardened" ||
+  fail 'the hardened render must run cleanly under the stubs'
+cmp -s "$sandbox/argv-pre-slice" "$sandbox/argv-hardened" ||
+  fail "the hardened render must pass byte-identical arguments to every command (diff: $(diff "$sandbox/argv-pre-slice" "$sandbox/argv-hardened" | head -20))"
+[[ -s $sandbox/argv-hardened ]] ||
+  fail 'the argument-vector capture is empty; the comparison above would pass on two dead runs'
 
 # The repo's REAL data file declares no system-scope record in this slice, so
 # the shipped render must contain no sudo either.
@@ -203,11 +270,11 @@ first_write_line="$(grep -nE '^(sudo )?defaults ' "$rendered_system" | head -1 |
 [[ -n $first_write_line ]] || fail 'system-record render must contain defaults writes'
 [[ $sudo_validate_line -lt $first_write_line ]] ||
   fail "the sudo -v prelude must come before any write (sudo -v at line $sudo_validate_line, first write at line $first_write_line)"
-grep -qxF 'sudo defaults write "/Library/Preferences/com.example.sys" "SysKey" -bool "false"' "$rendered_system" ||
+grep -qxF "sudo defaults write '/Library/Preferences/com.example.sys' 'SysKey' -bool 'false'" "$rendered_system" ||
   fail "the system record's write must be sudo-prefixed and target /Library/Preferences/<domain> (got: $(grep -F 'com.example.sys' "$rendered_system"))"
-grep -qxF 'defaults write "com.example.alpha" "AlphaKey" -bool "true"' "$rendered_system" ||
+grep -qxF "defaults write 'com.example.alpha' 'AlphaKey' -bool 'true'" "$rendered_system" ||
   fail 'the user record must keep its plain, un-sudoed write'
-refute_file_contains "$rendered_system" 'sudo defaults write "com.example.alpha"' \
+refute_file_contains "$rendered_system" "sudo defaults write 'com.example.alpha'" \
   'the user record must not be written through sudo'
 
 # ---- criterion 3: an explicit absolute plist_path wins over the default -----
@@ -229,7 +296,7 @@ EOF
 rendered_explicit="$sandbox/rendered-explicit"
 render_template "$explicit_path_src" "$rendered_explicit" "$render_error" ||
   fail "explicit-path render must succeed (stderr: $(cat "$render_error"))"
-grep -qxF 'sudo defaults write "/Library/Objective-See/LuLu/preferences.plist" "LuLuKey" -string "block"' "$rendered_explicit" ||
+grep -qxF "sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'LuLuKey' -string 'block'" "$rendered_explicit" ||
   fail "an explicit absolute plist_path must be the write target (got: $(grep -F LuLuKey "$rendered_explicit"))"
 refute_file_contains "$rendered_explicit" '/Library/Preferences/com.example.lulu' \
   'an explicit plist_path must replace the /Library/Preferences default, not coexist with it'
@@ -693,4 +760,4 @@ run_tool "$capture_reject_src" "$CAPTURE" com.example.cap CapKey --scope=bogus \
 [[ $capture_status -eq 3 ]] ||
   fail "capture --scope=bogus must exit 3 (got $capture_status)"
 
-printf 'macos-defaults-system-scope: OK (user-only render byte-identical with no sudo; one sudo -v before any write; explicit absolute plist_path honored, relative rejected everywhere; drift distinguishes value/<unset>/<unreadable> and never counts indeterminate as drift; capture appends scope: system and rejects the --host pairing)\n'
+printf 'macos-defaults-system-scope: OK (user-only render matches the hardened golden, passes byte-identical arguments to the pre-slice render, and contains no sudo; one sudo -v before any write; explicit absolute plist_path honored, relative rejected everywhere; drift distinguishes value/<unset>/<unreadable> and never counts indeterminate as drift; capture appends scope: system and rejects the --host pairing)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -9,6 +9,15 @@
 #     /Library/Preferences/<domain>, passes an absolute path through verbatim,
 #     and REJECTS a relative path rather than resolving it against whatever
 #     directory the caller happens to be standing in.
+#   - resolve_system_plist_path enforces the domain rule for EVERY system-scope
+#     record, not only for the ones that omit plist_path. The template rejects a
+#     traversal domain unconditionally, so a library that only checked it on the
+#     default-path branch was the MORE PERMISSIVE of the two consumers and the
+#     same YAML rendered one way and applied another.
+#   - Degenerate targets are rejected rather than resolved: a domain that is
+#     empty or nothing but dots, and a plist_path of exactly "/". None of them
+#     escape a directory, but none of them answer "does this resolve where I
+#     intend to write" either.
 #   - validate_record_scope accepts only user/system, rejects the set-but-empty
 #     scope "" (yq already defaulted an ABSENT field to "user", so "" can only
 #     mean an explicitly empty field), and rejects the meaningless pairs
@@ -89,6 +98,53 @@ status=0
 output="$(call_function resolve_system_plist_path com.example.rel './prefs.plist')" || status=$?
 [[ $status -ne 0 ]] ||
   fail "dot-relative path: resolve_system_plist_path must reject ./prefs.plist (got 0, stdout: '$output')"
+
+# reject_resolved_path <label> <domain> <plist_path> -- assert the pair is
+# refused with a nonzero status AND an empty stdout. Empty stdout matters as much
+# as the status: every caller reads the resolved path from stdout, so a refusal
+# that still printed something would hand a caller the very target it rejected.
+reject_resolved_path() { # <label> <domain> <plist_path>
+  local label="$1" domain="$2" declared_path="$3"
+  local reject_status=0 reject_output
+  reject_output="$(call_function resolve_system_plist_path "$domain" "$declared_path")" || reject_status=$?
+  [[ $reject_status -ne 0 ]] ||
+    fail "$label: resolve_system_plist_path must reject domain '$domain' plist_path '$declared_path' (got 0, stdout: '$reject_output')"
+  [[ -z $reject_output ]] ||
+    fail "$label: a rejected pair must print nothing on stdout (got '$reject_output')"
+}
+
+# case 4a: a traversal domain is rejected on the DEFAULT-path branch. Without the
+# slash rule, /Library/Preferences/../../tmp/owned is /tmp/owned, written as root.
+reject_resolved_path 'traversal domain, default path' '../../tmp/owned' ''
+
+# case 4b: the same traversal domain is rejected when the record ALSO declares a
+# plist_path. The template rejects this record outright, so a library that
+# accepted it made the two consumers disagree about the same YAML.
+reject_resolved_path 'traversal domain, declared path' '../../tmp/owned' \
+  '/Library/Preferences/com.example.sys.plist'
+
+# case 4c: a declared plist_path that walks back out is rejected in every
+# spelling, including the ones a bare "starts with /" check waves through.
+reject_resolved_path 'traversal path, interior' com.example.sys '/Library/Preferences/../../etc/x'
+reject_resolved_path 'traversal path, bare root parent' com.example.sys '/..'
+reject_resolved_path 'traversal path, trailing parent' com.example.sys '/Library/Preferences/..'
+reject_resolved_path 'traversal path, doubled slashes' com.example.sys '//Library/..//etc/x'
+
+# case 4d: degenerate targets. None of these escape a directory (`defaults`
+# appends .plist), so they are hygiene rather than traversal, but none of them
+# name a file anybody meant to write either.
+reject_resolved_path 'empty domain' '' ''
+reject_resolved_path 'dot domain' '.' ''
+reject_resolved_path 'dot-dot domain' '..' ''
+reject_resolved_path 'root plist_path' com.example.sys '/'
+
+# case 4e (control for 4a-4d): the real path a later slice depends on stays
+# ACCEPTED. Without this row every rejection above is satisfied by a function
+# that refuses everything.
+status=0
+output="$(call_function resolve_system_plist_path com.example.lulu '/Library/Objective-See/LuLu/preferences.plist')" || status=$?
+[[ $status -eq 0 && $output == '/Library/Objective-See/LuLu/preferences.plist' ]] ||
+  fail "LuLu path: the tracked Objective-See path must stay accepted verbatim (got status $status, output '$output')"
 
 # ---- validate_record_scope ---------------------------------------------------
 
@@ -290,4 +346,4 @@ mapfile -t sudo_arguments <"$sudo_log"
 [[ ${sudo_arguments[4]} == -bool ]] || fail "write: argument 5 must be the dashed type (got '${sudo_arguments[4]}')"
 [[ ${sudo_arguments[5]} == false ]] || fail "write: argument 6 must be the value (got '${sudo_arguments[5]}')"
 
-printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; re-sourcing under set -euo pipefail is a no-op that still fixes the constants; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'
+printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative, traversal and degenerate targets on BOTH branches while the tracked Objective-See path still resolves; re-sourcing under set -euo pipefail is a no-op that still fixes the constants; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# macos-defaults-scope-read.sh -- unit coverage for the scope-aware helpers in
+# macos-defaults-lib.sh: resolve_system_plist_path, validate_record_scope,
+# system_defaults_read_actual, and system_defaults_write.
+#
+# The properties pinned here, each a fail-closed rule a consumer depends on:
+#
+#   - resolve_system_plist_path defaults an empty declared path to
+#     /Library/Preferences/<domain>, passes an absolute path through verbatim,
+#     and REJECTS a relative path rather than resolving it against whatever
+#     directory the caller happens to be standing in.
+#   - validate_record_scope accepts only user/system, rejects the set-but-empty
+#     scope "" (yq already defaulted an ABSENT field to "user", so "" can only
+#     mean an explicitly empty field), and rejects the meaningless pairs
+#     scope=system+host and scope=user+plist_path.
+#   - system_defaults_read_actual distinguishes THREE outcomes: the value,
+#     "<unset>" (only when defaults itself says the pair does not exist), and
+#     "<unreadable>" for every other failure AND for a plist file that exists
+#     but cannot be read. An unknown failure must never collapse into
+#     "<unset>": that would report drift on a value nobody actually read.
+#
+# Pure stubs: no real chezmoi, git, or yq. The only binary the functions under
+# test invoke is `defaults` (and `sudo`), both stubbed per case.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook; the library's own override may be exported
+# on a developer machine.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $LIB ]] || fail "missing lib: $LIB"
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'chmod -R u+rwX "$work" 2>/dev/null; rm -rf "$work"' EXIT
+
+stub_bin="$work/bin"
+mkdir -p "$stub_bin"
+
+# call_function <function> [args...] -- run one library function with the stubs
+# on PATH. Prints its stdout, writes its stderr to "$work/err", returns its
+# status.
+call_function() { # <function> [args...]
+  PATH="$stub_bin:$PATH" LIB="$LIB" bash -c 'source "$LIB"; "$@"' _ "$@" 2>"$work/err"
+}
+
+# ---- resolve_system_plist_path ----------------------------------------------
+
+# case 1 (control): an empty declared path defaults to /Library/Preferences.
+status=0
+output="$(call_function resolve_system_plist_path com.example.sys '')" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "default path: resolve_system_plist_path must succeed on an empty declared path (got $status, stderr: $(cat "$work/err"))"
+[[ $output == '/Library/Preferences/com.example.sys' ]] ||
+  fail "default path: an empty declared path must resolve to /Library/Preferences/<domain> (got '$output')"
+
+# case 2: an explicit absolute path passes through verbatim.
+status=0
+output="$(call_function resolve_system_plist_path com.example.lulu /Library/Objective-See/LuLu/preferences.plist)" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "absolute path: resolve_system_plist_path must accept an absolute path (got $status, stderr: $(cat "$work/err"))"
+[[ $output == '/Library/Objective-See/LuLu/preferences.plist' ]] ||
+  fail "absolute path: an absolute declared path must pass through verbatim (got '$output')"
+
+# case 3: a relative path is rejected, never resolved against the working dir.
+status=0
+output="$(call_function resolve_system_plist_path com.example.rel 'Library/Preferences/rel.plist')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "relative path: resolve_system_plist_path must reject a relative path (got 0, stdout: '$output')"
+grep -qF 'absolute path is required' "$work/err" ||
+  fail "relative path: the rejection must say an absolute path is required (stderr: $(cat "$work/err"))"
+grep -qF 'Library/Preferences/rel.plist' "$work/err" ||
+  fail "relative path: the rejection must name the offending path (stderr: $(cat "$work/err"))"
+[[ -z $output ]] ||
+  fail "relative path: a rejected path must print nothing on stdout (got '$output')"
+
+# case 4: a dot-relative path is a relative path too.
+status=0
+output="$(call_function resolve_system_plist_path com.example.rel './prefs.plist')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "dot-relative path: resolve_system_plist_path must reject ./prefs.plist (got 0, stdout: '$output')"
+
+# ---- validate_record_scope ---------------------------------------------------
+
+# case 5 (control): user with no host and no path is valid.
+status=0
+output="$(call_function validate_record_scope user '' '')" || status=$?
+[[ $status -eq 0 && $output == user ]] ||
+  fail "scope user: must validate and print 'user' (got status $status, output '$output')"
+
+# case 6: system with no host and no path is valid.
+status=0
+output="$(call_function validate_record_scope system '' '')" || status=$?
+[[ $status -eq 0 && $output == system ]] ||
+  fail "scope system: must validate and print 'system' (got status $status, output '$output')"
+
+# case 7: user with a host stays valid (the pre-slice pairing, unchanged).
+status=0
+output="$(call_function validate_record_scope user current '')" || status=$?
+[[ $status -eq 0 && $output == user ]] ||
+  fail "scope user + host: the existing pairing must stay valid (got status $status, output '$output')"
+
+# case 8: an unknown scope is rejected.
+status=0
+output="$(call_function validate_record_scope bogus '' '')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "unknown scope: 'bogus' must be rejected (got 0, output '$output')"
+grep -qF 'unknown scope' "$work/err" ||
+  fail "unknown scope: the rejection must say the scope is unknown (stderr: $(cat "$work/err"))"
+[[ -z $output ]] ||
+  fail "unknown scope: a rejected scope must print nothing on stdout (got '$output')"
+
+# case 9: a set-but-empty scope is rejected, not treated as absent. yq defaults
+# an ABSENT scope to "user" before this function ever sees it, so "" here can
+# only mean an explicitly empty field in the record.
+status=0
+output="$(call_function validate_record_scope '' '' '')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "empty scope: a set-but-empty scope must be rejected (got 0, output '$output')"
+
+# case 10: system + host is a meaningless pair (ByHost storage is per-user).
+status=0
+output="$(call_function validate_record_scope system current '')" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "system + host: the pair must be rejected (got 0, output '$output')"
+grep -qF 'per-user' "$work/err" ||
+  fail "system + host: the rejection must explain ByHost storage is per-user (stderr: $(cat "$work/err"))"
+
+# case 11: user + plist_path is rejected; the path is only honored on system
+# records, and silently ignoring it would write the user domain instead.
+status=0
+output="$(call_function validate_record_scope user '' /Library/Preferences/x.plist)" || status=$?
+[[ $status -ne 0 ]] ||
+  fail "user + plist_path: the pair must be rejected (got 0, output '$output')"
+grep -qF 'plist_path' "$work/err" ||
+  fail "user + plist_path: the rejection must name plist_path (stderr: $(cat "$work/err"))"
+
+# ---- system_defaults_read_actual ----------------------------------------------
+
+# write_defaults_read_stub <ok|unset|denied> -- how `defaults read` behaves.
+write_defaults_read_stub() { # <ok|unset|denied>
+  case "$1" in
+    ok)
+      cat >"$stub_bin/defaults" <<'EOF'
+#!/bin/bash
+printf '1\n'
+exit 0
+EOF
+      ;;
+    unset)
+      cat >"$stub_bin/defaults" <<'EOF'
+#!/bin/bash
+printf 'The domain/default pair of (%s, %s) does not exist\n' "$2" "$3" >&2
+exit 1
+EOF
+      ;;
+    denied)
+      cat >"$stub_bin/defaults" <<'EOF'
+#!/bin/bash
+printf 'Operation not permitted\n' >&2
+exit 1
+EOF
+      ;;
+  esac
+  chmod +x "$stub_bin/defaults"
+}
+
+# case 12 (control): a successful read prints the value.
+write_defaults_read_stub ok
+status=0
+output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" || status=$?
+[[ $status -eq 0 && $output == 1 ]] ||
+  fail "read ok: a successful read must print the value (got status $status, output '$output')"
+
+# case 13: a does-not-exist failure is the ONE failure that means unset.
+write_defaults_read_stub unset
+output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" ||
+  fail "read unset: the three-outcome read must not return nonzero (stderr: $(cat "$work/err"))"
+[[ $output == '<unset>' ]] ||
+  fail "read unset: a does-not-exist failure must print <unset> (got '$output')"
+
+# case 14: any OTHER failure is indeterminate, with a marker DISTINCT from
+# <unset>. Collapsing it into <unset> would report drift on an unread value.
+write_defaults_read_stub denied
+output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" ||
+  fail "read denied: the three-outcome read must not return nonzero (stderr: $(cat "$work/err"))"
+[[ $output == '<unreadable>' ]] ||
+  fail "read denied: an unknown failure must print <unreadable>, never <unset> or a value (got '$output')"
+
+# case 15: a plist file that exists but cannot be read is indeterminate BEFORE
+# defaults is consulted. The stub would report a matching value, so a read that
+# skipped the file check would report all-clear here, which is exactly the
+# fail-open this case makes distinguishable.
+write_defaults_read_stub ok
+locked_plist="$work/locked.plist"
+: >"$locked_plist"
+chmod 000 "$locked_plist"
+output="$(call_function system_defaults_read_actual "$work/locked" SysKey)" ||
+  fail "read locked (.plist candidate): must not return nonzero (stderr: $(cat "$work/err"))"
+[[ $output == '<unreadable>' ]] ||
+  fail "read locked (.plist candidate): an existing unreadable <path>.plist must print <unreadable> (got '$output')"
+output="$(call_function system_defaults_read_actual "$locked_plist" SysKey)" ||
+  fail "read locked (exact path): must not return nonzero (stderr: $(cat "$work/err"))"
+[[ $output == '<unreadable>' ]] ||
+  fail "read locked (exact path): an existing unreadable plist must print <unreadable> (got '$output')"
+chmod u+rw "$locked_plist"
+
+# ---- system_defaults_write -----------------------------------------------------
+
+# case 16: the write goes through sudo with the exact argument shape
+# `defaults write <plist-path> <key> -<type> <value>`, asserted PER FIELD. The
+# sudo stub records each argument on its own line and does not execute anything.
+sudo_log="$work/sudo.log"
+cat >"$stub_bin/sudo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$@" >>"$sudo_log"
+exit 0
+EOF
+chmod +x "$stub_bin/sudo"
+: >"$sudo_log"
+status=0
+call_function system_defaults_write /Library/Preferences/com.example.sys SysKey bool false >/dev/null || status=$?
+[[ $status -eq 0 ]] ||
+  fail "write: system_defaults_write must succeed when sudo succeeds (got $status, stderr: $(cat "$work/err"))"
+mapfile -t sudo_arguments <"$sudo_log"
+[[ ${#sudo_arguments[@]} -eq 6 ]] ||
+  fail "write: sudo must receive exactly 6 arguments (got ${#sudo_arguments[@]}: $(cat "$sudo_log"))"
+[[ ${sudo_arguments[0]} == defaults ]] || fail "write: argument 1 must be 'defaults' (got '${sudo_arguments[0]}')"
+[[ ${sudo_arguments[1]} == write ]] || fail "write: argument 2 must be 'write' (got '${sudo_arguments[1]}')"
+[[ ${sudo_arguments[2]} == /Library/Preferences/com.example.sys ]] ||
+  fail "write: argument 3 must be the plist path (got '${sudo_arguments[2]}')"
+[[ ${sudo_arguments[3]} == SysKey ]] || fail "write: argument 4 must be the key (got '${sudo_arguments[3]}')"
+[[ ${sudo_arguments[4]} == -bool ]] || fail "write: argument 5 must be the dashed type (got '${sudo_arguments[4]}')"
+[[ ${sudo_arguments[5]} == false ]] || fail "write: argument 6 must be the value (got '${sudo_arguments[5]}')"
+
+printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; scope enum and pairings validated fail-closed; the system read distinguishes value/<unset>/<unreadable> and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -18,6 +18,9 @@
 #     "<unreadable>" for every other failure AND for a plist file that exists
 #     but cannot be read. An unknown failure must never collapse into
 #     "<unset>": that would report drift on a value nobody actually read.
+#   - The library survives being sourced twice under `set -euo pipefail`. Its
+#     read-outcome constants were `readonly`, so a second `source` failed the
+#     assignment, and under `set -e` that failure killed the CALLER outright.
 #
 # Pure stubs: no real chezmoi, git, or yq. The only binary the functions under
 # test invoke is `defaults` (and `sudo`), both stubbed per case.
@@ -214,6 +217,30 @@ output="$(call_function system_defaults_read_actual "$locked_plist" SysKey)" || 
   fail "read locked (exact path): an existing unreadable plist must report status 2 (got $status)"
 chmod u+rw "$locked_plist"
 
+# ---- re-sourcing the library --------------------------------------------------
+
+# case 16: sourcing the library twice under `set -euo pipefail` must survive.
+# `readonly` constants make the second source's assignment fail, and under
+# `set -e` that failure kills the CALLER, not just the source. Latent while no
+# caller sources twice, and a trap for the first one that does.
+status=0
+double_source_output="$(bash -c 'set -euo pipefail; source "$1"; source "$1"; printf "SURVIVED\n"' _ "$LIB" 2>"$work/err")" || status=$?
+[[ $status -eq 0 ]] ||
+  fail "double source: sourcing the library twice under set -euo pipefail must succeed (got $status, stderr: $(cat "$work/err"))"
+[[ $double_source_output == SURVIVED ]] ||
+  fail "double source: the caller must run past the second source (got '$double_source_output')"
+
+# case 17: the constants must still carry their documented values after a
+# re-source. A guard that skipped the assignment on an already-set value would
+# satisfy case 16 while leaving the caller reading whatever status codes the
+# environment handed it.
+status=0
+constants_output="$(SYSTEM_READ_OK=9 SYSTEM_READ_UNSET=9 SYSTEM_READ_UNREADABLE=9 \
+  bash -c 'set -euo pipefail; source "$1"; source "$1"; printf "%s %s %s\n" "$SYSTEM_READ_OK" "$SYSTEM_READ_UNSET" "$SYSTEM_READ_UNREADABLE"' \
+  _ "$LIB" 2>"$work/err")" || status=$?
+[[ $status -eq 0 && $constants_output == '0 1 2' ]] ||
+  fail "double source: the read-outcome constants must be 0 1 2 even when the environment presets them (got status $status, output '$constants_output')"
+
 # ---- system_defaults_write -----------------------------------------------------
 
 # case 16: the write goes through sudo with the exact argument shape
@@ -242,4 +269,4 @@ mapfile -t sudo_arguments <"$sudo_log"
 [[ ${sudo_arguments[4]} == -bool ]] || fail "write: argument 5 must be the dashed type (got '${sudo_arguments[4]}')"
 [[ ${sudo_arguments[5]} == false ]] || fail "write: argument 6 must be the value (got '${sudo_arguments[5]}')"
 
-printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'
+printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; re-sourcing under set -euo pipefail is a no-op that still fixes the constants; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -181,18 +181,20 @@ output="$(call_function system_defaults_read_actual /Library/Preferences/com.exa
 
 # case 13: a does-not-exist failure is the ONE failure that means unset.
 write_defaults_read_stub unset
-output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" ||
-  fail "read unset: the three-outcome read must not return nonzero (stderr: $(cat "$work/err"))"
-[[ $output == '<unset>' ]] ||
-  fail "read unset: a does-not-exist failure must print <unset> (got '$output')"
+status=0
+output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" || status=$?
+[[ $status -eq 1 ]] ||
+  fail "read unset: a does-not-exist failure must report the unset STATUS 1 (got $status, stderr: $(cat "$work/err"))"
+[[ -z $output ]] ||
+  fail "read unset: the unset outcome must print no value, so no value can impersonate it (got '$output')"
 
 # case 14: any OTHER failure is indeterminate, with a marker DISTINCT from
 # <unset>. Collapsing it into <unset> would report drift on an unread value.
 write_defaults_read_stub denied
-output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" ||
-  fail "read denied: the three-outcome read must not return nonzero (stderr: $(cat "$work/err"))"
-[[ $output == '<unreadable>' ]] ||
-  fail "read denied: an unknown failure must print <unreadable>, never <unset> or a value (got '$output')"
+status=0
+output="$(call_function system_defaults_read_actual /Library/Preferences/com.example.sys SysKey)" || status=$?
+[[ $status -eq 2 ]] ||
+  fail "read denied: an unknown failure must report the unreadable STATUS 2, never unset (got $status, stderr: $(cat "$work/err"))"
 
 # case 15: a plist file that exists but cannot be read is indeterminate BEFORE
 # defaults is consulted. The stub would report a matching value, so a read that
@@ -202,14 +204,14 @@ write_defaults_read_stub ok
 locked_plist="$work/locked.plist"
 : >"$locked_plist"
 chmod 000 "$locked_plist"
-output="$(call_function system_defaults_read_actual "$work/locked" SysKey)" ||
-  fail "read locked (.plist candidate): must not return nonzero (stderr: $(cat "$work/err"))"
-[[ $output == '<unreadable>' ]] ||
-  fail "read locked (.plist candidate): an existing unreadable <path>.plist must print <unreadable> (got '$output')"
-output="$(call_function system_defaults_read_actual "$locked_plist" SysKey)" ||
-  fail "read locked (exact path): must not return nonzero (stderr: $(cat "$work/err"))"
-[[ $output == '<unreadable>' ]] ||
-  fail "read locked (exact path): an existing unreadable plist must print <unreadable> (got '$output')"
+status=0
+output="$(call_function system_defaults_read_actual "$work/locked" SysKey)" || status=$?
+[[ $status -eq 2 ]] ||
+  fail "read locked (.plist candidate): an existing unreadable <path>.plist must report status 2 (got $status)"
+status=0
+output="$(call_function system_defaults_read_actual "$locked_plist" SysKey)" || status=$?
+[[ $status -eq 2 ]] ||
+  fail "read locked (exact path): an existing unreadable plist must report status 2 (got $status)"
 chmod u+rw "$locked_plist"
 
 # ---- system_defaults_write -----------------------------------------------------
@@ -240,4 +242,4 @@ mapfile -t sudo_arguments <"$sudo_log"
 [[ ${sudo_arguments[4]} == -bool ]] || fail "write: argument 5 must be the dashed type (got '${sudo_arguments[4]}')"
 [[ ${sudo_arguments[5]} == false ]] || fail "write: argument 6 must be the value (got '${sudo_arguments[5]}')"
 
-printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; scope enum and pairings validated fail-closed; the system read distinguishes value/<unset>/<unreadable> and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'
+printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -217,6 +217,27 @@ output="$(call_function system_defaults_read_actual "$locked_plist" SysKey)" || 
   fail "read locked (exact path): an existing unreadable plist must report status 2 (got $status)"
 chmod u+rw "$locked_plist"
 
+# case 15a: a failed mktemp refuses toward indeterminate AND says why. Status
+# alone cannot pin this: with the guard deleted the empty filename becomes an
+# ambiguous redirect, which ALSO ends at status 2, so the deliberate refusal and
+# the accident are indistinguishable by status. The explicit message is what
+# separates them.
+write_defaults_read_stub ok
+printf '#!/bin/bash\nexit 1\n' >"$stub_bin/mktemp"
+chmod +x "$stub_bin/mktemp"
+status=0
+output="$(call_function system_defaults_read_actual "$work/no-such-plist" SysKey)" || status=$?
+[[ $status -eq 2 ]] ||
+  fail "read mktemp failure: a failed mktemp must report the unreadable status 2 (got $status, stderr: $(cat "$work/err"))"
+grep -qF 'cannot classify' "$work/err" ||
+  fail "read mktemp failure: the refusal must name its reason, not fall through silently (stderr: $(cat "$work/err"))"
+if grep -qF 'ambiguous redirect' "$work/err"; then
+  fail "read mktemp failure: the temp file must never become an ambiguous redirect (stderr: $(cat "$work/err"))"
+fi
+[[ -z $output ]] ||
+  fail "read mktemp failure: an indeterminate read must print no value (got '$output')"
+rm -f "$stub_bin/mktemp"
+
 # ---- re-sourcing the library --------------------------------------------------
 
 # case 16: sourcing the library twice under `set -euo pipefail` must survive.

--- a/test/unit/macos-defaults-source-path-propagation.sh
+++ b/test/unit/macos-defaults-source-path-propagation.sh
@@ -268,45 +268,4 @@ grep -qF 'set but empty' "$work/err" ||
 [[ -z $output ]] ||
   fail "empty override: a rejected override must print no directory (got '$output')"
 
-# ---- case 8: every record field maps to its documented column ---------------
-# defaults_records_tsv is the one function all three tools share, so a field-order
-# or field-selection slip in its yq expression corrupts every tool at once. The
-# per-field assertions below fail on any swap; a whole-line substring match would
-# not, because a swapped domain and key still contain both strings.
-records_yaml="$work/records.yaml"
-cat >"$records_yaml" <<'EOF'
-macos:
-  defaults:
-    - domain: com.example.alpha
-      key: AlphaKey
-      type: bool
-      value: "true"
-      host: currentHost
-    - domain: com.example.beta
-      key: BetaKey
-      type: string
-      value: BetaValue
-EOF
-status=0
-records="$(bash -c 'source "$1"; defaults_records_tsv "$2"' _ "$LIB" "$records_yaml" 2>"$work/err")" || status=$?
-[[ $status -eq 0 ]] ||
-  fail "record shape: defaults_records_tsv must succeed on a well-formed file (got $status, stderr: $(cat "$work/err"))"
-
-line_one="$(printf '%s\n' "$records" | sed -n '1p')"
-IFS=$'\t' read -r got_domain got_key got_type got_value got_host <<<"$line_one"
-[[ $got_domain == com.example.alpha ]] || fail "record shape: column 1 must be the domain (got '$got_domain')"
-[[ $got_key == AlphaKey ]] || fail "record shape: column 2 must be the key (got '$got_key')"
-[[ $got_type == bool ]] || fail "record shape: column 3 must be the type (got '$got_type')"
-[[ $got_value == true ]] || fail "record shape: column 4 must be the value (got '$got_value')"
-[[ $got_host == currentHost ]] || fail "record shape: column 5 must be the host (got '$got_host')"
-
-# A record with no host must still yield the other four columns, with host empty.
-line_two="$(printf '%s\n' "$records" | sed -n '2p')"
-IFS=$'\t' read -r got_domain got_key got_type got_value got_host <<<"$line_two"
-[[ $got_domain == com.example.beta ]] || fail "record shape: hostless column 1 must be the domain (got '$got_domain')"
-[[ $got_key == BetaKey ]] || fail "record shape: hostless column 2 must be the key (got '$got_key')"
-[[ $got_type == string ]] || fail "record shape: hostless column 3 must be the type (got '$got_type')"
-[[ $got_value == BetaValue ]] || fail "record shape: hostless column 4 must be the value (got '$got_value')"
-[[ -z $got_host ]] || fail "record shape: an absent host must read back empty (got '$got_host')"
-
-printf 'macos-defaults-source-path-propagation: OK (control resolves; both branches propagate a failed source-path; an empty resolution fails closed with status 2; an inherited git context cannot retarget; a marked tree without data resolves to itself; a set-but-empty override is rejected; every record column maps to its documented field)\n'
+printf 'macos-defaults-source-path-propagation: OK (control resolves; both branches propagate a failed source-path; an empty resolution fails closed with status 2; an inherited git context cannot retarget; a marked tree without data resolves to itself; a set-but-empty override is rejected)\n'


### PR DESCRIPTION
## Context

The macOS settings this repo tracks are all per-user. Every one is written with a plain `defaults write`
against a user domain, and the runner that applies them needs no privileges at all. Most security-relevant
settings do not live there. They live in machine-wide plists owned by root, and writing one needs sudo.

This teaches the tooling that a tracked record has a scope. It adds the capability and declares nothing:
no security setting is turned on here, and the seven existing records are unchanged in meaning.

## Summary

- A record may now declare `scope: system` and be written to a root-owned plist.
- The runner asks for sudo once, and only when a system-scope record exists.
- A system record may name an explicit plist path, for products that store settings outside the default location.
- Reading a system setting now distinguishes unreadable from unset, so an unread value is never reported as drift.
- Record data can no longer reach shell source as live syntax.

Key files: `.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl`,
`dot_local/bin/macos-defaults-lib.sh`, the three `macos-defaults-*` tools.

## Why an explicit path, and why now

The default target is `/Library/Preferences/<domain>`, which covers most products. One that a later slice
needs does not follow it, keeping its policy under `/Library/Objective-See`. Supporting a declared path is
therefore not speculative generality: building only the default shape now would push the change into the
slice least able to absorb it. A declared path must be absolute, and a relative one is rejected rather than
resolved against whatever directory the tool happened to start in.

## Three outcomes when reading, not two

Drift previously had a value or an absence. A root-owned plist adds a third case: present but unreadable.
Collapsing that into "unset" would report drift on a value nobody actually read, and skipping it would hide
the setting entirely. It is now its own indeterminate row that never counts as drift.

The outcome travels as an exit status rather than a marker string. A string is representable as a real
value, so a setting whose live value happened to spell the marker would have been misreported. A status
cannot be impersonated by any value.

## What review changed

Adding sudo to a code path does not only make that path privileged. It raises the severity of every latent
defect the path already had, so the review covered the existing logic rather than only the new branch. That
was the right call: the worst finding was already on the main branch.

Record fields were interpolated into the generated script using a quoting helper that produces double
quotes. Nothing could break out of them, but a shell still expands command substitutions and variables
inside double quotes, so a field carrying one executed when the runner ran. On a system record that meant
executing under the sudo credential the new prelude had just cached. Every field is now wrapped in single
quotes, which suppress expansion entirely, with embedded quotes escaped. The one field that cannot be
quoted, because it has to become a bare option word, is instead restricted to a closed set of known types.

Three further defects came from the same family, each a check that answered a narrower question than the
code assumed. A path guard tested whether a path began with a slash, which is not the same as whether it
resolves where intended, so a parent-directory component escaped the target directory and was written as
root. The default path interpolated an unvalidated domain, which escaped the same way. And a blank field in
the data file, which is an ordinary typo, was rendered as the text a nil value stringifies to and written
verbatim, where it had previously produced a malformed command that failed loudly.

One record could also forge a second one. The tools read records as a stream of delimited fields, and a
field containing a delimiter or a newline fabricated an extra record that the runner never rendered and
nobody declared. Counting fields does not catch it, because a forged record is self-consistent by
construction. The stream is now checked against the number of records the data file actually declares.

## How it was reviewed

One adversarial pass over the slice, then a pass over the fixes themselves, since fixes are usually the
least examined code in a change. Both found real defects, including one introduced by the first round of
fixes. Every guard is pinned by a test that was confirmed to fail before its fix, verified by mutating the
code and checking the test reports failure, always alongside an unmutated control so a dead harness cannot
be mistaken for a passing one.

The slice's original self-supporting claim was that a user-only render stays byte-identical to `main`.
Single-quoting breaks that, so the claim is restated rather than quietly dropped: the test now pins the new
render byte for byte and separately asserts that the old and new renders pass identical argument vectors to
every command they invoke. That was verified to be the stronger of the two by regenerating the golden and
confirming the argument check still fires.

## Effect of merging

Advances `main` only. No security setting is declared, no record changes meaning, and the live machine
follows another branch, so nothing changes on any machine until a later cutover.
