### PR TITLE
feat(macos): require a control tier on every tracked setting

### DIFF
--- a/.chezmoidata/macos_defaults.yaml
+++ b/.chezmoidata/macos_defaults.yaml
@@ -1,13 +1,31 @@
 # macOS user defaults, declarative source of truth.
 #
-# Each record under `defaults:` becomes one `defaults write` invocation at
+# Each record under `defaults:` is one declared control, applied at
 # `chezmoi apply` time (Tier 1 runner: run_onchange_after_30-macos-defaults).
+# What the runner renders for a record is decided by its REQUIRED `tier`:
 #
-# Schema:
+#   tier: enforce   settable from the command line; renders one `defaults
+#                   write`. The only tier the runner (or any tool) ever
+#                   writes.
+#   tier: verify    readable but NOT settable on this macOS version; drift
+#                   detection only. Renders NO command; `just D` compares the
+#                   record's type/value against the live read.
+#   tier: manual    needs an interactive step or a device-management profile.
+#                   Renders a runbook pointer line and no command. Carries a
+#                   REQUIRED `runbook` field naming the runbook section, and
+#                   NO type/value/host/scope/plist_path.
+#
+# The tier is a property of the control on this OS version, not a preference:
+# when Apple removes a flag, the control moves enforce -> verify as a
+# one-line data change. A record with a missing or unrecognized tier, or a
+# payload that does not match its tier, ABORTS the render.
+#
+# Schema (enforce and verify):
 #   - domain: <string>   # com.apple.dock, NSGlobalDomain, etc.
 #     key:    <string>
 #     type:   bool|int|float|string
 #     value:  <scalar>   # must match `type`
+#     tier:   enforce|verify
 #     host:   current    # OPTIONAL, if set, runner uses `defaults -currentHost`
 #     scope:  user|system  # OPTIONAL, absent means user. A system record is
 #                          # written with sudo to a root-owned plist,
@@ -17,6 +35,15 @@
 #                          # plist path for a product that stores preferences
 #                          # outside /Library/Preferences (e.g. LuLu).
 #                          # Relative paths are rejected.
+#     runbook: <string>    # verify only, OPTIONAL: the runbook section that
+#                          # fixes a detected drift by hand. Forbidden on
+#                          # enforce records (nothing consumes it there).
+#
+# Schema (manual):
+#   - domain: <string>
+#     key:    <string>
+#     tier:   manual
+#     runbook: <string>  # REQUIRED: the runbook section that sets it by hand
 #
 # Each entry in `killall:` runs after the defaults loop. cfprefsd is required
 # for changes to take effect immediately (long-standing macOS plist-cache
@@ -28,30 +55,37 @@ macos:
       key: mru-spaces
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.dock
       key: expose-group-apps
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.WindowManager
       key: GloballyEnabled
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.WindowManager
       key: EnableStandardClickToShowDesktop
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.WindowManager
       key: EnableTilingByEdgeDrag
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.WindowManager
       key: EnableTilingOptionAccelerator
       type: bool
       value: false
+      tier: enforce
     - domain: com.apple.WindowManager
       key: EnableTopTilingByEdgeDrag
       type: bool
       value: false
+      tier: enforce
   killall:
     - Dock
     - Finder

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -1,19 +1,40 @@
 # macOS sudo-required system settings, declarative source of truth.
 #
-# Each record under `system_setup:` is a command run by the Tier 2 runner
-# (run_onchange_after_41-macos-system-setup) at `chezmoi apply` time. The
-# runner does `sudo -v` once upfront, then prefixes commands with `sudo` only
-# when `sudo: true`.
+# Each record under `system_setup:` is one declared control, consumed by the
+# Tier 2 runner (run_onchange_after_41-macos-system-setup) at `chezmoi apply`
+# time. What the runner renders for a record is decided by its REQUIRED
+# `tier`:
 #
-# All commands MUST be idempotent, the runner re-runs the entire list every
-# time the YAML changes (chezmoi hash gate). For non-idempotent commands,
-# put them in the runbook (docs/runbooks/macos-fresh-machine-quickstart.md)
-# instead of here.
+#   tier: enforce   settable from the command line; renders the declared
+#                   command (with a `sudo` prefix when `sudo: true`). The
+#                   only tier the runner ever runs a command for.
+#   tier: verify    readable but NOT settable on this macOS version; drift
+#                   detection only (the posture check consumes it). Renders
+#                   NO command, and must not declare `command` or `sudo`.
+#   tier: manual    needs an interactive step or a device-management profile.
+#                   Renders a runbook pointer line and no command. Carries a
+#                   REQUIRED `runbook` field naming the runbook section, and
+#                   must not declare `command` or `sudo`.
+#
+# The tier is a property of the control on this OS version, not a preference:
+# when Apple removes a flag, the control moves enforce -> verify as a
+# one-line data change. A record with a missing or unrecognized tier, or a
+# payload that does not match its tier, ABORTS the render.
+#
+# All enforce commands MUST be idempotent, the runner re-runs the entire list
+# every time the YAML changes (chezmoi hash gate). For non-idempotent
+# commands, use tier: manual and the runbook
+# (docs/runbooks/macos-fresh-machine-quickstart.md) instead.
 #
 # Schema:
-#   - description: <string>   # echoed before execution; trace output
-#     command:     <string>   # bash, NO `sudo` prefix
-#     sudo:        <bool>
+#   - description: <string>   # REQUIRED on every record; echoed before
+#                             # execution, and the record's identity in every
+#                             # render error
+#     tier:        enforce|verify|manual
+#     command:     <string>   # enforce only: bash, NO `sudo` prefix
+#     sudo:        <bool>     # enforce only, OPTIONAL
+#     runbook:     <string>   # manual: REQUIRED; verify: OPTIONAL; enforce:
+#                             # forbidden (nothing consumes it there)
 #
 # `tailnet_pins` is structured data, not commands: the runner template generates
 # an idempotent guard-then-append /etc/hosts command per entry (MagicDNS
@@ -29,6 +50,7 @@ macos:
     - description: "Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
       command: '"$HOME/.local/bin/install-nix-repair-hook.sh"'
       sudo: true
+      tier: enforce
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -192,7 +192,13 @@ record straight from the data file), and manual renders only a pointer at the
 runbook section that sets it by hand, through the same single-quoting helper
 as every other data field. The trailing refusal is unreachable while the
 validation pass above holds, and stays so this loop can never fail open into
-a write if the two passes ever drift apart. */}}
+a write if the two passes ever drift apart. Its message deliberately differs
+from the validation pass's, naming this loop as the site that caught the
+record: with byte-identical messages either copy could vanish and every test
+would stay green on the other's output, so the distinct marker is what lets
+each site be pinned alone. Do not quote the marker text in this comment; the
+source-form pin greps for it and a comment copy would satisfy the grep with
+the refusal gone. */}}
 {{ range .macos.defaults -}}
 {{ $tier := toString (index . "tier") -}}
 {{ if eq $tier "enforce" -}}
@@ -213,7 +219,7 @@ defaults {{ if index . "host" }}-currentHost {{ end }}write {{ template "shellSi
 {{ else if eq $tier "manual" -}}
 echo {{ template "shellSingleQuoted" (printf "manual control %s %s: not settable here; see the runbook section %s" .domain .key (toString (index . "runbook"))) }}
 {{ else -}}
-{{ fail (printf "macos_defaults.yaml: unrecognized tier %q on record %s %s (expected enforce, verify, or manual)" $tier .domain .key) -}}
+{{ fail (printf "macos_defaults.yaml: unrecognized tier %q on record %s %s reached the render loop; the validation pass no longer rejects it" $tier .domain .key) -}}
 {{ end -}}
 {{ end -}}
 

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -24,14 +24,81 @@ set -euo pipefail
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
 {{ $hasSystemScopeRecord := false -}}
-{{- /* Scope pass: validate every record's optional scope field and detect
-whether any record is system-scope. The field is read through hasKey/index,
-NEVER the bare dotted-field form: Go's text/template errors with `map has no
-entry for key "scope"` on that form when a record omits the key, which is the
-common case (same class of bug as the `index . "host"` guard below). An
-absent field means user scope; a present field must be exactly user or
-system, and system cannot pair with host (ByHost storage is per-user). */ -}}
+{{- /* Validation pass: every record must declare which control tier it
+belongs to, and its payload must MATCH the declared tier, before anything
+renders. The tier decides what the record IS; the payload never does
+(identity is not presence). Every optional field is read through
+hasKey/index, NEVER the bare dotted-field form: Go's text/template errors
+with `map has no entry for key "scope"` on that form when a record omits the
+key, which turns a loud, specific refusal into an opaque template panic. Any
+violation ABORTS the render via fail, so chezmoi refuses the whole apply:
+no warning, no skipped record, no partial best-effort script. */ -}}
 {{ range .macos.defaults -}}
+{{ $record := . -}}
+{{- /* Identity first. The domain and key name the record in every error
+below, and a blank one (an absent key and a blank scalar are both nil) would
+otherwise surface as the stringified literal <nil>. */ -}}
+{{ range $identityField := list "domain" "key" -}}
+{{ if kindIs "invalid" (index $record $identityField) -}}
+{{ fail (printf "macos_defaults.yaml: record %v %v has a blank %s; give it a value or remove the field" (index $record "domain") (index $record "key") $identityField) -}}
+{{ end -}}
+{{ end -}}
+{{- /* The control tier is REQUIRED: enforce (settable, render the write),
+verify (readable but not settable, drift detection only, render NO write), or
+manual (interactive or profile-managed, render a runbook pointer only). Three
+distinct refusals so the error names what is actually wrong: a missing field,
+a blank scalar (nil, which would otherwise stringify to the literal text
+<nil>), or a value outside the closed set. A set-but-empty tier is rejected
+as an unrecognized VALUE, never conflated with an absent field. */ -}}
+{{ if not (hasKey . "tier") -}}
+{{ fail (printf "macos_defaults.yaml: record %s %s has no tier; declare tier: enforce, verify, or manual" .domain .key) -}}
+{{ end -}}
+{{ if kindIs "invalid" (index . "tier") -}}
+{{ fail (printf "macos_defaults.yaml: record %s %s has a blank tier; declare tier: enforce, verify, or manual" .domain .key) -}}
+{{ end -}}
+{{ $tier := toString (index . "tier") -}}
+{{ if not (has $tier (list "enforce" "verify" "manual")) -}}
+{{ fail (printf "macos_defaults.yaml: unrecognized tier %q on record %s %s (expected enforce, verify, or manual)" $tier .domain .key) -}}
+{{ end -}}
+{{- /* The shared library refuses a whole data file whose record stream would be
+ambiguous, because a newline or a unit separator inside a field can forge a
+second record. Without the same rule here, one file would RENDER cleanly and
+then make every tool refuse it, and the operator would learn about it from a
+broken `just D` rather than at apply time. Reject at the same boundary. */ -}}
+{{ range $streamField := list "domain" "key" "value" "plist_path" -}}
+{{ $streamValue := toString (index $record $streamField | default "") -}}
+{{ if or (contains "\n" $streamValue) (contains "\x1f" $streamValue) -}}
+{{ fail (printf "macos_defaults.yaml: record %v %v has a %s containing a newline or a unit separator, which the record stream cannot represent unambiguously" (index $record "domain") (index $record "key") $streamField) -}}
+{{ end -}}
+{{ end -}}
+{{ if eq $tier "manual" -}}
+{{- /* A manual control is an identity plus a runbook pointer, nothing else.
+The runbook section name is REQUIRED, and absent, blank, and empty are three
+ways of pointing nowhere, each refused by name. Every write and read
+qualifier is refused too: a payload on a control the runner must never touch
+means the declared tier is wrong, and catching the lie here is the whole
+point of declaring tiers in data. */ -}}
+{{ if not (hasKey . "runbook") -}}
+{{ fail (printf "macos_defaults.yaml: manual record %s %s has no runbook; a manual control must name its runbook section" .domain .key) -}}
+{{ end -}}
+{{ if kindIs "invalid" (index . "runbook") -}}
+{{ fail (printf "macos_defaults.yaml: manual record %s %s has a blank runbook; name the runbook section" .domain .key) -}}
+{{ end -}}
+{{ if eq (toString (index . "runbook")) "" -}}
+{{ fail (printf "macos_defaults.yaml: manual record %s %s has an empty runbook; name the runbook section" .domain .key) -}}
+{{ end -}}
+{{ range $forbiddenField := list "type" "value" "host" "scope" "plist_path" -}}
+{{ if hasKey $record $forbiddenField -}}
+{{ fail (printf "macos_defaults.yaml: manual record %v %v carries %s; a manual control renders no write, so a write payload means the declared tier is wrong" (index $record "domain") (index $record "key") $forbiddenField) -}}
+{{ end -}}
+{{ end -}}
+{{ else -}}
+{{- /* enforce and verify records carry the full read/write payload: for
+enforce it is the write, for verify it is the read the drift checker compares
+and the value it must hold. The same validation covers both, so a control
+moving between the two tiers is a one-line data change. An absent scope means
+user; a present one must be exactly user or system, and system cannot pair
+with host (ByHost storage is per-user). */ -}}
 {{ $scope := "user" -}}
 {{ if hasKey . "scope" }}{{ $scope = index . "scope" }}{{ end -}}
 {{ if and (ne $scope "user") (ne $scope "system") -}}
@@ -62,22 +129,8 @@ silently accepting it now would be a fail-open regression rather than a new
 convenience. Reject it instead, which is louder than either behavior and says
 which field is at fault. An empty STRING is still legitimate and unaffected: it
 is a value, not a missing one. */ -}}
