### PR TITLE
feat(osquery): monitor declared posture controls and page durably

### DIFF
--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -1,0 +1,80 @@
+# macOS runtime posture controls, declarative source of truth.
+#
+# The declaration home for verify-tier controls that are neither a `defaults`
+# key nor a `system_setup` command ("FileVault is on", "the Guest account is
+# disabled"). Records here are rendered to
+# ~/.local/libexec/osquery/posture-controls.json (by
+# dot_local/libexec/osquery/posture-controls.json.tmpl) and consumed at RUNTIME
+# by the security-posture poller (firewall-gatekeeper-monitor.sh), which reads
+# the rendered file on every 60s tick: adding a control is a data change here
+# plus a `chezmoi apply`, never a poller edit. Slices 9 and 10 add records.
+#
+# Every record is tier: verify BY DEFINITION: the poller only ever READS state
+# and pages CRIT on a deviation from the declared value; it never fixes
+# anything. A record with any other tier is rejected at render time (the
+# template aborts the apply) AND at runtime (the poller pages a monitoring gap
+# and refuses the whole file): an enforce or manual control does not belong in
+# a file a read-only poller consumes.
+#
+# Schema (all fields required except remedy):
+#   - id:          <string>  # ^[a-z0-9_]+$, unique; the control's baseline
+#                            # field name. Must not collide with the poller's
+#                            # built-in fields (firewall, gatekeeper,
+#                            # screenlock).
+#     description: <string>  # noun phrase naming the control in a page
+#     tier:        verify    # the only accepted value
+#     reader:      <name>    # HOW the poller reads it; one of the poller's
+#                            # reader functions and its value domain:
+#                            #   fdesetup_status       -> on|off
+#                            #   csrutil_status        -> enabled|disabled
+#                            #   sysadminctl_autologin -> on|off
+#                            #   sysadminctl_guest     -> enabled|disabled
+#     expect:      <value>   # the value the control must hold, inside the
+#                            # reader's domain; ANY in-domain deviation pages
+#     remedy:      <string>  # OPTIONAL: the page's fix-it line. Keep it
+#                            # apostrophe-free (the alerting stack's render jq
+#                            # is bash single-quoted).
+#
+# Reader notes (each verified from the poller's gui/501 session context):
+#   - fdesetup_status runs `fdesetup status`, NOT osquery's disk_encryption
+#     table: FileVault lives on the APFS data volumes, so the obvious
+#     `WHERE name='/dev/disk0'` query reports 0 on a FileVault-on machine, a
+#     false negative that would page "FileVault off" on a healthy system.
+#   - csrutil_status runs `csrutil status`. osquery's sip_config agrees with
+#     it, but the authoritative tool needs no osqueryi startup. SIP is
+#     DELIBERATELY disabled on this machine, so the declared expect is
+#     `disabled`: the control asserts the operator-declared posture, not a
+#     blanket "enabled". Change the declaration when the intent changes.
+#   - sysadminctl_autologin / sysadminctl_guest run `sysadminctl ... status`,
+#     which reports the EFFECTIVE state on stderr and exits 0 in both states.
+#     `defaults read` was rejected as the reader: an absent autoLoginUser key
+#     (the healthy state) exits nonzero, which collides with the poller's
+#     indeterminate-on-nonzero discipline (a nonzero probe is never
+#     classified, so absence could never read as healthy).
+
+macos:
+  posture_controls:
+    - id: filevault
+      description: "FileVault disk encryption"
+      tier: verify
+      reader: fdesetup_status
+      expect: "on"
+      remedy: "Re-enable it: System Settings → Privacy & Security → FileVault"
+    - id: sip
+      description: "System Integrity Protection"
+      tier: verify
+      reader: csrutil_status
+      expect: "disabled"
+      remedy: "This machine declares SIP deliberately disabled; if enabling it was intended, update expect in macos_posture_controls.yaml, otherwise investigate (csrutil changes state from Recovery only)"
+    - id: autologin
+      description: "Automatic login at the login window"
+      tier: verify
+      reader: sysadminctl_autologin
+      expect: "off"
+      remedy: "Turn it off: System Settings → Users & Groups → Automatically log in as"
+    - id: guest
+      description: "The macOS Guest account"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+      remedy: "Disable it: System Settings → Users & Groups → Guest User"

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -25,10 +25,10 @@
 #     tier:        verify    # the only accepted value
 #     reader:      <name>    # HOW the poller reads it; one of the poller's
 #                            # reader functions and its value domain:
-#                            #   fdesetup_status       -> on|off
-#                            #   csrutil_status        -> enabled|disabled
-#                            #   sysadminctl_autologin -> on|off
-#                            #   sysadminctl_guest     -> enabled|disabled
+#                            #   fdesetup_status     -> on|off
+#                            #   csrutil_status      -> enabled|disabled
+#                            #   defaults_autologin  -> on|off
+#                            #   sysadminctl_guest   -> enabled|disabled
 #     expect:      <value>   # the value the control must hold, inside the
 #                            # reader's domain; ANY in-domain deviation pages
 #     remedy:      <string>  # OPTIONAL: the page's fix-it line. Keep it
@@ -45,12 +45,18 @@
 #     DELIBERATELY disabled on this machine, so the declared expect is
 #     `disabled`: the control asserts the operator-declared posture, not a
 #     blanket "enabled". Change the declaration when the intent changes.
-#   - sysadminctl_autologin / sysadminctl_guest run `sysadminctl ... status`,
-#     which reports the EFFECTIVE state on stderr and exits 0 in both states.
-#     `defaults read` was rejected as the reader: an absent autoLoginUser key
-#     (the healthy state) exits nonzero, which collides with the poller's
-#     indeterminate-on-nonzero discipline (a nonzero probe is never
-#     classified, so absence could never read as healthy).
+#   - defaults_autologin runs `defaults read` on loginwindow's autoLoginUser
+#     key: the control means "auto-login is not DECLARED", so the reader asks
+#     the declaration itself. An absent key (or a wholly absent loginwindow
+#     domain) is the healthy off; a present key is on whatever the value; any
+#     other read failure is indeterminate, distinguished by the canonical
+#     does-not-exist diagnostic. `sysadminctl -autologin status` was rejected:
+#     it reports the EFFECTIVE state and prints "Automatic login is disabled
+#     because FileVault is enabled." even with autoLoginUser set, so a
+#     configured auto-login would read healthy until FileVault went off and it
+#     silently activated.
+#   - sysadminctl_guest runs `sysadminctl -guestAccount status`, which reports
+#     the state on stderr and exits 0 in both states.
 
 macos:
   posture_controls:
@@ -69,7 +75,7 @@ macos:
     - id: autologin
       description: "Automatic login at the login window"
       tier: verify
-      reader: sysadminctl_autologin
+      reader: defaults_autologin
       expect: "off"
       remedy: "Turn it off: System Settings → Users & Groups → Automatically log in as"
     - id: guest

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -83,12 +83,22 @@ run_bounded() {
 
 # Read the built-in posture trio in a single combined query (one osqueryi
 # startup per tick, not one per protection). screenlock is folded in per R2-3.
-posture=$(run_bounded "$OSQUERYI" --json "
+# The exit status is captured, never erased: a FAILED osqueryi can still print
+# healthy-looking JSON, and believing it would advance the baseline on
+# untrustworthy data. Any nonzero exit, like any parse failure, empties the
+# read, so the whole trio routes to the monitoring-gap gate below -- the same
+# indeterminate-on-nonzero discipline the declared-control readers follow.
+posture_rc=0
+posture_raw=$(run_bounded "$OSQUERYI" --json "
   SELECT
     (SELECT global_state FROM alf) AS firewall,
     (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper,
     (SELECT enabled FROM screenlock) AS screenlock
-" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
+" 2>/dev/null) || posture_rc=$?
+posture=""
+if [[ $posture_rc -eq 0 ]]; then
+  posture=$(jq -c '.[0] // empty' <<<"$posture_raw" 2>/dev/null) || posture=""
+fi
 
 cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -286,43 +286,95 @@ if [[ -z $controls_problem ]]; then
   done
 fi
 
-# page_gap_once <marker_path> <title> <body> -- the shared page-once-via-marker
-# discipline for both the monitoring-gap and the persistence-gap paths: the same
-# notify-before-persist contract page_crit_and_persist gives the transition and
-# first-observation paths, in ONE place so the two markers cannot diverge. If the
-# marker is absent, send_alert FIRST and write the marker ONLY on success (best
-# effort: a marker in an unwritable dir cannot be written, so the page may
-# re-fire); return 0 when paged or already marked, nonzero when send_alert could
-# not store the page (so a persisting condition re-pages). The per-path bodies,
-# recovery-clear placement, and caller exit code stay OUTSIDE this helper.
+# page_gap_once <marker_path> <members> <title> <body> -- the shared
+# page-once-via-marker discipline for the monitoring-gap and persistence-gap
+# paths, refined to page-once-PER-MEMBER: the marker stores the space-separated
+# set of gapped members already paged for, so an ONGOING gap stays quiet while
+# a NEW member gapping during it still pages (one broken probe must never
+# silence word of a second one breaking). Same notify-before-persist contract
+# as page_crit_and_persist: send_alert FIRST, record the member set ONLY on
+# success (best effort: a marker in an unwritable dir cannot be written, so
+# the page may re-fire). When every current member is already covered, refresh
+# the marker to the CURRENT set so a member that recovers and later re-gaps
+# pages again. Return 0 when paged or already covered, nonzero when send_alert
+# could not store the page (so a persisting condition re-pages). The per-path
+# bodies, recovery-clear placement, and caller exit code stay OUTSIDE this
+# helper.
 page_gap_once() {
-  local marker="$1" title="$2" body="$3"
+  local marker="$1" members="$2" title="$3" body="$4"
+  local covered="" member_list=() member new_member=0
+  read -ra member_list <<<"$members"
   if [[ -f $marker ]]; then
+    covered=" $(cat "$marker" 2>/dev/null || true) "
+    for member in "${member_list[@]}"; do
+      if [[ $covered != *" $member "* ]]; then
+        new_member=1
+      fi
+    done
+  else
+    new_member=1
+  fi
+  if [[ $new_member -eq 0 ]]; then
+    printf '%s\n' "$members" >"$marker" 2>/dev/null || true
     return 0
   fi
   if send_alert CRIT "$title" "$body" "Sosumi"; then
-    : >"$marker" 2>/dev/null || true
+    printf '%s\n' "$members" >"$marker" 2>/dev/null || true
     return 0
   fi
   return 1
 }
 
-# R2-9 monitoring gap, extended to the declared controls. Any built-in scalar
-# missing or out of its exact domain (firewall 0/1/2, Gatekeeper 0/1,
-# screenlock 0/1), an unloadable or refused controls file, or any control probe
-# that came back indeterminate means the security state is UNKNOWN, not safe;
-# an empty or failed osqueryi read leaves all three built-ins empty and lands
-# here too. Do NOT persist (it would poison the baseline) and do NOT compare
-# (it would fabricate a transition): the last good baseline is preserved. Page
-# ONCE per gap (page_gap_once); if send_alert cannot store the page (it still
-# fires a last-resort local banner), log and exit nonzero so a PERSISTING gap
-# re-pages next tick. (Values are bracketed, [] for empty, and sanitized: raw
-# system-read text is data, never structure, and never reaches the page whole.)
+# Validate any existing baseline BEFORE trusting it (and before write_state
+# overwrites it): it must be owner-only (mode 600) AND parse to three in-domain
+# built-in scalars (same domains as the gap gate below). A group/world-readable,
+# corrupt, or out-of-domain baseline is not trustworthy (it could be planted to
+# mask a disabled protection, or fabricate a transition), so it is treated as no
+# prior baseline. GNU-first stat, BSD fallback.
+prev_valid=0
+prev_fw=""
+prev_gk=""
+prev_sl=""
+prev_json=""
+if [[ -f $STATE ]]; then
+  st_mode=$(stat -c '%a' "$STATE" 2>/dev/null || stat -f '%Lp' "$STATE" 2>/dev/null || echo "")
+  prev_json=$(cat "$STATE" 2>/dev/null || echo "")
+  prev_fw=$(jq -r '.firewall // empty' <<<"$prev_json" 2>/dev/null || echo "")
+  prev_gk=$(jq -r '.gatekeeper // empty' <<<"$prev_json" 2>/dev/null || echo "")
+  prev_sl=$(jq -r '.screenlock // empty' <<<"$prev_json" 2>/dev/null || echo "")
+  if [[ $st_mode == "600" && $prev_fw =~ ^[012]$ && $prev_gk =~ ^[01]$ && $prev_sl =~ ^[01]$ ]]; then
+    prev_valid=1
+  fi
+fi
+
+# R2-9 monitoring gap, extended to the declared controls and made PER MEMBER.
+# The members: the built-in trio (ONE combined probe, trusted or distrusted as
+# a unit), the controls file, and each declared control. A gapped member's
+# state is UNKNOWN, not safe: page (once per member, via the marker's member
+# set), do NOT persist its read (it would poison the baseline), and do NOT
+# compare it (it would fabricate a transition). But a gap on one member must
+# NEVER blind the others: every member that read cleanly is still compared,
+# paged, and persisted below, with only the gapped members' baseline fields
+# preserved from the prior. A monitor that went blind on unrelated controls
+# because one probe broke would lose a real regression during the outage --
+# permanently, because the baseline moves on after the deviant control
+# recovers. A built-in scalar missing or out of its exact domain (firewall
+# 0/1/2, Gatekeeper 0/1, screenlock 0/1) gaps the trio; an empty or failed
+# osqueryi read leaves all three empty and lands there too. If send_alert
+# cannot store the gap page (it still fires a last-resort local banner), log
+# and exit nonzero so a PERSISTING gap re-pages next tick. (Values are
+# bracketed, [] for empty, and sanitized: raw system-read text is data, never
+# structure, and never reaches the page whole.)
+trio_clean=1
 gap_detail=""
+gap_members=""
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
+  trio_clean=0
+  gap_members="posture_query"
   gap_detail="the posture query returned an unreadable value (firewall=[$(sanitize "$cur_fw")] gatekeeper=[$(sanitize "$cur_gk")] screenlock=[$(sanitize "$cur_sl")])"
 fi
 if [[ -n $controls_problem ]]; then
+  gap_members+="${gap_members:+ }controls_file"
   gap_detail+="${gap_detail:+; }$controls_problem"
 fi
 indeterminate_ids=""
@@ -332,39 +384,28 @@ for control_index in "${!control_ids[@]}"; do
   fi
 done
 if [[ -n $indeterminate_ids ]]; then
+  gap_members+="${gap_members:+ }$indeterminate_ids"
   gap_detail+="${gap_detail:+; }indeterminate posture control read(s): [$indeterminate_ids]"
 fi
 if [[ -n $gap_detail ]]; then
-  gap_body="**Security-posture monitoring gap**"$'\n'"- $gap_detail: the security posture is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi, a posture probe, or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query and the control probes by hand, then re-check."
-  if ! page_gap_once "$GAP" "🔴 **CRITICAL**" "$gap_body"; then
+  gap_body="**Security-posture monitoring gap**"$'\n'"- $gap_detail: the security posture there is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi, a posture probe, or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query and the control probes by hand, then re-check."
+  if ! page_gap_once "$GAP" "$gap_members" "🔴 **CRITICAL**" "$gap_body"; then
     printf 'firewall-gatekeeper-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
     exit 1
   fi
-  exit 0
+else
+  # A fully clean read cleared every gap (recovery): drop the marker so a
+  # future gap pages again. Done before the normal transition/persist logic.
+  rm -f "$GAP" 2>/dev/null || true
 fi
 
-# A fully valid read cleared the gap (recovery): drop the marker so a future
-# gap pages again. Done before the normal transition/persist logic.
-rm -f "$GAP" 2>/dev/null || true
-
-# Validate any existing baseline BEFORE trusting it (and before write_state
-# overwrites it): it must be owner-only (mode 600) AND parse to three in-domain
-# built-in scalars (same domains as above). A group/world-readable, corrupt, or
-# out-of-domain baseline is not trustworthy (it could be planted to mask a
-# disabled protection, or fabricate a transition), so it is treated as no prior
-# baseline. GNU-first stat, BSD fallback.
-prev_valid=0
-prev_fw=""
-prev_gk=""
-prev_sl=""
-if [[ -f $STATE ]]; then
-  st_mode=$(stat -c '%a' "$STATE" 2>/dev/null || stat -f '%Lp' "$STATE" 2>/dev/null || echo "")
-  prev_fw=$(jq -r '.firewall // empty' <"$STATE" 2>/dev/null || echo "")
-  prev_gk=$(jq -r '.gatekeeper // empty' <"$STATE" 2>/dev/null || echo "")
-  prev_sl=$(jq -r '.screenlock // empty' <"$STATE" 2>/dev/null || echo "")
-  if [[ $st_mode == "600" && $prev_fw =~ ^[012]$ && $prev_gk =~ ^[01]$ && $prev_sl =~ ^[01]$ ]]; then
-    prev_valid=1
-  fi
+# With the trio unreadable AND no trusted prior baseline there is nothing to
+# anchor a comparison or a persist to: any baseline written now would carry no
+# valid trio and be distrusted next tick, so comparing the declared controls
+# would re-page the same first observation every tick. The gap page above
+# already said the posture is unknown; stop here and retry next tick.
+if [[ $trio_clean -eq 0 && $prev_valid -eq 0 ]]; then
+  exit 0
 fi
 
 # Per-control priors, each trusted independently: a control's prior field must
@@ -378,7 +419,7 @@ control_prevs=()
 for control_index in "${!control_ids[@]}"; do
   control_prev=""
   if [[ $prev_valid -eq 1 ]]; then
-    control_prev=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key] // empty' <"$STATE" 2>/dev/null || echo "")
+    control_prev=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key] // empty' <<<"$prev_json" 2>/dev/null || echo "")
     domain=$(reader_domain "${control_readers[$control_index]}")
     case " $domain " in
       *" $control_prev "*) ;;
@@ -388,15 +429,32 @@ for control_index in "${!control_ids[@]}"; do
   control_prevs+=("$control_prev")
 done
 
-# The baseline to persist: the built-in trio plus one field per declared
-# control (normalized enum values only), so the next run can trust per-control
-# priors. Built AFTER the gap gate, so every merged value is in-domain.
-baseline_json="$posture"
+# The baseline to persist: for every member that read cleanly, the value read
+# THIS tick; for every gapped member, the trusted prior field preserved
+# unchanged, so a member's real transitions are still detected across another
+# member's outage. With a refused controls file the declared set is unknown,
+# so a trusted prior's fields are preserved wholesale under the fresh trio.
+# Normalized enum values only, in-domain by construction.
+if [[ $trio_clean -eq 1 ]]; then
+  baseline_json="$posture"
+else
+  baseline_json=$(jq -cn --arg fw "$prev_fw" --arg gk "$prev_gk" --arg sl "$prev_sl" \
+    '{firewall: $fw, gatekeeper: $gk, screenlock: $sl}')
+fi
+if [[ -n $controls_problem && $prev_valid -eq 1 ]]; then
+  baseline_json=$(jq -c --argjson trio "$baseline_json" '. + $trio' <<<"$prev_json")
+fi
 for control_index in "${!control_ids[@]}"; do
-  baseline_json=$(jq -c \
-    --arg key "${control_ids[$control_index]}" \
-    --arg value "${control_values[$control_index]}" \
-    '. + {($key): $value}' <<<"$baseline_json")
+  control_field="${control_values[$control_index]}"
+  if [[ $control_field == "indeterminate" ]]; then
+    control_field="${control_prevs[$control_index]}" # trusted prior, may be empty
+  fi
+  if [[ -n $control_field ]]; then
+    baseline_json=$(jq -c \
+      --arg key "${control_ids[$control_index]}" \
+      --arg value "$control_field" \
+      '. + {($key): $value}' <<<"$baseline_json")
+  fi
 done
 
 # Persist the current posture owner-only (0600) so a later run can trust its own
@@ -426,7 +484,7 @@ persist_baseline() {
     return 0
   fi
   degraded_body="**Security-posture monitor degraded**"$'\n'"- The posture monitor could not persist its baseline: it cannot advance state, so a stale baseline could mask the next real change and blind the monitor."$'\n'"- Check the state directory free space and permissions. **Check now.**"
-  page_gap_once "$PERSIST_GAP" "🔴 **CRITICAL**" "$degraded_body" || true
+  page_gap_once "$PERSIST_GAP" "baseline_persist" "🔴 **CRITICAL**" "$degraded_body" || true
   exit 1
 }
 
@@ -495,6 +553,9 @@ if [[ $prev_valid -eq 0 ]]; then
     first_obs_blocks+=("**Screen lock is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the screen-lock password requirement is already off, anyone at the machine has access. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
   fi
   for control_index in "${!control_ids[@]}"; do
+    if [[ ${control_values[$control_index]} == "indeterminate" ]]; then
+      continue # gapped member: paged above, never compared
+    fi
     if [[ ${control_values[$control_index]} != "${control_expects[$control_index]}" ]]; then
       first_obs_blocks+=("$(control_block "$control_index" 1)")
     fi
@@ -538,14 +599,16 @@ sl_to_text() {
 # protection-off shape: bold header, Was/Now state, then a decision-first next
 # step.
 crit_blocks=()
-if [[ $cur_fw != "$prev_fw" && $cur_fw == "0" ]]; then
-  crit_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(fw_to_text "$prev_fw")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
-fi
-if [[ $cur_gk != "$prev_gk" && $cur_gk == "0" ]]; then
-  crit_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gk_to_text "$prev_gk")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security (spctl cannot enable Gatekeeper from the CLI on macOS 15+)")
-fi
-if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
-  crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
+if [[ $trio_clean -eq 1 ]]; then
+  if [[ $cur_fw != "$prev_fw" && $cur_fw == "0" ]]; then
+    crit_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(fw_to_text "$prev_fw")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
+  fi
+  if [[ $cur_gk != "$prev_gk" && $cur_gk == "0" ]]; then
+    crit_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gk_to_text "$prev_gk")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security (spctl cannot enable Gatekeeper from the CLI on macOS 15+)")
+  fi
+  if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
+    crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
+  fi
 fi
 # Declared controls: page on a REGRESSION (the prior held the declared value,
 # the current does not) and on a first observation of a deviation (no trusted
@@ -557,6 +620,9 @@ for control_index in "${!control_ids[@]}"; do
   control_value="${control_values[$control_index]}"
   control_expect="${control_expects[$control_index]}"
   control_prev="${control_prevs[$control_index]}"
+  if [[ $control_value == "indeterminate" ]]; then
+    continue # gapped member: paged above, never compared
+  fi
   if [[ $control_value == "$control_expect" ]]; then
     continue
   fi

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -63,6 +63,17 @@ sanitize() {
   printf '%s' "${text:0:160}"
 }
 
+# sanitize_span <text> -- sanitize, then wrap in a Discord inline-code span:
+# the same chokepoint treatment render-page.sh gives attacker-influenceable
+# fields (backticks stripped so the span cannot be broken out of, newlines and
+# tabs squashed, length-capped, wrapped in backticks). Character-stripping
+# alone leaves markdown STRUCTURE intact -- emphasis, [links](...), @mentions
+# survive sanitize as plain characters -- so every value that crosses into a
+# notification body goes through here and renders inert inside the span.
+sanitize_span() {
+  printf '`%s`' "$(sanitize "$1")"
+}
+
 # Bound every probe so a WEDGED tool (a hung table or a stuck status call never
 # closing stdout) becomes a monitoring gap, not silent blindness. Without a
 # deadline, `|| true` handles an EXIT but not a HANG, launchd skips ticks while
@@ -248,7 +259,7 @@ controls_problem=""
 load_controls() {
   local count index record id tier reader expect description remedy domain
   if [[ ! -f $CONTROLS_FILE ]]; then
-    controls_problem="posture-controls file missing at [$(sanitize "$CONTROLS_FILE")]"
+    controls_problem="posture-controls file missing at $(sanitize_span "$CONTROLS_FILE")"
     return 0
   fi
   # Slurp (-s) so the WHOLE file must be exactly ONE top-level array: a
@@ -286,18 +297,18 @@ load_controls() {
         ;;
     esac
     if [[ $tier != "verify" ]]; then
-      controls_problem="posture-controls record [$id] declares tier [$(sanitize "$tier")], not verify; the poller only reads controls, so the record does not belong in its file"
+      controls_problem="posture-controls record [$id] declares tier $(sanitize_span "$tier"), not verify; the poller only reads controls, so the record does not belong in its file"
       return 0
     fi
     domain=$(reader_domain "$reader")
     if [[ -z $domain ]]; then
-      controls_problem="posture-controls record [$id] names unknown reader [$(sanitize "$reader")]"
+      controls_problem="posture-controls record [$id] names unknown reader $(sanitize_span "$reader")"
       return 0
     fi
     case " $domain " in
       *" $expect "*) ;;
       *)
-        controls_problem="posture-controls record [$id] expects [$(sanitize "$expect")], outside the $reader domain ($domain)"
+        controls_problem="posture-controls record [$id] expects $(sanitize_span "$expect"), outside the $reader domain ($domain)"
         return 0
         ;;
     esac
@@ -411,16 +422,16 @@ fi
 # 0/1/2, Gatekeeper 0/1, screenlock 0/1) gaps the trio; an empty or failed
 # osqueryi read leaves all three empty and lands there too. If send_alert
 # cannot store the gap page (it still fires a last-resort local banner), log
-# and exit nonzero so a PERSISTING gap re-pages next tick. (Values are
-# bracketed, [] for empty, and sanitized: raw system-read text is data, never
-# structure, and never reaches the page whole.)
+# and exit nonzero so a PERSISTING gap re-pages next tick. (Values cross into
+# the body only through sanitize_span: raw system-read text is data, never
+# structure, and never reaches the page whole or outside an inline-code span.)
 trio_clean=1
 gap_detail=""
 gap_members=""
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
   trio_clean=0
   gap_members="posture_query"
-  gap_detail="the posture query returned an unreadable value (firewall=[$(sanitize "$cur_fw")] gatekeeper=[$(sanitize "$cur_gk")] screenlock=[$(sanitize "$cur_sl")])"
+  gap_detail="the posture query returned an unreadable value (firewall=$(sanitize_span "$cur_fw") gatekeeper=$(sanitize_span "$cur_gk") screenlock=$(sanitize_span "$cur_sl"))"
 fi
 if [[ -n $controls_problem ]]; then
   gap_members+="${gap_members:+ }controls_file"
@@ -575,10 +586,12 @@ page_crit_and_persist() {
 # control_block <index> <first_observation:0|1> -- the CRIT block for a
 # declared control deviating from its declared value. Everything in it is
 # either this script's own text, a normalized enum value, or a sanitized
-# record field; raw probe output never appears.
+# record field wrapped in an inline-code span (description and remedy come
+# from the data file, so they are data, never notification structure); raw
+# probe output never appears.
 control_block() {
   local control_index="$1" first_observation="$2"
-  local description="${control_descriptions[$control_index]}"
+  local description="\`${control_descriptions[$control_index]}\`"
   local expect="${control_expects[$control_index]}"
   local value="${control_values[$control_index]}"
   local remedy="${control_remedies[$control_index]}"
@@ -589,7 +602,7 @@ control_block() {
     block="**${description}: now ${value}, declared ${expect}**"$'\n'"- **Was:** ${control_prevs[$control_index]}"$'\n'"- **Now:** **${value}**"$'\n'"- Did you change this? If not, something else did, **investigate now**."
   fi
   if [[ -n $remedy ]]; then
-    block+=$'\n'"- ${remedy}"
+    block+=$'\n'"- \`${remedy}\`"
   fi
   printf '%s' "$block"
 }

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -212,7 +212,17 @@ load_controls() {
     controls_problem="posture-controls file missing at [$(sanitize "$CONTROLS_FILE")]"
     return 0
   fi
-  if ! count=$(jq -er 'if type == "array" then length else error("not an array") end' <"$CONTROLS_FILE" 2>/dev/null); then
+  # Slurp (-s) so the WHOLE file must be exactly ONE top-level array: a
+  # multi-document file (say, two arrays back to back) parses per document,
+  # would emit one length per document, poison the loop arithmetic, and
+  # silently monitor zero controls. The integer guard is belt-and-braces for
+  # the same reason: count feeds bash arithmetic, so anything but one plain
+  # integer is refused before it can be evaluated.
+  if ! count=$(jq -ser 'if (length == 1 and (.[0] | type == "array")) then (.[0] | length) else error("not one array") end' <"$CONTROLS_FILE" 2>/dev/null); then
+    controls_problem="the posture-controls file is not a JSON array"
+    return 0
+  fi
+  if ! [[ $count =~ ^[0-9]+$ ]]; then
     controls_problem="the posture-controls file is not a JSON array"
     return 0
   fi

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -409,22 +409,32 @@ if [[ $trio_clean -eq 0 && $prev_valid -eq 0 ]]; then
 fi
 
 # Per-control priors, each trusted independently: a control's prior field must
-# exist in a trusted baseline AND sit inside its reader's domain, else that ONE
-# control has no trusted prior (first-observation semantics for it) while the
-# others keep theirs. This is what makes adding a control to the data file a
-# quiet upgrade on a healthy machine instead of a page storm or a global
-# baseline reset. An out-of-domain prior is never compared: comparing it would
-# fabricate a transition, and it never reaches a page.
+# exist in a trusted baseline, sit inside its reader's domain, AND have been
+# recorded under the SAME declared expect (the baseline stores it as
+# "<id>:expect" beside each value; ':' cannot appear in an id, so the pair can
+# never collide). Any miss means that ONE control has no trusted prior
+# (first-observation semantics for it) while the others keep theirs. This is
+# what makes adding a control to the data file a quiet upgrade on a healthy
+# machine instead of a page storm or a global baseline reset. An out-of-domain
+# prior is never compared: comparing it would fabricate a transition, and it
+# never reaches a page. A prior recorded under a DIFFERENT expect is never
+# compared either: an operator tightening a declaration over a steady-deviant
+# value would otherwise read as steady-deviant and stay silent, turning a
+# hardening change into a silent no-op.
 control_prevs=()
 for control_index in "${!control_ids[@]}"; do
   control_prev=""
   if [[ $prev_valid -eq 1 ]]; then
     control_prev=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key] // empty' <<<"$prev_json" 2>/dev/null || echo "")
+    control_prev_expect=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key + ":expect"] // empty' <<<"$prev_json" 2>/dev/null || echo "")
     domain=$(reader_domain "${control_readers[$control_index]}")
     case " $domain " in
       *" $control_prev "*) ;;
       *) control_prev="" ;;
     esac
