### PR TITLE
feat(macos): declare the application firewall baseline

### DIFF
--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -82,9 +82,10 @@ macos:
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on"
       sudo: true
       tier: enforce
-    - description: "Firewall: logging (no logging flag on macOS 26.2)"
-      tier: manual
-      runbook: "Firewall logging"
+    # Firewall logging is deliberately NOT declared, in any tier: on this
+    # macOS version there is nothing to enable. socketfilterfw has no logging
+    # flag, and firewall activity already flows to the unified log by default
+    # (see the runbook section "Firewall log diagnostics" for viewing it).
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -51,12 +51,15 @@ macos:
       command: '"$HOME/.local/bin/install-nix-repair-hook.sh"'
       sudo: true
       tier: enforce
-    # Application firewall baseline. ORDER IS LOAD-BEARING: stealth mode and
-    # both signed-software policies are preferences that are inert while the
-    # firewall's global state is off, so the global-state record must stay
-    # strictly first. A reorder ships a setting that reads back as configured
-    # while nothing enforces it.
-    - description: "Firewall: enable the application firewall (must stay before the records below, which are inert while it is off)"
+    # Application firewall baseline. ORDER IS LOAD-BEARING for
+    # partial-execution safety, not for the final state: the subordinate
+    # setters store their configuration independently and enabling the global
+    # state consumes it, so a run that completes lands identically in any
+    # order. A run that dies partway does not: global-first leaves the
+    # firewall ON (at worst missing a subordinate policy), while any other
+    # order can stop with subordinate policies stored and the firewall still
+    # OFF.
+    - description: "Firewall: enable the application firewall (must stay before the records below so a partial run leaves the firewall on, never policies stored with the firewall off)"
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
       sudo: true
       tier: enforce

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -51,6 +51,37 @@ macos:
       command: '"$HOME/.local/bin/install-nix-repair-hook.sh"'
       sudo: true
       tier: enforce
+    # Application firewall baseline. ORDER IS LOAD-BEARING: stealth mode and
+    # both signed-software policies are preferences that are inert while the
+    # firewall's global state is off, so the global-state record must stay
+    # strictly first. A reorder ships a setting that reads back as configured
+    # while nothing enforces it.
+    - description: "Firewall: enable the application firewall (must stay before the records below, which are inert while it is off)"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
+      sudo: true
+      tier: enforce
+    - description: "Firewall: enable stealth mode (drop unsolicited probes silently)"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
+      sudo: true
+      tier: enforce
+    # Two independent signed-software policies, both declared so neither is
+    # left at whatever the machine happens to carry: --setallowsigned governs
+    # BUILT-IN signed software, --setallowsignedapp governs DOWNLOADED signed
+    # software.
+    - description: "Firewall: auto-allow incoming connections for built-in signed software"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on"
+      sudo: true
+      tier: enforce
+    # Settable but not readable: socketfilterfw on macOS 26.2 has no
+    # --getallowsignedapp, so this record's applied state can never be
+    # drift-checked; the apply is fire-and-forget.
+    - description: "Firewall: auto-allow incoming connections for downloaded signed software"
+      command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on"
+      sudo: true
+      tier: enforce
+    - description: "Firewall: logging (no logging flag on macOS 26.2)"
+      tier: manual
+      runbook: "Firewall logging"
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -72,9 +72,9 @@ macos:
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on"
       sudo: true
       tier: enforce
-    # Settable but not readable: socketfilterfw on macOS 26.2 has no
-    # --getallowsignedapp, so this record's applied state can never be
-    # drift-checked; the apply is fire-and-forget.
+    # There is no --getallowsignedapp getter; BOTH signed-software states read
+    # back through the single --getallowsigned getter, one per output line, so
+    # a drift check must parse two lines rather than expect one per flag.
     - description: "Firewall: auto-allow incoming connections for downloaded signed software"
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on"
       sudo: true

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -42,6 +42,26 @@ System Settings → Privacy & Security → grant the following:
 Each grant requires opening the Privacy sheet and dragging the app into the listed sheet. There's no CLI
 surface.
 
+### Firewall logging
+
+Declared `tier: manual` in `.chezmoidata/macos_system_setup.yaml` because there is nothing to automate:
+on macOS 26.2 `socketfilterfw` has no logging flag (older releases had `--setloggingmode`; 26.2 lists
+none in `-h` or its man page), and the Firewall pane in System Settings exposes no logging toggle. The
+firewall daemon already writes its activity to the unified log, so enabling logging by hand means
+capturing that stream:
+
+```bash
+# Watch firewall activity live:
+log stream --predicate 'process == "socketfilterfw"' --info
+
+# Review recent history:
+log show --last 1h --predicate 'process == "socketfilterfw"' --info
+```
+
+Do not resurrect the legacy `defaults write /Library/Preferences/com.apple.alf loggingenabled` toggle:
+nothing on 26.2 documents that the daemon still reads it, and a preference written under a subsystem that
+ignores it reads back as configured while doing nothing.
+
 ### Hardware pairing
 
 - **Bluetooth**: pair AirPods, mice, keyboards via System Settings → Bluetooth.

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -42,13 +42,12 @@ System Settings → Privacy & Security → grant the following:
 Each grant requires opening the Privacy sheet and dragging the app into the listed sheet. There's no CLI
 surface.
 