-{{ $record := . -}}
-{{ range $blankField := list "domain" "key" "value" -}}
-{{ if kindIs "invalid" (index $record $blankField) -}}
-{{ fail (printf "macos_defaults.yaml: record %v %v has a blank %s; give it a value or remove the field" (index $record "domain") (index $record "key") $blankField) -}}
-{{ end -}}
-{{ end -}}
-{{- /* The shared library refuses a whole data file whose record stream would be
-ambiguous, because a newline or a unit separator inside a field can forge a
-second record. Without the same rule here, one file would RENDER cleanly and
-then make every tool refuse it, and the operator would learn about it from a
-broken `just D` rather than at apply time. Reject at the same boundary. */ -}}
-{{ range $streamField := list "domain" "key" "value" "plist_path" -}}
-{{ $streamValue := toString (index $record $streamField | default "") -}}
-{{ if or (contains "\n" $streamValue) (contains "\x1f" $streamValue) -}}
-{{ fail (printf "macos_defaults.yaml: record %v %v has a %s containing a newline or a unit separator, which the record stream cannot represent unambiguously" (index $record "domain") (index $record "key") $streamField) -}}
-{{ end -}}
+{{ if kindIs "invalid" (index $record "value") -}}
+{{ fail (printf "macos_defaults.yaml: record %v %v has a blank value; give it a value or remove the field" (index $record "domain") (index $record "key")) -}}
 {{ end -}}
 {{- /* A plist_path is meaningful only for a system record. The shared tools
 reject the pairing already; without this the template would silently IGNORE the
@@ -112,7 +165,19 @@ rule is "does this resolve where I intend to write" and these do not. */ -}}
 {{ fail (printf "macos_defaults.yaml: system-scope plist_path %q on record %s %s is the filesystem root; it names no plist" $declaredPath .domain .key) -}}
 {{ end -}}
 {{ end -}}
+{{ if eq $tier "enforce" -}}
+{{- /* Nothing consumes a runbook on an enforced control, and silently
+ignored data is how a mislabeled tier hides; refuse it. On a verify record a
+runbook is allowed: the posture check that consumes verify records can point
+the operator at the fix for a detected drift. */ -}}
+{{ if hasKey . "runbook" -}}
+{{ fail (printf "macos_defaults.yaml: enforce record %s %s carries runbook; either drop the field or declare the tier that consumes it" .domain .key) -}}
+{{ end -}}
+{{- /* Only an ENFORCED system record needs the sudo prelude: a verify record
+never writes, so it must never cost a credential prompt either. */ -}}
 {{ if eq $scope "system" }}{{ $hasSystemScopeRecord = true }}{{ end -}}
+{{ end -}}
+{{ end -}}
 {{ end -}}
 {{ if $hasSystemScopeRecord -}}
 # Sudo prelude: at least one record targets a root-owned system plist, so
@@ -120,7 +185,17 @@ rule is "does this resolve where I intend to write" and these do not. */ -}}
 sudo -v
 {{ end -}}
 # Main loop: one `defaults write` per record.
+{{- /* Per ENFORCE record, that is. The branch below decides by the DECLARED
+tier: verify renders nothing at all (the write branch is not taken, so this
+runner physically cannot set a verify control; the drift checker reads the
+record straight from the data file), and manual renders only a pointer at the
+runbook section that sets it by hand, through the same single-quoting helper
+as every other data field. The trailing refusal is unreachable while the
+validation pass above holds, and stays so this loop can never fail open into
+a write if the two passes ever drift apart. */}}
 {{ range .macos.defaults -}}
+{{ $tier := toString (index . "tier") -}}
+{{ if eq $tier "enforce" -}}
 {{ $scope := "user" -}}
 {{ if hasKey . "scope" }}{{ $scope = index . "scope" }}{{ end -}}
 {{ if eq $scope "system" -}}
@@ -133,6 +208,12 @@ declared path must be absolute, never resolved against a working directory. */ -
 sudo defaults write {{ template "shellSingleQuoted" $plistPath }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
 {{ else -}}
 defaults {{ if index . "host" }}-currentHost {{ end }}write {{ template "shellSingleQuoted" .domain }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
+{{ end -}}
+{{ else if eq $tier "verify" -}}
+{{ else if eq $tier "manual" -}}
+echo {{ template "shellSingleQuoted" (printf "manual control %s %s: not settable here; see the runbook section %s" .domain .key (toString (index . "runbook"))) }}
+{{ else -}}
+{{ fail (printf "macos_defaults.yaml: unrecognized tier %q on record %s %s (expected enforce, verify, or manual)" $tier .domain .key) -}}
 {{ end -}}
 {{ end -}}
 

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -102,7 +102,13 @@ at all (the command branch is not taken, so this runner physically cannot
 set a verify control), and manual renders only a pointer at the runbook
 section that sets it by hand. The trailing refusal is unreachable while the
 validation pass above holds, and stays so this loop can never fail open into
-running a command if the two passes ever drift apart. */ -}}
+running a command if the two passes ever drift apart. Its message deliberately
+differs from the validation pass's, naming this loop as the site that caught
+the record: with byte-identical messages either copy could vanish and every
+test would stay green on the other's output, so the distinct marker is what
+lets each site be pinned alone. Do not quote the marker text in this comment;
+the source-form pin greps for it and a comment copy would satisfy the grep
+with the refusal gone. */ -}}
 {{ range .macos.system_setup -}}
 {{ $tier := toString (index . "tier") -}}
 {{ if eq $tier "enforce" -}}
@@ -112,7 +118,7 @@ echo "→ {{ .description }}"
 {{ else if eq $tier "manual" -}}
 echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook section %s" .description (toString (index . "runbook"))) }}
 {{ else -}}
-{{ fail (printf "macos_system_setup.yaml: unrecognized tier %q on record %q (expected enforce, verify, or manual)" $tier .description) -}}
+{{ fail (printf "macos_system_setup.yaml: unrecognized tier %q on record %q reached the render loop; the validation pass no longer rejects it" $tier .description) -}}
 {{ end -}}
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -20,7 +20,7 @@ sudo -v
 
 {{ range .macos.system_setup -}}
 echo "→ {{ .description }}"
-{{ if .sudo }}sudo {{ end }}{{ .command }}
+{{ if index . "sudo" }}sudo {{ end }}{{ .command }}
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).
      Guard-then-append keeps each idempotent across runner re-runs. The sh -c

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -1,3 +1,11 @@
+{{- /* shellSingleQuoted, same helper and same rationale as the Tier 1 runner:
+the one way a data field becomes a shell word. POSIX single quotes with every
+embedded single quote rewritten to '\'', so bash performs no expansion of any
+kind inside it. The enforce branch below is EXEMPT by design: an enforce
+record's command field IS shell source, declared as such in the schema, and
+its description keeps its historical double-quoted echo. Every NEW emission of
+data (the manual runbook pointer) goes through this helper. */ -}}
+{{- define "shellSingleQuoted" }}{{ printf "'%s'" (replace "'" "'\\''" (toString .)) }}{{ end -}}
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # Tier 2, macOS sudo system-setup runner.
@@ -6,21 +14,106 @@
 
 set -euo pipefail
 
-{{/* `index`, not `.macos.tailnet_pins`: Go's text/template errors on an absent
-     key with the .field form; `index` returns the empty value (falsy in `if`,
-     a no-op under `range`), the repo's documented Tier-1 runner gotcha. */ -}}
+{{/* `index`, not the dotted-field form, for every optional key: Go's
+     text/template errors on an absent key with the dotted form; `index`
+     returns the empty value (falsy in `if`, a no-op under `range`), the
+     repo's documented Tier-1 runner gotcha. */ -}}
 {{ $pins := index .macos "tailnet_pins" -}}
+{{- /* Validation pass: every record must declare which control tier it
+belongs to, and its payload must MATCH the declared tier, before anything
+renders. The tier decides what the record IS; the payload never does. Any
+violation ABORTS the render via fail, so chezmoi refuses the whole apply: no
+warning, no skipped record, no partial best-effort script. */ -}}
+{{ $enforceRecordCount := 0 -}}
+{{ range .macos.system_setup -}}
+{{- /* Identity first: the description names the record in every error below
+and in the runner's own trace output, so it is required on every record. */ -}}
+{{ if or (not (hasKey . "description")) (kindIs "invalid" (index . "description")) (eq (toString (index . "description")) "") -}}
+{{ fail "macos_system_setup.yaml: a record has no description; every record needs one, it is the identity in every error and trace line" -}}
+{{ end -}}
+{{- /* The control tier is REQUIRED: enforce (render the command), verify
+(drift detection only, render NO command), or manual (render a runbook
+pointer only). Three distinct refusals so the error names what is actually
+wrong; a blank scalar is nil and would otherwise stringify to the literal
+text <nil>, and a set-but-empty tier is rejected as an unrecognized VALUE,
+never conflated with an absent field. */ -}}
+{{ if not (hasKey . "tier") -}}
+{{ fail (printf "macos_system_setup.yaml: record %q has no tier; declare tier: enforce, verify, or manual" .description) -}}
+{{ end -}}
+{{ if kindIs "invalid" (index . "tier") -}}
+{{ fail (printf "macos_system_setup.yaml: record %q has a blank tier; declare tier: enforce, verify, or manual" .description) -}}
+{{ end -}}
+{{ $tier := toString (index . "tier") -}}
+{{ if not (has $tier (list "enforce" "verify" "manual")) -}}
+{{ fail (printf "macos_system_setup.yaml: unrecognized tier %q on record %q (expected enforce, verify, or manual)" $tier .description) -}}
+{{ end -}}
+{{ if eq $tier "enforce" -}}
+{{ if or (not (hasKey . "command")) (kindIs "invalid" (index . "command")) (eq (toString (index . "command")) "") -}}
+{{ fail (printf "macos_system_setup.yaml: enforce record %q has no command; an enforce control is a command, so declare one or change the tier" .description) -}}
+{{ end -}}
+{{- /* Nothing consumes a runbook on an enforced control, and silently
+ignored data is how a mislabeled tier hides; refuse it. On a verify record a
+runbook is allowed: the posture check that consumes verify records can point
+the operator at the fix for a detected drift. */ -}}
+{{ if hasKey . "runbook" -}}
+{{ fail (printf "macos_system_setup.yaml: enforce record %q carries runbook; either drop the field or declare the tier that consumes it" .description) -}}
+{{ end -}}
+{{ $enforceRecordCount = add $enforceRecordCount 1 -}}
+{{ else -}}
+{{- /* verify and manual controls are the ones this runner must never run a
+command for; a record that declares one is lying about its tier, and the
+whole point of declaring tiers in data is that the lie aborts the render
+instead of executing. The sudo flag only qualifies a command, so it is
+refused on the same grounds. */ -}}
+{{ if hasKey . "command" -}}
+{{ fail (printf "macos_system_setup.yaml: %s record %q carries command, a mutating payload; the runner never runs a command for a %s control, so the declared tier is wrong" $tier .description $tier) -}}
+{{ end -}}
+{{ if hasKey . "sudo" -}}
+{{ fail (printf "macos_system_setup.yaml: %s record %q carries sudo; sudo qualifies a command and a %s control has none" $tier .description $tier) -}}
+{{ end -}}
+{{ if eq $tier "manual" -}}
+{{ if not (hasKey . "runbook") -}}
+{{ fail (printf "macos_system_setup.yaml: manual record %q has no runbook; a manual control must name its runbook section" .description) -}}
+{{ end -}}
+{{ if kindIs "invalid" (index . "runbook") -}}
+{{ fail (printf "macos_system_setup.yaml: manual record %q has a blank runbook; name the runbook section" .description) -}}
+{{ end -}}
+{{ if eq (toString (index . "runbook")) "" -}}
+{{ fail (printf "macos_system_setup.yaml: manual record %q has an empty runbook; name the runbook section" .description) -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
 {{ if and (eq (len .macos.system_setup) 0) (not $pins) -}}
 # Early-return if nothing is configured (avoids spurious sudo prompt).
 exit 0
 {{ else -}}
+{{- /* The sudo prelude is only worth a password prompt when something will
+use the credential: an enforce command or a generated pin command. A file of
+only verify/manual records renders its pointers and asks for nothing. */ -}}
+{{ if or (gt $enforceRecordCount 0) $pins -}}
 # Pre-flight: refresh sudo timestamp upfront. One password prompt at start;
 # none during the loop, it covers the generated tailnet-pin commands too.
 sudo -v
 
+{{ end -}}
+{{- /* The branch below decides by the DECLARED tier: verify renders nothing
+at all (the command branch is not taken, so this runner physically cannot
+set a verify control), and manual renders only a pointer at the runbook
+section that sets it by hand. The trailing refusal is unreachable while the
+validation pass above holds, and stays so this loop can never fail open into
+running a command if the two passes ever drift apart. */ -}}
 {{ range .macos.system_setup -}}
+{{ $tier := toString (index . "tier") -}}
+{{ if eq $tier "enforce" -}}
 echo "→ {{ .description }}"
 {{ if index . "sudo" }}sudo {{ end }}{{ .command }}
+{{ else if eq $tier "verify" -}}
+{{ else if eq $tier "manual" -}}
+echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook section %s" .description (toString (index . "runbook"))) }}
+{{ else -}}
+{{ fail (printf "macos_system_setup.yaml: unrecognized tier %q on record %q (expected enforce, verify, or manual)" $tier .description) -}}
+{{ end -}}
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).
      Guard-then-append keeps each idempotent across runner re-runs. The sh -c

--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -18,14 +18,30 @@ require_readable_data_file "$DATA_FILE" || exit $?
 # Pre-flight: close System Settings if open (same reason as runner).
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
-# Main loop: one `defaults write` per record. A system-scope record goes
-# through sudo to its resolved plist path; user-scope records write exactly as
-# before. A record that fails validation (unknown scope, a meaningless field
-# pairing, a relative plist_path) aborts the run with the data-file status 2
-# before anything is written for it.
+# Main loop: one `defaults write` per ENFORCE record. The tier decides what
+# happens, before any payload field is even looked at: verify records are
+# read-only by declaration and manual records are runbook-applied, so both are
+# skipped without a write, and an unrecognized tier refuses the run (the
+# stream already refused the whole file; the case here keeps this loop from
+# ever failing open into a write if the stream's rules drift). A system-scope
+# record goes through sudo to its resolved plist path; user-scope records
+# write exactly as before. A record that fails validation (unknown scope, a
+# meaningless field pairing, a relative plist_path) aborts the run with the
+# data-file status 2 before anything is written for it.
 defaults_records_unit_separated "$DATA_FILE" |
-  while IFS=$'\x1f' read -r domain key type value host scope plist_path; do
+  while IFS=$'\x1f' read -r domain key type value host scope plist_path tier; do
     [[ -z $domain ]] && continue
+    case "$tier" in
+      enforce) ;;
+      verify | manual)
+        continue
+        ;;
+      *)
+        printf 'error: unrecognized tier %q on record %s %s; refusing to write\n' \
+          "$tier" "$domain" "$key" >&2
+        exit 2
+        ;;
+    esac
     scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
     if [[ $scope == system ]]; then
       resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2