+    if [[ $control_prev_expect != "${control_expects[$control_index]}" ]]; then
+      control_prev=""
+    fi
   fi
   control_prevs+=("$control_prev")
 done
@@ -450,10 +460,13 @@ for control_index in "${!control_ids[@]}"; do
     control_field="${control_prevs[$control_index]}" # trusted prior, may be empty
   fi
   if [[ -n $control_field ]]; then
+    # The value AND the expect it was recorded under: the pair is what lets
+    # the next run detect a changed declaration and re-arm the control.
     baseline_json=$(jq -c \
       --arg key "${control_ids[$control_index]}" \
       --arg value "$control_field" \
-      '. + {($key): $value}' <<<"$baseline_json")
+      --arg expect "${control_expects[$control_index]}" \
+      '. + {($key): $value, ($key + ":expect"): $expect}' <<<"$baseline_json")
   fi
 done
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -71,6 +71,7 @@ sanitize() {
 # survive sanitize as plain characters -- so every value that crosses into a
 # notification body goes through here and renders inert inside the span.
 sanitize_span() {
+  # shellcheck disable=SC2016 # literal Discord inline-code backticks, no expansion intended
   printf '`%s`' "$(sanitize "$1")"
 }
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -3,8 +3,11 @@
 # firewall-gatekeeper-monitor.sh, polled every 60s by a launchd StartInterval
 # agent. The security-posture monitor: it reads the live firewall (alf),
 # Gatekeeper, AND screen-lock state via osqueryi in the gui/501 user session,
-# compares against the previous run's baseline, and pages CRIT only on a
-# protection turning OFF. Silent in steady state.
+# plus every control declared in posture-controls.json (the chezmoi render of
+# .chezmoidata/macos_posture_controls.yaml: FileVault, SIP, automatic login,
+# the Guest account, and whatever later slices declare), compares against the
+# previous run's baseline, and pages CRIT only on a protection turning OFF or
+# a declared control deviating from its declared value. Silent in steady state.
 #
 # R2-3: screen-lock-off detection lives HERE, not in the root-daemon pack. The
 # screenlock osquery table is scoped to the logged-in user, so the ROOT osqueryd
@@ -18,6 +21,19 @@ STATE="${OSQUERY_POSTURE_STATE:-$HOME/.local/state/osquery-posture-state.json}"
 GAP="$STATE.gap"                 # page-once marker for a monitoring gap (R2-9)
 PERSIST_GAP="$STATE.persist-gap" # page-once marker for a baseline-persist failure
 OSQUERYI="${OSQUERYI:-$(command -v osqueryi || echo /usr/local/bin/osqueryi)}"
+# The declared posture controls, rendered by chezmoi from
+# .chezmoidata/macos_posture_controls.yaml. The poller reads the FILE rather
+# than carrying the control list in its body, so adding a control is a data
+# change. It lives beside this script so the pipeline-integrity watch and the
+# known-good manifest cover it: the file decides WHAT gets monitored, so it is
+# part of the monitor's body.
+CONTROLS_FILE="${OSQUERY_POSTURE_CONTROLS:-$HOME/.local/libexec/osquery/posture-controls.json}"
+# Absolute probe paths by default: the LaunchAgent PATH is minimal, and a
+# status probe that silently resolved to something unexpected would be an
+# untrustworthy read. The env overrides are the test seam.
+FDESETUP="${OSQUERY_POSTURE_FDESETUP:-/usr/bin/fdesetup}"
+CSRUTIL="${OSQUERY_POSTURE_CSRUTIL:-/usr/bin/csrutil}"
+SYSADMINCTL="${OSQUERY_POSTURE_SYSADMINCTL:-/usr/sbin/sysadminctl}"
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -28,33 +44,237 @@ mkdir -p "$(dirname "$STATE")"
 # failure, or the empty-read guard below).
 trap 'rm -f "$STATE.tmp"' EXIT
 
-# Read the current posture in a single combined query (one osqueryi startup per
-# tick, not one per protection). screenlock is folded in per R2-3.
-#
-# Bound the query so a WEDGED osqueryi (a hung table never closes its stdout)
-# becomes a monitoring gap, not silent blindness. Without a deadline, `|| true`
-# handles an osqueryi EXIT but not a HANG, launchd skips ticks while the process
-# lives, and the uptime-watchdog cannot catch it (its probe queries a different
-# table that answers while a posture table hangs). gtimeout preferred, timeout
-# fallback (the codebase convention); if neither is on PATH, degrade to an
-# unbounded read (no worse than before; the darwin fleet has one). The bound is
-# well under the 60s tick and env-overridable. On timeout osqueryi is killed, its
-# stdout closes, and the read collapses to empty, which the gap gate below pages.
-posture_query=("$OSQUERYI" --json "
+# sanitize <text> -- neutralize a value before it reaches a notification body:
+# newlines/CR/tabs flatten to spaces; backslash, backtick, dollar, and both
+# quote characters are removed (apostrophes because the downstream render jq is
+# bash single-quoted); the result is length-capped. System-read text is DATA,
+# never structure. The normalized enum values a reader returns bypass this only
+# because they are this script's own fixed constants, never probe output.
+sanitize() {
+  local text="${1//$'\n'/ }"
+  text=${text//$'\r'/ }
+  text=${text//$'\t'/ }
+  text=${text//\\/}
+  text=${text//\`/}
+  text=${text//\$/}
+  text=${text//\'/}
+  text=${text//\"/}
+  printf '%s' "${text:0:160}"
+}
+
+# Bound every probe so a WEDGED tool (a hung table or a stuck status call never
+# closing stdout) becomes a monitoring gap, not silent blindness. Without a
+# deadline, `|| true` handles an EXIT but not a HANG, launchd skips ticks while
+# the process lives, and the uptime-watchdog cannot catch it (its probe queries
+# a different table that answers while a posture read hangs). gtimeout
+# preferred, timeout fallback (the codebase convention); if neither is on PATH,
+# degrade to an unbounded read (no worse than before; the darwin fleet has
+# one). The bound is well under the 60s tick and env-overridable. On timeout
+# the probe is killed and exits nonzero, which classifies as indeterminate (or,
+# for the combined osqueryi read, collapses to empty), and the gap gate pages.
+posture_timeout_bin="$(command -v gtimeout || command -v timeout || true)"
+run_bounded() {
+  if [[ -n $posture_timeout_bin ]]; then
+    "$posture_timeout_bin" "${OSQUERY_POSTURE_TIMEOUT:-20}" "$@"
+  else
+    "$@"
+  fi
+}
+
+# Read the built-in posture trio in a single combined query (one osqueryi
+# startup per tick, not one per protection). screenlock is folded in per R2-3.
+posture=$(run_bounded "$OSQUERYI" --json "
   SELECT
     (SELECT global_state FROM alf) AS firewall,
     (SELECT assessments_enabled FROM gatekeeper) AS gatekeeper,
     (SELECT enabled FROM screenlock) AS screenlock
-")
-posture_timeout_bin="$(command -v gtimeout || command -v timeout || true)"
-if [[ -n $posture_timeout_bin ]]; then
-  posture_query=("$posture_timeout_bin" "${OSQUERY_POSTURE_TIMEOUT:-20}" "${posture_query[@]}")
-fi
-posture=$("${posture_query[@]}" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
+" 2>/dev/null | jq -c '.[0] // empty' 2>/dev/null || true)
 
 cur_fw=$(jq -r '.firewall // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_gk=$(jq -r '.gatekeeper // empty' <<<"$posture" 2>/dev/null || echo "")
 cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
+
+# ---- declared posture controls ----------------------------------------------
+
+# reader_domain <reader> -> the reader's space-separated value domain, empty
+# for an unknown reader. This table, the template's $readerDomains, and
+# read_control below name the same reader set; the render test and the
+# poller-vs-data agreement test hold them together.
+reader_domain() {
+  case "$1" in
+    fdesetup_status | sysadminctl_autologin) printf 'on off' ;;
+    csrutil_status | sysadminctl_guest) printf 'enabled disabled' ;;
+  esac
+}
+
+# classify_probe <output> <rc> <needle_a> <value_a> <needle_b> <value_b>
+# The indeterminate-on-nonzero discipline (absorbed from the retired
+# apply-time posture reminder): a probe that exits NONZERO is INDETERMINATE
+# regardless of what it printed, because a failed probe's output is
+# untrustworthy; it may print healthy-looking text yet have failed. A
+# zero-exit probe must match EXACTLY ONE of the two needles; both or neither
+# is indeterminate too (an ambiguous probe is never guessed at).
+classify_probe() {
+  local output="$1" rc="$2" needle_a="$3" value_a="$4" needle_b="$5" value_b="$6"
+  local hit_a=0 hit_b=0
+  if [[ $rc -ne 0 ]]; then
+    printf 'indeterminate'
+    return 0
+  fi
+  if [[ $output == *"$needle_a"* ]]; then hit_a=1; fi
+  if [[ $output == *"$needle_b"* ]]; then hit_b=1; fi
+  if [[ $hit_a -eq 1 && $hit_b -eq 0 ]]; then
+    printf '%s' "$value_a"
+  elif [[ $hit_b -eq 1 && $hit_a -eq 0 ]]; then
+    printf '%s' "$value_b"
+  else
+    printf 'indeterminate'
+  fi
+}
+
+# read_control <reader> -> the normalized value, or "indeterminate". One
+# read-only status invocation of the authoritative tool per control, bounded
+# like the combined query, with stdout and stderr captured together
+# (sysadminctl reports on stderr; verified on the target machine). Raw probe
+# text NEVER leaves this function: only the fixed normalized values do.
+#
+# Reader choices (each verified from the poller's gui/501 session context):
+#   - fdesetup, NOT osquery's disk_encryption table: FileVault lives on the
+#     APFS data volumes, so the obvious /dev/disk0 query reports 0 on a
+#     FileVault-on machine, a false negative that would page a healthy system.
+#   - csrutil: agrees with osquery's sip_config; the authoritative tool needs
+#     no osqueryi startup.
+#   - sysadminctl for automatic login and the Guest account: it reports the
+#     EFFECTIVE state and exits 0 in both states. `defaults read` was rejected
+#     because an absent autoLoginUser key (the healthy state) exits nonzero,
+#     which the discipline above must refuse to classify.
+read_control() {
+  local reader="$1" output="" rc=0
+  case "$reader" in
+    fdesetup_status)
+      output=$(run_bounded "$FDESETUP" status 2>&1) || rc=$?
+      classify_probe "$output" "$rc" "FileVault is On." on "FileVault is Off." off
+      ;;
+    csrutil_status)
+      output=$(run_bounded "$CSRUTIL" status 2>&1) || rc=$?
+      classify_probe "$output" "$rc" \
+        "System Integrity Protection status: enabled." enabled \
+        "System Integrity Protection status: disabled." disabled
+      ;;
+    sysadminctl_autologin)
+      # ON prints "Automatic login user: <name>"; every OFF form prints
+      # "Automatic login is ..." (OFF., disabled because FileVault is
+      # enabled., disabled by your system administrator.), enumerated from
+      # the binary's message strings. A username that happens to contain the
+      # off needle trips the both-needles arm: indeterminate, never a silent
+      # all-clear.
+      output=$(run_bounded "$SYSADMINCTL" -autologin status 2>&1) || rc=$?
+      classify_probe "$output" "$rc" "Automatic login user:" on "Automatic login is" off
+      ;;
+    sysadminctl_guest)
+      output=$(run_bounded "$SYSADMINCTL" -guestAccount status 2>&1) || rc=$?
+      classify_probe "$output" "$rc" "Guest account enabled." enabled "Guest account disabled." disabled
+      ;;
+    *)
+      # Unreachable behind load_controls' reader validation; fail closed
+      # anyway rather than fabricate a value.
+      printf 'indeterminate'
+      ;;
+  esac
+}
+
+# load_controls -- read and validate the declared-controls file into the
+# control_* arrays, fail-closed BEFORE any probe runs: an unreadable file, a
+# non-verify tier, an unknown reader, a malformed or colliding id, an
+# out-of-domain expect, or a missing description sets controls_problem (which
+# the gap gate pages) and stops. The poller must never guess what to monitor.
+# The template already refuses these at render time; this re-validation
+# defends the deployed file itself.
+control_ids=()
+control_descriptions=()
+control_readers=()
+control_expects=()
+control_remedies=()
+controls_problem=""
+load_controls() {
+  local count index record id tier reader expect description remedy domain
+  if [[ ! -f $CONTROLS_FILE ]]; then
+    controls_problem="posture-controls file missing at [$(sanitize "$CONTROLS_FILE")]"
+    return 0
+  fi
+  if ! count=$(jq -er 'if type == "array" then length else error("not an array") end' <"$CONTROLS_FILE" 2>/dev/null); then
+    controls_problem="the posture-controls file is not a JSON array"
+    return 0
+  fi
+  for ((index = 0; index < count; index++)); do
+    record=$(jq -c ".[$index]" <"$CONTROLS_FILE" 2>/dev/null || echo "")
+    id=$(jq -r '.id // empty' <<<"$record" 2>/dev/null || echo "")
+    tier=$(jq -r '.tier // empty' <<<"$record" 2>/dev/null || echo "")
+    reader=$(jq -r '.reader // empty' <<<"$record" 2>/dev/null || echo "")
+    expect=$(jq -r '.expect // empty' <<<"$record" 2>/dev/null || echo "")
+    description=$(sanitize "$(jq -r '.description // empty' <<<"$record" 2>/dev/null || echo "")")
+    remedy=$(sanitize "$(jq -r '.remedy // empty' <<<"$record" 2>/dev/null || echo "")")
+    if ! [[ $id =~ ^[a-z0-9_]+$ ]]; then
+      controls_problem="posture-controls record $index has a missing or malformed id"
+      return 0
+    fi
+    # ids become baseline field names, so they may appear once and must not
+    # shadow the built-in trio.
+    case " firewall gatekeeper screenlock ${control_ids[*]-} " in
+      *" $id "*)
+        controls_problem="posture-controls record [$id] collides with another monitored field"
+        return 0
+        ;;
+    esac
+    if [[ $tier != "verify" ]]; then
+      controls_problem="posture-controls record [$id] declares tier [$(sanitize "$tier")], not verify; the poller only reads controls, so the record does not belong in its file"
+      return 0
+    fi
+    domain=$(reader_domain "$reader")
+    if [[ -z $domain ]]; then
+      controls_problem="posture-controls record [$id] names unknown reader [$(sanitize "$reader")]"
+      return 0
+    fi
+    case " $domain " in
+      *" $expect "*) ;;
+      *)
+        controls_problem="posture-controls record [$id] expects [$(sanitize "$expect")], outside the $reader domain ($domain)"
+        return 0
+        ;;
+    esac
+    if [[ -z $description ]]; then
+      controls_problem="posture-controls record [$id] has no description"
+      return 0
+    fi
+    control_ids+=("$id")
+    control_descriptions+=("$description")
+    control_readers+=("$reader")
+    control_expects+=("$expect")
+    control_remedies+=("$remedy")
+  done
+  return 0
+}
+load_controls
+if [[ -n $controls_problem ]]; then
+  # A refused file is refused WHOLE: records loaded before the offender must
+  # not be consulted by any later step, or a half-validated file would be
+  # half-monitored.
+  control_ids=()
+  control_descriptions=()
+  control_readers=()
+  control_expects=()
+  control_remedies=()
+fi
+
+# Read every declared control, only behind a clean load: a refused file must
+# page BEFORE any probe runs, and a probe driven by an invalid record would be
+# a read nothing declared.
+control_values=()
+if [[ -z $controls_problem ]]; then
+  for control_index in "${!control_ids[@]}"; do
+    control_values+=("$(read_control "${control_readers[$control_index]}")")
+  done
+fi
 
 # page_gap_once <marker_path> <title> <body> -- the shared page-once-via-marker
 # discipline for both the monitoring-gap and the persistence-gap paths: the same
@@ -77,17 +297,35 @@ page_gap_once() {
   return 1
 }
 
-# R2-9 monitoring gap. Any scalar missing or out of its exact domain (firewall
-# 0/1/2, Gatekeeper 0/1, screenlock 0/1) means the security state is UNKNOWN, not
-# safe; an empty or failed read leaves all three empty and lands here too. Do NOT
-# persist it (it would poison the baseline) and do NOT compare it (it would
-# fabricate a transition): the last good baseline is preserved. Page ONCE per gap
-# (page_gap_once); if send_alert cannot store the page (it still fires a
-# last-resort local banner), log and exit nonzero so a PERSISTING gap re-pages
-# next tick. (Values are bracketed, [] for empty, to keep the page apostrophe-free
-# for the alerting stack.)
+# R2-9 monitoring gap, extended to the declared controls. Any built-in scalar
+# missing or out of its exact domain (firewall 0/1/2, Gatekeeper 0/1,
+# screenlock 0/1), an unloadable or refused controls file, or any control probe
+# that came back indeterminate means the security state is UNKNOWN, not safe;
+# an empty or failed osqueryi read leaves all three built-ins empty and lands
+# here too. Do NOT persist (it would poison the baseline) and do NOT compare
+# (it would fabricate a transition): the last good baseline is preserved. Page
+# ONCE per gap (page_gap_once); if send_alert cannot store the page (it still
+# fires a last-resort local banner), log and exit nonzero so a PERSISTING gap
+# re-pages next tick. (Values are bracketed, [] for empty, and sanitized: raw
+# system-read text is data, never structure, and never reaches the page whole.)
+gap_detail=""
 if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
-  gap_body="**Security-posture monitoring gap**"$'\n'"- The posture query returned an unreadable value (firewall=[$cur_fw] gatekeeper=[$cur_gk] screenlock=[$cur_sl]): the firewall / Gatekeeper / screen-lock state is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query by hand, then re-check."
+  gap_detail="the posture query returned an unreadable value (firewall=[$(sanitize "$cur_fw")] gatekeeper=[$(sanitize "$cur_gk")] screenlock=[$(sanitize "$cur_sl")])"
+fi
+if [[ -n $controls_problem ]]; then
+  gap_detail+="${gap_detail:+; }$controls_problem"
+fi
+indeterminate_ids=""
+for control_index in "${!control_ids[@]}"; do
+  if [[ ${control_values[$control_index]} == "indeterminate" ]]; then
+    indeterminate_ids+="${indeterminate_ids:+ }${control_ids[$control_index]}"
+  fi
+done
+if [[ -n $indeterminate_ids ]]; then
+  gap_detail+="${gap_detail:+; }indeterminate posture control read(s): [$indeterminate_ids]"
+fi
+if [[ -n $gap_detail ]]; then
+  gap_body="**Security-posture monitoring gap**"$'\n'"- $gap_detail: the security posture is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi, a posture probe, or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query and the control probes by hand, then re-check."
   if ! page_gap_once "$GAP" "🔴 **CRITICAL**" "$gap_body"; then
     printf 'firewall-gatekeeper-monitor: send_alert could not queue the monitoring-gap page; no marker written, retrying next tick\n' >&2
     exit 1
@@ -95,13 +333,13 @@ if ! [[ $cur_fw =~ ^[012]$ && $cur_gk =~ ^[01]$ && $cur_sl =~ ^[01]$ ]]; then
   exit 0
 fi
 
-# A valid read cleared the gap (recovery): drop the marker so a future gap pages
-# again. Done before the normal transition/persist logic.
+# A fully valid read cleared the gap (recovery): drop the marker so a future
+# gap pages again. Done before the normal transition/persist logic.
 rm -f "$GAP" 2>/dev/null || true
 
 # Validate any existing baseline BEFORE trusting it (and before write_state
 # overwrites it): it must be owner-only (mode 600) AND parse to three in-domain
-# scalars (same domains as above). A group/world-readable, corrupt, or
+# built-in scalars (same domains as above). A group/world-readable, corrupt, or
 # out-of-domain baseline is not trustworthy (it could be planted to mask a
 # disabled protection, or fabricate a transition), so it is treated as no prior
 # baseline. GNU-first stat, BSD fallback.
@@ -119,6 +357,38 @@ if [[ -f $STATE ]]; then
   fi
 fi
 
+# Per-control priors, each trusted independently: a control's prior field must
+# exist in a trusted baseline AND sit inside its reader's domain, else that ONE
+# control has no trusted prior (first-observation semantics for it) while the
+# others keep theirs. This is what makes adding a control to the data file a
+# quiet upgrade on a healthy machine instead of a page storm or a global
+# baseline reset. An out-of-domain prior is never compared: comparing it would
+# fabricate a transition, and it never reaches a page.
+control_prevs=()
+for control_index in "${!control_ids[@]}"; do
+  control_prev=""
+  if [[ $prev_valid -eq 1 ]]; then
+    control_prev=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key] // empty' <"$STATE" 2>/dev/null || echo "")
+    domain=$(reader_domain "${control_readers[$control_index]}")
+    case " $domain " in
+      *" $control_prev "*) ;;
+      *) control_prev="" ;;
+    esac
+  fi
+  control_prevs+=("$control_prev")
+done
+
+# The baseline to persist: the built-in trio plus one field per declared
+# control (normalized enum values only), so the next run can trust per-control
+# priors. Built AFTER the gap gate, so every merged value is in-domain.
+baseline_json="$posture"
+for control_index in "${!control_ids[@]}"; do
+  baseline_json=$(jq -c \
+    --arg key "${control_ids[$control_index]}" \
+    --arg value "${control_values[$control_index]}" \
+    '. + {($key): $value}' <<<"$baseline_json")
+done
+
 # Persist the current posture owner-only (0600) so a later run can trust its own
 # baseline. Written via a private temp file plus an atomic rename. Ordering for an
 # OFF transition is notify-before-persist (see below): the baseline advances ONLY
