### PR TITLE
fix(brew): declare the installed packages missing from the manifest

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -12,6 +12,7 @@ packages:
         - openhue/cli
         - oven-sh/bun
         - owenthereal/upterm
+        - rjyo/moshi
         - steipete/tap
         - vjeantet/tap
         - xdevplatform/tap
@@ -34,6 +35,7 @@ packages:
         - openhue/cli
         - oven-sh/bun
         - owenthereal/upterm
+        - rjyo/moshi
         - steipete/tap
         - vjeantet/tap
         - xdevplatform/tap
@@ -126,6 +128,7 @@ packages:
         - pv
         - restic
         - ripgrep
+        - rjyo/moshi/moshi-hook
         - ruff
         - sd
         - sevenzip
@@ -156,6 +159,7 @@ packages:
         - xcode-build-server
         - xcodegen
         - xz
+        - yakitrak/yakitrak/notesmd-cli
         - yq
         - zoxide
       casks:
@@ -168,6 +172,8 @@ packages:
         - chatgpt
         - claude
         - claude-code@latest
+        - codex
+        - codex-app
         - discord
         - docker-desktop
         - espanso
@@ -193,6 +199,7 @@ packages:
         - openemu
         - osquery
         - oversight
+        - paseo
         - proton-drive
         - proton-mail
         - proton-mail-bridge


### PR DESCRIPTION
## Context

Package installation on this machine is declarative. A data file lists every formula and cask that should
be present, and the install step runs the package manager's bundle command with cleanup enabled, which
removes anything installed that the list does not name. An omission is therefore not a gap, it is an
instruction to uninstall.

Five packages are installed and in daily use on this machine but appear nowhere in that list on this
branch, including the coding agent tooling. Nothing is wrong today, because the live machine applies from
a different branch. The moment it is pointed at this one, the cleanup step would remove them.

## Summary

- Declares three casks and two formulae that are installed but were unlisted.
- Adds the third-party source one of those formulae comes from, to both required trust lists.
- Removes the last known way the branch cutover could uninstall working tools.
- Data only, seven added lines, no behavior change on any machine today.

Key files: `.chezmoidata/system_packages_autoinstall.yaml`.

## The trust list is the part that is easy to get wrong

One formula comes from a third-party source that was missing from both the source list and the trusted
source list. Declaring the formula alone would have made things worse rather than better: the bundle step
refuses to load an untrusted source outright, so the run would fail instead of quietly under-installing.
Both lists now name it, matching how every other third-party source in the file is handled, and matching
what the install script's own comments say it requires.

## A rename that is only half visible from here

One of the new formulae is the upstream successor to a package the list already declares under its old
name. Both are installed here, as separate versions with separate install records, so the old declaration
was kept: dropping it would uninstall a working tool.

The upstream picture is less tidy. The old formula no longer exists at its source; only the new one does,
alongside a migration mapping the old name onto it. So the old declaration behaves differently depending
on the machine. Here it matches what is already installed and does nothing. On a fresh machine it resolves
through the migration and installs the successor instead. Nothing breaks either way, but the declared set
has stopped being a description of what a fresh install would produce, which is the property that makes a
declarative list worth having. Retiring the old name is tracked separately rather than folded in here.

## Verified rather than assumed

Every entry was confirmed installed before being declared, and confirmed absent from the file before being
added, using read-only queries. The cask and formula split was checked per entry, since a cask declared as
a formula fails silently. Both third-party formulae are declared with their fully qualified names, matching
the file's existing convention. All four edited lists were checked to still be in order.

No package was installed, removed, upgraded or otherwise touched to produce this change.

One claim in the original task turned out to be wrong and is worth recording: a reported sorting error in
the formula list does not exist, and the list verifies as correctly ordered.

## Found while verifying, not fixed here

Six more packages and one more source are installed but undeclared, carrying the same risk. They are
tracked separately because each needs its own decision rather than a reflexive addition. One of them is
also provided by the development environment, so an undeclared copy may be deliberate. Two packages are
declared but not installed, meaning the cutover would add them; that also needs a ruling rather than a
guess.

## Effect of merging

No machine changes. The live machine follows another branch and already has these packages. This removes a
hazard that would otherwise appear at cutover.