--- a/dot_local/bin/executable_macos-defaults-capture.sh
+++ b/dot_local/bin/executable_macos-defaults-capture.sh
@@ -7,6 +7,11 @@
 # is already tracked but the live value DIVERGES: exit 4 (drift), resolve
 # via `just defaults-apply` (revert) or hand-edit YAML (capture intent).
 #
+# Every appended record declares `tier: enforce`: capture exists to track a
+# value the operator just set and read back, which is the definition of a
+# settable control. A control that belongs to another tier is declared by
+# hand-editing the YAML, not through this tool.
+#
 # Usage: macos-defaults-capture.sh <domain> <key> [--host current] [--scope user|system]
 #
 # --scope system captures from the record's system plist path
@@ -187,7 +192,7 @@ tmp="$(mktemp "${DATA_FILE}.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 
 yq eval \
-  ".macos.defaults += [{\"domain\": \"$domain\", \"key\": \"$key\", \"type\": \"$schema_type\", \"value\": $yaml_value$([[ -n $host ]] && printf ', "host": "%s"' "$host")$([[ $scope == system ]] && printf ', "scope": "system"')}]" \
+  ".macos.defaults += [{\"domain\": \"$domain\", \"key\": \"$key\", \"type\": \"$schema_type\", \"value\": $yaml_value, \"tier\": \"enforce\"$([[ -n $host ]] && printf ', "host": "%s"' "$host")$([[ $scope == system ]] && printf ', "scope": "system"')}]" \
   "$DATA_FILE" >"$tmp"
 
 mv "$tmp" "$DATA_FILE"

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -53,17 +53,34 @@ print_header() {
 }
 
 # Each record arrives as one unit-separated line: domain, key, type, value,
-# host, scope, plist_path. A record that fails validation (unknown scope, a
-# meaningless field pairing, a relative plist_path) aborts with the data-file
-# status 2 rather than being misread. A system-scope record has THREE read
-# outcomes: the value, <unset> (genuinely not set, compared as drift like any
-# other value), and <unreadable> (indeterminate: reported as its own row,
-# counted separately, never as drift and never skipped).
+# host, scope, plist_path, tier. The tier decides what happens first: enforce
+# AND verify records are both compared (detecting drift on a control nobody
+# can set from here is the verify tier's whole purpose), manual records have
+# no check by design (they carry no expected value, only a runbook pointer)
+# and are skipped, and an unrecognized tier aborts rather than guessing (the
+# stream already refused the whole file; the case here keeps this loop honest
+# if the stream's rules ever drift). A record that fails validation (unknown
+# scope, a meaningless field pairing, a relative plist_path) aborts with the
+# data-file status 2 rather than being misread. A system-scope record has
+# THREE read outcomes: the value, <unset> (genuinely not set, compared as
+# drift like any other value), and <unreadable> (indeterminate: reported as
+# its own row, counted separately, never as drift and never skipped).
 # Note: yq emits a single newline for an empty array; the inline guard below
 # skips that empty row so the script exits 0 cleanly when nothing is tracked.
 defaults_records_unit_separated "$DATA_FILE" |
-  while IFS=$'\x1f' read -r domain key type value host scope plist_path; do
+  while IFS=$'\x1f' read -r domain key type value host scope plist_path tier; do
     [[ -z $domain ]] && continue
+    case "$tier" in
+      enforce | verify) ;;
+      manual)
+        continue
+        ;;
+      *)
+        printf 'error: unrecognized tier %q on record %s %s; refusing to report on it\n' \
+          "$tier" "$domain" "$key" >&2
+        exit 2
+        ;;
+    esac
     scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
     expected="$(normalize "$type" "$value")"
     if [[ $scope == system ]]; then

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -100,13 +100,21 @@ require_readable_data_file() { # <path>
 }
 
 # defaults_records_join_expression <record-selector>, the yq expression that
-# joins one record selection into SEVEN fields separated by the ASCII unit
-# separator (0x1f): domain, key, type, value, host, scope, plist_path. Shared by
-# the stream below and by the per-record locator, so the two can never drift into
-# describing different records.
+# joins one record selection into EIGHT fields separated by the ASCII unit
+# separator (0x1f): domain, key, type, value, host, scope, plist_path, tier.
+# Shared by the stream below and by the per-record locator, so the two can
+# never drift into describing different records.
+#
+# type, value, and tier are BARE selectors, deliberately. join renders a null
+# (absent on a manual-tier record) as the empty string already, and the
+# tempting explicit spelling, `.value // ""`, is WRONG here: yq's alternative
+# operator fires on false as well as null, so a legitimate `value: false`
+# (most of the tracked records) would collapse to an empty write. The
+# defaulted fields below are safe with // only because none of them can hold
+# a legitimate false.
 defaults_records_join_expression() { # <record-selector>
   local unit_separator=$'\x1f'
-  printf '%s | [.domain, .key, .type, .value, (.host // ""), (.scope // "user"), (.plist_path // "")] | join("%s")' \
+  printf '%s | [.domain, .key, .type, .value, (.host // ""), (.scope // "user"), (.plist_path // ""), .tier] | join("%s")' \
     "$1" "$unit_separator"
 }
 
@@ -120,7 +128,7 @@ defaults_records_field_count() { # <line>
 }
 
 # defaults_records_locate_malformed <path> <declared-count>, describe the FIRST