@@ -127,7 +397,7 @@ fi
 write_state() {
   (
     umask 077
-    printf '%s\n' "$posture" >"$STATE.tmp"
+    printf '%s\n' "$baseline_json" >"$STATE.tmp"
   ) && mv -f "$STATE.tmp" "$STATE" && chmod 600 "$STATE"
 }
 
@@ -172,15 +442,37 @@ page_crit_and_persist() {
   persist_baseline
 }
 
+# control_block <index> <first_observation:0|1> -- the CRIT block for a
+# declared control deviating from its declared value. Everything in it is
+# either this script's own text, a normalized enum value, or a sanitized
+# record field; raw probe output never appears.
+control_block() {
+  local control_index="$1" first_observation="$2"
+  local description="${control_descriptions[$control_index]}"
+  local expect="${control_expects[$control_index]}"
+  local value="${control_values[$control_index]}"
+  local remedy="${control_remedies[$control_index]}"
+  local block
+  if [[ $first_observation -eq 1 ]]; then
+    block="**${description}: ${value} at first observation, declared ${expect}**"$'\n'"- **Now:** **${value}**"$'\n'"- The monitor has no prior baseline for this control and it already deviates from its declared value, a pre-existing exposure. Did you change it? If not, **investigate now**."
+  else
+    block="**${description}: now ${value}, declared ${expect}**"$'\n'"- **Was:** ${control_prevs[$control_index]}"$'\n'"- **Now:** **${value}**"$'\n'"- Did you change this? If not, something else did, **investigate now**."
+  fi
+  if [[ -n $remedy ]]; then
+    block+=$'\n'"- ${remedy}"
+  fi
+  printf '%s' "$block"
+}
+
 # No trustworthy prior baseline (first run, or a lost/deleted/planted/corrupt
 # state file). DIVERGENCE from c69baab's silent first-run seed (F4, banked from
 # the slice-6 alerter review): the alerter log-onlys firewall/Gatekeeper
 # off-events and relies on THIS poller to page them, so a protection ALREADY off
 # with no prior baseline would otherwise be silently accepted and go unpaged
-# forever. Page each already-off protection as a first-observation exposure
-# (screenlock too: it is poller-only, and an already-off lock is a real exposure),
-# with the same notify-before-persist durability. If all three are ON, seed
-# silently.
+# forever. Page each already-off protection and each already-deviant declared
+# control as a first-observation exposure (screenlock too: it is poller-only,
+# and an already-off lock is a real exposure), with the same
+# notify-before-persist durability. If everything is healthy, seed silently.
 if [[ $prev_valid -eq 0 ]]; then
   first_obs_blocks=()
   if [[ $cur_fw == "0" ]]; then