-### Firewall logging
+### Firewall log diagnostics
 
-Declared `tier: manual` in `.chezmoidata/macos_system_setup.yaml` because there is nothing to automate:
-on macOS 26.2 `socketfilterfw` has no logging flag (older releases had `--setloggingmode`; 26.2 lists
-none in `-h` or its man page), and the Firewall pane in System Settings exposes no logging toggle. The
-firewall daemon already writes its activity to the unified log, so enabling logging by hand means
-capturing that stream:
+Nothing to enable here, this section is view-only. Firewall logging is on by default on macOS 26.2 and
+its activity flows to the unified log automatically. `socketfilterfw` has no logging flag (older releases
+had `--setloggingmode`; 26.2 lists none in `-h` or its man page), the Firewall pane in System Settings
+exposes no logging toggle, and `/var/log/appfirewall.log` no longer exists. To view the activity:
 
 ```bash
 # Watch firewall activity live:

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -131,7 +131,7 @@ sudo -v
 
 echo "→ Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
 sudo "$HOME/.local/bin/install-nix-repair-hook.sh"
-echo "→ Firewall: enable the application firewall (must stay before the records below, which are inert while it is off)"
+echo "→ Firewall: enable the application firewall (must stay before the records below so a partial run leaves the firewall on, never policies stored with the firewall off)"
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
 echo "→ Firewall: enable stealth mode (drop unsolicited probes silently)"
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -157,16 +157,24 @@ render_current() { # <template> <out-file>
 tier1_rendered="$work/tier1.rendered"
 render_current "$TIER1_TEMPLATE" "$tier1_rendered" ||
   fail "the Tier 1 runner must render against the real data (stderr: $(cat "$render_error"))"
-if [[ -z "$(tr -d '[:space:]' <"$tier1_rendered")" ]]; then
-  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+# The skip is gated on the ACTUAL host OS, never on the render coming out
+# empty: emptiness conflates "non-darwin host" (skip, by design) with "the
+# template's OS guard is broken on darwin" (a failure this test exists to
+# catch). An empty render on darwin must fail loudly, not skip.
+[[ "$(uname)" == Darwin ]] || {
+  printf 'SKIP: non-darwin host; the runners render empty by design off darwin\n'
   exit 0
-fi
+}
+[[ -n "$(tr -d '[:space:]' <"$tier1_rendered")" ]] ||
+  fail "the Tier 1 runner rendered EMPTY on a darwin host; its OS guard is broken (template: $TIER1_TEMPLATE; stderr: $(cat "$render_error"))"
 cmp -s "$tier1_golden" "$tier1_rendered" ||
   fail "the Tier 1 runner must render byte-identically to its pre-tier golden (diff: $(diff "$tier1_golden" "$tier1_rendered" | head -20))"
 
 tier2_rendered="$work/tier2.rendered"
 render_current "$TIER2_TEMPLATE" "$tier2_rendered" ||
   fail "the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
+[[ -n "$(tr -d '[:space:]' <"$tier2_rendered")" ]] ||
+  fail "the Tier 2 runner rendered EMPTY on a darwin host; its OS guard is broken (template: $TIER2_TEMPLATE; stderr: $(cat "$render_error"))"
 cmp -s "$tier2_golden" "$tier2_rendered" ||
   fail "the Tier 2 runner must render byte-identically to its golden (diff: $(diff "$tier2_golden" "$tier2_rendered" | head -20))"
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -3,7 +3,7 @@
 # record in .chezmoidata/macos_defaults.yaml and
 # .chezmoidata/macos_system_setup.yaml, and backfilling `tier: enforce` onto the
 # records that existed before the field did is RENDER-NEUTRAL: both runner
-# templates render byte-identically to their pre-tier renders.
+# templates render byte-identically to their goldens below.
 #
 # The properties pinned:
 #   1. Completeness, not a count: EVERY record in both real data files declares
@@ -13,12 +13,15 @@
 #   2. Byte identity: the Tier 1 and Tier 2 runners, rendered against the
 #      repo's REAL data, match the goldens below exactly.
 #
-# The goldens are the renders of both templates at commit 5774ce0 (this slice's
-# base, before the tier field existed) against the real data of that commit,
-# captured byte for byte including the trailing blank line. They pin that the
-# tier MECHANISM changed nothing about what the existing controls execute. A
-# later slice that declares NEW records changes the real render legitimately;
-# it must re-derive these goldens as part of its own render assertions.
+# The Tier 1 golden is the render of that template at commit 5774ce0 (the
+# tier slice's base, before the tier field existed) against the real data of
+# that commit, captured byte for byte including the trailing blank line: the
+# tier MECHANISM changed nothing about what the existing controls execute.
+# The Tier 2 golden was re-derived by the firewall-baseline slice after it
+# declared the firewall records, so it pins the 5774ce0 render PLUS exactly
+# those records' lines and nothing else. A later slice that declares NEW
+# records changes the real render legitimately; it must re-derive these
+# goldens as part of its own render assertions.
 #
 # Real chezmoi and yq; nothing is executed, only rendered.
 set -euo pipefail
@@ -77,7 +80,7 @@ invalid_setup_tiers="$(yq eval -r \
 [[ -z $invalid_setup_tiers ]] ||
   fail "every macos_system_setup.yaml tier must be enforce, verify, or manual; violated on: $invalid_setup_tiers"
 
-# ---- 2: both runners render byte-identically to the pre-tier goldens ---------
+# ---- 2: both runners render byte-identically to their goldens ----------------
 
 # The Tier 1 runner at 5774ce0, rendered against that commit's real data.
 tier1_golden="$work/tier1.golden"
@@ -110,7 +113,9 @@ killall 'cfprefsd' 2>/dev/null || true
 
 GOLDEN_EOF
 
-# The Tier 2 runner at 5774ce0, rendered against that commit's real data.
+# The Tier 2 runner's 5774ce0 render plus the firewall-baseline records
+# (global state first; stealth and both signed-software policies after it;
+# the manual logging record as a pointer, never a command).
 tier2_golden="$work/tier2.golden"
 cat >"$tier2_golden" <<'GOLDEN_EOF'
 #!/bin/bash
@@ -126,6 +131,15 @@ sudo -v
 
 echo "→ Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
 sudo "$HOME/.local/bin/install-nix-repair-hook.sh"
+echo "→ Firewall: enable the application firewall (must stay before the records below, which are inert while it is off)"
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+echo "→ Firewall: enable stealth mode (drop unsolicited probes silently)"
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
+echo "→ Firewall: auto-allow incoming connections for built-in signed software"
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on
+echo "→ Firewall: auto-allow incoming connections for downloaded signed software"
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
+echo '→ MANUAL Firewall: logging (no logging flag on macOS 26.2): see the runbook section Firewall logging'
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 
@@ -154,6 +168,6 @@ tier2_rendered="$work/tier2.rendered"
 render_current "$TIER2_TEMPLATE" "$tier2_rendered" ||
   fail "the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
 cmp -s "$tier2_golden" "$tier2_rendered" ||
-  fail "the Tier 2 runner must render byte-identically to its pre-tier golden (diff: $(diff "$tier2_golden" "$tier2_rendered" | head -20))"
+  fail "the Tier 2 runner must render byte-identically to its golden (diff: $(diff "$tier2_golden" "$tier2_rendered" | head -20))"
 
-printf 'macos-control-tier-render-stability: OK (every real record declares a recognized tier; both runners render byte-identically to their 5774ce0 goldens)\n'
+printf 'macos-control-tier-render-stability: OK (every real record declares a recognized tier; both runners render byte-identically to their goldens)\n'

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -114,8 +114,9 @@ killall 'cfprefsd' 2>/dev/null || true
 GOLDEN_EOF
 
 # The Tier 2 runner's 5774ce0 render plus the firewall-baseline records
-# (global state first; stealth and both signed-software policies after it;
-# the manual logging record as a pointer, never a command).
+# (global state first; stealth and both signed-software policies after it).
+# No manual logging record: firewall logging on this macOS version is on by
+# default and cannot be enabled by hand, so nothing renders for it.
 tier2_golden="$work/tier2.golden"
 cat >"$tier2_golden" <<'GOLDEN_EOF'
 #!/bin/bash
@@ -139,7 +140,6 @@ echo "→ Firewall: auto-allow incoming connections for built-in signed software
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on
 echo "→ Firewall: auto-allow incoming connections for downloaded signed software"
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
-echo '→ MANUAL Firewall: logging (no logging flag on macOS 26.2): see the runbook section Firewall logging'
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -2,8 +2,7 @@
 # macos-firewall-globalstate-order.sh -- the firewall baseline declared in
 # .chezmoidata/macos_system_setup.yaml renders through the Tier 2 runner as
 # four sudo-prefixed, idempotent socketfilterfw commands with the global-state
-# command STRICTLY first, and the logging control renders as a runbook
-# pointer, never a command.
+# command STRICTLY first.
 #
 # Why the order is a correctness property, not cosmetics: partial-execution
 # safety. The subordinate setters store their configuration independently and
@@ -23,17 +22,18 @@
 #      --setallowsigned (built-in) and --setallowsignedapp (downloaded) are
 #      independent policies, and a single "a signed-app command is present"
 #      assertion passes with one of the two missing.
-#   3. The logging record renders NO command and DOES render its runbook
-#      pointer; a completeness diff pins the render's socketfilterfw lines to
-#      exactly the four declared commands, so the logging record cannot
-#      contribute one.
+#   3. The render's socketfilterfw lines are EXACTLY the four declared
+#      commands, byte for byte; a completeness diff, so an extra or altered
+#      line is reported by name.
 #   4. Every socketfilterfw command in the data is an idempotent set-to-state
 #      form with an explicit trailing state, never a toggle: the runner
 #      re-runs the whole list on any data change, so a toggle would flip
 #      protection OFF on the second run. Asserted over EVERY declared firewall
 #      command, not a count.
-#   5. Every manual record's runbook field resolves to a real markdown heading
-#      in the runbook, so the logging pointer cannot dangle.
+#   5. The data declares NO manual records. The only one ever declared here
+#      (firewall logging) described an action that does not exist on this
+#      macOS version, and a manual record no reader can complete is worse
+#      than no record; this pins its removal.
 #
 # Real chezmoi against the REAL .chezmoidata; nothing is executed, only
 # rendered.
@@ -46,7 +46,6 @@ unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_F
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
 SETUP_YAML="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
-RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
 
 # The tool is not on PATH; every declared command carries the absolute path.
 SOCKETFILTERFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
@@ -54,11 +53,6 @@ GLOBAL_STATE_COMMAND="$SOCKETFILTERFW --setglobalstate on"
 STEALTH_COMMAND="$SOCKETFILTERFW --setstealthmode on"
 ALLOW_BUILTIN_SIGNED_COMMAND="$SOCKETFILTERFW --setallowsigned on"
 ALLOW_DOWNLOADED_SIGNED_COMMAND="$SOCKETFILTERFW --setallowsignedapp on"
-
-# The logging record's identity in the data, and the pointer line the manual
-# tier renders for it (byte-exact, shellSingleQuoted by the runner).
-LOGGING_DESCRIPTION="Firewall: logging (no logging flag on macOS 26.2)"
-LOGGING_RUNBOOK_SECTION="Firewall logging"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -71,7 +65,7 @@ for tool in chezmoi yq; do
     exit 0
   }
 done
-for required_file in "$TEMPLATE" "$SETUP_YAML" "$RUNBOOK"; do
+for required_file in "$TEMPLATE" "$SETUP_YAML"; do
   [[ -f $required_file ]] || fail "missing file: $required_file"
 done
 
@@ -113,46 +107,19 @@ while IFS= read -r firewall_command; do
     fail "firewall command is not an idempotent set-to-state form: $firewall_command"
 done <"$declared_firewall_commands"
 
-# The logging record exists exactly once, is tier manual, and carries no
-# mutating payload (no command, no sudo). Its runbook field names the
-# expected section.
-logging_record_count="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
-  '[.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION))] | length' \
+# Criterion 5: this data file declares NO manual records, asserted explicitly
+# so nothing here passes by iterating an empty set. The only manual record
+# ever declared (firewall logging) described an action that cannot be
+# performed: socketfilterfw on 26.2 has no logging flag, and firewall
+# activity flows to the unified log by default, so there is nothing to enable
+# by hand. If a legitimate manual record lands later, replace this assertion
+# with a check that its runbook field resolves to a real markdown heading in
+# the runbook (see git history for the loop this replaced).
+manual_record_descriptions="$(yq eval -r \
+  '[.macos.system_setup[] | select(.tier == "manual") | .description] | join(", ")' \
   "$SETUP_YAML")"
-[[ $logging_record_count -eq 1 ]] ||
-  fail "expected exactly one logging record (description: $LOGGING_DESCRIPTION); found $logging_record_count"
-
-logging_tier="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
-  '.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | .tier' \
-  "$SETUP_YAML")"
-[[ $logging_tier == "manual" ]] ||
-  fail "the logging record must be tier: manual (socketfilterfw on 26.2 has no logging flag); found tier: $logging_tier"
-
-logging_payload_keys="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
-  '[.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | keys | .[] | select(. == "command" or . == "sudo")] | join(",")' \
-  "$SETUP_YAML")"
-[[ -z $logging_payload_keys ]] ||
-  fail "the logging record must carry no mutating payload; found: $logging_payload_keys"
-
-logging_runbook="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
-  '.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | .runbook' \
-  "$SETUP_YAML")"
-[[ $logging_runbook == "$LOGGING_RUNBOOK_SECTION" ]] ||
-  fail "the logging record must point at the runbook section \"$LOGGING_RUNBOOK_SECTION\"; found: $logging_runbook"
-
-# Criterion 5: EVERY manual record's runbook field resolves to a real markdown
-# heading in the runbook. An absent runbook field surfaces as the literal text
-# null and fails the heading lookup, so a dangling or missing pointer cannot
-# pass.
-runbook_headings="$work/runbook-headings"
-sed -E -n 's/^#{1,6} //p' "$RUNBOOK" >"$runbook_headings"
-manual_runbook_sections="$work/manual-runbook-sections"
-yq eval -r '[.macos.system_setup[] | select(.tier == "manual") | .runbook] | .[]' \
-  "$SETUP_YAML" >"$manual_runbook_sections"
-while IFS= read -r runbook_section; do
-  grep -qxF -- "$runbook_section" "$runbook_headings" ||
-    fail "manual record points at runbook section \"$runbook_section\", which is not a heading in $RUNBOOK"
-done <"$manual_runbook_sections"
+[[ -z $manual_record_descriptions ]] ||
+  fail "this data file must declare no manual records (nothing firewall-manual exists to perform on this macOS version); found: $manual_record_descriptions"
 
 # ---- render properties (criteria 1, 2, 3; darwin render only) ---------------
 
@@ -201,14 +168,9 @@ allow_downloaded_signed_line="$(line_number_of_unique_line "sudo $ALLOW_DOWNLOAD
 ((global_state_line < allow_downloaded_signed_line)) ||
   fail "global state (line $global_state_line) must render before the downloaded signed-software policy (line $allow_downloaded_signed_line)"
 
-# Criterion 3: the logging record renders its runbook pointer...
-manual_pointer_line="echo '→ MANUAL ${LOGGING_DESCRIPTION}: see the runbook section ${LOGGING_RUNBOOK_SECTION}'"
-grep -qxF -- "$manual_pointer_line" "$rendered" ||
-  fail "the logging record must render its runbook pointer (expected: $manual_pointer_line)"
-
-# ...and NO command: every socketfilterfw line in the render is one of the
-# four declared sudo-prefixed commands, byte for byte. A completeness diff,
-# not a count, so an extra or altered line is reported by name.
+# Criterion 3: every socketfilterfw line in the render is one of the four
+# declared sudo-prefixed commands, byte for byte. A completeness diff, not a
+# count, so an extra or altered line is reported by name.
 rendered_firewall_lines="$work/rendered-firewall-lines"
 { grep -F 'socketfilterfw' "$rendered" || true; } | LC_ALL=C sort >"$rendered_firewall_lines"
 expected_rendered_firewall_lines="$work/expected-rendered-firewall-lines"
@@ -221,4 +183,4 @@ EOF
 cmp -s "$expected_rendered_firewall_lines" "$rendered_firewall_lines" ||
   fail "the render must contain exactly the four declared socketfilterfw command lines (diff: $(diff "$expected_rendered_firewall_lines" "$rendered_firewall_lines" || true))"
 
-printf 'macos-firewall-globalstate-order: OK (global state renders first; both signed-software policies render sudo-prefixed; the logging record renders a pointer and no command; every declared firewall command is set-to-state; every manual runbook pointer resolves)\n'
+printf 'macos-firewall-globalstate-order: OK (global state renders first; both signed-software policies render sudo-prefixed; the render carries exactly the four declared commands; every declared firewall command is set-to-state; the data declares no manual records)\n'

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -157,10 +157,16 @@ render_error="$work/render.err"
 HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
   <"$TEMPLATE" >"$rendered" 2>"$render_error" ||
   fail "the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
-if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
-  printf 'SKIP: empty render (non-darwin host); render assertions not exercised\n'
+# The skip is gated on the ACTUAL host OS, never on the render coming out
+# empty: emptiness conflates "non-darwin host" (skip, by design) with "the
+# template's OS guard is broken on darwin" (a failure this test exists to
+# catch). An empty render on darwin must fail loudly, not skip.
+[[ "$(uname)" == Darwin ]] || {
+  printf 'SKIP: non-darwin host; render assertions not exercised\n'
   exit 0
-fi
+}
+[[ -n "$(tr -d '[:space:]' <"$rendered")" ]] ||
+  fail "the Tier 2 runner rendered EMPTY on a darwin host; its OS guard is broken (template: $TEMPLATE; stderr: $(cat "$render_error"))"
 
 # Whole-line match (-x) pins the sudo prefix; uniqueness makes the returned
 # line number meaningful for the order comparison.

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -5,16 +5,18 @@
 # command STRICTLY first, and the logging control renders as a runbook
 # pointer, never a command.
 #
-# Why the order is a correctness property, not cosmetics: stealth mode and the
-# signed-software policies are preferences that are inert while the firewall's
-# global state is off. On a fresh or drifted machine a record that renders
-# before the global-state record writes a setting with no protection behind
-# it: it reads back as set and nothing enforces it.
+# Why the order is a correctness property, not cosmetics: partial-execution
+# safety. The subordinate setters store their configuration independently and
+# enabling the global state consumes it, so a run that completes lands
+# identically in any order; a run that dies partway does not. Global-first
+# leaves the machine with the firewall ON (at worst missing a subordinate
+# policy), while any other order can stop with subordinate policies stored
+# and the firewall still OFF.
 #
 # The properties pinned, one per acceptance criterion:
 #   1. Global state renders strictly before stealth (and before both
-#      signed-software commands, the same inert-preference class), compared by
-#      LINE NUMBER in the render; a presence-only assertion would pass with
+#      signed-software commands, the same subordinate-policy class), compared
+#      by LINE NUMBER in the render; a presence-only assertion would pass with
 #      the order reversed. Each command is pinned sudo-prefixed as a whole
 #      line.
 #   2. BOTH signed-software commands render, each asserted individually:
@@ -185,11 +187,11 @@ line_number_of_unique_line() { # <exact-line> <label>
 
 # Criterion 1: global state strictly before stealth, by line number. The two
 # signed-software policies are held behind the global-state line too: they are
-# the same inert-while-off preference class.
+# the same subordinate-policy class, with the same partial-run exposure.
 global_state_line="$(line_number_of_unique_line "sudo $GLOBAL_STATE_COMMAND" "the sudo-prefixed global-state command")"
 stealth_line="$(line_number_of_unique_line "sudo $STEALTH_COMMAND" "the sudo-prefixed stealth command")"
 ((global_state_line < stealth_line)) ||
-  fail "global state (line $global_state_line) must render STRICTLY BEFORE stealth (line $stealth_line); stealth is inert while the firewall is off"
+  fail "global state (line $global_state_line) must render STRICTLY BEFORE stealth (line $stealth_line); a partial run must not stop with stealth stored and the firewall still off"
 
 # Criterion 2: each signed-software command individually, sudo-prefixed.
 allow_builtin_signed_line="$(line_number_of_unique_line "sudo $ALLOW_BUILTIN_SIGNED_COMMAND" "the sudo-prefixed built-in signed-software command")"

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -100,7 +100,11 @@ cmp -s "$expected_firewall_commands" "$declared_firewall_commands" ||
 
 # Criterion 4: EVERY declared firewall command is a set-to-state form with an
 # explicit trailing state. A completeness loop, not a count: a fifth command
-# sneaking in as a toggle must fail here by name.
+# sneaking in as a toggle must fail here by name. Against TODAY'S data this
+# loop is shadowed: the exact-command set compare above fires first on any
+# deviation from the four baseline commands. It is a forward-looking layer,
+# not dead code: it fails when a future toggle command lands alongside a
+# co-evolved whitelist, so keep it.
 set_to_state_pattern='^/usr/libexec/ApplicationFirewall/socketfilterfw --set[a-z]+ (on|off)$'
 while IFS= read -r firewall_command; do
   [[ $firewall_command =~ $set_to_state_pattern ]] ||

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# macos-firewall-globalstate-order.sh -- the firewall baseline declared in
+# .chezmoidata/macos_system_setup.yaml renders through the Tier 2 runner as
+# four sudo-prefixed, idempotent socketfilterfw commands with the global-state
+# command STRICTLY first, and the logging control renders as a runbook
+# pointer, never a command.
+#
+# Why the order is a correctness property, not cosmetics: stealth mode and the
+# signed-software policies are preferences that are inert while the firewall's
+# global state is off. On a fresh or drifted machine a record that renders
+# before the global-state record writes a setting with no protection behind
+# it: it reads back as set and nothing enforces it.
+#
+# The properties pinned, one per acceptance criterion:
+#   1. Global state renders strictly before stealth (and before both
+#      signed-software commands, the same inert-preference class), compared by
+#      LINE NUMBER in the render; a presence-only assertion would pass with
+#      the order reversed. Each command is pinned sudo-prefixed as a whole
+#      line.
+#   2. BOTH signed-software commands render, each asserted individually:
+#      --setallowsigned (built-in) and --setallowsignedapp (downloaded) are
+#      independent policies, and a single "a signed-app command is present"
+#      assertion passes with one of the two missing.
+#   3. The logging record renders NO command and DOES render its runbook
+#      pointer; a completeness diff pins the render's socketfilterfw lines to
+#      exactly the four declared commands, so the logging record cannot
+#      contribute one.
+#   4. Every socketfilterfw command in the data is an idempotent set-to-state
+#      form with an explicit trailing state, never a toggle: the runner
+#      re-runs the whole list on any data change, so a toggle would flip
+#      protection OFF on the second run. Asserted over EVERY declared firewall
+#      command, not a count.
+#   5. Every manual record's runbook field resolves to a real markdown heading
+#      in the runbook, so the logging pointer cannot dangle.
+#
+# Real chezmoi against the REAL .chezmoidata; nothing is executed, only
+# rendered.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any chezmoi call. Git exports GIT_DIR to
+# every hook it runs and this suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+SETUP_YAML="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
+RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
+
+# The tool is not on PATH; every declared command carries the absolute path.
+SOCKETFILTERFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
+GLOBAL_STATE_COMMAND="$SOCKETFILTERFW --setglobalstate on"
+STEALTH_COMMAND="$SOCKETFILTERFW --setstealthmode on"
+ALLOW_BUILTIN_SIGNED_COMMAND="$SOCKETFILTERFW --setallowsigned on"
+ALLOW_DOWNLOADED_SIGNED_COMMAND="$SOCKETFILTERFW --setallowsignedapp on"
+
+# The logging record's identity in the data, and the pointer line the manual
+# tier renders for it (byte-exact, shellSingleQuoted by the runner).
+LOGGING_DESCRIPTION="Firewall: logging (no logging flag on macOS 26.2)"
+LOGGING_RUNBOOK_SECTION="Firewall logging"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the firewall baseline\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$TEMPLATE" "$SETUP_YAML" "$RUNBOOK"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# ---- data-level properties (criteria 4 and 5; OS-independent) ---------------
+
+# Criteria 2 and 4, data half: the declared socketfilterfw commands are
+# EXACTLY the four baseline commands. Set equality via a sorted byte compare
+# asserts each command individually and reports a missing or an extra one by
+# name, where a count or a single-presence grep would stay green.
+declared_firewall_commands="$work/declared-firewall-commands"
+yq eval -r \
+  '[.macos.system_setup[] | select(has("command")) | .command | select(test("socketfilterfw"))] | .[]' \
+  "$SETUP_YAML" | LC_ALL=C sort >"$declared_firewall_commands"
+
+expected_firewall_commands="$work/expected-firewall-commands"
+LC_ALL=C sort >"$expected_firewall_commands" <<EOF
+$GLOBAL_STATE_COMMAND
+$STEALTH_COMMAND
+$ALLOW_BUILTIN_SIGNED_COMMAND
+$ALLOW_DOWNLOADED_SIGNED_COMMAND
+EOF
+
+cmp -s "$expected_firewall_commands" "$declared_firewall_commands" ||
+  fail "the declared socketfilterfw commands must be exactly the four baseline commands (diff: $(diff "$expected_firewall_commands" "$declared_firewall_commands" || true))"
+
+# Criterion 4: EVERY declared firewall command is a set-to-state form with an
+# explicit trailing state. A completeness loop, not a count: a fifth command
+# sneaking in as a toggle must fail here by name.
+set_to_state_pattern='^/usr/libexec/ApplicationFirewall/socketfilterfw --set[a-z]+ (on|off)$'
+while IFS= read -r firewall_command; do
+  [[ $firewall_command =~ $set_to_state_pattern ]] ||
+    fail "firewall command is not an idempotent set-to-state form: $firewall_command"
+done <"$declared_firewall_commands"
+
+# The logging record exists exactly once, is tier manual, and carries no
+# mutating payload (no command, no sudo). Its runbook field names the
+# expected section.
+logging_record_count="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
+  '[.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION))] | length' \
+  "$SETUP_YAML")"
+[[ $logging_record_count -eq 1 ]] ||
+  fail "expected exactly one logging record (description: $LOGGING_DESCRIPTION); found $logging_record_count"
+
+logging_tier="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
+  '.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | .tier' \
+  "$SETUP_YAML")"
+[[ $logging_tier == "manual" ]] ||
+  fail "the logging record must be tier: manual (socketfilterfw on 26.2 has no logging flag); found tier: $logging_tier"
+
+logging_payload_keys="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
+  '[.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | keys | .[] | select(. == "command" or . == "sudo")] | join(",")' \
+  "$SETUP_YAML")"
+[[ -z $logging_payload_keys ]] ||
+  fail "the logging record must carry no mutating payload; found: $logging_payload_keys"
+
+logging_runbook="$(LOGGING_DESCRIPTION="$LOGGING_DESCRIPTION" yq eval -r \
+  '.macos.system_setup[] | select(.description == strenv(LOGGING_DESCRIPTION)) | .runbook' \
+  "$SETUP_YAML")"
+[[ $logging_runbook == "$LOGGING_RUNBOOK_SECTION" ]] ||
+  fail "the logging record must point at the runbook section \"$LOGGING_RUNBOOK_SECTION\"; found: $logging_runbook"
+
+# Criterion 5: EVERY manual record's runbook field resolves to a real markdown
+# heading in the runbook. An absent runbook field surfaces as the literal text
+# null and fails the heading lookup, so a dangling or missing pointer cannot
+# pass.
+runbook_headings="$work/runbook-headings"
+sed -E -n 's/^#{1,6} //p' "$RUNBOOK" >"$runbook_headings"
+manual_runbook_sections="$work/manual-runbook-sections"
+yq eval -r '[.macos.system_setup[] | select(.tier == "manual") | .runbook] | .[]' \
+  "$SETUP_YAML" >"$manual_runbook_sections"
+while IFS= read -r runbook_section; do
+  grep -qxF -- "$runbook_section" "$runbook_headings" ||
+    fail "manual record points at runbook section \"$runbook_section\", which is not a heading in $RUNBOOK"
+done <"$manual_runbook_sections"
+
+# ---- render properties (criteria 1, 2, 3; darwin render only) ---------------
+
+render_home="$work/render-home"
+mkdir -p "$render_home"
+rendered="$work/rendered"
+render_error="$work/render.err"
+HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$TEMPLATE" >"$rendered" 2>"$render_error" ||
+  fail "the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
+if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
+  printf 'SKIP: empty render (non-darwin host); render assertions not exercised\n'
+  exit 0
+fi
+
+# Whole-line match (-x) pins the sudo prefix; uniqueness makes the returned
+# line number meaningful for the order comparison.
+line_number_of_unique_line() { # <exact-line> <label>
+  local hits
+  hits="$(grep -nxF -- "$1" "$rendered")" ||
+    fail "$2 must render exactly once; not found: $1"
+  [[ $(printf '%s\n' "$hits" | wc -l) -eq 1 ]] ||
+    fail "$2 must render exactly once; found multiple: $hits"
+  printf '%s' "${hits%%:*}"
+}
+
+# Criterion 1: global state strictly before stealth, by line number. The two
+# signed-software policies are held behind the global-state line too: they are
+# the same inert-while-off preference class.
+global_state_line="$(line_number_of_unique_line "sudo $GLOBAL_STATE_COMMAND" "the sudo-prefixed global-state command")"
+stealth_line="$(line_number_of_unique_line "sudo $STEALTH_COMMAND" "the sudo-prefixed stealth command")"
+((global_state_line < stealth_line)) ||
+  fail "global state (line $global_state_line) must render STRICTLY BEFORE stealth (line $stealth_line); stealth is inert while the firewall is off"
+
+# Criterion 2: each signed-software command individually, sudo-prefixed.
+allow_builtin_signed_line="$(line_number_of_unique_line "sudo $ALLOW_BUILTIN_SIGNED_COMMAND" "the sudo-prefixed built-in signed-software command")"
+allow_downloaded_signed_line="$(line_number_of_unique_line "sudo $ALLOW_DOWNLOADED_SIGNED_COMMAND" "the sudo-prefixed downloaded signed-software command")"
+((global_state_line < allow_builtin_signed_line)) ||
+  fail "global state (line $global_state_line) must render before the built-in signed-software policy (line $allow_builtin_signed_line)"
+((global_state_line < allow_downloaded_signed_line)) ||
+  fail "global state (line $global_state_line) must render before the downloaded signed-software policy (line $allow_downloaded_signed_line)"
+
+# Criterion 3: the logging record renders its runbook pointer...
+manual_pointer_line="echo '→ MANUAL ${LOGGING_DESCRIPTION}: see the runbook section ${LOGGING_RUNBOOK_SECTION}'"
+grep -qxF -- "$manual_pointer_line" "$rendered" ||
+  fail "the logging record must render its runbook pointer (expected: $manual_pointer_line)"
+
+# ...and NO command: every socketfilterfw line in the render is one of the
+# four declared sudo-prefixed commands, byte for byte. A completeness diff,
+# not a count, so an extra or altered line is reported by name.
+rendered_firewall_lines="$work/rendered-firewall-lines"
+{ grep -F 'socketfilterfw' "$rendered" || true; } | LC_ALL=C sort >"$rendered_firewall_lines"
+expected_rendered_firewall_lines="$work/expected-rendered-firewall-lines"
+LC_ALL=C sort >"$expected_rendered_firewall_lines" <<EOF
+sudo $GLOBAL_STATE_COMMAND
+sudo $STEALTH_COMMAND
+sudo $ALLOW_BUILTIN_SIGNED_COMMAND
+sudo $ALLOW_DOWNLOADED_SIGNED_COMMAND
+EOF
+cmp -s "$expected_rendered_firewall_lines" "$rendered_firewall_lines" ||
+  fail "the render must contain exactly the four declared socketfilterfw command lines (diff: $(diff "$expected_rendered_firewall_lines" "$rendered_firewall_lines" || true))"
+
+printf 'macos-firewall-globalstate-order: OK (global state renders first; both signed-software policies render sudo-prefixed; the logging record renders a pointer and no command; every declared firewall command is set-to-state; every manual runbook pointer resolves)\n'


### PR DESCRIPTION
## Context

The repository tracks macOS settings as data, and a previous change taught it that every setting declares
whether it can be enforced from the command line, only checked, or needs a person. Until now nothing
security-relevant was actually declared. The application firewall is the first.

Four controls are declared here, all enforceable. Their order in the file is the order they run in, and
that turns out to matter.

## Summary

- Declares the application firewall as four enforced controls: global state, stealth mode, and both signed-software policies.
- Pins the order so the firewall is switched on before anything that depends on it.
- Adds a firewall diagnostics section to the fresh-machine runbook.
- Fixes a test that could pass by skipping itself when the thing it tests was broken.
- Data and tests only; nothing is applied by merging.

Key files: `.chezmoidata/macos_system_setup.yaml`, `docs/runbooks/macos-fresh-machine-quickstart.md`,
`test/integration/macos-firewall-globalstate-order.sh`.

## Why four controls and not three

The plan called for one signed-software policy. There are two, and they are separate decisions: one governs
software built into the system, the other governs software that was downloaded. Declaring one leaves the
other at whatever the machine happens to carry, which is the situation the record exists to end. Both are
declared.

This was found by checking the tool on the machine before writing anything, rather than after.

## Why the order is pinned

Running the controls in a different order reaches the same end state, so the ordering is not about
correctness of the final configuration. It is about what happens when a run stops partway. Switching the
firewall on first means an interrupted run leaves protection on and possibly a missing refinement.
The reverse order can leave refinements stored while protection is still off, which reads as configured
and is not.

The test compares line numbers rather than checking both commands are present, because a presence check
passes with the order reversed, which is the entire failure being guarded against.

An earlier version of this description claimed the stealth setting was inert while the firewall was off.
That was checked against the system itself and is not true: the settings are stored independently. The
narrower claim above is what the code now says.

## A test that could not fail

These tests skip themselves on machines where the settings do not apply, and they decided that by checking
whether the rendered output came out empty. Emptiness was standing in for "wrong kind of machine", and the
two are not the same: on the right kind of machine, empty output means the renderer is broken. A
deliberately broken renderer made the test print a skip notice and report success, with none of its
assertions run.

The skip now depends on the actual machine type. On the right machine, empty output is a failure that names
the file responsible. Both tests using this pattern were fixed, and the fix was proven by breaking the
renderer and watching them go from green to red.

## What was removed, and why

The plan included a control for turning on firewall logging by hand, with a runbook entry explaining how.
There is nothing to turn on: the setting was removed from the system tool two versions ago, the old log file
no longer exists, and firewall activity already goes to the system log by default.

A manual control that cannot be carried out is worse than no control, because someone will follow it and
believe they changed something. The control is gone. The runbook keeps the commands for viewing firewall
activity, retitled as diagnostics.

## Not demonstrated on this machine, and why

The applied firewall state was not demonstrated live. The source tree currently carries duplicate profile
directories that make the configuration tool reject the whole source, so applying is blocked. This is
tracked separately as a prerequisite for the final acceptance drill.

Rendering is unaffected by that blocker, so every claim here is proven by rendering the real runner against
the real data and asserting on what it emits. The machine's own firewall was never touched: every check was
read-only.

## Also found, tracked separately

Two problems in the same runner, both older than this change and both out of its scope: data is placed into
a privileged shell without quoting, and one entry checks only whether a hostname is present rather than
whether it is correct, so a stale address is never fixed.

## Effect of merging

Advances `main` only. The live machine follows another branch, so nothing changes anywhere until a later
cutover.