-# record that does not render as exactly one seven-field line. Only ever called
+# record that does not render as exactly one eight-field line. Only ever called
 # on the failure path, so its per-record yq calls cost nothing in the normal case.
 defaults_records_locate_malformed() { # <path> <declared-count>
   local data_file="$1" declared_record_count="$2"
@@ -128,7 +136,7 @@ defaults_records_locate_malformed() { # <path> <declared-count>
   for ((index = 0; index < declared_record_count; index++)); do
     record_render="$(yq eval -r "$(defaults_records_join_expression ".macos.defaults[$index]")" "$data_file")" || continue
     line_count="$(printf '%s\n' "$record_render" | wc -l | tr -d ' ')"
-    if [[ $line_count -ne 1 || $(defaults_records_field_count "$record_render") -ne 7 ]]; then
+    if [[ $line_count -ne 1 || $(defaults_records_field_count "$record_render") -ne 8 ]]; then
       printf 'record %d (domain %s, key %s)' "$index" \
         "$(yq eval -r ".macos.defaults[$index].domain" "$data_file" | head -1)" \
         "$(yq eval -r ".macos.defaults[$index].key" "$data_file" | head -1)"
@@ -139,24 +147,32 @@ defaults_records_locate_malformed() { # <path> <declared-count>
 }
 
 # defaults_records_unit_separated <path>, emit each tracked record as one line
-# of SEVEN fields joined by the ASCII unit separator (0x1f):
-#   domain, key, type, value, host, scope, plist_path
-# host and plist_path are empty when absent; an ABSENT scope defaults to
-# "user" here, so a scope that reaches a caller empty was explicitly empty in
-# the record (a record error, rejected by validate_record_scope below). The
-# unit separator is not IFS whitespace, so an empty INTERIOR field survives
-# `IFS=$'\x1f' read` intact, unlike a tab-separated stream, whose collapse is
-# exactly why the optional columns do not extend one.
+# of EIGHT fields joined by the ASCII unit separator (0x1f):
+#   domain, key, type, value, host, scope, plist_path, tier
+# host, plist_path, and (on manual records) type and value are empty when
+# absent; an ABSENT scope defaults to "user" here, so a scope that reaches a
+# caller empty was explicitly empty in the record (a record error, rejected by
+# validate_record_scope below). The unit separator is not IFS whitespace, so an
+# empty INTERIOR field survives `IFS=$'\x1f' read` intact, unlike a
+# tab-separated stream, whose collapse is exactly why the optional columns do
+# not extend one.
+#
+# The TIER is validated here, for the whole file, before a single record is
+# emitted: every record must declare enforce, verify, or manual, and a missing
+# or blank tier arrives as the empty string and is refused like any other
+# unrecognized value. Refusing in the stream is what makes every tool
+# fail-closed at once: no caller can act on a record whose tier is unknown,
+# because no such record ever reaches a caller.
 #
 # The stream is SELF-VALIDATING, because the separator on its own guarantees
 # nothing. A field value carrying a literal 0x1f byte, a NEWLINE, or both is not
 # a formatting nuisance, it is record forgery. One record whose value was
-#   v<0x1f><0x1f>system<0x1f>\nEVIL.DOMAIN<0x1f>EVILKEY<0x1f>bool<0x1f>true
+#   v<0x1f><0x1f>system<0x1f><0x1f>enforce<0x1f>\nEVIL.DOMAIN<0x1f>EVILKEY<0x1f>bool<0x1f>true
 # emitted two well-formed-LOOKING lines and made apply perform TWO root writes,
 # the second fully attacker-controlled, while the template rendered only one.
-# Both halves of that payload carry exactly seven fields, so a per-line field
+# Both halves of that payload carry exactly eight fields, so a per-line field
 # count does not catch it on its own. Two checks together do:
-#   - every line must carry exactly seven fields, which catches a separator
+#   - every line must carry exactly eight fields, which catches a separator
 #     injected without a newline;
 #   - the number of emitted lines must equal the number of DECLARED records,
 #     which catches a newline whether or not the halves are balanced.
@@ -190,17 +206,32 @@ defaults_records_unit_separated() { # <path>
   fi
 
   local line field_count emitted_line_count=0
+  local record_domain record_key record_tier
   local -a validated_lines=()
   while IFS= read -r line; do
     # yq prints a single empty line for an empty array; that is not a record.
     [[ -z $line ]] && continue
     field_count="$(defaults_records_field_count "$line")"
-    if [[ $field_count -ne 7 ]]; then
-      printf 'error: %s: %s renders %s fields, not 7; a field value contains a unit separator (0x1f) or a newline\n' \
+    if [[ $field_count -ne 8 ]]; then
+      printf 'error: %s: %s renders %s fields, not 8; a field value contains a unit separator (0x1f) or a newline\n' \
         "$data_file" "$(defaults_records_locate_malformed "$data_file" "$declared_record_count")" \
         "$field_count" >&2
       return 2
     fi
+    # The tier gate. Only the three declared tiers pass; a record whose tier
+    # is missing or blank arrives here as the empty string and lands in the
+    # same refusal, so absent, blank, and unrecognized all fail closed. The
+    # refusal covers the WHOLE file (nothing has been emitted yet), because a
+    # caller must not act on the records beside one it cannot classify.
+    IFS=$'\x1f' read -r record_domain record_key _ _ _ _ _ record_tier <<<"$line"
+    case "$record_tier" in
+      enforce | verify | manual) ;;
+      *)
+        printf 'error: %s: record (domain %s, key %s) has a missing, blank, or unrecognized tier %q; declare tier: enforce, verify, or manual\n' \
+          "$data_file" "$record_domain" "$record_key" "$record_tier" >&2
+        return 2
+        ;;
+    esac
     validated_lines+=("$line")
     emitted_line_count=$((emitted_line_count + 1))
   done <<<"$raw_records"

--- a/test/integration/macos-control-tier-refusal.sh
+++ b/test/integration/macos-control-tier-refusal.sh
@@ -498,8 +498,10 @@ render_template "$TIER2_TEMPLATE" "$verify_payload_src" "$sandbox/rendered-smugg
   fail 'a verify system_setup record carrying a command must fail the render'
 assert_file_contains "$render_error" 'carries command' \
   "the refusal must name the smuggled command field (stderr: $(cat "$render_error"))"
-refute_file_contains "$sandbox/rendered-smuggled" 'printf smuggled-write-ran' \
-  'the smuggled command must never reach the rendered runner'
+# Deliberately NOT asserted: that the rejected render's output file lacks the
+# smuggled command. The required failure above already dies if the render
+# succeeds, and a failed render's stdout is empty by chezmoi's buffering (see
+# the note on the reject helpers), so that refute could never fail.
 
 assert_tier2_rejects 'manual system_setup record carrying command' \
   'carries command' 'manual record smuggling a command' <<'EOF'

--- a/test/integration/macos-control-tier-refusal.sh
+++ b/test/integration/macos-control-tier-refusal.sh
@@ -1,0 +1,845 @@
+#!/usr/bin/env bash
+# macos-control-tier-refusal.sh -- the tiered control model: every record in
+# macos_defaults.yaml and macos_system_setup.yaml declares which of three tiers
+# it belongs to, and every consumer refuses, fail-closed, anything that does
+# not match its declared tier.
+#
+#   enforce  settable from the command line; the runner renders the write.
+#   verify   readable but NOT settable; drift detection only. The runner
+#            renders NO mutating command: the branch that emits one is not
+#            taken, so the runner physically cannot set it.
+#   manual   needs an interactive step or a management profile; carries a
+#            REQUIRED runbook field and renders a pointer line, no command.
+#
+# The refusal is the load-bearing part, so it is pinned as TOTAL:
+#   1. A record with no tier ABORTS the render, naming the record. Not a
+#      warning, not a skipped record; a mixed file emits no write at all.
+#   2. An unrecognized tier value aborts the render naming the value. A blank
+#      tier and a set-but-empty tier are rejected as their own cases, never
+#      conflated with absent, and nothing ever renders the literal text <nil>.
+#   3. A verify record renders no mutating command, asserted as the ABSENCE of
+#      the specific write string beside a control record that proves writes
+#      render, and contributes no sudo prelude.
+#   4. A verify or manual record carrying a mutating payload aborts the render
+#      (defaults: a manual record carrying any write field; system_setup: a
+#      command or sudo on any non-enforce record). On a verify defaults record
+#      type/value are the READ expectation the drift checker compares, the one
+#      payload shape that is legitimate there.
+#   5. A manual record without a runbook (absent, blank, or empty) aborts.
+#   6. A manual record renders a runbook pointer and no command, and the
+#      pointer goes through the single-quoting helper, so hostile runbook or
+#      description text arrives literal and executes nothing.
+#   7. The tools inherit the same refusal through the shared record stream:
+#      apply writes ONLY enforce records, drift checks enforce AND verify but
+#      never manual, capture appends tier: enforce, and an unknown tier makes
+#      every one of them refuse the whole file before acting on any of it.
+#
+# Real chezmoi and yq; `defaults`, `sudo`, `osascript`, and `killall` are
+# stubbed. Never runs real sudo, never touches /Library.
+#
+# This test deals in LITERAL shell-injection payloads, so $(...) inside single
+# quotes is deliberate (it must NOT expand here).
+# shellcheck disable=SC2016
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any git or chezmoi call. Git exports GIT_DIR
+# to every hook it runs and this suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TIER1_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+TIER2_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
+CAPTURE="$REPO_ROOT/dot_local/bin/executable_macos-defaults-capture.sh"
+DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it happens to be the last
+# statement, so every negative below goes through these helpers.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+refute_file_matches() { # <file> <regex> <message>
+  if grep -qE -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the tier model\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$TIER1_TEMPLATE" "$TIER2_TEMPLATE" "$LIB" "$APPLY" "$CAPTURE" "$DRIFT"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+render_home="$sandbox/render-home"
+mkdir -p "$render_home" "$sandbox/home"
+render_error="$sandbox/render.err"
+
+# make_defaults_source / make_setup_source -- create a chezmoi source tree
+# whose one data file is read from stdin; print the tree's path.
+make_defaults_source() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/defaults-src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_defaults.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+make_setup_source() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/setup-src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_system_setup.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+render_template() { # <template> <source-dir> <out-file> <err-file>
+  HOME="$render_home" chezmoi --source "$2" execute-template --no-tty <"$1" >"$3" 2>"$4"
+}
+
+# Non-darwin hosts render an empty body, so there is nothing to exercise.
+probe_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.probe
+      key: ProbeKey
+      type: bool
+      value: true
+      tier: enforce
+  killall: []
+EOF
+)"
+render_template "$TIER1_TEMPLATE" "$probe_src" "$sandbox/rendered-probe" "$render_error" ||
+  fail "the probe render must succeed (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$sandbox/rendered-probe")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# assert_tier1_rejects / assert_tier2_rejects <label> <stderr-fragment...> --
+# feed a fixture on stdin, require the render to FAIL, require the message to
+# carry every named fragment, and require that nothing executable leaked into
+# the output: a render that failed only after emitting a write has already
+# written the attacker's script.
+assert_tier1_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
+  local label="$1"
+  shift
+  local source_dir out_file status=0 fragment
+  source_dir="$(make_defaults_source)"
+  out_file="$sandbox/rejected-tier1"
+  render_template "$TIER1_TEMPLATE" "$source_dir" "$out_file" "$render_error" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "$label: the render must fail (got 0, render: $(cat "$out_file"))"
+  for fragment in "$@"; do
+    assert_file_contains "$render_error" "$fragment" \
+      "$label: the failure must name '$fragment' (stderr: $(cat "$render_error"))"
+  done
+  if grep -qE '^(sudo )?defaults ' "$out_file"; then
+    fail "$label: a rejected render must emit no write line (got: $(grep -E '^(sudo )?defaults ' "$out_file"))"
+  fi
+}
+
+assert_tier2_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
+  local label="$1"
+  shift
+  local source_dir out_file status=0 fragment
+  source_dir="$(make_setup_source)"
+  out_file="$sandbox/rejected-tier2"
+  render_template "$TIER2_TEMPLATE" "$source_dir" "$out_file" "$render_error" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "$label: the render must fail (got 0, render: $(cat "$out_file"))"
+  for fragment in "$@"; do
+    assert_file_contains "$render_error" "$fragment" \
+      "$label: the failure must name '$fragment' (stderr: $(cat "$render_error"))"
+  done
+  refute_file_matches "$out_file" '^(sudo )?[^#[:space:]]' \
+    "$label: a rejected render must emit no command line (render: $(cat "$out_file"))"
+}
+
+# ---- 1: a record with no tier aborts the render -------------------------------
+
+# The valid enforce record comes FIRST, so a runner that warned and continued,
+# or skipped the offender, would have emitted that record's write; the
+# no-write-emitted check inside the helper is what makes the abort total.
+assert_tier1_rejects 'defaults record with no tier' \
+  'has no tier' 'com.example.untiered' 'UntieredKey' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.tiered
+      key: TieredKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.untiered
+      key: UntieredKey
+      type: bool
+      value: true
+  killall: []
+EOF
+
+assert_tier2_rejects 'system_setup record with no tier' \
+  'has no tier' 'untiered setup record' <<'EOF'
+macos:
+  system_setup:
+    - description: "tiered setup record"
+      command: 'printf tiered-ran'
+      tier: enforce
+    - description: "untiered setup record"
+      command: 'printf untiered-ran'
+EOF
+
+# ---- 2: an unrecognized tier aborts the render, naming the value --------------
+
+assert_tier1_rejects 'unrecognized defaults tier' \
+  'unrecognized tier "enforced"' 'com.example.typo' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.typo
+      key: TypoKey
+      type: bool
+      value: true
+      tier: enforced
+  killall: []
+EOF
+
+# A blank scalar is nil, and stringifying nil yields the literal text <nil>.
+# It must be rejected as its own case, and the message must not carry <nil>.
+blank_tier_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.blanktier
+      key: BlankTierKey
+      type: bool
+      value: true
+      tier:
+  killall: []
+EOF
+)"
+blank_tier_status=0
+render_template "$TIER1_TEMPLATE" "$blank_tier_src" "$sandbox/rendered-blank-tier" "$render_error" ||
+  blank_tier_status=$?
+[[ $blank_tier_status -ne 0 ]] || fail 'a blank tier must fail the render'
+assert_file_contains "$render_error" 'has a blank tier' \
+  "a blank tier must be named as blank (stderr: $(cat "$render_error"))"
+refute_file_contains "$render_error" '<nil>' \
+  'a blank tier must never surface as the stringified literal <nil>'
+
+# A set-but-empty tier is an unrecognized VALUE, never treated as absent.
+empty_tier_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.emptytier
+      key: EmptyTierKey
+      type: bool
+      value: true
+      tier: ""
+  killall: []
+EOF
+)"
+empty_tier_status=0
+render_template "$TIER1_TEMPLATE" "$empty_tier_src" "$sandbox/rendered-empty-tier" "$render_error" ||
+  empty_tier_status=$?
+[[ $empty_tier_status -ne 0 ]] || fail 'a set-but-empty tier must fail the render'
+assert_file_contains "$render_error" 'unrecognized tier ""' \
+  "an empty tier must be rejected as an unrecognized value (stderr: $(cat "$render_error"))"
+refute_file_contains "$render_error" 'has no tier' \
+  'a set-but-empty tier must not be conflated with an absent one'
+
+assert_tier2_rejects 'unrecognized system_setup tier' \
+  'unrecognized tier "bogus"' 'bogus-tier record' <<'EOF'
+macos:
+  system_setup:
+    - description: "bogus-tier record"
+      command: 'printf bogus-ran'
+      tier: bogus
+EOF
+
+# ---- 3: a verify record renders no mutating command ---------------------------
+
+# The verify record carries the FULL write-shaped payload (its read
+# expectation), so the write branch has everything it would need; the enforce
+# record beside it proves the write branch renders. The absent string is the
+# SPECIFIC write, not a shorter render.
+verify_render_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.enforced
+      key: EnforcedKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.verifyme
+      key: VerifyKey
+      type: bool
+      value: false
+      tier: verify
+  killall:
+    - Dock
+EOF
+)"
+rendered_verify="$sandbox/rendered-verify"
+render_template "$TIER1_TEMPLATE" "$verify_render_src" "$rendered_verify" "$render_error" ||
+  fail "a verify defaults record must render cleanly (stderr: $(cat "$render_error"))"
+grep -qxF "defaults write 'com.example.enforced' 'EnforcedKey' -bool 'true'" "$rendered_verify" ||
+  fail "the enforce control record must still render its write (render: $(cat "$rendered_verify"))"
+refute_file_contains "$rendered_verify" "defaults write 'com.example.verifyme' 'VerifyKey' -bool 'false'" \
+  'a verify record must not render its specific defaults write'
+refute_file_contains "$rendered_verify" 'com.example.verifyme' \
+  'a verify record must contribute nothing at all to the rendered runner'
+
+# A verify record at system scope is a READ of a root plist, not a write, so
+# it must not pull in the sudo prelude either.
+verify_system_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.sysverify
+      key: SysVerifyKey
+      type: bool
+      value: true
+      tier: verify
+      scope: system
+  killall: []
+EOF
+)"
+rendered_verify_system="$sandbox/rendered-verify-system"
+render_template "$TIER1_TEMPLATE" "$verify_system_src" "$rendered_verify_system" "$render_error" ||
+  fail "a system-scope verify record must render cleanly (stderr: $(cat "$render_error"))"
+refute_file_matches "$rendered_verify_system" '^sudo' \
+  'a verify-only data file must render no sudo invocation, the -v prelude included'
+refute_file_contains "$rendered_verify_system" 'sudo -v' \
+  'a verify-only data file must render no sudo prelude'
+refute_file_matches "$rendered_verify_system" '^(sudo )?defaults ' \
+  'a verify-only data file must render no defaults invocation at all'
+
+# system_setup: a verify record contributes nothing to the render, and a
+# verify-only file must not render the spurious sudo -v prelude.
+verify_setup_src="$(
+  make_setup_source <<'EOF'
+macos:
+  system_setup:
+    - description: "enforced setup control"
+      command: 'printf enforced-setup-ran'
+      tier: enforce
+    - description: "verify-only setup control"
+      tier: verify
+EOF
+)"
+rendered_verify_setup="$sandbox/rendered-verify-setup"
+render_template "$TIER2_TEMPLATE" "$verify_setup_src" "$rendered_verify_setup" "$render_error" ||
+  fail "a verify system_setup record must render cleanly (stderr: $(cat "$render_error"))"
+grep -qxF 'printf enforced-setup-ran' "$rendered_verify_setup" ||
+  fail "the enforce control record must still render its command (render: $(cat "$rendered_verify_setup"))"
+refute_file_contains "$rendered_verify_setup" 'verify-only setup control' \
+  'a verify system_setup record must contribute nothing to the rendered runner'
+
+verify_only_setup_src="$(
+  make_setup_source <<'EOF'
+macos:
+  system_setup:
+    - description: "verify-only setup control"
+      tier: verify
+EOF
+)"
+rendered_verify_only_setup="$sandbox/rendered-verify-only-setup"
+render_template "$TIER2_TEMPLATE" "$verify_only_setup_src" "$rendered_verify_only_setup" "$render_error" ||
+  fail "a verify-only system_setup file must render cleanly (stderr: $(cat "$render_error"))"
+refute_file_matches "$rendered_verify_only_setup" '^sudo' \
+  'a verify-only system_setup file must render no sudo invocation'
+refute_file_contains "$rendered_verify_only_setup" 'sudo -v' \
+  'a verify-only system_setup file must render no sudo prelude'
+
+# ---- 4: a verify or manual record carrying a mutating payload aborts ----------
+
+assert_tier1_rejects 'manual defaults record carrying value' \
+  'carries value' 'com.example.manualvalue' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.manualvalue
+      key: ManualValueKey
+      value: true
+      tier: manual
+      runbook: Some section
+  killall: []
+EOF
+
+assert_tier1_rejects 'manual defaults record carrying scope' \
+  'carries scope' 'com.example.manualscope' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.manualscope
+      key: ManualScopeKey
+      tier: manual
+      runbook: Some section
+      scope: system
+  killall: []
+EOF
+
+verify_payload_src="$(
+  make_setup_source <<'EOF'
+macos:
+  system_setup:
+    - description: "verify record smuggling a command"
+      command: 'printf smuggled-write-ran'
+      tier: verify
+EOF
+)"
+verify_payload_status=0
+render_template "$TIER2_TEMPLATE" "$verify_payload_src" "$sandbox/rendered-smuggled" "$render_error" ||
+  verify_payload_status=$?
+[[ $verify_payload_status -ne 0 ]] ||
+  fail 'a verify system_setup record carrying a command must fail the render'
+assert_file_contains "$render_error" 'carries command' \
+  "the refusal must name the smuggled command field (stderr: $(cat "$render_error"))"
+refute_file_contains "$sandbox/rendered-smuggled" 'printf smuggled-write-ran' \
+  'the smuggled command must never reach the rendered runner'
+
+assert_tier2_rejects 'manual system_setup record carrying command' \
+  'carries command' 'manual record smuggling a command' <<'EOF'
+macos:
+  system_setup:
+    - description: "manual record smuggling a command"
+      command: 'printf manual-smuggled-ran'
+      tier: manual
+      runbook: Some section
+EOF
+
+assert_tier2_rejects 'verify system_setup record carrying sudo' \
+  'carries sudo' 'verify record smuggling sudo' <<'EOF'
+macos:
+  system_setup:
+    - description: "verify record smuggling sudo"
+      sudo: true
+      tier: verify
+EOF
+
+# ---- 5: a manual record without a runbook aborts -------------------------------
+
+assert_tier1_rejects 'manual defaults record with no runbook' \
+  'has no runbook' 'com.example.norunbook' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.norunbook
+      key: NoRunbookKey
+      tier: manual
+  killall: []
+EOF
+
+blank_runbook_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.blankrunbook
+      key: BlankRunbookKey
+      tier: manual
+      runbook:
+  killall: []
+EOF
+)"
+blank_runbook_status=0
+render_template "$TIER1_TEMPLATE" "$blank_runbook_src" "$sandbox/rendered-blank-runbook" "$render_error" ||
+  blank_runbook_status=$?
+[[ $blank_runbook_status -ne 0 ]] || fail 'a blank runbook must fail the render'
+assert_file_contains "$render_error" 'has a blank runbook' \
+  "a blank runbook must be named as blank (stderr: $(cat "$render_error"))"
+refute_file_contains "$render_error" '<nil>' \
+  'a blank runbook must never surface as the stringified literal <nil>'
+
+assert_tier1_rejects 'manual defaults record with an empty runbook' \
+  'has an empty runbook' 'com.example.emptyrunbook' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.emptyrunbook
+      key: EmptyRunbookKey
+      tier: manual
+      runbook: ""
+  killall: []
+EOF
+
+assert_tier2_rejects 'manual system_setup record with no runbook' \
+  'has no runbook' 'manual record without a runbook' <<'EOF'
+macos:
+  system_setup:
+    - description: "manual record without a runbook"
+      tier: manual
+EOF
+
+# An enforce record has no consumer for a runbook, and silently ignored data
+# is how a mislabeled tier hides; carrying one aborts.
+assert_tier1_rejects 'enforce defaults record carrying runbook' \
+  'carries runbook' 'com.example.enforcebook' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.enforcebook
+      key: EnforceBookKey
+      type: bool
+      value: true
+      tier: enforce
+      runbook: Some section
+  killall: []
+EOF
+
+assert_tier2_rejects 'enforce system_setup record carrying runbook' \
+  'carries runbook' 'enforce record with a runbook' <<'EOF'
+macos:
+  system_setup:
+    - description: "enforce record with a runbook"
+      command: 'printf enforce-book-ran'
+      tier: enforce
+      runbook: Some section
+EOF
+
+# ---- 6: a manual record renders a runbook pointer and no command ---------------
+
+manual_render_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.enforced
+      key: EnforcedKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.byhand
+      key: ByHandKey
+      tier: manual
+      runbook: Firewall logging
+  killall: []
+EOF
+)"
+rendered_manual="$sandbox/rendered-manual"
+render_template "$TIER1_TEMPLATE" "$manual_render_src" "$rendered_manual" "$render_error" ||
+  fail "a manual defaults record must render cleanly (stderr: $(cat "$render_error"))"
+grep -qxF "echo 'manual control com.example.byhand ByHandKey: not settable here; see the runbook section Firewall logging'" "$rendered_manual" ||
+  fail "a manual record must render its exact runbook pointer (render: $(cat "$rendered_manual"))"
+refute_file_contains "$rendered_manual" "defaults write 'com.example.byhand'" \
+  'a manual record must render no defaults write'
+grep -qxF "defaults write 'com.example.enforced' 'EnforcedKey' -bool 'true'" "$rendered_manual" ||
+  fail 'the enforce record beside a manual one must keep its write'
+
+# The pointer is a NEW data-to-shell emission path, so it gets the same
+# injection proof as the write path: hostile runbook text must arrive literal
+# and execute nothing, apostrophe included.
+manual_injection_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.hostilebook
+      key: HostileBookKey
+      tier: manual
+      runbook: "it's $(touch runbook-marker)`touch runbook-tick`$INJECTED_VARIABLE"
+  killall: []
+EOF
+)"
+rendered_hostile_manual="$sandbox/rendered-hostile-manual"
+render_template "$TIER1_TEMPLATE" "$manual_injection_src" "$rendered_hostile_manual" "$render_error" ||
+  fail "a hostile runbook is a legal, if nasty, value and must render (stderr: $(cat "$render_error"))"
+stub_bin="$sandbox/bin"
+mkdir -p "$stub_bin"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/osascript"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/killall"
+chmod +x "$stub_bin/osascript" "$stub_bin/killall"
+marker_dir="$sandbox/markers"
+mkdir -p "$marker_dir"
+manual_pointer_output="$sandbox/manual-pointer.out"
+(
+  cd "$marker_dir" || exit 1
+  PATH="$stub_bin:$PATH" INJECTED_VARIABLE=EXPANDED_VARIABLE_VALUE \
+    bash "$rendered_hostile_manual"
+) >"$manual_pointer_output" 2>&1 ||
+  fail "the rendered manual pointer must run cleanly (output: $(cat "$manual_pointer_output"))"
+created_markers="$(find "$marker_dir" -mindepth 1 -print)"
+[[ -z $created_markers ]] ||
+  fail "no runbook payload may execute; the rendered script created: $created_markers"
+assert_file_contains "$manual_pointer_output" 'it'\''s $(touch runbook-marker)`touch runbook-tick`$INJECTED_VARIABLE' \
+  "the hostile runbook must arrive as literal text (output: $(cat "$manual_pointer_output"))"
+refute_file_contains "$manual_pointer_output" 'EXPANDED_VARIABLE_VALUE' \
+  'a $VAR in a runbook must never be expanded against the runner environment'
+
+# system_setup: a manual-only file renders the pointer, no sudo of any kind,
+# and survives the same hostile text through the same single-quoting helper.
+manual_setup_src="$(
+  make_setup_source <<'EOF'
+macos:
+  system_setup:
+    - description: "Turn on firewall logging"
+      tier: manual
+      runbook: Firewall logging
+    - description: "hostile pointer it's $(touch setup-marker)`touch setup-tick`$INJECTED_VARIABLE"
+      tier: manual
+      runbook: "Section $(touch setup-runbook-marker)"
+EOF
+)"
+rendered_manual_setup="$sandbox/rendered-manual-setup"
+render_template "$TIER2_TEMPLATE" "$manual_setup_src" "$rendered_manual_setup" "$render_error" ||
+  fail "a manual system_setup record must render cleanly (stderr: $(cat "$render_error"))"
+grep -qxF "echo '→ MANUAL Turn on firewall logging: see the runbook section Firewall logging'" "$rendered_manual_setup" ||
+  fail "a manual system_setup record must render its exact runbook pointer (render: $(cat "$rendered_manual_setup"))"
+refute_file_matches "$rendered_manual_setup" '^sudo' \
+  'a manual-only system_setup file must render no sudo invocation'
+refute_file_contains "$rendered_manual_setup" 'sudo -v' \
+  'a manual-only system_setup file must render no sudo prelude'
+manual_setup_output="$sandbox/manual-setup.out"
+(
+  cd "$marker_dir" || exit 1
+  INJECTED_VARIABLE=EXPANDED_VARIABLE_VALUE bash "$rendered_manual_setup"
+) >"$manual_setup_output" 2>&1 ||
+  fail "the rendered manual-only system_setup runner must run cleanly (output: $(cat "$manual_setup_output"))"
+created_markers="$(find "$marker_dir" -mindepth 1 -print)"
+[[ -z $created_markers ]] ||
+  fail "no system_setup pointer payload may execute; created: $created_markers"
+assert_file_contains "$manual_setup_output" 'Section $(touch setup-runbook-marker)' \
+  "the hostile system_setup runbook must arrive as literal text (output: $(cat "$manual_setup_output"))"
+refute_file_contains "$manual_setup_output" 'EXPANDED_VARIABLE_VALUE' \
+  'a $VAR in a system_setup pointer must never be expanded against the runner environment'
+
+# ---- source form: the tier is read through index, never the dotted form --------
+
+for guarded_template in "$TIER1_TEMPLATE" "$TIER2_TEMPLATE"; do
+  assert_file_contains "$guarded_template" 'index . "tier"' \
+    "$(basename "$guarded_template") must read the tier through index"
+  refute_file_matches "$guarded_template" '\.tier' \
+    "$(basename "$guarded_template") must not use the bare dotted tier field form anywhere"
+  refute_file_matches "$guarded_template" '\.runbook' \
+    "$(basename "$guarded_template") must not use the bare dotted runbook field form anywhere"
+done
+
+# ---- 7: the tools inherit the refusal through the shared record stream ---------
+
+# The stream refuses a file with an untiered record, names it, and emits
+# NOTHING a caller could act on.
+untiered_stream_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.streamok
+      key: StreamOkKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.streambad
+      key: StreamBadKey
+      type: bool
+      value: true
+  killall: []
+EOF
+)"
+stream_status=0
+stream_output="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$untiered_stream_src/.chezmoidata/macos_defaults.yaml" 2>"$sandbox/stream.err")" || stream_status=$?
+[[ $stream_status -eq 2 ]] ||
+  fail "the record stream must refuse an untiered record with status 2 (got $stream_status)"
+[[ -z $stream_output ]] ||
+  fail "a refused stream must emit nothing, not a partial record list (got: $(printf '%s' "$stream_output" | cat -v))"
+assert_file_contains "$sandbox/stream.err" 'com.example.streambad' \
+  "the stream refusal must name the untiered record (stderr: $(cat "$sandbox/stream.err"))"
+assert_file_contains "$sandbox/stream.err" 'tier' \
+  "the stream refusal must say the tier is the problem (stderr: $(cat "$sandbox/stream.err"))"
+
+unknown_tier_stream_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.streamodd
+      key: StreamOddKey
+      type: bool
+      value: true
+      tier: bogus
+  killall: []
+EOF
+)"
+stream_status=0
+stream_output="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$unknown_tier_stream_src/.chezmoidata/macos_defaults.yaml" 2>"$sandbox/stream.err")" || stream_status=$?
+[[ $stream_status -eq 2 ]] ||
+  fail "the record stream must refuse an unrecognized tier with status 2 (got $stream_status)"
+[[ -z $stream_output ]] ||
+  fail 'a stream refused for an unrecognized tier must emit nothing'
+assert_file_contains "$sandbox/stream.err" 'bogus' \
+  "the stream refusal must name the unrecognized tier value (stderr: $(cat "$sandbox/stream.err"))"
+
+# A valid mixed file streams every record with the tier as field 8, so the
+# tools decide by DECLARED tier, not by which payload fields happen to exist.
+mixed_stream_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.applyenforce
+      key: ApplyKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.applyverify
+      key: VerifyKey
+      type: bool
+      value: true
+      tier: verify
+      scope: system
+    - domain: com.example.applymanual
+      key: ManualKey
+      tier: manual
+      runbook: Some section
+  killall: []
+EOF
+)"
+mixed_stream="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$mixed_stream_src/.chezmoidata/macos_defaults.yaml")" ||
+  fail 'the stream must accept a valid mixed-tier file'
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path got_tier \
+  <<<"$(printf '%s\n' "$mixed_stream" | sed -n '1p')"
+[[ $got_domain == com.example.applyenforce ]] || fail "stream field 1 must be the domain (got '$got_domain')"
+[[ $got_key == ApplyKey ]] || fail "stream field 2 must be the key (got '$got_key')"
+[[ $got_type == bool ]] || fail "stream field 3 must be the type (got '$got_type')"
+[[ $got_value == true ]] || fail "stream field 4 must be the value (got '$got_value')"
+[[ -z $got_host ]] || fail "stream field 5 must be the empty absent host (got '$got_host')"
+[[ $got_scope == user ]] || fail "stream field 6 must default to user scope (got '$got_scope')"
+[[ -z $got_plist_path ]] || fail "stream field 7 must be the empty absent plist path (got '$got_plist_path')"
+[[ $got_tier == enforce ]] || fail "stream field 8 must be the tier (got '$got_tier')"
+IFS=$'\x1f' read -r _ _ _ _ _ _ _ got_tier \
+  <<<"$(printf '%s\n' "$mixed_stream" | sed -n '3p')"
+[[ $got_tier == manual ]] ||
+  fail "a manual record must stream with its tier intact (got '$got_tier')"
+
+# ---- apply writes ONLY enforce records ------------------------------------------
+
+defaults_log="$sandbox/defaults.log"
+sudo_log="$sandbox/sudo.log"
+cat >"$stub_bin/sudo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$sudo_log"
+exec "\$@"
+EOF
+cat >"$stub_bin/defaults" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$defaults_log"
+if [[ \$1 == read-type ]]; then printf 'Type is boolean\n'; exit 0; fi
+if [[ \$1 == read ]]; then
+  case "\$2" in
+    com.example.driftenforce | com.example.captured) printf '1\n' ;;
+    *) printf 'off\n' ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$stub_bin/sudo" "$stub_bin/defaults"
+
+run_tool() { # <source-dir> <script> [args...]
+  local source_dir="$1"
+  shift
+  (
+    cd "$sandbox" || exit 1
+    MACOS_DEFAULTS_SOURCE_DIR="$source_dir" HOME="$sandbox/home" \
+      PATH="$stub_bin:$PATH" bash "$@"
+  )
+}
+
+: >"$defaults_log"
+: >"$sudo_log"
+run_tool "$mixed_stream_src" "$APPLY" ||
+  fail 'apply must succeed on a valid mixed-tier file'
+assert_file_contains "$defaults_log" 'write com.example.applyenforce ApplyKey -bool true' \
+  "apply must write the enforce record (defaults log: $(cat "$defaults_log"))"
+refute_file_contains "$defaults_log" 'com.example.applyverify' \
+  'apply must never touch a verify record; it is not settable, that is the tier'
+refute_file_contains "$sudo_log" 'com.example.applyverify' \
+  'apply must never sudo-write a verify record, system scope or not'
+refute_file_contains "$defaults_log" 'com.example.applymanual' \
+  'apply must never touch a manual record'
+refute_file_contains "$sudo_log" 'write' \
+  'apply must perform no root write at all when no enforce record is system scope'
+
+# apply refuses the whole file on an unknown tier, before any write.
+: >"$defaults_log"
+apply_unknown_status=0
+run_tool "$unknown_tier_stream_src" "$APPLY" 2>"$sandbox/apply-unknown.err" || apply_unknown_status=$?
+[[ $apply_unknown_status -ne 0 ]] ||
+  fail 'apply must refuse a file carrying an unrecognized tier'
+[[ ! -s $defaults_log ]] ||
+  fail "apply must write nothing from a file it refused (defaults log: $(cat "$defaults_log"))"
+
+# ---- drift checks enforce AND verify, skips manual -------------------------------
+
+drift_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.driftenforce
+      key: EnforceKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.driftverify
+      key: VerifyKey
+      type: bool
+      value: true
+      tier: verify
+    - domain: com.example.driftmanual
+      key: ManualKey
+      tier: manual
+      runbook: Some section
+  killall: []
+EOF
+)"
+drift_out="$sandbox/drift.out"
+drift_status=0
+run_tool "$drift_src" "$DRIFT" >"$drift_out" 2>"$sandbox/drift.err" || drift_status=$?
+[[ $drift_status -eq 1 ]] ||
+  fail "drift must exit 1 when a verify control has drifted (got $drift_status, stderr: $(cat "$sandbox/drift.err"))"
+assert_file_contains "$drift_out" 'com.example.driftverify' \
+  "a drifted verify control must be reported; detecting it is the tier's whole job (stdout: $(cat "$drift_out"))"
+refute_file_contains "$drift_out" 'com.example.driftenforce' \
+  'a matching enforce control must not be reported as drift'
+refute_file_contains "$drift_out" 'com.example.driftmanual' \
+  'a manual control has no check and must never appear in the drift report'
+
+drift_unknown_status=0
+run_tool "$unknown_tier_stream_src" "$DRIFT" >"$drift_out" 2>"$sandbox/drift.err" || drift_unknown_status=$?
+[[ $drift_unknown_status -eq 2 ]] ||
+  fail "drift must exit 2 on a file carrying an unrecognized tier (got $drift_unknown_status)"
+
+# ---- capture appends tier: enforce, and the result round-trips -------------------
+
+capture_src="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults: []
+  killall: []
+EOF
+)"
+capture_data_file="$capture_src/.chezmoidata/macos_defaults.yaml"
+run_tool "$capture_src" "$CAPTURE" com.example.captured CapturedKey ||
+  fail 'capture must succeed against the stubbed defaults'
+captured_tier="$(yq eval -r \
+  '.macos.defaults[] | select(.domain == "com.example.captured") | .tier' \
+  "$capture_data_file")"
+[[ $captured_tier == enforce ]] ||
+  fail "capture must declare tier: enforce on the record it appends (got '$captured_tier')"
+bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+  "$LIB" "$capture_data_file" >/dev/null ||
+  fail 'a captured record must round-trip through the tier-validating stream'
+
+printf 'macos-control-tier-refusal: OK (missing, blank, empty, and unrecognized tiers abort both renders naming the record; verify renders no write and no sudo; mutating payloads on verify/manual abort; manual requires a runbook and renders a literal-quoted pointer only; apply writes only enforce, drift checks verify and skips manual, capture appends tier: enforce; the stream refuses whole files fail-closed)\n'