@@ -192,6 +484,11 @@ if [[ $prev_valid -eq 0 ]]; then
   if [[ $cur_sl == "0" ]]; then
     first_obs_blocks+=("**Screen lock is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the screen-lock password requirement is already off, anyone at the machine has access. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
   fi
+  for control_index in "${!control_ids[@]}"; do
+    if [[ ${control_values[$control_index]} != "${control_expects[$control_index]}" ]]; then
+      first_obs_blocks+=("$(control_block "$control_index" 1)")
+    fi
+  done
   if [[ ${#first_obs_blocks[@]} -eq 0 ]]; then
     persist_baseline # healthy first observation: seed the baseline silently
     exit 0
@@ -224,10 +521,12 @@ sl_to_text() {
   esac
 }
 
-# A trusted baseline exists: page CRIT only on a protection turning OFF. A
-# re-enable (OFF -> ON) is good news, not actionable, and there is no notice
-# channel, so it is silent. Each block mirrors the results-alerter protection-off
-# shape: bold header, Was/Now state, then a decision-first next step.
+# A trusted baseline exists: page CRIT only on a protection turning OFF or a
+# declared control leaving its declared value. A re-enable (a return to the
+# declared/on state) is good news, not actionable, and there is no notice
+# channel, so it is silent. Each block mirrors the results-alerter
+# protection-off shape: bold header, Was/Now state, then a decision-first next
+# step.
 crit_blocks=()
 if [[ $cur_fw != "$prev_fw" && $cur_fw == "0" ]]; then
   crit_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(fw_to_text "$prev_fw")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
@@ -238,13 +537,32 @@ fi
 if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
   crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
 fi
+# Declared controls: page on a REGRESSION (the prior held the declared value,
+# the current does not) and on a first observation of a deviation (no trusted
+# prior for this one control). Steady-deviant is silent (the regression already
+# paged once; the baseline is the page-once marker), and a return to the
+# declared value is silent recovery that re-arms the marker via the persist
+# below.
+for control_index in "${!control_ids[@]}"; do
+  control_value="${control_values[$control_index]}"
+  control_expect="${control_expects[$control_index]}"
+  control_prev="${control_prevs[$control_index]}"
+  if [[ $control_value == "$control_expect" ]]; then
+    continue
+  fi
+  if [[ -z $control_prev ]]; then
+    crit_blocks+=("$(control_block "$control_index" 1)")
+  elif [[ $control_prev == "$control_expect" ]]; then
+    crit_blocks+=("$(control_block "$control_index" 0)")
+  fi
+done
 
-# No OFF transition (steady state or a re-enable): refresh the baseline, silent.
+# No deviation (steady state or a recovery): refresh the baseline, silent.
 if [[ ${#crit_blocks[@]} -eq 0 ]]; then
   persist_baseline
   exit 0
 fi
 
-# An OFF transition: page (notify-before-persist), then advance the baseline. One
-# page for the tick, even when several protections turned off together.
+# A deviation: page (notify-before-persist), then advance the baseline. One
+# page for the tick, even when several protections deviated together.
 page_crit_and_persist "${crit_blocks[@]}"

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -81,9 +81,14 @@ sanitize_span() {
 # a different table that answers while a posture read hangs). gtimeout
 # preferred, timeout fallback (the codebase convention); if neither is on PATH,
 # degrade to an unbounded read (no worse than before; the darwin fleet has
-# one). The bound is well under the 60s tick and env-overridable. On timeout
-# the probe is killed and exits nonzero, which classifies as indeterminate (or,
-# for the combined osqueryi read, collapses to empty), and the gap gate pages.
+# one). The bound is PER PROBE (20s default, env-overridable): a tick running
+# the combined query plus four control probes all wedged can total ~100s, past
+# the 60s interval, in which case launchd (which never overlaps runs) simply
+# starts the next tick late. The bound's job is to guarantee the tick ENDS and
+# the gap gate pages, not to keep a worst-case tick under the interval. On
+# timeout the probe is killed and exits nonzero, which classifies as
+# indeterminate (or, for the combined osqueryi read, collapses to empty), and
+# the gap gate pages.
 posture_timeout_bin="$(command -v gtimeout || command -v timeout || true)"
 run_bounded() {
   if [[ -n $posture_timeout_bin ]]; then

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -118,26 +118,38 @@ reader_domain() {
   esac
 }
 
-# classify_probe <output> <rc> <needle_a> <value_a> <needle_b> <value_b>
+# classify_probe <output> <rc> <needle> <value> [<needle> <value>]...
 # The indeterminate-on-nonzero discipline (absorbed from the retired
 # apply-time posture reminder): a probe that exits NONZERO is INDETERMINATE
 # regardless of what it printed, because a failed probe's output is
 # untrustworthy; it may print healthy-looking text yet have failed. A
-# zero-exit probe must match EXACTLY ONE of the two needles; both or neither
-# is indeterminate too (an ambiguous probe is never guessed at).
+# zero-exit probe's needle hits must all agree on EXACTLY ONE value; no hit,
+# or hits mapping to conflicting values, is indeterminate too (an ambiguous
+# probe is never guessed at). Needles are exact message forms enumerated from
+# each binary's strings, so no needle is a substring of a different value's
+# form.
 classify_probe() {
-  local output="$1" rc="$2" needle_a="$3" value_a="$4" needle_b="$5" value_b="$6"
-  local hit_a=0 hit_b=0
+  local output="$1" rc="$2"
+  local needle value matched=""
+  shift 2
   if [[ $rc -ne 0 ]]; then
     printf 'indeterminate'
     return 0
   fi
-  if [[ $output == *"$needle_a"* ]]; then hit_a=1; fi
-  if [[ $output == *"$needle_b"* ]]; then hit_b=1; fi
-  if [[ $hit_a -eq 1 && $hit_b -eq 0 ]]; then
-    printf '%s' "$value_a"
-  elif [[ $hit_b -eq 1 && $hit_a -eq 0 ]]; then
-    printf '%s' "$value_b"
+  while [[ $# -ge 2 ]]; do
+    needle="$1"
+    value="$2"
+    shift 2
+    if [[ $output == *"$needle"* ]]; then
+      if [[ -z $matched ]]; then
+        matched="$value"
+      elif [[ $matched != "$value" ]]; then
+        matched="conflict:" # ':' cannot appear in a domain value
+      fi
+    fi
+  done
+  if [[ -n $matched && $matched != "conflict:" ]]; then
+    printf '%s' "$matched"
   else
     printf 'indeterminate'
   fi
@@ -169,8 +181,20 @@ read_control() {
   local reader="$1" output="" rc=0
   case "$reader" in
     fdesetup_status)
+      # Every zero-exit status form enumerated from the binary's strings
+      # (macOS 26.2): the plain On./Off. pair plus the restart-transition
+      # variants. "Off, but will be enabled after the next restart." is OFF:
+      # deferred enablement means the data is not yet encrypted, a real
+      # exposure until the restart completes; "On, but needs to be restarted
+      # to finish." reports the protection on. Error-prefixed forms exit
+      # nonzero and stay indeterminate.
       output=$(run_bounded "$FDESETUP" status 2>&1) || rc=$?
-      classify_probe "$output" "$rc" "FileVault is On." on "FileVault is Off." off
+      classify_probe "$output" "$rc" \
+        "FileVault is On." on \
+        "FileVault is On, but needs to be restarted to finish." on \
+        "FileVault is Off." off \
+        "FileVault is Off, but will be enabled after the next restart." off \
+        "FileVault is Off, but needs to be restarted to finish." off
       ;;
     csrutil_status)
       output=$(run_bounded "$CSRUTIL" status 2>&1) || rc=$?

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -479,7 +479,7 @@ if [[ $prev_valid -eq 0 ]]; then
     first_obs_blocks+=("**Firewall is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the firewall is already off, a pre-existing exposure. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
   fi
   if [[ $cur_gk == "0" ]]; then
-    first_obs_blocks+=("**Gatekeeper is OFF (first observation)**"$'\n'"- **Now:** **DISABLED**"$'\n'"- The monitor has no prior baseline and Gatekeeper is already disabled, a pre-existing exposure. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security")
+    first_obs_blocks+=("**Gatekeeper is OFF (first observation)**"$'\n'"- **Now:** **DISABLED**"$'\n'"- The monitor has no prior baseline and Gatekeeper is already disabled, a pre-existing exposure. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security (spctl cannot enable Gatekeeper from the CLI on macOS 15+)")
   fi
   if [[ $cur_sl == "0" ]]; then
     first_obs_blocks+=("**Screen lock is OFF (first observation)**"$'\n'"- **Now:** **OFF**"$'\n'"- The monitor has no prior baseline and the screen-lock password requirement is already off, anyone at the machine has access. Did you turn it off? If not, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")
@@ -532,7 +532,7 @@ if [[ $cur_fw != "$prev_fw" && $cur_fw == "0" ]]; then
   crit_blocks+=("**Firewall turned OFF**"$'\n'"- **Was:** $(fw_to_text "$prev_fw")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Network → Firewall")
 fi
 if [[ $cur_gk != "$prev_gk" && $cur_gk == "0" ]]; then
-  crit_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gk_to_text "$prev_gk")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security")
+  crit_blocks+=("**Gatekeeper turned OFF**"$'\n'"- **Was:** $(gk_to_text "$prev_gk")"$'\n'"- **Now:** **DISABLED**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Privacy & Security (spctl cannot enable Gatekeeper from the CLI on macOS 15+)")
 fi
 if [[ $cur_sl != "$prev_sl" && $cur_sl == "0" ]]; then
   crit_blocks+=("**Screen lock turned OFF**"$'\n'"- **Was:** $(sl_to_text "$prev_sl")"$'\n'"- **Now:** **OFF**"$'\n'"- Did you turn this off? If not, something else did, **investigate now**."$'\n'"- Re-enable it: System Settings → Lock Screen → Require password")

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -34,6 +34,7 @@ CONTROLS_FILE="${OSQUERY_POSTURE_CONTROLS:-$HOME/.local/libexec/osquery/posture-
 FDESETUP="${OSQUERY_POSTURE_FDESETUP:-/usr/bin/fdesetup}"
 CSRUTIL="${OSQUERY_POSTURE_CSRUTIL:-/usr/bin/csrutil}"
 SYSADMINCTL="${OSQUERY_POSTURE_SYSADMINCTL:-/usr/sbin/sysadminctl}"
+DEFAULTS="${OSQUERY_POSTURE_DEFAULTS:-/usr/bin/defaults}"
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -112,7 +113,7 @@ cur_sl=$(jq -r '.screenlock // empty' <<<"$posture" 2>/dev/null || echo "")
 # poller-vs-data agreement test hold them together.
 reader_domain() {
   case "$1" in
-    fdesetup_status | sysadminctl_autologin) printf 'on off' ;;
+    fdesetup_status | defaults_autologin) printf 'on off' ;;
     csrutil_status | sysadminctl_guest) printf 'enabled disabled' ;;
   esac
 }
@@ -145,8 +146,9 @@ classify_probe() {
 # read_control <reader> -> the normalized value, or "indeterminate". One
 # read-only status invocation of the authoritative tool per control, bounded
 # like the combined query, with stdout and stderr captured together
-# (sysadminctl reports on stderr; verified on the target machine). Raw probe
-# text NEVER leaves this function: only the fixed normalized values do.
+# (sysadminctl and defaults report on stderr; verified on the target machine).
+# Raw probe text NEVER leaves this function: only the fixed normalized values
+# do.
 #
 # Reader choices (each verified from the poller's gui/501 session context):
 #   - fdesetup, NOT osquery's disk_encryption table: FileVault lives on the
@@ -154,10 +156,15 @@ classify_probe() {
 #     FileVault-on machine, a false negative that would page a healthy system.
 #   - csrutil: agrees with osquery's sip_config; the authoritative tool needs
 #     no osqueryi startup.
-#   - sysadminctl for automatic login and the Guest account: it reports the
-#     EFFECTIVE state and exits 0 in both states. `defaults read` was rejected
-#     because an absent autoLoginUser key (the healthy state) exits nonzero,
-#     which the discipline above must refuse to classify.
+#   - defaults read of loginwindow's autoLoginUser for automatic login: the
+#     control means "auto-login is not DECLARED", so the reader asks the
+#     declaration itself. `sysadminctl -autologin status` was rejected: it
+#     reports the EFFECTIVE state and prints "Automatic login is disabled
+#     because FileVault is enabled." (in the binary's message strings) even
+#     when autoLoginUser IS set, so a configured auto-login would read healthy
+#     until FileVault went off and it silently activated.
+#   - sysadminctl for the Guest account: it reports the state on stderr and
+#     exits 0 in both states.
 read_control() {
   local reader="$1" output="" rc=0
   case "$reader" in
@@ -171,15 +178,23 @@ read_control() {
         "System Integrity Protection status: enabled." enabled \
         "System Integrity Protection status: disabled." disabled
       ;;
-    sysadminctl_autologin)
-      # ON prints "Automatic login user: <name>"; every OFF form prints
-      # "Automatic login is ..." (OFF., disabled because FileVault is
-      # enabled., disabled by your system administrator.), enumerated from
-      # the binary's message strings. A username that happens to contain the
-      # off needle trips the both-needles arm: indeterminate, never a silent
-      # all-clear.
-      output=$(run_bounded "$SYSADMINCTL" -autologin status 2>&1) || rc=$?
-      classify_probe "$output" "$rc" "Automatic login user:" on "Automatic login is" off
+    defaults_autologin)
+      # Declared intent, three outcomes. Exit 0 means the autoLoginUser key
+      # EXISTS: a user is declared for automatic login (on), whatever the
+      # value. `defaults read` exits nonzero BOTH for an absent key (the
+      # healthy state) and for a hard read failure, so only the canonical
+      # does-not-exist diagnostic (which also covers a wholly absent
+      # loginwindow domain: nothing declared either way) maps to off; any
+      # other nonzero, a timeout kill included, is indeterminate. Absent is
+      # thereby distinguished from unreadable, never conflated.
+      output=$(run_bounded "$DEFAULTS" read /Library/Preferences/com.apple.loginwindow autoLoginUser 2>&1) || rc=$?
+      if [[ $rc -eq 0 ]]; then
+        printf 'on'
+      elif [[ $output == *"autoLoginUser) does not exist"* ]]; then
+        printf 'off'
+      else
+        printf 'indeterminate'
+      fi
       ;;
     sysadminctl_guest)
       output=$(run_bounded "$SYSADMINCTL" -guestAccount status 2>&1) || rc=$?

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -1,0 +1,77 @@
+{{- /* posture-controls.json: the runtime rendering of
+.chezmoidata/macos_posture_controls.yaml, read on every tick by
+firewall-gatekeeper-monitor.sh. It lives in ~/.local/libexec/osquery so the
+pipeline-integrity watch and the known-good manifest cover it: this file
+decides WHAT the posture poller monitors, so it is part of the monitor's body.
+
+NOTE for agents: this is a template, so the mandated agent apply
+(`chezmoi apply --exclude=templates`) skips it; a posture_controls data change
+reaches the machine at the next interactive apply, the same lag every
+macos_defaults / macos_system_setup data change already has.
+
+Validation mirrors the tier-guard discipline of the Tier 1/2 runners: any
+malformed record ABORTS the render (and with it the apply), naming the record.
+A posture control is verify BY DEFINITION (the poller only READS state), so
+any other tier is refused outright. The poller re-validates the deployed file
+at runtime and pages a monitoring gap on a bad one, so both halves fail
+closed. `index`, never the bare dotted form, for every optional field: the
+dotted form errors on absent keys; a blank scalar is nil and would stringify
+to the literal text <nil>, so blank is its own refusal, never conflated with
+absent. The reader/domain table below must match the poller's reader_domain
+function; the poller-vs-data agreement test holds the two together. */ -}}
+{{- if not (hasKey .macos "posture_controls") -}}
+{{-   fail "macos_posture_controls.yaml: macos.posture_controls is missing" -}}
+{{- end -}}
+{{- $seenIds := dict -}}
+{{- $readerDomains := dict
+      "fdesetup_status" (list "on" "off")
+      "csrutil_status" (list "enabled" "disabled")
+      "sysadminctl_autologin" (list "on" "off")
+      "sysadminctl_guest" (list "enabled" "disabled") -}}
+{{- range .macos.posture_controls -}}
+{{-   if not (hasKey . "id") -}}
+{{-     fail "macos_posture_controls.yaml: a record has no id; every control needs one, it is the identity in every error and every page" -}}
+{{-   end -}}
+{{-   if kindIs "invalid" (index . "id") -}}
+{{-     fail "macos_posture_controls.yaml: a record has a blank id; every control needs one" -}}
+{{-   end -}}
+{{-   $id := toString (index . "id") -}}
+{{-   if not (regexMatch "^[a-z0-9_]+$" $id) -}}
+{{-     fail (printf "macos_posture_controls.yaml: id %q is not lowercase [a-z0-9_]; it becomes a baseline field name and page text, so it stays strict" $id) -}}
+{{-   end -}}
+{{-   if has $id (list "firewall" "gatekeeper" "screenlock") -}}
+{{-     fail (printf "macos_posture_controls.yaml: id %q collides with a built-in poller field" $id) -}}
+{{-   end -}}
+{{-   if hasKey $seenIds $id -}}
+{{-     fail (printf "macos_posture_controls.yaml: duplicate id %q; ids are baseline field names, so each may appear once" $id) -}}
+{{-   end -}}
+{{-   $_ := set $seenIds $id true -}}
+{{-   if not (hasKey . "tier") -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q has no tier; a posture control is verify by definition, declare tier: verify" $id) -}}
+{{-   end -}}
+{{-   if kindIs "invalid" (index . "tier") -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q has a blank tier; declare tier: verify" $id) -}}
+{{-   end -}}
+{{-   $tier := toString (index . "tier") -}}
+{{-   if ne $tier "verify" -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q declares tier %q, not verify; the poller only READS controls, so an enforce or manual control does not belong in this file" $id $tier) -}}
+{{-   end -}}
+{{-   if or (not (hasKey . "reader")) (kindIs "invalid" (index . "reader")) -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q has no reader; name how the poller reads it" $id) -}}
+{{-   end -}}
+{{-   $reader := toString (index . "reader") -}}
+{{-   if not (hasKey $readerDomains $reader) -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q names unknown reader %q (known: %s)" $id $reader (keys $readerDomains | sortAlpha | join ", ")) -}}
+{{-   end -}}
+{{-   if or (not (hasKey . "expect")) (kindIs "invalid" (index . "expect")) -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q has no expect; declare the value the control must hold" $id) -}}
+{{-   end -}}
+{{-   $expect := toString (index . "expect") -}}
+{{-   if not (has $expect (get $readerDomains $reader)) -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q expects %q, outside the %s domain %v (a bare YAML boolean stringifies to true/false, which no reader returns)" $id $expect $reader (get $readerDomains $reader)) -}}
+{{-   end -}}
+{{-   if or (not (hasKey . "description")) (kindIs "invalid" (index . "description")) (eq (toString (index . "description")) "") -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q has no description; a page must name the control" $id) -}}
+{{-   end -}}
+{{- end -}}
+{{ toJson .macos.posture_controls }}

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -26,7 +26,7 @@ function; the poller-vs-data agreement test holds the two together. */ -}}
 {{- $readerDomains := dict
       "fdesetup_status" (list "on" "off")
       "csrutil_status" (list "enabled" "disabled")
-      "sysadminctl_autologin" (list "on" "off")
+      "defaults_autologin" (list "on" "off")
       "sysadminctl_guest" (list "enabled" "disabled") -}}
 {{- range .macos.posture_controls -}}
 {{-   if not (hasKey . "id") -}}

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -140,17 +140,14 @@ exit "${POLLER_CSRUTIL_EXIT:-0}"
 SHIM
   chmod +x "$POLLER_HOME/bin/csrutil"
 
-  # sysadminctl: only `-autologin status` and `-guestAccount status`. The real
-  # tool reports on STDERR with an NSLog prefix (verified on the target
-  # machine), so the stub mirrors that.
+  # sysadminctl: only `-guestAccount status` (automatic login reads the
+  # loginwindow DECLARATION via the defaults stub below, never sysadminctl's
+  # effective state). The real tool reports on STDERR with an NSLog prefix
+  # (verified on the target machine), so the stub mirrors that.
   cat >"$POLLER_HOME/bin/sysadminctl" <<'SHIM'
 #!/usr/bin/env bash
 printf 'sysadminctl %s\n' "$*" >>"$POLLER_PROBE_CALLS"
 case "$*" in
-  "-autologin status")
-    printf '%s\n' "${POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT-2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login is OFF.}" >&2
-    exit "${POLLER_SYSADMINCTL_AUTOLOGIN_EXIT:-0}"
-    ;;
   "-guestAccount status")
     printf '%s\n' "${POLLER_SYSADMINCTL_GUEST_OUTPUT-2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account disabled.}" >&2
     exit "${POLLER_SYSADMINCTL_GUEST_EXIT:-0}"
@@ -163,11 +160,42 @@ esac
 SHIM
   chmod +x "$POLLER_HOME/bin/sysadminctl"
 
+  # defaults: only the exact read of loginwindow's autoLoginUser key (the
+  # declared-intent auto-login reader) is legitimate; every other argv is a
+  # recorded violation. POLLER_DEFAULTS_AUTOLOGIN_MODE models the three real
+  # outcomes (each verified on the target machine): absent (the canonical
+  # does-not-exist diagnostic on stderr, exit 1 -- the healthy no-declaration
+  # state, and the default), present (a username on stdout, exit 0),
+  # unreadable (a non-canonical failure, exit 1).
+  cat >"$POLLER_HOME/bin/defaults" <<'SHIM'
+#!/usr/bin/env bash
+printf 'defaults %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ "$*" != "read /Library/Preferences/com.apple.loginwindow autoLoginUser" ]]; then
+  printf 'defaults %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+case "${POLLER_DEFAULTS_AUTOLOGIN_MODE:-absent}" in
+  present)
+    printf '%s\n' "${POLLER_DEFAULTS_AUTOLOGIN_USER-stephen}"
+    exit 0
+    ;;
+  unreadable)
+    printf '2026-07-27 00:00:00.000 defaults[100:100]\nCould not read domain /Library/Preferences/com.apple.loginwindow\n' >&2
+    exit 1
+    ;;
+  *)
+    printf '2026-07-27 00:00:00.000 defaults[100:100]\nThe domain/default pair of (/Library/Preferences/com.apple.loginwindow, autoLoginUser) does not exist\n' >&2
+    exit 1
+    ;;
+esac
+SHIM
+  chmod +x "$POLLER_HOME/bin/defaults"
+
   # Tools the poller has NO business invoking at all, status or otherwise: any
   # call is a recorded violation. run_poller prepends this bin dir to PATH, so
   # a stray PATH-resolved invocation is caught even without an env override.
   local forbidden_tool
-  for forbidden_tool in sudo spctl defaults socketfilterfw launchctl; do
+  for forbidden_tool in sudo spctl socketfilterfw launchctl; do
     cat >"$POLLER_HOME/bin/$forbidden_tool" <<'SHIM'
 #!/usr/bin/env bash
 printf '%s %s\n' "$(basename "$0")" "$*" >>"$POLLER_MUTATION_LOG"
@@ -228,6 +256,7 @@ run_poller() {
     OSQUERY_POSTURE_FDESETUP="$POLLER_HOME/bin/fdesetup" \
     OSQUERY_POSTURE_CSRUTIL="$POLLER_HOME/bin/csrutil" \
     OSQUERY_POSTURE_SYSADMINCTL="$POLLER_HOME/bin/sysadminctl" \
+    OSQUERY_POSTURE_DEFAULTS="$POLLER_HOME/bin/defaults" \
     bash "$POLLER_TOOL" "$@"
 }
 

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -80,6 +80,13 @@ exit_code="${POLLER_OSQUERYI_EXIT:-0}"
 if [[ $exit_code -ne 0 ]]; then
   exit "$exit_code"
 fi
+# POLLER_OSQUERYI_EXIT_AFTER_OUTPUT models a FAILED query that still printed
+# healthy-looking JSON (rows emitted, then a nonzero death). A failed probe's
+# output is untrustworthy; the poller must refuse it, not baseline it.
+if [[ -n ${POLLER_OSQUERYI_EXIT_AFTER_OUTPUT:-} ]]; then
+  printf '%s\n' "${POLLER_OSQUERYI_JSON:-[]}"
+  exit "$POLLER_OSQUERYI_EXIT_AFTER_OUTPUT"
+fi
 printf '%s\n' "${POLLER_OSQUERYI_JSON:-[]}"
 SHIM
   chmod +x "$POLLER_HOME/bin/osqueryi"

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -113,13 +113,19 @@ SHIM
   # fdesetup: only `status` is legitimate. Output FIRST, then the exit status:
   # the indeterminate-on-nonzero tests need a probe that prints healthy-looking
   # text AND fails. ${VAR-default} (not :-) so a test can program deliberately
-  # empty output.
+  # empty output. POLLER_FDESETUP_SLEEP models a WEDGED tool exactly like the
+  # osqueryi stub's hook: exec into sleep (a single process, no child holding
+  # stdout), so a bounded poller kills it at the bound and gaps while an
+  # unbounded poller blocks. Every probe stub below carries the same hook.
   cat >"$POLLER_HOME/bin/fdesetup" <<'SHIM'
 #!/usr/bin/env bash
 printf 'fdesetup %s\n' "$*" >>"$POLLER_PROBE_CALLS"
 if [[ "$*" != "status" ]]; then
   printf 'fdesetup %s\n' "$*" >>"$POLLER_MUTATION_LOG"
   exit 97
+fi
+if [[ -n ${POLLER_FDESETUP_SLEEP:-} ]]; then
+  exec sleep "$POLLER_FDESETUP_SLEEP"
 fi
 printf '%s\n' "${POLLER_FDESETUP_OUTPUT-FileVault is On.}"
 exit "${POLLER_FDESETUP_EXIT:-0}"
@@ -135,6 +141,9 @@ if [[ "$*" != "status" ]]; then
   printf 'csrutil %s\n' "$*" >>"$POLLER_MUTATION_LOG"
   exit 97
 fi
+if [[ -n ${POLLER_CSRUTIL_SLEEP:-} ]]; then
+  exec sleep "$POLLER_CSRUTIL_SLEEP"
+fi
 printf '%s\n' "${POLLER_CSRUTIL_OUTPUT-System Integrity Protection status: disabled.}"
 exit "${POLLER_CSRUTIL_EXIT:-0}"
 SHIM
@@ -149,6 +158,9 @@ SHIM
 printf 'sysadminctl %s\n' "$*" >>"$POLLER_PROBE_CALLS"
 case "$*" in
   "-guestAccount status")
+    if [[ -n ${POLLER_SYSADMINCTL_SLEEP:-} ]]; then
+      exec sleep "$POLLER_SYSADMINCTL_SLEEP"
+    fi
     printf '%s\n' "${POLLER_SYSADMINCTL_GUEST_OUTPUT-2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account disabled.}" >&2
     exit "${POLLER_SYSADMINCTL_GUEST_EXIT:-0}"
     ;;
@@ -173,6 +185,9 @@ printf 'defaults %s\n' "$*" >>"$POLLER_PROBE_CALLS"
 if [[ "$*" != "read /Library/Preferences/com.apple.loginwindow autoLoginUser" ]]; then
   printf 'defaults %s\n' "$*" >>"$POLLER_MUTATION_LOG"
   exit 97
+fi
+if [[ -n ${POLLER_DEFAULTS_SLEEP:-} ]]; then
+  exec sleep "$POLLER_DEFAULTS_SLEEP"
 fi
 case "${POLLER_DEFAULTS_AUTOLOGIN_MODE:-absent}" in
   present)

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -453,6 +453,20 @@ assert_probe_calls() {
   fi
 }
 
+# assert_probe_argv <exact-line> <n> -- the probe log holds exactly <n> lines
+# matching "<tool> <argv>" WHOLE. A per-member property, not a per-tool count:
+# a bare count would pass under a doubled probe of one subcommand that starved
+# another (e.g. autologin probed twice, guest never).
+assert_probe_argv() {
+  local count
+  count=$(grep -cxF -- "$1" "$POLLER_PROBE_CALLS" || true)
+  if [[ $count -ne $2 ]]; then
+    printf 'expected %s exact call(s) of [%s], got %s; probe log:\n%s\n' \
+      "$2" "$1" "$count" "$(cat "$POLLER_PROBE_CALLS")" >&2
+    return 1
+  fi
+}
+
 # assert_no_probe_calls -- the poller invoked no probe stub at all (a refused
 # controls file must be rejected BEFORE any read runs).
 assert_no_probe_calls() {

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -22,13 +22,23 @@
 # A fresh temp HOME keeps every run off the operator's real ~/.local/state and
 # ~/.local/libexec. Sourced by the poller suite; no main.
 
-POLLER_TOOL="${BATS_TEST_DIRNAME}/../../dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh"
+# BATS_TEST_DIRNAME under bats; the lib's own location when a plain suite *.sh
+# sources this file directly (both are exactly two levels below the repo root).
+POLLER_TOOL="${BATS_TEST_DIRNAME:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/../../dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh"
 
 # set_posture <json-array> -- the JSON array of row objects the osqueryi stub
 # returns. osquery --json emits an array and the poller reads .[0]; scalars are
 # strings, matching osquery's JSON output for these integer columns.
 set_posture() {
   export POLLER_OSQUERYI_JSON="$1"
+}
+
+# set_posture_controls <json-array> -- the declared-controls file the poller
+# reads (normally the chezmoi render of macos_posture_controls.yaml). The
+# harness default is an EMPTY declaration; a posture-controls test installs its
+# own records.
+set_posture_controls() {
+  printf '%s\n' "$1" >"$OSQUERY_POSTURE_CONTROLS"
 }
 
 setup_poller_harness() {
@@ -75,6 +85,90 @@ SHIM
   chmod +x "$POLLER_HOME/bin/osqueryi"
   export POLLER_OSQUERYI="$POLLER_HOME/bin/osqueryi"
 
+  # The declared-controls file. Default: an EMPTY declaration (no extra
+  # controls), so the legacy firewall/Gatekeeper/screen-lock tests exercise
+  # exactly the pre-controls surface; posture-controls tests install records
+  # via set_posture_controls.
+  export OSQUERY_POSTURE_CONTROLS="$POLLER_HOME/posture-controls.json"
+  printf '[]\n' >"$OSQUERY_POSTURE_CONTROLS"
+
+  # Recording, programmable probe stubs for the declared-control readers, plus
+  # always-refuse spies for tools the poller must never touch. EVERY invocation
+  # lands in $POLLER_PROBE_CALLS ("tool argv"); any argv that is not the exact
+  # read-only status query lands in $POLLER_MUTATION_LOG and fails with exit
+  # 97. The poller must never invoke a mutating command, and
+  # assert_no_mutation_attempt pins that the violation log stayed empty.
+  export POLLER_PROBE_CALLS="$POLLER_HOME/probe-calls.log"
+  export POLLER_MUTATION_LOG="$POLLER_HOME/mutation-violations.log"
+  : >"$POLLER_PROBE_CALLS"
+  : >"$POLLER_MUTATION_LOG"
+
+  # fdesetup: only `status` is legitimate. Output FIRST, then the exit status:
+  # the indeterminate-on-nonzero tests need a probe that prints healthy-looking
+  # text AND fails. ${VAR-default} (not :-) so a test can program deliberately
+  # empty output.
+  cat >"$POLLER_HOME/bin/fdesetup" <<'SHIM'
+#!/usr/bin/env bash
+printf 'fdesetup %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ "$*" != "status" ]]; then
+  printf 'fdesetup %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+printf '%s\n' "${POLLER_FDESETUP_OUTPUT-FileVault is On.}"
+exit "${POLLER_FDESETUP_EXIT:-0}"
+SHIM
+  chmod +x "$POLLER_HOME/bin/fdesetup"
+
+  # csrutil: only `status`. Default matches the repo declaration (SIP is
+  # deliberately disabled on this machine, expect: disabled).
+  cat >"$POLLER_HOME/bin/csrutil" <<'SHIM'
+#!/usr/bin/env bash
+printf 'csrutil %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ "$*" != "status" ]]; then
+  printf 'csrutil %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+printf '%s\n' "${POLLER_CSRUTIL_OUTPUT-System Integrity Protection status: disabled.}"
+exit "${POLLER_CSRUTIL_EXIT:-0}"
+SHIM
+  chmod +x "$POLLER_HOME/bin/csrutil"
+
+  # sysadminctl: only `-autologin status` and `-guestAccount status`. The real
+  # tool reports on STDERR with an NSLog prefix (verified on the target
+  # machine), so the stub mirrors that.
+  cat >"$POLLER_HOME/bin/sysadminctl" <<'SHIM'
+#!/usr/bin/env bash
+printf 'sysadminctl %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+case "$*" in
+  "-autologin status")
+    printf '%s\n' "${POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT-2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login is OFF.}" >&2
+    exit "${POLLER_SYSADMINCTL_AUTOLOGIN_EXIT:-0}"
+    ;;
+  "-guestAccount status")
+    printf '%s\n' "${POLLER_SYSADMINCTL_GUEST_OUTPUT-2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account disabled.}" >&2
+    exit "${POLLER_SYSADMINCTL_GUEST_EXIT:-0}"
+    ;;
+  *)
+    printf 'sysadminctl %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+    exit 97
+    ;;
+esac
+SHIM
+  chmod +x "$POLLER_HOME/bin/sysadminctl"
+
+  # Tools the poller has NO business invoking at all, status or otherwise: any
+  # call is a recorded violation. run_poller prepends this bin dir to PATH, so
+  # a stray PATH-resolved invocation is caught even without an env override.
+  local forbidden_tool
+  for forbidden_tool in sudo spctl defaults socketfilterfw launchctl; do
+    cat >"$POLLER_HOME/bin/$forbidden_tool" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$POLLER_MUTATION_LOG"
+exit 97
+SHIM
+    chmod +x "$POLLER_HOME/bin/$forbidden_tool"
+  done
+
   # Recording send_alert spy at the NEW dispatch path the poller sources. It
   # never delivers; it records each call's argv and the baseline as it stood at
   # call time, so a test can prove the ordering (notify-before-persist).
@@ -115,11 +209,18 @@ teardown_poller_harness() {
 
 # run_poller [args...] -- run the poller under the harness env. HOME is the temp
 # home so the sourced dispatch spy and the default state path resolve inside the
-# sandbox; OSQUERYI points at the recording stub.
+# sandbox; OSQUERYI and the posture-probe overrides point at the recording
+# stubs, and the stub bin dir leads PATH so any stray PATH-resolved tool call
+# hits a spy instead of the real system.
 run_poller() {
   HOME="$POLLER_HOME" \
+    PATH="$POLLER_HOME/bin:$PATH" \
     OSQUERYI="$POLLER_OSQUERYI" \
     OSQUERY_POSTURE_STATE="$OSQUERY_POSTURE_STATE" \
+    OSQUERY_POSTURE_CONTROLS="$OSQUERY_POSTURE_CONTROLS" \
+    OSQUERY_POSTURE_FDESETUP="$POLLER_HOME/bin/fdesetup" \
+    OSQUERY_POSTURE_CSRUTIL="$POLLER_HOME/bin/csrutil" \
+    OSQUERY_POSTURE_SYSADMINCTL="$POLLER_HOME/bin/sysadminctl" \
     bash "$POLLER_TOOL" "$@"
 }
 
@@ -285,6 +386,39 @@ assert_no_baseline() {
   if [[ -f $OSQUERY_POSTURE_STATE ]]; then
     printf 'expected NO baseline file, but %s exists with:\n%s\n' \
       "$OSQUERY_POSTURE_STATE" "$(cat "$OSQUERY_POSTURE_STATE")" >&2
+    return 1
+  fi
+}
+
+# assert_probe_calls <tool> <n> -- the poller invoked the stubbed <tool>
+# exactly <n> times (each stub logs "tool argv", one line per call).
+assert_probe_calls() {
+  local count
+  count=$(grep -c "^$1 " "$POLLER_PROBE_CALLS" || true)
+  if [[ $count -ne $2 ]]; then
+    printf 'expected %s call(s) to %s, got %s; probe log:\n%s\n' \
+      "$2" "$1" "$count" "$(cat "$POLLER_PROBE_CALLS")" >&2
+    return 1
+  fi
+}
+
+# assert_no_probe_calls -- the poller invoked no probe stub at all (a refused
+# controls file must be rejected BEFORE any read runs).
+assert_no_probe_calls() {
+  if [[ -s $POLLER_PROBE_CALLS ]]; then
+    printf 'expected NO probe invocation, but the stubs recorded:\n%s\n' \
+      "$(cat "$POLLER_PROBE_CALLS")" >&2
+    return 1
+  fi
+}
+
+# assert_no_mutation_attempt -- no stubbed tool ever saw a non-status argv, and
+# no always-refuse spy (sudo, spctl, defaults, socketfilterfw, launchctl) was
+# invoked at all: the poller never runs a mutating command.
+assert_no_mutation_attempt() {
+  if [[ -s $POLLER_MUTATION_LOG ]]; then
+    printf 'expected NO mutating invocation, but the spies recorded:\n%s\n' \
+      "$(cat "$POLLER_MUTATION_LOG")" >&2
     return 1
   fi
 }

--- a/test/integration/macos-posture-controls-agreement.sh
+++ b/test/integration/macos-posture-controls-agreement.sh
@@ -70,11 +70,11 @@ while IFS=$'\t' read -r reader expect; do
     csrutil_status)
       export POLLER_CSRUTIL_OUTPUT="System Integrity Protection status: ${expect}."
       ;;
-    sysadminctl_autologin)
+    defaults_autologin)
       if [[ $expect == "on" ]]; then
-        export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="stub sysadminctl Automatic login user: stub"
+        export POLLER_DEFAULTS_AUTOLOGIN_MODE=present
       else
-        export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="stub sysadminctl Automatic login is OFF."
+        export POLLER_DEFAULTS_AUTOLOGIN_MODE=absent
       fi
       ;;
     sysadminctl_guest)

--- a/test/integration/macos-posture-controls-agreement.sh
+++ b/test/integration/macos-posture-controls-agreement.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# macos-posture-controls-agreement.sh -- the poller's monitored set and the
+# repo's declared record set are ENUMERATED AND DIFFED (slice 6): a control
+# declared in .chezmoidata/macos_posture_controls.yaml but never read, or read
+# but never declared, FAILS here rather than passing quietly. Completeness
+# guards beat count guards: this is set equality, not a length check.
+#
+# How: convert the real YAML records to the JSON the poller consumes (the
+# render test pins that the chezmoi template produces exactly this), program
+# every stub healthy FROM the records themselves, run the real poller once, and
+# require the persisted baseline's key set to equal {firewall, gatekeeper,
+# screenlock} plus exactly the declared ids. A record the poller drops leaves a
+# missing key; a read the poller hardcodes adds an extra one; either diffs.
+#
+# A record naming a reader this test cannot map fails LOUDLY: slices 9 and 10
+# add records here, and each new reader must land with a poller function, a
+# harness stub, and a mapping below, or this gate refuses.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DATA_FILE="$REPO_ROOT/.chezmoidata/macos_posture_controls.yaml"
+
+# shellcheck source=../fixtures/osquery-poller-lib.bash
+source "$REPO_ROOT/test/fixtures/osquery-poller-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in yq jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the declared-controls agreement\n' "$tool"
+    exit 0
+  }
+done
+[[ -f $DATA_FILE ]] || fail "missing data file: $DATA_FILE"
+
+records_json="$(yq -o=json '.macos.posture_controls' "$DATA_FILE")" ||
+  fail "could not convert the declared records to JSON"
+jq -e 'type == "array" and length > 0' <<<"$records_json" >/dev/null ||
+  fail "macos_posture_controls.yaml must declare a non-empty record list"
+
+# Every shipped record is verify; anything else has no business in a file the
+# poller only reads from.
+bad_tiers="$(jq -r '.[] | select(.tier != "verify") | .id' <<<"$records_json")"
+[[ -z $bad_tiers ]] || fail "non-verify tier(s) in the shipped data: $bad_tiers"
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$records_json"
+
+# Program every stub HEALTHY from the record's own reader and expect, so the
+# run is silent and the baseline seeds. An unmapped reader fails the gate.
+while IFS=$'\t' read -r reader expect; do
+  case "$reader" in
+    fdesetup_status)
+      if [[ $expect == "on" ]]; then
+        export POLLER_FDESETUP_OUTPUT="FileVault is On."
+      else
+        export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+      fi
+      ;;
+    csrutil_status)
+      export POLLER_CSRUTIL_OUTPUT="System Integrity Protection status: ${expect}."
+      ;;
+    sysadminctl_autologin)
+      if [[ $expect == "on" ]]; then
+        export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="stub sysadminctl Automatic login user: stub"
+      else
+        export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="stub sysadminctl Automatic login is OFF."
+      fi
+      ;;
+    sysadminctl_guest)
+      export POLLER_SYSADMINCTL_GUEST_OUTPUT="stub sysadminctl Guest account ${expect}."
+      ;;
+    *)
+      fail "record reader '$reader' has no mapping here: add the poller reader, the harness stub, and this mapping together"
+      ;;
+  esac
+done < <(jq -r '.[] | [.reader, .expect] | @tsv' <<<"$records_json")
+
+poller_status=0
+poller_output="$(run_poller 2>&1)" || poller_status=$?
+[[ $poller_status -eq 0 ]] ||
+  fail "the poller must exit 0 on an all-healthy declared set, got $poller_status: $poller_output"
+[[ ! -s $POLLER_SEND_ALERT_LOG ]] ||
+  fail "an all-healthy declared set must page nothing; send_alert saw: $(cat "$POLLER_SEND_ALERT_LOG")"
+[[ -f $OSQUERY_POSTURE_STATE ]] ||
+  fail "the healthy run must seed a baseline"
+
+# THE DIFF: baseline keys == built-in fields + declared ids, exactly.
+expected_keys="$POLLER_HOME/expected-keys"
+actual_keys="$POLLER_HOME/actual-keys"
+{
+  printf '%s\n' firewall gatekeeper screenlock
+  jq -r '.[].id' <<<"$records_json"
+} | LC_ALL=C sort >"$expected_keys"
+jq -r 'keys_unsorted[]' "$OSQUERY_POSTURE_STATE" | LC_ALL=C sort >"$actual_keys"
+diff -u "$expected_keys" "$actual_keys" >&2 ||
+  fail "monitored set != declared set: a control declared but never read (missing key) or read but never declared (extra key)"
+
+printf 'ok: the poller monitors exactly the declared posture controls\n'

--- a/test/integration/macos-posture-controls-agreement.sh
+++ b/test/integration/macos-posture-controls-agreement.sh
@@ -101,6 +101,10 @@ actual_keys="$POLLER_HOME/actual-keys"
 {
   printf '%s\n' firewall gatekeeper screenlock
   jq -r '.[].id' <<<"$records_json"
+  # One recorded-declaration field per control: the poller persists the expect
+  # each value was recorded under, so a changed declaration re-arms the control
+  # instead of reading as a silent steady-deviant.
+  jq -r '.[].id + ":expect"' <<<"$records_json"
 } | LC_ALL=C sort >"$expected_keys"
 jq -r 'keys_unsorted[]' "$OSQUERY_POSTURE_STATE" | LC_ALL=C sort >"$actual_keys"
 diff -u "$expected_keys" "$actual_keys" >&2 ||

--- a/test/integration/macos-posture-controls-render.sh
+++ b/test/integration/macos-posture-controls-render.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# macos-posture-controls-render.sh -- the posture-controls declaration file
+# (.chezmoidata/macos_posture_controls.yaml) is rendered by
+# dot_local/libexec/osquery/posture-controls.json.tmpl into the JSON the
+# security-posture poller reads at runtime. Two properties are pinned here:
+#
+#   1. AGREEMENT: the rendered JSON is exactly the declared record list (via a
+#      yq conversion of the same YAML), so what the poller consumes IS what the
+#      data file declares; there is no second list to drift.
+#   2. REFUSAL, fail-closed: a record that is malformed or mis-tiered ABORTS
+#      the render (and with it the apply), naming the offender. A verify-only
+#      file must reject enforce and manual records outright: the poller only
+#      READS controls, so a record carrying any other tier is lying about what
+#      consumes it. Absent, blank, and wrong-value tiers are three distinct
+#      refusals (a blank YAML scalar is nil and would otherwise stringify to
+#      the literal text <nil>). Missing/malformed/duplicate ids, unknown
+#      readers, out-of-domain expects, and missing descriptions abort too.
+#
+# Real chezmoi and yq; renders into a sandbox HOME. Never applies anything.
+#
+# This test writes LITERAL fixture text with $-free content only, but keeps the
+# refusal-message fragments exact.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any git or chezmoi call. Git exports GIT_DIR
+# to every hook it runs and this suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/dot_local/libexec/osquery/posture-controls.json.tmpl"
+DATA_FILE="$REPO_ROOT/.chezmoidata/macos_posture_controls.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+for tool in chezmoi yq jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the posture-controls render\n' "$tool"
+    exit 0
+  }
+done
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+[[ -f $DATA_FILE ]] || fail "missing data file: $DATA_FILE"
+
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+render_home="$sandbox/render-home"
+mkdir -p "$render_home"
+render_error="$sandbox/render.err"
+
+# make_source -- create a chezmoi source tree whose one data file is read from
+# stdin; print the tree's path.
+make_source() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/posture-src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_posture_controls.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+render_template() { # <source-dir> <out-file> <err-file>
+  HOME="$render_home" chezmoi --source "$1" execute-template --no-tty <"$TEMPLATE" >"$2" 2>"$3"
+}
+
+# assert_rejects <label> <stderr-fragment...> -- feed a fixture on stdin,
+# require the render to FAIL, and require the message to carry every named
+# fragment.
+assert_rejects() {
+  local label="$1"
+  shift
+  local source_dir out_file status=0 fragment
+  source_dir="$(make_source)"
+  out_file="$sandbox/rejected"
+  render_template "$source_dir" "$out_file" "$render_error" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "$label: the render must fail (got 0, render: $(cat "$out_file"))"
+  for fragment in "$@"; do
+    assert_file_contains "$render_error" "$fragment" \
+      "$label: the failure must name '$fragment' (stderr: $(cat "$render_error"))"
+  done
+}
+
+# ---- 1: agreement -- the real data renders to exactly the declared records ---
+
+real_source="$(make_source <"$DATA_FILE")"
+render_template "$real_source" "$sandbox/rendered.json" "$render_error" ||
+  fail "the real macos_posture_controls.yaml must render (stderr: $(cat "$render_error"))"
+jq -e 'type == "array" and length > 0' "$sandbox/rendered.json" >/dev/null 2>&1 ||
+  fail "the render must be a non-empty JSON array; got: $(cat "$sandbox/rendered.json")"
+yq -o=json '.macos.posture_controls' "$DATA_FILE" | jq -S . >"$sandbox/declared.json" ||
+  fail "yq could not convert the declared records"
+jq -S . "$sandbox/rendered.json" >"$sandbox/rendered.sorted.json" ||
+  fail "the render is not valid JSON"
+diff -u "$sandbox/declared.json" "$sandbox/rendered.sorted.json" >&2 ||
+  fail "the rendered JSON must equal the declared record list byte-for-byte (after key sort); the render and the data have drifted apart"
+
+# Every declared record is verify: the repo data itself must never carry
+# another tier (the render would refuse it, but pin the data too).
+bad_tiers="$(jq -r '.[] | select(.tier != "verify") | .id' "$sandbox/rendered.json")"
+[[ -z $bad_tiers ]] || fail "non-verify tier(s) in the shipped data: $bad_tiers"
+
+# ---- 2: refusal, fail-closed ------------------------------------------------
+
+# A valid record comes FIRST in each fixture, so a template that warned and
+# skipped the offender instead of aborting would render cleanly, and the
+# required render failure is what catches it.
+valid_record='    - id: filevault
+      description: "FileVault disk encryption"
+      tier: verify
+      reader: fdesetup_status
+      expect: "on"'
+
+assert_rejects 'enforce-tier record' 'guest' 'tier "enforce"' 'not verify' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      tier: enforce
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'manual-tier record' 'guest' 'tier "manual"' 'not verify' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      tier: manual
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'record with no tier' 'guest' 'has no tier' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'record with a blank tier' 'guest' 'blank tier' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      tier:
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'record with no id' 'has no id' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - description: "The macOS Guest account"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'record with a malformed id' 'Guest Account' 'not lowercase' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: "Guest Account"
+      description: "The macOS Guest account"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'record whose id collides with a built-in poller field' 'firewall' 'built-in' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: firewall
+      description: "A collision with the legacy firewall field"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+assert_rejects 'duplicate id' 'duplicate id' 'filevault' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: filevault
+      description: "A second FileVault record"
+      tier: verify
+      reader: fdesetup_status
+      expect: "on"
+EOF
+
+assert_rejects 'unknown reader' 'guest' 'unknown reader' 'wombat_status' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      tier: verify
+      reader: wombat_status
+      expect: "disabled"
+EOF
+
+assert_rejects 'out-of-domain expect' 'guest' 'outside the sysadminctl_guest domain' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      description: "The macOS Guest account"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "wombat"
+EOF
+
+assert_rejects 'record with no description' 'guest' 'has no description' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: guest
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+EOF
+
+# A boolean expect (unquoted YAML true) stringifies to "true", which lands
+# outside every reader domain; the render must refuse it rather than quietly
+# monitor for a value no reader ever returns. (Unquoted `on`/`off` are STRINGS
+# under chezmoi's YAML 1.2 parser, verified empirically, so those are fine.)
+assert_rejects 'boolean expect' 'filevault2' 'outside the fdesetup_status domain' <<EOF
+macos:
+  posture_controls:
+$valid_record
+    - id: filevault2
+      description: "A FileVault record with a boolean expect"
+      tier: verify
+      reader: fdesetup_status
+      expect: true
+EOF
+
+printf 'ok: posture-controls render agreement and fail-closed refusal\n'

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -54,9 +54,14 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
 
   assert_no_page
-  # One status probe per declared control.
-  assert_probe_calls fdesetup 1
-  assert_probe_calls csrutil 1
+  # One status probe per declared control, asserted by EXACT argv: the
+  # per-tool count alone would pass under a doubled probe of one subcommand
+  # that starved another.
+  assert_probe_argv 'fdesetup status' 1
+  assert_probe_argv 'csrutil status' 1
+  assert_probe_argv 'sysadminctl -guestAccount status' 1
+  assert_probe_argv 'defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser' 1
+  # And no OTHER invocation of the shared tools beyond those exact reads.
   assert_probe_calls sysadminctl 1
   assert_probe_calls defaults 1
   # The baseline carries the legacy trio AND one field per declared control.

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -971,6 +971,16 @@ assert_bounded_hang_gaps() { # <control-id> <started-seconds>
   assert_page_body_lacks '--master-enable'
 }
 
+@test "T-PCTL-honest-timeout-comment: the source never claims the probe bound keeps a worst-case tick under the 60s interval" {
+  # Five sequential probes at the 20s default total ~100s; the bound
+  # guarantees the tick ENDS, not that it fits the interval. The old claim
+  # ('well under the 60s tick') was false and must not return.
+  if grep -qF -- 'well under the 60s tick' "$POLLER_TOOL"; then
+    echo "the poller source again claims the per-probe bound keeps the tick under 60s"
+    false
+  fi
+}
+
 @test "T-PCTL-no-master-enable-in-source: the poller source never mentions spctl --master-enable" {
   if grep -qF -- 'master-enable' "$POLLER_TOOL"; then
     echo "the poller source still names the removed spctl --master-enable flag"

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -570,3 +570,41 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_baseline_unchanged
 }
 
+# --- the Gatekeeper remedy names System Settings, never the removed CLI flag ---
+
+@test "T-PCTL-gatekeeper-remedy-names-system-settings: the Gatekeeper-off page points at System Settings and says the CLI cannot re-enable it" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  set_posture '[{"firewall":"1","gatekeeper":"0","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_body_has 'Gatekeeper turned OFF'
+  assert_page_body_has 'System Settings → Privacy & Security'
+  assert_page_body_has 'cannot enable Gatekeeper from the CLI'
+  assert_page_body_lacks '--master-enable' # removed on macOS 15+; naming it would be a lie
+}
+
+@test "T-PCTL-gatekeeper-first-observation-remedy: the first-observation Gatekeeper page carries the same System Settings remedy" {
+  set_posture '[{"firewall":"1","gatekeeper":"0","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_body_has 'Gatekeeper is OFF (first observation)'
+  assert_page_body_has 'cannot enable Gatekeeper from the CLI'
+  assert_page_body_lacks '--master-enable'
+}
+
+@test "T-PCTL-no-master-enable-in-source: the poller source never mentions spctl --master-enable" {
+  if grep -qF -- 'master-enable' "$POLLER_TOOL"; then
+    echo "the poller source still names the removed spctl --master-enable flag"
+    false
+  fi
+}

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -1,0 +1,572 @@
+#!/usr/bin/env bats
+# The security-posture poller's DECLARED controls (slice 6): the poller reads
+# ~/.local/libexec/osquery/posture-controls.json (the chezmoi render of
+# .chezmoidata/macos_posture_controls.yaml) and monitors each record with the
+# reader it names, against the value it declares. Adding a control is a data
+# change; the poller carries no control list in its body.
+#
+# The rules pinned here:
+#   - a control deviating from its declared value pages EXACTLY ONE CRIT naming
+#     it, stays quiet while the deviation persists, and re-pages after a
+#     restore-then-regress (the persisted baseline is the page-once marker);
+#   - a probe that exits nonzero is INDETERMINATE regardless of what it printed
+#     (unit suite: macos-posture-indeterminate.sh asserts this per control);
+#   - a missing/malformed/mis-tiered controls file, an unknown reader, and an
+#     unparseable or ambiguous probe are all MONITORING GAPS: page once,
+#     preserve the baseline, never a silent pass (fail-open is the cardinal
+#     sin);
+#   - a non-verify tier is refused BEFORE any probe runs: the poller only READS
+#     controls, so an enforce record in its file is a declaration error;
+#   - the poller never invokes a mutating command (recording spies + an empty
+#     violation log), and no system-read value reaches a notification body
+#     unneutralized.
+
+load ../fixtures/osquery-poller-lib
+
+setup() { setup_poller_harness; }
+teardown() { teardown_poller_harness; }
+
+# The four repo-like records (same ids/readers/expects as
+# .chezmoidata/macos_posture_controls.yaml; remedies shortened). The
+# poller-vs-repo-data agreement lives in macos-posture-controls-agreement.sh.
+declare_posture_controls() {
+  set_posture_controls '[
+    {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on","remedy":"Re-enable it: System Settings, Privacy & Security, FileVault"},
+    {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"disabled","remedy":"Update the declared expect or investigate"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
+    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","remedy":"Disable it: System Settings, Users & Groups"}
+  ]'
+}
+
+# A baseline where every legacy field and every declared control is healthy.
+healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","sip":"disabled","autologin":"off","guest":"disabled"}'
+
+@test "T-PCTL-healthy-reads-and-baseline: a healthy tick reads every declared control once and persists each value into the baseline" {
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected exit 0 on a healthy tick, got $status: $output"
+    false
+  }
+
+  assert_no_page
+  # One status probe per declared control (sysadminctl serves two controls).
+  assert_probe_calls fdesetup 1
+  assert_probe_calls csrutil 1
+  assert_probe_calls sysadminctl 2
+  # The baseline carries the legacy trio AND one field per declared control.
+  assert_baseline_scalar firewall 1
+  assert_baseline_scalar filevault on
+  assert_baseline_scalar sip disabled
+  assert_baseline_scalar autologin off
+  assert_baseline_scalar guest disabled
+}
+
+@test "T-PCTL-legacy-baseline-gains-control-fields: a valid legacy-only baseline plus healthy controls stays silent and gains the control fields (the add-a-control-later path)" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected exit 0, got $status: $output"
+    false
+  }
+
+  assert_no_page # healthy first observation of the new controls: silent seed
+  assert_baseline_scalar filevault on
+  assert_baseline_scalar guest disabled
+}
+
+# --- one page per regression, quiet while it persists, re-page after restore ---
+# The persisted baseline is the page-once marker: a deviation pages on the
+# transition tick, the baseline advances to the deviant value (quiet ticks
+# follow), a restore advances it back (clearing the marker), and a second
+# regression pages again.
+
+@test "T-PCTL-filevault-lifecycle: FileVault off pages one CRIT naming it, stays quiet while off, and re-pages after restore-then-regress" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+  run run_poller # tick 1: the regression pages
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has 'Re-enable it: System Settings, Privacy & Security, FileVault'
+  assert_page_body_lacks 'Guest'            # only the control that changed is named
+  assert_page_body_lacks 'Automatic login'
+  # Notify-before-persist: at page time the baseline still held the prior value.
+  assert_page_saw_baseline "$healthy_seed"
+  assert_baseline_scalar filevault off
+
+  run run_poller # tick 2: still off, quiet
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+
+  unset POLLER_FDESETUP_OUTPUT
+  run run_poller # tick 3: restored, silent, the marker (baseline) clears
+  [[ $status -eq 0 ]] || {
+    echo "tick 3 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_baseline_scalar filevault on
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+  run run_poller # tick 4: a later regression pages again
+  [[ $status -eq 0 ]] || {
+    echo "tick 4 status $status: $output"
+    false
+  }
+  assert_page_count 2
+}
+
+@test "T-PCTL-sip-lifecycle: SIP deviating from its DECLARED state (disabled) pages once, stays quiet, and re-pages after restore-then-regress" {
+  # SIP is deliberately disabled on this machine: expect is the operator's
+  # declaration, not a blanket enabled. SIP turning ON is therefore the
+  # deviation here.
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_CSRUTIL_OUTPUT="System Integrity Protection status: enabled."
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'System Integrity Protection: now enabled, declared disabled'
+  assert_page_saw_baseline "$healthy_seed"
+  assert_baseline_scalar sip enabled
+
+  run run_poller # still deviant, quiet
+  assert_page_count 1
+
+  unset POLLER_CSRUTIL_OUTPUT
+  run run_poller # restored to the declared state, silent
+  assert_page_count 1
+  assert_baseline_scalar sip disabled
+
+  export POLLER_CSRUTIL_OUTPUT="System Integrity Protection status: enabled."
+  run run_poller
+  assert_page_count 2
+}
+
+@test "T-PCTL-autologin-lifecycle: automatic login turning on pages once naming it, stays quiet, and re-pages after restore-then-regress" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login user: stephen"
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'Automatic login at the login window: now on, declared off'
+  # The username from the probe output is data the page must NOT carry.
+  assert_page_body_lacks 'stephen'
+  assert_baseline_scalar autologin on
+
+  run run_poller
+  assert_page_count 1
+
+  unset POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT
+  run run_poller
+  assert_page_count 1
+  assert_baseline_scalar autologin off
+
+  export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login user: stephen"
+  run run_poller
+  assert_page_count 2
+}
+
+@test "T-PCTL-guest-lifecycle: the Guest account turning on pages once naming it, stays quiet, and re-pages after restore-then-regress" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_SYSADMINCTL_GUEST_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account enabled."
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'The macOS Guest account: now enabled, declared disabled'
+  assert_baseline_scalar guest enabled
+
+  run run_poller
+  assert_page_count 1
+
+  unset POLLER_SYSADMINCTL_GUEST_OUTPUT
+  run run_poller
+  assert_page_count 1
+  assert_baseline_scalar guest disabled
+
+  export POLLER_SYSADMINCTL_GUEST_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account enabled."
+  run run_poller
+  assert_page_count 2
+}
+
+@test "T-PCTL-first-observation-deviation-pages: a control already deviant with no prior baseline pages as a first observation, then seeds and quiets" {
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'FileVault disk encryption: off at first observation, declared on'
+  assert_page_body_lacks 'now off' # a first observation, not a transition
+  assert_baseline_scalar filevault off
+
+  run run_poller # identical next tick: seeded, steady-deviant, silent
+  assert_page_count 1
+}
+
+@test "T-PCTL-out-of-domain-control-prior-distrusted: an out-of-domain prior for one control becomes a first observation, never a fabricated transition" {
+  # A prior of "wombat" is outside the fdesetup_status domain. Trusting it
+  # would fabricate a "now off" transition line reading Was: wombat; the prior
+  # is distrusted instead, so this is a first observation of an already-off
+  # control.
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"wombat","sip":"disabled","autologin":"off","guest":"disabled"}'
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_body_has 'off at first observation'
+  assert_page_body_lacks 'wombat' # the untrusted prior never reaches a page
+}
+
+@test "T-PCTL-multi-deviation-single-page: a legacy protection and a declared control regressing in one tick share a single counted CRIT page" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1 # one page for the tick, never one per control
+  assert_page_body_has 'Firewall turned OFF'
+  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '· 2' # the count title marks two deviations in one page
+}
+
+# --- gaps: a control the poller cannot read or trust is NEVER a silent pass ---
+
+@test "T-PCTL-missing-controls-file-gaps: a missing controls file pages a monitoring gap and preserves the baseline" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  rm "$OSQUERY_POSTURE_CONTROLS"
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'posture-controls file missing'
+  assert_gap_marker
+  assert_baseline_unchanged # a blind poller must never advance state
+}
+
+@test "T-PCTL-malformed-controls-file-gaps: a controls file that is not a JSON array pages a monitoring gap" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '{"not":"an array"}'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'not a JSON array'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-nonverify-tier-refused-before-reads: an enforce-tier record pages a gap naming it and no probe ever runs" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '[{"id":"guest","description":"The macOS Guest account","tier":"enforce","reader":"sysadminctl_guest","expect":"disabled"}]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'guest'
+  assert_page_body_has 'not verify'
+  assert_no_probe_calls # refusal precedes every read
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-unknown-reader-gaps: a record naming a reader the poller lacks pages a gap and no probe ever runs" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '[{"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"wombat_status","expect":"disabled"}]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'unknown reader'
+  assert_no_probe_calls
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-duplicate-id-gaps: two records sharing an id page a gap (ids are baseline field names)" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '[
+    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"},
+    {"id":"guest","description":"A second guest record","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}
+  ]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'collides'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-builtin-id-collision-gaps: a record whose id shadows a built-in field pages a gap" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '[{"id":"firewall","description":"A collision","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'collides'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-out-of-domain-expect-gaps: a record expecting a value outside its reader domain pages a gap" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  set_posture_controls '[{"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"wombat"}]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'outside'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-unparseable-probe-gaps: a zero-exit probe whose output matches no known state is indeterminate and pages a gap naming the control" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT="FileVault is Wombat."
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'filevault'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-ambiguous-probe-gaps: a probe printing BOTH state needles is indeterminate (never guessed at) and pages a gap" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT=$'FileVault is On.\nFileVault is Off.'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'filevault'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-gap-recovery-then-regression-pages: after a control gap recovers, a real later regression still pages (the gap never poisoned the baseline)" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_FDESETUP_EXIT=1
+  run run_poller # tick 1: indeterminate probe, gap page
+  assert_page_count 1
+  assert_gap_marker
+
+  unset POLLER_FDESETUP_EXIT
+  run run_poller # tick 2: recovered, marker clears, steady state
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_no_gap_marker
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+  run run_poller # tick 3: a REAL regression against the preserved baseline
+  assert_page_count 2
+  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+}
+
+# --- the poller never mutates, and system-read text never reaches a page raw ---
+
+@test "T-PCTL-no-mutating-invocation: healthy, deviant, and gap ticks invoke only status probes; the violation log stays empty" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller # healthy tick
+  [[ $status -eq 0 ]]
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+  run run_poller # deviant tick (pages)
+  [[ $status -eq 0 ]]
+  export POLLER_CSRUTIL_EXIT=1
+  run run_poller # gap tick (indeterminate probe)
+  [[ $status -eq 0 ]]
+
+  # The probes DID run (the spies are live), and nothing but the exact
+  # read-only status queries was ever invoked.
+  assert_probe_calls fdesetup 3
+  assert_probe_calls csrutil 3
+  assert_probe_calls sysadminctl 6
+  assert_no_mutation_attempt
+}
+
+@test "T-PCTL-legacy-gap-values-neutralized: hostile bytes in an osqueryi scalar never reach the gap page body raw" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  # An out-of-domain firewall value carrying shell metacharacters: the gap body
+  # quotes the offending values, so they must arrive neutralized (no backtick,
+  # no dollar, no backslash, no quotes) with the page still firing.
+  set_posture '[{"firewall":"0`touch HOME-pwned`$(reboot)\\\"x","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  if grep -qF -- '`' "$POLLER_SEND_ALERT_LOG"; then
+    echo "a backtick from the system read reached the page body: $(cat "$POLLER_SEND_ALERT_LOG")"
+    false
+  fi
+  if grep -qF -- '$(' "$POLLER_SEND_ALERT_LOG"; then
+    echo "a command substitution from the system read reached the page body"
+    false
+  fi
+  if grep -qF -- '\' "$POLLER_SEND_ALERT_LOG"; then
+    echo "a backslash from the system read reached the page body"
+    false
+  fi
+  [[ ! -e HOME-pwned && ! -e $POLLER_HOME/HOME-pwned ]] || {
+    echo "the hostile value executed"
+    false
+  }
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-probe-output-never-in-page: a hostile probe output is normalized away; only the fixed enum or a gap ever reaches a page" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_FDESETUP_OUTPUT='`touch probe-pwned`$(reboot) "hostile" FileVault is Wombat.'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1 # indeterminate -> gap page, never silent
+  assert_page_body_has 'monitoring gap'
+  if grep -qF -- '`' "$POLLER_SEND_ALERT_LOG"; then
+    echo "a backtick from the probe output reached the page body: $(cat "$POLLER_SEND_ALERT_LOG")"
+    false
+  fi
+  if grep -qF -- '$(' "$POLLER_SEND_ALERT_LOG"; then
+    echo "a command substitution from the probe output reached the page body"
+    false
+  fi
+  [[ ! -e probe-pwned && ! -e $POLLER_HOME/probe-pwned ]] || {
+    echo "the hostile probe output executed"
+    false
+  }
+  assert_baseline_unchanged
+}
+

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -456,6 +456,105 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_baseline_unchanged
 }
 
+@test "T-PCTL-gap-on-one-control-never-blinds-another: a SIP probe outage never suppresses a FileVault regression on a later tick (per-member gaps)" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_CSRUTIL_EXIT=1
+  run run_poller # tick 1: the SIP probe fails, one gap page naming sip
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'sip'
+  assert_gap_marker
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off."
+  run run_poller # tick 2: SIP still failing AND FileVault regresses: the regression pages
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_baseline_scalar filevault off
+  assert_baseline_scalar sip disabled # the gapped member's prior is preserved, never dropped
+
+  unset POLLER_FDESETUP_OUTPUT
+  run run_poller # tick 3: FileVault restores while SIP still gaps: silent recovery
+  [[ $status -eq 0 ]] || {
+    echo "tick 3 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_baseline_scalar filevault on
+
+  unset POLLER_CSRUTIL_EXIT
+  run run_poller # tick 4: SIP recovers: clean tick, marker clears, no page
+  [[ $status -eq 0 ]] || {
+    echo "tick 4 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_no_gap_marker
+}
+
+@test "T-PCTL-new-gap-member-pages-during-ongoing-gap: a second probe breaking during an ongoing gap pages again (the marker covers members, not the world)" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_CSRUTIL_EXIT=1
+  run run_poller # tick 1: sip gaps, pages once
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+
+  export POLLER_FDESETUP_EXIT=1
+  run run_poller # tick 2: filevault ALSO gaps: a new member, so it pages
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_page_body_has 'filevault'
+
+  run run_poller # tick 3: same two members gapped: covered, no re-page
+  [[ $status -eq 0 ]] || {
+    echo "tick 3 status $status: $output"
+    false
+  }
+  assert_page_count 2
+}
+
+@test "T-PCTL-controls-file-gap-never-blinds-builtins: a refused controls file never suppresses a firewall-off page (the trio still compares)" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  rm "$OSQUERY_POSTURE_CONTROLS"
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller # tick 1: the controls file is missing, gap page
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'posture-controls file missing'
+
+  set_posture '[{"firewall":"0","gatekeeper":"1","screenlock":"1"}]'
+  run run_poller # tick 2: file still missing AND the firewall turns off: it pages
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_page_body_has 'Firewall turned OFF'
+  assert_baseline_scalar firewall 0
+}
+
 @test "T-PCTL-gap-recovery-then-regression-pages: after a control gap recovers, a real later regression still pages (the gap never poisoned the baseline)" {
   seed_baseline "$healthy_seed"
   declare_posture_controls

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -135,6 +135,43 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_page_count 2
 }
 