--- a/test/integration/macos-control-tier-refusal.sh
+++ b/test/integration/macos-control-tier-refusal.sh
@@ -13,19 +13,29 @@
 #
 # The refusal is the load-bearing part, so it is pinned as TOTAL:
 #   1. A record with no tier ABORTS the render, naming the record. Not a
-#      warning, not a skipped record; a mixed file emits no write at all.
-#   2. An unrecognized tier value aborts the render naming the value. A blank
+#      warning, not a skipped record: a fixture that skipped the offender
+#      would render cleanly, and the required failure catches it. (That a
+#      failed render emits no write at all is chezmoi's own guarantee; see
+#      the note on the reject helpers.)
+#   2. An unrecognized tier value aborts the render naming the value, from
+#      the VALIDATION pass, never the render loop's distinctly-marked
+#      fail-closed arm (whose presence is pinned in source form). A blank
 #      tier and a set-but-empty tier are rejected as their own cases, never
-#      conflated with absent, and nothing ever renders the literal text <nil>.
+#      conflated with absent, and nothing ever renders the literal text
+#      <nil>. Blank is pinned against BOTH templates.
 #   3. A verify record renders no mutating command, asserted as the ABSENCE of
 #      the specific write string beside a control record that proves writes
 #      render, and contributes no sudo prelude.
 #   4. A verify or manual record carrying a mutating payload aborts the render
-#      (defaults: a manual record carrying any write field; system_setup: a
-#      command or sudo on any non-enforce record). On a verify defaults record
-#      type/value are the READ expectation the drift checker compares, the one
-#      payload shape that is legitimate there.
-#   5. A manual record without a runbook (absent, blank, or empty) aborts.
+#      (defaults: a manual record carrying any of the five forbidden write
+#      fields, one fixture per member so the list is pinned by completeness;
+#      system_setup: a command or sudo on any non-enforce record). On a verify
+#      defaults record type/value are the READ expectation the drift checker
+#      compares, the one payload shape that is legitimate there. The inverse
+#      lie aborts too: an enforce system_setup record with no command (absent,
+#      blank, or empty).
+#   5. A manual record without a runbook (absent, blank, or empty) aborts,
+#      empty pinned against BOTH templates.
 #   6. A manual record renders a runbook pointer and no command, and the
 #      pointer goes through the single-quoting helper, so hostile runbook or
 #      description text arrives literal and executes nothing.
@@ -33,6 +43,8 @@
 #      apply writes ONLY enforce records, drift checks enforce AND verify but
 #      never manual, capture appends tier: enforce, and an unknown tier makes
 #      every one of them refuse the whole file before acting on any of it.
+#      Behind that gate, apply's and drift's own in-loop refusal is reached
+#      via a doctored stream and refuses fail-closed on its own.
 #
 # Real chezmoi and yq; `defaults`, `sudo`, `osascript`, and `killall` are
 # stubbed. Never runs real sudo, never touches /Library.
@@ -137,10 +149,15 @@ if [[ -z "$(tr -d '[:space:]' <"$sandbox/rendered-probe")" ]]; then
 fi
 
 # assert_tier1_rejects / assert_tier2_rejects <label> <stderr-fragment...> --
-# feed a fixture on stdin, require the render to FAIL, require the message to
-# carry every named fragment, and require that nothing executable leaked into
-# the output: a render that failed only after emitting a write has already
-# written the attacker's script.
+# feed a fixture on stdin, require the render to FAIL, and require the message
+# to carry every named fragment.
+#
+# Deliberately NOT asserted: that the rejected render's stdout carries no
+# write or command line. chezmoi buffers the whole render and discards it on
+# failure (verified empirically: a template that emits two lines and then
+# calls fail exits 1 with ZERO bytes on stdout), so that assertion is
+# satisfied by chezmoi's buffering no matter where our validation sits, and
+# an assertion that cannot fail reads as coverage while pinning nothing.
 assert_tier1_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
   local label="$1"
   shift
@@ -154,9 +171,6 @@ assert_tier1_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
     assert_file_contains "$render_error" "$fragment" \
       "$label: the failure must name '$fragment' (stderr: $(cat "$render_error"))"
   done
-  if grep -qE '^(sudo )?defaults ' "$out_file"; then
-    fail "$label: a rejected render must emit no write line (got: $(grep -E '^(sudo )?defaults ' "$out_file"))"
-  fi
 }
 
 assert_tier2_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
@@ -172,15 +186,13 @@ assert_tier2_rejects() { # <label> <stderr-fragment...>   (fixture on stdin)
     assert_file_contains "$render_error" "$fragment" \
       "$label: the failure must name '$fragment' (stderr: $(cat "$render_error"))"
   done
-  refute_file_matches "$out_file" '^(sudo )?[^#[:space:]]' \
-    "$label: a rejected render must emit no command line (render: $(cat "$out_file"))"
 }
 
 # ---- 1: a record with no tier aborts the render -------------------------------
 
-# The valid enforce record comes FIRST, so a runner that warned and continued,
-# or skipped the offender, would have emitted that record's write; the
-# no-write-emitted check inside the helper is what makes the abort total.
+# The valid enforce record comes FIRST, so a template that warned and skipped
+# the offender instead of aborting would render the file cleanly, and the
+# helper's required render failure is what catches it.
 assert_tier1_rejects 'defaults record with no tier' \
   'has no tier' 'com.example.untiered' 'UntieredKey' <<'EOF'
 macos:
@@ -221,6 +233,13 @@ macos:
       tier: enforced
   killall: []
 EOF
+# The unrecognized-tier check exists at TWO sites per template: the validation
+# pass and the render loop's fail-closed else arm, with deliberately distinct
+# messages. The refusal above must come from the VALIDATION pass: if the loop
+# marker shows up here, the validation copy is gone and the loop copy is
+# masking its absence.
+refute_file_contains "$render_error" 'reached the render loop' \
+  'an unrecognized defaults tier must be refused by the validation pass, not the render loop'
 
 # A blank scalar is nil, and stringifying nil yields the literal text <nil>.
 # It must be rejected as its own case, and the message must not carry <nil>.
@@ -275,6 +294,31 @@ macos:
       command: 'printf bogus-ran'
       tier: bogus
 EOF
+# Same two-site rule as Tier 1: the refusal must come from the validation
+# pass, never the render loop's distinctly-marked else arm.
+refute_file_contains "$render_error" 'reached the render loop' \
+  'an unrecognized system_setup tier must be refused by the validation pass, not the render loop'
+
+# The Tier 2 blank tier is its own case too, tested here directly rather than
+# assumed covered by the Tier 1 case above: the two templates carry separate
+# copies of the branch, and one of them silently rotting is exactly what
+# per-template pins exist to catch.
+blank_tier_setup_src="$(
+  make_setup_source <<'EOF'
+macos:
+  system_setup:
+    - description: "blank-tier setup record"
+      tier:
+EOF
+)"
+blank_tier_setup_status=0
+render_template "$TIER2_TEMPLATE" "$blank_tier_setup_src" "$sandbox/rendered-blank-tier-setup" "$render_error" ||
+  blank_tier_setup_status=$?
+[[ $blank_tier_setup_status -ne 0 ]] || fail 'a blank system_setup tier must fail the render'
+assert_file_contains "$render_error" 'has a blank tier' \
+  "a blank system_setup tier must be named as blank (stderr: $(cat "$render_error"))"
+refute_file_contains "$render_error" '<nil>' \
+  'a blank system_setup tier must never surface as the stringified literal <nil>'
 
 # ---- 3: a verify record renders no mutating command ---------------------------
 
@@ -398,6 +442,46 @@ macos:
   killall: []
 EOF
 
+# The forbidden-field list on a manual defaults record is pinned by
+# COMPLETENESS: one fixture per member (type, value, host, scope, plist_path,
+# each carried alone so the refusal names exactly that field), so removing ANY
+# single member from the template's list fails the member's own case here.
+assert_tier1_rejects 'manual defaults record carrying type' \
+  'carries type' 'com.example.manualtype' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.manualtype
+      key: ManualTypeKey
+      type: bool
+      tier: manual
+      runbook: Some section
+  killall: []
+EOF
+
+assert_tier1_rejects 'manual defaults record carrying host' \
+  'carries host' 'com.example.manualhost' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.manualhost
+      key: ManualHostKey
+      tier: manual
+      runbook: Some section
+      host: current
+  killall: []
+EOF
+
+assert_tier1_rejects 'manual defaults record carrying plist_path' \
+  'carries plist_path' 'com.example.manualplist' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.manualplist
+      key: ManualPlistKey
+      tier: manual
+      runbook: Some section
+      plist_path: /Library/Preferences/com.example.manualplist.plist
+  killall: []
+EOF
+
 verify_payload_src="$(
   make_setup_source <<'EOF'
 macos:
@@ -434,6 +518,36 @@ macos:
     - description: "verify record smuggling sudo"
       sudo: true
       tier: verify
+EOF
+
+# The inverse lie: an enforce record IS a command, so a record that declares
+# the tier without one aborts. Absent, blank (nil), and empty-string are three
+# ways of declaring no command; each aborts on its own fixture, so the branch
+# cannot rot down to a sampled subset.
+assert_tier2_rejects 'enforce system_setup record with no command' \
+  'has no command' 'enforce record without a command' <<'EOF'
+macos:
+  system_setup:
+    - description: "enforce record without a command"
+      tier: enforce
+EOF
+
+assert_tier2_rejects 'enforce system_setup record with a blank command' \
+  'has no command' 'enforce record with a blank command' <<'EOF'
+macos:
+  system_setup:
+    - description: "enforce record with a blank command"
+      command:
+      tier: enforce
+EOF
+
+assert_tier2_rejects 'enforce system_setup record with an empty command' \
+  'has no command' 'enforce record with an empty command' <<'EOF'
+macos:
+  system_setup:
+    - description: "enforce record with an empty command"
+      command: ""
+      tier: enforce
 EOF
 
 # ---- 5: a manual record without a runbook aborts -------------------------------
@@ -485,6 +599,17 @@ macos:
   system_setup:
     - description: "manual record without a runbook"
       tier: manual
+EOF
+
+# Pinned against Tier 2 directly, not assumed covered by the Tier 1 case
+# above: the empty-runbook branch is a separate copy in each template.
+assert_tier2_rejects 'manual system_setup record with an empty runbook' \
+  'has an empty runbook' 'manual record with an empty runbook' <<'EOF'
+macos:
+  system_setup:
+    - description: "manual record with an empty runbook"
+      tier: manual
+      runbook: ""
 EOF
 
 # An enforce record has no consumer for a runbook, and silently ignored data
@@ -625,6 +750,13 @@ for guarded_template in "$TIER1_TEMPLATE" "$TIER2_TEMPLATE"; do
     "$(basename "$guarded_template") must not use the bare dotted tier field form anywhere"
   refute_file_matches "$guarded_template" '\.runbook' \
     "$(basename "$guarded_template") must not use the bare dotted runbook field form anywhere"
+  # The render loop's fail-closed else arm is unreachable while the validation
+  # pass holds, so no fixture can reach it; its distinctly-marked fail is
+  # pinned here in source form. Together with the validation-site refutes in
+  # section 2, each of the two copies is individually removable only by
+  # turning a test red.
+  assert_file_contains "$guarded_template" 'reached the render loop' \
+    "$(basename "$guarded_template") must keep the render loop's distinctly-marked fail-closed tier refusal"
 done
 
 # ---- 7: the tools inherit the refusal through the shared record stream ---------
@@ -821,6 +953,53 @@ run_tool "$unknown_tier_stream_src" "$DRIFT" >"$drift_out" 2>"$sandbox/drift.err
 [[ $drift_unknown_status -eq 2 ]] ||
   fail "drift must exit 2 on a file carrying an unrecognized tier (got $drift_unknown_status)"
 