+@test "T-PCTL-filevault-restart-forms-classify: the real fdesetup restart-transition outputs classify explicitly instead of gapping forever" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  # Deferred enablement: the data is NOT yet encrypted, so this is off, a
+  # real deviation page, never a permanently-indeterminate monitoring gap.
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off, but will be enabled after the next restart."
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_lacks 'monitoring gap'
+  assert_baseline_scalar filevault off
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is On, but needs to be restarted to finish."
+  run run_poller # an On transition form: classifies on, silent recovery
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_baseline_scalar filevault on
+
+  export POLLER_FDESETUP_OUTPUT="FileVault is Off, but needs to be restarted to finish."
+  run run_poller # the Off transition form: a regression again
+  [[ $status -eq 0 ]] || {
+    echo "tick 3 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_baseline_scalar filevault off
+}
+
 @test "T-PCTL-sip-lifecycle: SIP deviating from its DECLARED state (disabled) pages once, stays quiet, and re-pages after restore-then-regress" {
   # SIP is deliberately disabled on this machine: expect is the operator's
   # declaration, not a blanket enabled. SIP turning ON is therefore the

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -39,7 +39,9 @@ declare_posture_controls() {
 }
 
 # A baseline where every legacy field and every declared control is healthy.
-healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","sip":"disabled","autologin":"off","guest":"disabled"}'
+# Each control persists as a value plus the "<id>:expect" it was recorded
+# under, so a changed declaration re-arms the control (first observation).
+healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled"}'
 
 @test "T-PCTL-healthy-reads-and-baseline: a healthy tick reads every declared control once and persists each value into the baseline" {
   declare_posture_controls
@@ -245,12 +247,45 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_page_count 1
 }
 
+@test "T-PCTL-expect-change-rearms-control: changing a declared expect makes the next tick a first observation, never a silent steady-deviant" {
+  # Baseline and live SIP are both disabled, recorded under expect=disabled;
+  # the operator then TIGHTENS the declaration to expect=enabled. The prior
+  # was recorded under the OLD declaration, so it must not read as
+  # steady-deviant: that would turn a hardening change into a silent no-op.
+  seed_baseline "$healthy_seed"
+  set_posture_controls '[
+    {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on","remedy":"Re-enable it: System Settings, Privacy & Security, FileVault"},
+    {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"enabled","remedy":"Update the declared expect or investigate"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
+    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","remedy":"Disable it: System Settings, Users & Groups"}
+  ]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller # tick 1: live sip=disabled deviates from the NEW declaration
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'System Integrity Protection: disabled at first observation, declared enabled'
+  assert_baseline_scalar sip disabled
+  assert_baseline_scalar 'sip:expect' enabled # the new declaration is recorded
+
+  run run_poller # tick 2: recorded under the new declaration: steady-deviant, silent
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+}
+
 @test "T-PCTL-out-of-domain-control-prior-distrusted: an out-of-domain prior for one control becomes a first observation, never a fabricated transition" {
   # A prior of "wombat" is outside the fdesetup_status domain. Trusting it
   # would fabricate a "now off" transition line reading Was: wombat; the prior
   # is distrusted instead, so this is a first observation of an already-off
   # control.
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"wombat","sip":"disabled","autologin":"off","guest":"disabled"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"wombat","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled"}'
   declare_posture_controls
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
   export POLLER_FDESETUP_OUTPUT="FileVault is Off."

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -33,7 +33,7 @@ declare_posture_controls() {
   set_posture_controls '[
     {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on","remedy":"Re-enable it: System Settings, Privacy & Security, FileVault"},
     {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"disabled","remedy":"Update the declared expect or investigate"},
-    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"defaults_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
     {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","remedy":"Disable it: System Settings, Users & Groups"}
   ]'
 }
@@ -54,10 +54,11 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
 
   assert_no_page
-  # One status probe per declared control (sysadminctl serves two controls).
+  # One status probe per declared control.
   assert_probe_calls fdesetup 1
   assert_probe_calls csrutil 1
-  assert_probe_calls sysadminctl 2
+  assert_probe_calls sysadminctl 1
+  assert_probe_calls defaults 1
   # The baseline carries the legacy trio AND one field per declared control.
   assert_baseline_scalar firewall 1
   assert_baseline_scalar filevault on
@@ -167,12 +168,12 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_page_count 2
 }
 
-@test "T-PCTL-autologin-lifecycle: automatic login turning on pages once naming it, stays quiet, and re-pages after restore-then-regress" {
+@test "T-PCTL-autologin-lifecycle: a DECLARED auto-login user pages once naming it, stays quiet, and re-pages after restore-then-regress" {
   seed_baseline "$healthy_seed"
   declare_posture_controls
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 
-  export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login user: stephen"
+  export POLLER_DEFAULTS_AUTOLOGIN_MODE=present # autoLoginUser declared: stephen
   run run_poller
   [[ $status -eq 0 ]] || {
     echo "tick 1 status $status: $output"
@@ -188,14 +189,56 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   run run_poller
   assert_page_count 1
 
-  unset POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT
+  unset POLLER_DEFAULTS_AUTOLOGIN_MODE # back to absent: the declaration removed
   run run_poller
   assert_page_count 1
   assert_baseline_scalar autologin off
 
-  export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login user: stephen"
+  export POLLER_DEFAULTS_AUTOLOGIN_MODE=present
   run run_poller
   assert_page_count 2
+}
+
+@test "T-PCTL-autologin-reads-declared-intent: a declared auto-login pages even while FileVault forces manual login (the effective state is not the question)" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  # autoLoginUser IS set while sysadminctl would report "Automatic login is
+  # disabled because FileVault is enabled." (a FileVault-driven message printed
+  # regardless of the declaration; verified in the binary's strings). An
+  # effective-state reader reads this machine healthy, and the auto-login
+  # activates unflagged the moment FileVault goes off. The control means
+  # "auto-login is not DECLARED", so the declaration must win.
+  export POLLER_DEFAULTS_AUTOLOGIN_MODE=present
+  export POLLER_SYSADMINCTL_AUTOLOGIN_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Automatic login is disabled because FileVault is enabled."
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'Automatic login at the login window: now on, declared off'
+}
+
+@test "T-PCTL-autologin-unreadable-gaps: a defaults failure that is NOT the canonical absent diagnostic is indeterminate, never a silent healthy" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  # Nonzero exit without "autoLoginUser) does not exist": absent must be
+  # distinguished from unreadable, so this is a monitoring gap.
+  export POLLER_DEFAULTS_AUTOLOGIN_MODE=unreadable
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'autologin'
+  assert_baseline_unchanged
 }
 
 @test "T-PCTL-guest-lifecycle: the Guest account turning on pages once naming it, stays quiet, and re-pages after restore-then-regress" {
@@ -256,7 +299,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   set_posture_controls '[
     {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on","remedy":"Re-enable it: System Settings, Privacy & Security, FileVault"},
     {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"enabled","remedy":"Update the declared expect or investigate"},
-    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"defaults_autologin","expect":"off","remedy":"Turn it off: System Settings, Users & Groups"},
     {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","remedy":"Disable it: System Settings, Users & Groups"}
   ]'
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
@@ -659,7 +702,8 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   # read-only status queries was ever invoked.
   assert_probe_calls fdesetup 3
   assert_probe_calls csrutil 3
-  assert_probe_calls sysadminctl 6
+  assert_probe_calls sysadminctl 3
+  assert_probe_calls defaults 3
   assert_no_mutation_attempt
 }
 

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -357,6 +357,30 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_baseline_unchanged
 }
 
+@test "T-PCTL-multidoc-controls-file-gaps: a controls file holding two top-level arrays pages a gap instead of silently monitoring zero controls" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  # Two JSON documents: an empty array, then the real record list. Each parses
+  # alone, so a per-document validation passes both; only a whole-file
+  # single-array rule can refuse this shape, under which every declared
+  # control would otherwise silently vanish.
+  printf '%s\n%s\n' '[]' '[{"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}]' \
+    >"$OSQUERY_POSTURE_CONTROLS"
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'not a JSON array'
+  assert_no_probe_calls # the refused file is refused whole, before any read
+  assert_baseline_unchanged
+}
+
 @test "T-PCTL-nonverify-tier-refused-before-reads: an enforce-tier record pages a gap naming it and no probe ever runs" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -102,7 +102,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '`FileVault disk encryption`: now off, declared on'
   assert_page_body_has 'Re-enable it: System Settings, Privacy & Security, FileVault'
   assert_page_body_lacks 'Guest'            # only the control that changed is named
   assert_page_body_lacks 'Automatic login'