+# ---- the tools' OWN in-loop tier refusal, reached by bypassing the stream --------
+
+# The refusals above pin the shared stream's gate: an unknown tier never
+# reaches a tool's loop through the real library. Apply and drift each carry
+# their own case arm behind that gate as defence in depth for the day the
+# stream's rules drift, and an arm no test can reach reads as protection
+# while providing none. So reach it: copy each tool beside a doctored lib
+# whose stream emits the one record the real gate refuses, and require the
+# tool's own arm to refuse it, fail-closed, before acting on the record.
+bypass_dir="$sandbox/bypass-tools"
+mkdir -p "$bypass_dir"
+cp "$APPLY" "$bypass_dir/macos-defaults-apply.sh"
+cp "$DRIFT" "$bypass_dir/macos-defaults-drift.sh"
+cp "$LIB" "$bypass_dir/macos-defaults-lib.sh"
+cat >>"$bypass_dir/macos-defaults-lib.sh" <<'EOF'
+
+# TEST DOUBLE: emit one record with a tier the real stream's gate refuses,
+# so the calling tool's own case arm is the only guard left standing.
+defaults_records_unit_separated() {
+  printf 'com.example.bypassgate\x1fBypassGateKey\x1fbool\x1ftrue\x1f\x1fuser\x1f\x1fmystery\n'
+}
+EOF
+
+: >"$defaults_log"
+: >"$sudo_log"
+apply_bypass_status=0
+run_tool "$mixed_stream_src" "$bypass_dir/macos-defaults-apply.sh" \
+  2>"$sandbox/apply-bypass.err" || apply_bypass_status=$?
+[[ $apply_bypass_status -eq 2 ]] ||
+  fail "apply's own loop must refuse an unknown tier with status 2 when the stream gate is bypassed (got $apply_bypass_status)"
+assert_file_contains "$sandbox/apply-bypass.err" 'unrecognized tier' \
+  "apply's own refusal must name the tier as the problem (stderr: $(cat "$sandbox/apply-bypass.err"))"
+assert_file_contains "$sandbox/apply-bypass.err" 'refusing to write' \
+  "the refusal must be apply's own arm, not the stream's (stderr: $(cat "$sandbox/apply-bypass.err"))"
+refute_file_contains "$defaults_log" 'com.example.bypassgate' \
+  'apply must not fall through to the write path on a tier it cannot classify'
+
+drift_bypass_status=0
+run_tool "$mixed_stream_src" "$bypass_dir/macos-defaults-drift.sh" \
+  >"$drift_out" 2>"$sandbox/drift-bypass.err" || drift_bypass_status=$?
+[[ $drift_bypass_status -eq 2 ]] ||
+  fail "drift's own loop must refuse an unknown tier with status 2 when the stream gate is bypassed (got $drift_bypass_status)"
+assert_file_contains "$sandbox/drift-bypass.err" 'refusing to report on it' \
+  "the refusal must be drift's own arm, not the stream's (stderr: $(cat "$sandbox/drift-bypass.err"))"
+refute_file_contains "$drift_out" 'com.example.bypassgate' \
+  'drift must not report a comparison for a tier it cannot classify'
+
 # ---- capture appends tier: enforce, and the result round-trips -------------------
 
 capture_src="$(
@@ -842,4 +1021,4 @@ bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
   "$LIB" "$capture_data_file" >/dev/null ||
   fail 'a captured record must round-trip through the tier-validating stream'
 
-printf 'macos-control-tier-refusal: OK (missing, blank, empty, and unrecognized tiers abort both renders naming the record; verify renders no write and no sudo; mutating payloads on verify/manual abort; manual requires a runbook and renders a literal-quoted pointer only; apply writes only enforce, drift checks verify and skips manual, capture appends tier: enforce; the stream refuses whole files fail-closed)\n'
+printf 'macos-control-tier-refusal: OK (missing, blank, empty, and unrecognized tiers abort both renders naming the record; every forbidden manual field and a commandless enforce record abort; verify renders no write and no sudo; manual requires a runbook and renders a literal-quoted pointer only; apply writes only enforce, drift checks verify and skips manual, capture appends tier: enforce; the stream refuses whole files fail-closed and apply/drift refuse on their own arms behind it)\n'

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# macos-control-tier-render-stability.sh -- the tier field is REQUIRED on every
+# record in .chezmoidata/macos_defaults.yaml and
+# .chezmoidata/macos_system_setup.yaml, and backfilling `tier: enforce` onto the
+# records that existed before the field did is RENDER-NEUTRAL: both runner
+# templates render byte-identically to their pre-tier renders.
+#
+# The properties pinned:
+#   1. Completeness, not a count: EVERY record in both real data files declares
+#      a tier, and every declared tier is one of enforce/verify/manual. A new
+#      record cannot land without one, because the runners abort the render,
+#      and this guard reports the gap by name before an apply ever trips it.
+#   2. Byte identity: the Tier 1 and Tier 2 runners, rendered against the
+#      repo's REAL data, match the goldens below exactly.
+#
+# The goldens are the renders of both templates at commit 5774ce0 (this slice's
+# base, before the tier field existed) against the real data of that commit,
+# captured byte for byte including the trailing blank line. They pin that the
+# tier MECHANISM changed nothing about what the existing controls execute. A
+# later slice that declares NEW records changes the real render legitimately;
+# it must re-derive these goldens as part of its own render assertions.
+#
+# Real chezmoi and yq; nothing is executed, only rendered.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any chezmoi call. Git exports GIT_DIR to
+# every hook it runs and this suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TIER1_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+TIER2_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+DEFAULTS_YAML="$REPO_ROOT/.chezmoidata/macos_defaults.yaml"
+SETUP_YAML="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise render stability\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$TIER1_TEMPLATE" "$TIER2_TEMPLATE" "$DEFAULTS_YAML" "$SETUP_YAML"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# ---- 1: every real record declares a recognized tier -------------------------
+
+missing_defaults_tiers="$(yq eval -r \
+  '[.macos.defaults[] | select(has("tier") | not) | .domain + " " + .key] | join(", ")' \
+  "$DEFAULTS_YAML")"
+[[ -z $missing_defaults_tiers ]] ||
+  fail "every macos_defaults.yaml record must declare a tier; missing on: $missing_defaults_tiers"
+
+invalid_defaults_tiers="$(yq eval -r \
+  '[.macos.defaults[] | select(.tier != "enforce" and .tier != "verify" and .tier != "manual") | .domain + " " + .key] | join(", ")' \
+  "$DEFAULTS_YAML")"
+[[ -z $invalid_defaults_tiers ]] ||
+  fail "every macos_defaults.yaml tier must be enforce, verify, or manual; violated on: $invalid_defaults_tiers"
+
+missing_setup_tiers="$(yq eval -r \
+  '[.macos.system_setup[] | select(has("tier") | not) | .description] | join(", ")' \
+  "$SETUP_YAML")"
+[[ -z $missing_setup_tiers ]] ||
+  fail "every macos_system_setup.yaml record must declare a tier; missing on: $missing_setup_tiers"
+
+invalid_setup_tiers="$(yq eval -r \
+  '[.macos.system_setup[] | select(.tier != "enforce" and .tier != "verify" and .tier != "manual") | .description] | join(", ")' \
+  "$SETUP_YAML")"
+[[ -z $invalid_setup_tiers ]] ||
+  fail "every macos_system_setup.yaml tier must be enforce, verify, or manual; violated on: $invalid_setup_tiers"
+
+# ---- 2: both runners render byte-identically to the pre-tier goldens ---------
+
+# The Tier 1 runner at 5774ce0, rendered against that commit's real data.
+tier1_golden="$work/tier1.golden"
+cat >"$tier1_golden" <<'GOLDEN_EOF'
+#!/bin/bash
+# Tier 1, macOS user defaults runner.
+# chezmoi hash-gates on the rendered template body; this script re-runs only
+# when .chezmoidata/macos_defaults.yaml changes.
+
+set -euo pipefail
+
+# Pre-flight: close System Settings if open. macOS caches plist values inside
+# Settings and writes them back on close, silently overwriting our writes.
+osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
+
+# Main loop: one `defaults write` per record.
+defaults write 'com.apple.dock' 'mru-spaces' -bool 'false'
+defaults write 'com.apple.dock' 'expose-group-apps' -bool 'false'
+defaults write 'com.apple.WindowManager' 'GloballyEnabled' -bool 'false'
+defaults write 'com.apple.WindowManager' 'EnableStandardClickToShowDesktop' -bool 'false'
+defaults write 'com.apple.WindowManager' 'EnableTilingByEdgeDrag' -bool 'false'
+defaults write 'com.apple.WindowManager' 'EnableTilingOptionAccelerator' -bool 'false'
+defaults write 'com.apple.WindowManager' 'EnableTopTilingByEdgeDrag' -bool 'false'
+# Post-loop: restart user-facing processes so changes take effect immediately.
+# cfprefsd kill is non-negotiable (caches plist values in memory).
+killall 'Dock' 2>/dev/null || true
+killall 'Finder' 2>/dev/null || true
+killall 'SystemUIServer' 2>/dev/null || true
+killall 'cfprefsd' 2>/dev/null || true
+
+GOLDEN_EOF
+
+# The Tier 2 runner at 5774ce0, rendered against that commit's real data.
+tier2_golden="$work/tier2.golden"
+cat >"$tier2_golden" <<'GOLDEN_EOF'
+#!/bin/bash
+# Tier 2, macOS sudo system-setup runner.
+# chezmoi hash-gates on the rendered template body; this script re-runs only
+# when .chezmoidata/macos_system_setup.yaml changes.
+
+set -euo pipefail
+
+# Pre-flight: refresh sudo timestamp upfront. One password prompt at start;
+# none during the loop, it covers the generated tailnet-pin commands too.
+sudo -v
+
+echo "→ Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
+sudo "$HOME/.local/bin/install-nix-repair-hook.sh"
+echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
+sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
+
+GOLDEN_EOF
+
+render_home="$work/render-home"
+mkdir -p "$render_home"
+render_error="$work/render.err"
+
+render_current() { # <template> <out-file>
+  HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+    <"$1" >"$2" 2>"$render_error"
+}
+
+tier1_rendered="$work/tier1.rendered"
+render_current "$TIER1_TEMPLATE" "$tier1_rendered" ||
+  fail "the Tier 1 runner must render against the real data (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$tier1_rendered")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+cmp -s "$tier1_golden" "$tier1_rendered" ||
+  fail "the Tier 1 runner must render byte-identically to its pre-tier golden (diff: $(diff "$tier1_golden" "$tier1_rendered" | head -20))"
+
+tier2_rendered="$work/tier2.rendered"
+render_current "$TIER2_TEMPLATE" "$tier2_rendered" ||
+  fail "the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
+cmp -s "$tier2_golden" "$tier2_rendered" ||
+  fail "the Tier 2 runner must render byte-identically to its pre-tier golden (diff: $(diff "$tier2_golden" "$tier2_rendered" | head -20))"
+
+printf 'macos-control-tier-render-stability: OK (every real record declares a recognized tier; both runners render byte-identically to their 5774ce0 goldens)\n'

--- a/test/integration/macos-defaults-injection.sh
+++ b/test/integration/macos-defaults-injection.sh
@@ -103,6 +103,7 @@ macos:
       key: ProbeKey
       type: bool
       value: true
+      tier: enforce
   killall: []
 EOF
 )"
@@ -146,6 +147,7 @@ macos:
       key: UserTypeKey
       type: 'bool true; touch hostile-user-type-marker #'
       value: true
+      tier: enforce
   killall: []
 EOF
 
@@ -157,6 +159,7 @@ macos:
       type: 'bool true; touch hostile-system-type-marker #'
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -170,34 +173,42 @@ macos:
       key: K1
       type: array
       value: v
+      tier: enforce
     - domain: com.example.t2
       key: K2
       type: bool
       value: true
+      tier: enforce
     - domain: com.example.t3
       key: K3
       type: data
       value: v
+      tier: enforce
     - domain: com.example.t4
       key: K4
       type: date
       value: v
+      tier: enforce
     - domain: com.example.t5
       key: K5
       type: dict
       value: v
+      tier: enforce
     - domain: com.example.t6
       key: K6
       type: float
       value: 1.5
+      tier: enforce
     - domain: com.example.t7
       key: K7
       type: int
       value: 7
+      tier: enforce
     - domain: com.example.t8
       key: K8
       type: string
       value: v
+      tier: enforce
   killall: []
 EOF
 )"
@@ -221,17 +232,20 @@ macos:
       key: "UserKey$(touch user-key-marker)"
       type: string
       value: "$(touch user-value-marker)`touch user-tick-marker`$INJECTED_VARIABLE"
+      tier: enforce
     - domain: "com.example.sysdomain$(touch system-domain-marker)"
       key: SysDomainKey
       type: bool
       value: true
       scope: system
+      tier: enforce
     - domain: com.example.syspath
       key: "SysPathKey$(touch system-key-marker)"
       type: string
       value: "$(touch system-value-marker)"
       scope: system
       plist_path: "/Library/Preferences/sys$(touch system-path-marker).plist"
+      tier: enforce
   killall:
     - "Dock$(touch killall-marker)`touch killall-tick-marker`"
 EOF
@@ -299,6 +313,7 @@ macos:
       key: ApostropheKey
       type: string
       value: "it's $(touch apostrophe-marker) done"
+      tier: enforce
   killall: []
 EOF
 )"
@@ -330,6 +345,7 @@ macos:
       type: string
       value:
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -340,6 +356,7 @@ macos:
       key:
       type: string
       value: v
+      tier: enforce
   killall: []
 EOF
 
@@ -350,6 +367,7 @@ macos:
       key: BlankDomainKey
       type: string
       value: v
+      tier: enforce
   killall: []
 EOF
 
@@ -365,6 +383,7 @@ macos:
       type: string
       value: ""
       scope: system
+      tier: enforce
   killall: []
 EOF
 )"
@@ -382,6 +401,7 @@ macos:
       type: bool
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -394,6 +414,7 @@ macos:
       value: true
       scope: system
       plist_path: /Library/Preferences/../../etc/owned.plist
+      tier: enforce
 EOF
 
 assert_render_rejects 'plist_path on a user-scope record' 'outside scope system' <<'EOF'
@@ -404,6 +425,7 @@ macos:
       type: bool
       value: true
       plist_path: /Library/Preferences/com.example.userpath.plist
+      tier: enforce
   killall: []
 EOF
 
@@ -415,6 +437,7 @@ macos:
       type: bool
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -426,6 +449,7 @@ macos:
       type: bool
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -437,6 +461,7 @@ macos:
       type: bool
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 
@@ -449,6 +474,7 @@ macos:
       value: true
       scope: system
       plist_path: "/"
+      tier: enforce
   killall: []
 EOF
 
@@ -464,6 +490,7 @@ macos:
       value: block
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -496,6 +523,7 @@ macos:
       type: string
       value: v
       scope: system
+      tier: enforce
   killall: []
 EOF
 )"
@@ -507,7 +535,7 @@ benign_write_count="$(grep -cF 'sudo [defaults] [write]' "$stub_log" || true)"
   fail "one system record must produce exactly one root write (got $benign_write_count; log: $(cat "$stub_log"))"
 
 # The forging payload: unit separators plus a newline inside ONE record's value.
-# It is BALANCED on purpose, so both halves carry exactly seven fields and a
+# It is BALANCED on purpose, so both halves carry exactly eight fields and a
 # field-count check alone waves them through; only comparing the number of
 # emitted lines against the number of DECLARED records catches it.
 forging_src="$(
@@ -517,8 +545,9 @@ macos:
     - domain: com.example.sys
       key: SysKey
       type: string
-      value: "v\x1f\x1fsystem\x1f\nEVIL.DOMAIN\x1fEVILKEY\x1fbool\x1ftrue"
+      value: "v\x1f\x1fsystem\x1f\x1fenforce\nEVIL.DOMAIN\x1fEVILKEY\x1fbool\x1ftrue"
       scope: system
+      tier: enforce
   killall: []
 EOF
 )"
@@ -569,6 +598,7 @@ macos:
       key: SepKey
       type: string
       value: "a\x1fb"
+      tier: enforce
   killall: []
 EOF
 )"

--- a/test/integration/macos-defaults-source-path.sh
+++ b/test/integration/macos-defaults-source-path.sh
@@ -86,6 +86,7 @@ macos:
       key: s10flag
       type: bool
       value: true
+      tier: enforce
   killall: []
 EOF
 }

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -110,11 +110,13 @@ macos:
       key: AlphaKey
       type: bool
       value: true
+      tier: enforce
     - domain: com.example.beta
       key: BetaKey
       type: string
       value: BetaValue
       host: current
+      tier: enforce
   killall:
     - Dock
     - cfprefsd
@@ -248,11 +250,13 @@ macos:
       key: AlphaKey
       type: bool
       value: true
+      tier: enforce
     - domain: com.example.sys
       key: SysKey
       type: bool
       value: false
       scope: system
+      tier: enforce
   killall:
     - cfprefsd
 EOF
@@ -289,6 +293,7 @@ macos:
       value: block
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -313,6 +318,7 @@ macos:
       value: true
       scope: system
       plist_path: Library/Preferences/rel.plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -336,6 +342,7 @@ macos:
       value: true
       scope: system
       host: current
+      tier: enforce
   killall: []
 EOF
 )"
@@ -354,6 +361,7 @@ macos:
       type: bool
       value: true
       scope: bogus
+      tier: enforce
   killall: []
 EOF
 )"
@@ -364,12 +372,14 @@ render_template "$bogus_scope_src" "$sandbox/rendered-bogus" "$render_error" || 
 assert_file_contains "$render_error" 'unknown scope' \
   "the unknown-scope render failure must say so (stderr: $(cat "$render_error"))"
 
-# ---- the shared record stream: one line, seven fields, empties survive ------
+# ---- the shared record stream: one line, eight fields, empties survive ------
 
 # The unit separator (0x1f) is not IFS whitespace, so an empty INTERIOR field
 # (here: host absent while scope and plist_path follow it) must survive the
 # read intact. Under a tab-separated stream the empty host would collapse and
-# shift scope left into host, which is the regression this section pins.
+# shift scope left into host, which is the regression this section pins. The
+# tier travels as field 8, so every tool decides by DECLARED tier rather than
+# by which payload fields happen to exist.
 columns_src="$(
   make_source_dir <<'EOF'
 macos:
@@ -380,15 +390,18 @@ macos:
       value: FullValue
       scope: system
       plist_path: /Library/Objective-See/full.plist
+      tier: enforce
     - domain: com.example.minimal
       key: MinimalKey
       type: bool
       value: true
+      tier: enforce
     - domain: com.example.byhost
       key: ByHostKey
       type: int
       value: 7
       host: current
+      tier: enforce
   killall: []
 EOF
 )"
@@ -396,7 +409,7 @@ record_stream="$(bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
   "$LIB" "$columns_src/.chezmoidata/macos_defaults.yaml")" ||
   fail 'defaults_records_unit_separated must succeed on a well-formed file'
 
-IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path got_tier \
   <<<"$(printf '%s\n' "$record_stream" | sed -n '1p')"
 [[ $got_domain == com.example.full ]] || fail "record stream: field 1 must be the domain (got '$got_domain')"
 [[ $got_key == FullKey ]] || fail "record stream: field 2 must be the key (got '$got_key')"
@@ -407,19 +420,22 @@ IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got
 [[ $got_scope == system ]] || fail "record stream: field 6 must be the scope (got '$got_scope')"
 [[ $got_plist_path == /Library/Objective-See/full.plist ]] ||
   fail "record stream: field 7 must be the plist path (got '$got_plist_path')"
+[[ $got_tier == enforce ]] || fail "record stream: field 8 must be the tier (got '$got_tier')"
 
-IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path got_tier \
   <<<"$(printf '%s\n' "$record_stream" | sed -n '2p')"
 [[ $got_domain == com.example.minimal ]] || fail "record stream: minimal field 1 must be the domain (got '$got_domain')"
 [[ -z $got_host ]] || fail "record stream: minimal host must be empty (got '$got_host')"
 [[ $got_scope == user ]] ||
   fail "record stream: an ABSENT scope must default to user in the stream (got '$got_scope')"
 [[ -z $got_plist_path ]] || fail "record stream: minimal plist path must be empty (got '$got_plist_path')"
+[[ $got_tier == enforce ]] || fail "record stream: minimal tier must survive as field 8 (got '$got_tier')"
 
-IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path \
+IFS=$'\x1f' read -r got_domain got_key got_type got_value got_host got_scope got_plist_path got_tier \
   <<<"$(printf '%s\n' "$record_stream" | sed -n '3p')"
 [[ $got_host == current ]] || fail "record stream: field 5 must be the host (got '$got_host')"
 [[ $got_scope == user ]] || fail "record stream: byhost scope must default to user (got '$got_scope')"
+[[ $got_tier == enforce ]] || fail "record stream: byhost tier must survive as field 8 (got '$got_tier')"
 
 # ---- tool stubs --------------------------------------------------------------
 
@@ -497,17 +513,20 @@ macos:
       key: AlphaKey
       type: bool
       value: true
+      tier: enforce
     - domain: com.example.sys
       key: SysKey
       type: bool
       value: false
       scope: system
+      tier: enforce
     - domain: com.example.lulu
       key: LuLuKey
       type: string
       value: block
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -550,6 +569,7 @@ macos:
       value: true
       scope: system
       plist_path: Library/Preferences/rel.plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -576,6 +596,7 @@ macos:
       type: bool
       value: true
       scope: bogus
+      tier: enforce
   killall: []
 EOF
 )"
@@ -597,6 +618,7 @@ macos:
       type: bool
       value: true
       scope: system
+      tier: enforce
   killall: []
 EOF
 )"
@@ -650,6 +672,7 @@ macos:
       value: true
       scope: system
       plist_path: $locked_plist
+      tier: enforce
   killall: []
 EOF
 )"
@@ -683,6 +706,7 @@ macos:
       type: bool
       value: true
       scope: bogus
+      tier: enforce
   killall: []
 EOF
 )"
@@ -705,6 +729,7 @@ macos:
       key: CapKey
       type: bool
       value: true
+      tier: enforce
   killall: []
 EOF
 )"

--- a/test/integration/macos-system-setup-sudo-guard.sh
+++ b/test/integration/macos-system-setup-sudo-guard.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# macos-system-setup-sudo-guard.sh -- the Tier 2 runner template reads the
+# OPTIONAL per-record `sudo` field through `index`, never the bare dotted-field
+# form. Go's text/template errors with `map has no entry for key "sudo"` on the
+# field form when a record omits the key, which turned a legitimate record
+# without the field into an opaque template panic instead of a render.
+#
+# The properties pinned, one per acceptance criterion:
+#   1. A record with NO sudo key renders, and its command line carries no
+#      `sudo ` prefix.
+#   2. A `sudo: true` record keeps its `sudo ` prefix.
+#   3. A `sudo: false` record renders without the prefix (falsy, not panicking,
+#      is the field form's one working case; it must keep working).
+#   4. Source form, the belt behind the behavioral pin above: the template
+#      reads the field through `index . "sudo"` and never the bare dotted form.
+#
+# Real chezmoi; nothing is executed, only rendered.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any chezmoi call. Git exports GIT_DIR to
+# every hook it runs and this suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it happens to be the last
+# statement, so every negative below goes through these helpers.
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+refute_file_matches() { # <file> <regex> <message>
+  if grep -qE -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+command -v chezmoi >/dev/null 2>&1 || {
+  printf 'SKIP: chezmoi not on PATH; cannot render the Tier 2 runner\n'
+  exit 0
+}
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# One fixture, three records: sudo absent, sudo true, sudo false. Each record
+# carries `tier: enforce`, the field the tier-model slice makes required on
+# every record.
+source_dir="$work/src"
+mkdir -p "$source_dir/.chezmoidata"
+cat >"$source_dir/.chezmoidata/macos_system_setup.yaml" <<'EOF'
+macos:
+  system_setup:
+    - description: "record without a sudo key"
+      command: 'printf no-sudo-key-ran'
+      tier: enforce
+    - description: "record with sudo true"
+      command: 'printf sudo-true-ran'
+      sudo: true
+      tier: enforce
+    - description: "record with sudo false"
+      command: 'printf sudo-false-ran'
+      sudo: false
+      tier: enforce
+EOF
+
+render_home="$work/render-home"
+mkdir -p "$render_home"
+rendered="$work/rendered"
+render_error="$work/render.err"
+HOME="$render_home" chezmoi --source "$source_dir" execute-template --no-tty \
+  <"$TEMPLATE" >"$rendered" 2>"$render_error" ||
+  fail "a record without a sudo key must render, not abort the template (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+  exit 0
+fi
+
+# Criterion 1: no sudo key, no prefix. The -x match pins the WHOLE line, so a
+# prefix of any kind fails it; the explicit refute below is the belt for a
+# render that emitted the command twice.
+grep -qxF 'printf no-sudo-key-ran' "$rendered" ||
+  fail "a record without a sudo key must render its bare command (rendered: $(cat "$rendered"))"
+refute_file_contains "$rendered" 'sudo printf no-sudo-key-ran' \
+  'a record without a sudo key must never gain a sudo prefix'
+
+# Criterion 2: sudo true keeps its prefix.
+grep -qxF 'sudo printf sudo-true-ran' "$rendered" ||
+  fail "a sudo: true record must keep its sudo prefix (rendered: $(cat "$rendered"))"
+
+# Criterion 3: sudo false renders without the prefix.
+grep -qxF 'printf sudo-false-ran' "$rendered" ||
+  fail "a sudo: false record must render its bare command (rendered: $(cat "$rendered"))"
+refute_file_contains "$rendered" 'sudo printf sudo-false-ran' \
+  'a sudo: false record must never gain a sudo prefix'
+
+# Criterion 4, source form: the field is read through index; the bare dotted
+# form appears nowhere in the template, comments included, so it cannot creep
+# back in behind a passing render.
+grep -qF 'index . "sudo"' "$TEMPLATE" ||
+  fail 'the template must read the sudo field through index . "sudo"'
+refute_file_matches "$TEMPLATE" '\.sudo' \
+  'the template must not use the bare dotted sudo field form anywhere'
+
+printf 'macos-system-setup-sudo-guard: OK (a record without a sudo key renders its bare command; sudo: true keeps its prefix; sudo: false stays bare; the field is read through index)\n'


### PR DESCRIPTION
## Context

Most macOS security settings cannot be set from the command line on current versions. Apple removed the
flags that once set them, so a script that tries either fails or, worse, appears to succeed while doing
nothing. A hardening guide will still list them, which means any honest system has to distinguish what it
can enforce from what it can only check from what a person has to do by hand.

This adds that distinction to the data. Every tracked setting now declares which of the three it is, and
both runners refuse to proceed on a record that does not.

## Summary

- Every record now declares a control tier: enforce, verify, or manual.
- A record with a missing, blank, or unrecognized tier refuses the whole render rather than being skipped.
- A verify record emits no command that changes anything; a manual record emits only a pointer to a runbook.
- A record whose payload contradicts its declared tier refuses, so a mislabelled control cannot hide.
- The seven existing settings are backfilled, so both runners render byte-identically to before.

Key files: the two runner templates, `dot_local/bin/macos-defaults-lib.sh`, the three `macos-defaults-*`
tools, and the two tracked data files.

## Why the tier lives in the data

Whether a setting is enforceable is a fact about the operating system, not a preference. When Apple removes
the flag that sets something, the control moves from enforce to verify. Putting that in the data makes the
move a one-line change plus a runbook entry, rather than an edit to the scripts. The alternative, inferring
the tier from which fields a record happens to carry, was rejected deliberately: the payload would then
decide what the control is, and a typo would silently reclassify it. The declared tier decides, and a
payload that disagrees is treated as a mistake worth refusing.

## Refusal is total, and that is the property under test

The failure this prevents is a script that looks like it applied a setting while doing nothing, which is
exactly what a removed flag produces. So there is no path where an unrecognized tier yields a partial
script, a warning, or a skipped record: the render aborts and names the offending record. The same holds
for a verify control, which must never produce a write, and for a manual one, which must never produce a
command.

Two refusals for each rule are kept deliberately, one before anything renders and one inside the render
loop. The first gives a clean early error. The second is what stops the loop failing open if the two ever
drift apart. They are now worded distinctly so each is individually pinned by a test, since identical
wording had left either one silently removable.

## What review changed

An independent test-quality pass mutated the production code and found five places where the suite stayed
green:

A list of five payload fields forbidden on a manual record had fixtures for only two, so three members
could be dropped unnoticed. Every member is now pinned individually. A refusal in the second runner had no
test at all. Two more branches in that runner were covered only through the first runner, on the assumption
the copies matched, which is the assumption that let them diverge in the first place.

Three assertions could never fail. They checked that a rejected render emits no command, but the rendering
tool buffers output and discards it entirely when a render fails, so those assertions were satisfied by the
tool rather than by anything in this repository. They are gone, with a note explaining why, since an
assertion that cannot fail is worse than none: it reads as coverage.

Each tool also carried a fail-closed branch that nothing could reach, because a shared guard rejects bad
records earlier. Rather than delete them, the tests now drive each tool past that guard so the branch is
genuinely exercised. The branches matter: without them, one tool would fall through to a write and another
to a bogus comparison the day the shared rules change.

## Known design debt, tracked not fixed

Six validation rules now exist in both runners, and overlapping rules exist again in the shared shell
library: one policy, three implementations, two languages. This has already caused one divergence in an
earlier change, where the library accepted a record the runner refused. An agreement test over a shared
list of hostile records is tracked separately, as is splitting two library functions that have accumulated
validation until each does several jobs.

## Effect of merging

Advances `main` only. No control is declared verify or manual yet, because none exists in the data; this
ships the mechanism and the refusal, proved against fixtures. Both runners render exactly what they
rendered before, so no machine behaves differently, and the live machine follows another branch regardless.