@@ -149,7 +149,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
     false
   }
   assert_page_count 1
-  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '`FileVault disk encryption`: now off, declared on'
   assert_page_body_lacks 'monitoring gap'
   assert_baseline_scalar filevault off
 
@@ -188,7 +188,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'System Integrity Protection: now enabled, declared disabled'
+  assert_page_body_has '`System Integrity Protection`: now enabled, declared disabled'
   assert_page_saw_baseline "$healthy_seed"
   assert_baseline_scalar sip enabled
 
@@ -218,7 +218,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'Automatic login at the login window: now on, declared off'
+  assert_page_body_has '`Automatic login at the login window`: now on, declared off'
   # The username from the probe output is data the page must NOT carry.
   assert_page_body_lacks 'stephen'
   assert_baseline_scalar autologin on
@@ -255,7 +255,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
     false
   }
   assert_page_count 1
-  assert_page_body_has 'Automatic login at the login window: now on, declared off'
+  assert_page_body_has '`Automatic login at the login window`: now on, declared off'
 }
 
 @test "T-PCTL-autologin-unreadable-gaps: a defaults failure that is NOT the canonical absent diagnostic is indeterminate, never a silent healthy" {
@@ -291,7 +291,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'The macOS Guest account: now enabled, declared disabled'
+  assert_page_body_has '`The macOS Guest account`: now enabled, declared disabled'
   assert_baseline_scalar guest enabled
 
   run run_poller
@@ -319,7 +319,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'FileVault disk encryption: off at first observation, declared on'
+  assert_page_body_has '`FileVault disk encryption`: off at first observation, declared on'
   assert_page_body_lacks 'now off' # a first observation, not a transition
   assert_baseline_scalar filevault off
 
@@ -348,7 +348,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   }
   assert_page_count 1
   assert_page_severity_is CRIT
-  assert_page_body_has 'System Integrity Protection: disabled at first observation, declared enabled'
+  assert_page_body_has '`System Integrity Protection`: disabled at first observation, declared enabled'
   assert_baseline_scalar sip disabled
   assert_baseline_scalar 'sip:expect' enabled # the new declaration is recorded
 
@@ -393,7 +393,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
 
   assert_page_count 1 # one page for the tick, never one per control
   assert_page_body_has 'Firewall turned OFF'
-  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '`FileVault disk encryption`: now off, declared on'
   assert_page_body_has '· 2' # the count title marks two deviations in one page
 }
 
@@ -617,7 +617,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
     false
   }
   assert_page_count 2
-  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '`FileVault disk encryption`: now off, declared on'
   assert_baseline_scalar filevault off
   assert_baseline_scalar sip disabled # the gapped member's prior is preserved, never dropped
 
@@ -716,7 +716,7 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   export POLLER_FDESETUP_OUTPUT="FileVault is Off."
   run run_poller # tick 3: a REAL regression against the preserved baseline
   assert_page_count 2
-  assert_page_body_has 'FileVault disk encryption: now off, declared on'
+  assert_page_body_has '`FileVault disk encryption`: now off, declared on'
 }
 
 # --- the poller never mutates, and system-read text never reaches a page raw ---
@@ -748,8 +748,9 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline
   # An out-of-domain firewall value carrying shell metacharacters: the gap body
-  # quotes the offending values, so they must arrive neutralized (no backtick,
-  # no dollar, no backslash, no quotes) with the page still firing.
+  # quotes the offending values, so they must arrive neutralized (no dollar, no
+  # backslash, no quotes, the value's OWN backticks stripped) inside the body's
+  # inline-code span, with the page still firing.
   set_posture '[{"firewall":"0`touch HOME-pwned`$(reboot)\\\"x","gatekeeper":"1","screenlock":"1"}]'
 
   run run_poller
@@ -760,10 +761,9 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
 
   assert_page_count 1
   assert_page_body_has 'monitoring gap'
-  if grep -qF -- '`' "$POLLER_SEND_ALERT_LOG"; then
-    echo "a backtick from the system read reached the page body: $(cat "$POLLER_SEND_ALERT_LOG")"
-    false
-  fi
+  # The exact sanitized value inside our span: had any of the value's own
+  # backticks survived, the span content (and this match) would break.
+  assert_page_body_has '(firewall=`0touch HOME-pwned(reboot)x`'
   if grep -qF -- '$(' "$POLLER_SEND_ALERT_LOG"; then
     echo "a command substitution from the system read reached the page body"
     false
@@ -807,6 +807,42 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
     false
   }
   assert_baseline_unchanged
+}
+
+@test "T-PCTL-gap-values-inline-code-span: a system-read value crosses into a gap page only inside an inline-code span (no structure forgery)" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  # Markdown that survives character-stripping unchanged: emphasis, a link, a
+  # mention. It must arrive WRAPPED in an inline-code span so none of it can
+  # render as notification structure (a fake header, a live link, a ping).
+  set_posture '[{"firewall":"x] **FAKE CRITICAL** [open](https://example.invalid) @everyone [","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has '`x] **FAKE CRITICAL** [open](https://example.invalid) @everyone [`'
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-description-inline-code-span: description and remedy from the data file reach a page only inside inline-code spans" {
+  set_posture_controls '[{"id":"guest","description":"x] **FAKE CRITICAL** [open](https://example.invalid) @everyone [","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","remedy":"r] **FAKE REMEDY** [r"}]'
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_SYSADMINCTL_GUEST_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account enabled."
+
+  run run_poller # first observation of a deviant control: pages
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_body_has '`x] **FAKE CRITICAL** [open](https://example.invalid) @everyone [`'
+  assert_page_body_has '`r] **FAKE REMEDY** [r`'
 }
 
 # --- the Gatekeeper remedy names System Settings, never the removed CLI flag ---

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -719,6 +719,95 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_page_body_has '`FileVault disk encryption`: now off, declared on'
 }
 
+# --- bounded probes: a WEDGED status tool becomes a gap, not silent blindness ---
+# One hang test per probe path (fdesetup, csrutil, sysadminctl, defaults),
+# mirroring the osqueryi hang test: the stub execs into a 30s sleep, the 1s
+# bound kills it, and the control gaps. The wallclock guard is what makes an
+# UNBOUNDED probe fail here: without it, the 30s sleep would end, the probe
+# would return empty at exit 0, and the very same gap assertions would pass
+# late, hiding a removed run_bounded.
+
+assert_bounded_hang_gaps() { # <control-id> <started-seconds>
+  local elapsed=$((SECONDS - $2))
+  [[ $elapsed -lt 10 ]] || {
+    echo "the poller ran ${elapsed}s: the wedged probe was not killed at the bound"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has "$1"
+  assert_baseline_unchanged
+}
+
+@test "T-PCTL-fdesetup-hang-pages-gap: a wedged fdesetup is killed at the bound and gaps the filevault control" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_FDESETUP_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps filevault "$started"
+}
+
+@test "T-PCTL-csrutil-hang-pages-gap: a wedged csrutil is killed at the bound and gaps the sip control" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_CSRUTIL_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps sip "$started"
+}
+
+@test "T-PCTL-sysadminctl-hang-pages-gap: a wedged sysadminctl is killed at the bound and gaps the guest control" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_SYSADMINCTL_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps guest "$started"
+}
+
+@test "T-PCTL-defaults-hang-pages-gap: a wedged defaults read is killed at the bound and gaps the autologin control" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_DEFAULTS_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps autologin "$started"
+}
+
 # --- the poller never mutates, and system-read text never reaches a page raw ---
 
 @test "T-PCTL-no-mutating-invocation: healthy, deviant, and gap ticks invoke only status probes; the violation log stays empty" {

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -101,6 +101,30 @@ teardown() { teardown_poller_harness; }
   assert_mode 600 "$OSQUERY_POSTURE_STATE"
 }
 
+@test "T-POLL-failed-read-healthy-output-gaps: a nonzero osqueryi exit with healthy-looking JSON is a monitoring gap, never a trusted read" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  # The printed posture is healthy AND in-domain but DIFFERS from the baseline
+  # (firewall 2, block-all): a poller that trusted the output of a failed query
+  # would silently advance the baseline on untrustworthy data.
+  set_posture '[{"firewall":"2","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_OSQUERYI_EXIT_AFTER_OUTPUT=1 # healthy JSON printed, then a nonzero exit
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "expected exit 0 after paging the gap, got $status: $output"
+    false
+  }
+
+  # Indeterminate-on-nonzero for the built-in trio too: gap page, marker, and a
+  # byte-for-byte untouched baseline (no advance on a failed probe's output).
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_gap_marker
+  assert_baseline_unchanged
+}
+
 @test "T-POLL-empty-read-preserves-baseline: an empty osqueryi result pages the monitoring gap and leaves the good baseline intact at 0600" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline

--- a/test/unit/macos-posture-indeterminate.sh
+++ b/test/unit/macos-posture-indeterminate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# macos-posture-indeterminate.sh -- the indeterminate-on-nonzero discipline,
+# asserted PER declared posture control (slice 6, absorbed from the retired
+# apply-time posture reminder): a probe that exits NONZERO is INDETERMINATE
+# regardless of what it printed, because a failed probe's output is
+# untrustworthy. Untrustworthy means it may print healthy-looking text yet have
+# failed, so each stub here prints EXACTLY the healthy text for its control and
+# exits 1. The required outcome, per control:
+#
+#   - a monitoring-gap page fires, naming the control (never a silent pass:
+#     fail-open is the cardinal sin);
+#   - the read is never classified as the healthy value: the baseline is
+#     byte-for-byte untouched, so no healthy value was persisted and no
+#     transition was fabricated.
+#
+# Runs the real poller against the recording harness (stubbed osqueryi, probe
+# stubs, send_alert spy); no live machine, no chezmoi apply.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/osquery-poller-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/osquery-poller-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# One case per control: <control-id> <healthy-looking-output-env> <exit-env>.
+# The healthy text is the stub default, so only the exit override is set; the
+# point is exactly that healthy-looking output plus a nonzero exit must never
+# read as healthy.
+run_case() { # <control-id> <exit-override-env-var>
+  local control_id="$1" exit_env="$2" poller_status=0
+
+  setup_poller_harness
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  set_posture_controls '[
+    {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on"},
+    {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"disabled"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off"},
+    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}
+  ]'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","sip":"disabled","autologin":"off","guest":"disabled"}'
+  snapshot_baseline
+
+  export "$exit_env=1" # healthy default output + nonzero exit
+  run_poller >/dev/null 2>&1 || poller_status=$?
+  unset "$exit_env"
+
+  # The gap page fired (exit 0 after a queued page) and named the control.
+  [[ $poller_status -eq 0 ]] ||
+    fail "$control_id: expected exit 0 after paging the gap, got $poller_status"
+  assert_page_count 1 ||
+    fail "$control_id: a nonzero probe must page a monitoring gap, never pass silently"
+  assert_page_severity_is CRIT ||
+    fail "$control_id: the gap page must be CRIT"
+  assert_page_body_has 'monitoring gap' ||
+    fail "$control_id: the page must name the monitoring gap"
+  assert_page_body_has "$control_id" ||
+    fail "$control_id: the gap page must name the control that gapped"
+  # Never classified as healthy: the baseline is byte-for-byte untouched, so
+  # the healthy-looking output was not believed and nothing advanced.
+  assert_baseline_unchanged ||
+    fail "$control_id: a nonzero probe must never advance the baseline"
+  # And never a mutating call, even on the failure path.
+  assert_no_mutation_attempt ||
+    fail "$control_id: the failure path invoked a non-status command"
+
+  teardown_poller_harness
+}
+
+run_case filevault POLLER_FDESETUP_EXIT
+run_case sip POLLER_CSRUTIL_EXIT
+run_case autologin POLLER_SYSADMINCTL_AUTOLOGIN_EXIT
+run_case guest POLLER_SYSADMINCTL_GUEST_EXIT
+
+printf 'ok: nonzero probes are indeterminate for every declared control\n'

--- a/test/unit/macos-posture-indeterminate.sh
+++ b/test/unit/macos-posture-indeterminate.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# macos-posture-indeterminate.sh -- the indeterminate-on-nonzero discipline,
+# macos-posture-indeterminate.sh -- the untrustworthy-failure discipline,
 # asserted PER declared posture control (slice 6, absorbed from the retired
-# apply-time posture reminder): a probe that exits NONZERO is INDETERMINATE
-# regardless of what it printed, because a failed probe's output is
-# untrustworthy. Untrustworthy means it may print healthy-looking text yet have
-# failed, so each stub here prints EXACTLY the healthy text for its control and
-# exits 1. The required outcome, per control:
+# apply-time posture reminder): a probe failure is INDETERMINATE regardless of
+# what it printed, because a failed probe's output is untrustworthy. For the
+# classify_probe readers that means a nonzero exit with EXACTLY the healthy
+# text; for defaults_autologin (whose healthy absent state is itself nonzero,
+# gated on the canonical does-not-exist diagnostic) it means a nonzero exit
+# WITHOUT that diagnostic. The required outcome, per control:
 #
 #   - a monitoring-gap page fires, naming the control (never a silent pass:
 #     fail-open is the cardinal sin);
@@ -29,27 +30,31 @@ fail() {
   exit 1
 }
 
-# One case per control: <control-id> <healthy-looking-output-env> <exit-env>.
-# The healthy text is the stub default, so only the exit override is set; the
-# point is exactly that healthy-looking output plus a nonzero exit must never
-# read as healthy.
-run_case() { # <control-id> <exit-override-env-var>
-  local control_id="$1" exit_env="$2" poller_status=0
+# One case per control: <control-id> <env-assignment>. For the classify_probe
+# readers the assignment is an exit override with the stub's healthy default
+# output kept: the point is exactly that healthy-looking output plus a nonzero
+# exit must never read as healthy. For the defaults_autologin reader the
+# HEALTHY state is itself a nonzero exit carrying the canonical does-not-exist
+# diagnostic, so its untrustworthy-failure form is a nonzero exit WITHOUT that
+# diagnostic (the stub's unreadable mode): only the canonical needle may ever
+# map a failure to healthy.
+run_case() { # <control-id> <env-assignment VAR=VALUE>
+  local control_id="$1" env_assignment="$2" poller_status=0
 
   setup_poller_harness
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
   set_posture_controls '[
     {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on"},
     {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"disabled"},
-    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off"},
+    {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"defaults_autologin","expect":"off"},
     {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}
   ]'
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled"}'
   snapshot_baseline
 
-  export "$exit_env=1" # healthy default output + nonzero exit
+  export "${env_assignment?}" # the untrustworthy-failure form for this control
   run_poller >/dev/null 2>&1 || poller_status=$?
-  unset "$exit_env"
+  unset "${env_assignment%%=*}"
 
   # The gap page fired (exit 0 after a queued page) and named the control.
   [[ $poller_status -eq 0 ]] ||
@@ -73,9 +78,9 @@ run_case() { # <control-id> <exit-override-env-var>
   teardown_poller_harness
 }
 
-run_case filevault POLLER_FDESETUP_EXIT
-run_case sip POLLER_CSRUTIL_EXIT
-run_case autologin POLLER_SYSADMINCTL_AUTOLOGIN_EXIT
-run_case guest POLLER_SYSADMINCTL_GUEST_EXIT
+run_case filevault POLLER_FDESETUP_EXIT=1
+run_case sip POLLER_CSRUTIL_EXIT=1
+run_case autologin POLLER_DEFAULTS_AUTOLOGIN_MODE=unreadable
+run_case guest POLLER_SYSADMINCTL_GUEST_EXIT=1
 
-printf 'ok: nonzero probes are indeterminate for every declared control\n'
+printf 'ok: untrustworthy probe failures are indeterminate for every declared control\n'

--- a/test/unit/macos-posture-indeterminate.sh
+++ b/test/unit/macos-posture-indeterminate.sh
@@ -44,7 +44,7 @@ run_case() { # <control-id> <exit-override-env-var>
     {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"sysadminctl_autologin","expect":"off"},
     {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}
   ]'
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","sip":"disabled","autologin":"off","guest":"disabled"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled"}'
   snapshot_baseline
 
   export "$exit_env=1" # healthy default output + nonzero exit


### PR DESCRIPTION
## Context

Earlier changes in this series taught the settings data that every control declares whether it can be
enforced, only checked, or needs a person. The check-only kind had nowhere to go: a control that is
readable but not settable produced, at best, a line of text during an apply that scrolled past unread.

A poller already exists that reads firewall, Gatekeeper and screen-lock state every minute and raises a
critical alert when a protection turns off, with durable delivery and page-once behavior already solved.
This extends that poller rather than building a second one, because two mechanisms reading the same set of
controls is exactly the kind of divergence this project keeps repairing.

## Summary

- Four more protections are now monitored: disk encryption, system integrity protection, auto-login and the guest account.
- The list of monitored controls moves out of the script into a data file, so adding one is a data change.
- A probe that fails is reported as indeterminate rather than believed, even when its output looks healthy.
- A test proves the monitored set and the declared set are the same, in both directions.
- A wedged probe can no longer stop all monitoring silently.

Key files: `.chezmoidata/macos_posture_controls.yaml`, the poller, and four test files.

## Which reader was chosen for each control, and why

The plan left this open deliberately and required evidence rather than assumption. Each reader was
verified from the context the poller actually runs in, not from an interactive shell, and each was also
run under a deliberately stripped environment to catch a hidden dependency on something a login shell
provides and a background agent does not.

Disk encryption is read with the system's own status tool rather than the general-purpose query engine.
That engine reports the physical container as unencrypted while encryption is on, because the encryption
lives on the volumes inside it. The obvious query therefore returns a confident wrong answer on a healthy
machine, and a monitor that raises false alarms is worse than one that stays quiet: it teaches the
operator to dismiss the channel, which disables the true alarms arriving later through it.

Auto-login is read from the declaration rather than from whether auto-login could happen right now. Those
differ: when disk encryption is on, the system reports auto-login as disabled even if a user is configured
for it. Reading the effective state would call that machine healthy, and turning encryption off later
would silently activate an auto-login nobody had flagged.

The other two read cleanly and agree with their alternatives.

## What review changed

Two independent reviews produced ten findings, and the two most serious were failures to distrust.

A query that failed but still printed plausible output was accepted as truth, and its value became the new
baseline. The discipline this change was meant to adopt (a failed probe's output is untrustworthy no
matter what it says) was applied to the four new controls and not to the three that came before them.

Worse, one unreadable control silenced every readable one. A single failing probe raised a gap notice, and
that notice suppressed comparison of everything else, so a real protection could switch off during the
outage, switch back, and never be reported. Gaps are now per control: the broken one is reported, and the
rest are still compared and still raise alarms.

Three more were quieter versions of the same theme. Tightening a control's declared expectation was
treated as an ongoing known deviation and passed silently, so hardening something could do nothing at all.
A malformed data file containing two documents parsed without complaint and yielded no controls, so
everything stopped being watched with no notice. And a value read from the system could forge structure
inside an alert body, which is now neutralized the same way the rest of this repository's alerting does it.

## The one thing no reviewer found by reading

Removing the timeout from a probe survived every test. A status tool that hangs would freeze the poller,
the scheduler would skip ticks while it lived, and every protection would go unwatched with nothing
reported, which is the worst failure this system has.

It survived because the test fixtures had no way to make a probe hang, so the behavior was unreachable
rather than untested. The fixtures now support it and each probe path is pinned. The assertion is on
elapsed time, deliberately: without a timeout the probe eventually returns anyway and every other
assertion passes, just later. Time is the only dimension where the correct and broken versions differ.

## What could not be demonstrated

The settings were not applied and no live protection was touched; every check here was read-only. The
source tree currently carries duplicate profile directories that block applying, tracked separately.

The poller itself runs standalone from the source tree against stubbed probes and a stubbed alert
dispatcher, so its behavior is proven without a live machine.

## Effect of merging

Advances `main` only. Nothing is enforced or changed by this: every control here is report-only by
definition. The live machine follows another branch.
