### PR TITLE
feat(ssh): generate, install and verify a public-key-only sshd drop-in

### DIFF
--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -86,6 +86,15 @@ macos:
     # macOS version there is nothing to enable. socketfilterfw has no logging
     # flag, and firewall activity already flows to the unified log by default
     # (see the runbook section "Firewall log diagnostics" for viewing it).
+    #
+    # SSH: the drop-in write is enforce-tier because it is INERT for a running
+    # sshd (the configuration is re-read only on restart); the disruptive
+    # reload is a separate control and is deliberately not declared here. No
+    # sudo prefix: the script escalates per operation itself (covered by the
+    # runner's upfront sudo -v), and its verification runs unprivileged.
+    - description: "SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
+      command: '"$HOME/.local/bin/ssh-hardening.sh"'
+      tier: enforce
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -25,10 +25,11 @@
 #   SSH_HARDENING_SUDO  privilege wrapper for writes; set EMPTY to run
 #                       unprivileged against a sandbox tree (default sudo)
 #   SSH_HARDENING_ALLOW_MISSING_SSHD
-#                       explicit test seam: when set AND $SSHD_BIN cannot run,
-#                       --verify skips (exit 0) WITHOUT a verified claim.
-#                       Never set in the default path; absent it, an
-#                       unrunnable verifier fails closed.
+#                       explicit test seam: when set to a TRUE-ish value AND
+#                       $SSHD_BIN cannot run, --verify skips (exit 0) WITHOUT a
+#                       verified claim. '0', 'false', 'no', 'off' and the empty
+#                       string all read as OFF. Never set in the default path;
+#                       absent it, an unrunnable verifier fails closed.
 set -euo pipefail
 
 # sshd matches configuration keywords AND their yes/no arguments
@@ -44,6 +45,10 @@ SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 # `-` not `:-`: set-but-empty means "no wrapper, run the commands directly",
 # which is how tests write into a user-owned sandbox without privilege.
 SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
+
+# This file, for the install path's strict child verify. BASH_SOURCE and not
+# $0, so a caller that rewrites $0 cannot redirect the re-invocation.
+SSH_HARDENING_SELF="${BASH_SOURCE[0]}"
 
 # sshd resolves a RELATIVE Include argument against its compiled-in
 # configuration directory, not the working directory (verified two ways: a
@@ -205,7 +210,18 @@ EOF
 # SSH_HARDENING_ALLOW_MISSING_SSHD test seam and never claims verified.
 
 VERIFY_FAILURES=()
-VERIFY_SKIPPED=0
+
+# verify_skip_allowed: the SSH_HARDENING_ALLOW_MISSING_SSHD seam is ON only for
+# an explicitly TRUE-ish value. It used to be tested for being NONEMPTY, so
+# every value turned it on -- including `0`, the one value a reader would
+# expect to turn it OFF. A seam that disables verification when set to "off" is
+# a trap, and this is the whole list of values that arm it.
+verify_skip_allowed() {
+  case "${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # add_failure <message>: record a problem once. The include graph is walked
 # from both roots, so a drop-in reached through the main config's Include and
@@ -266,12 +282,16 @@ required_value() {
 # each named: correct, wrong value, absent. Every one is asserted
 # individually; completeness beats counting.
 assert_output_hardened() {
-  local label="$1" output="$2" i key want got
+  local label="$1" output="$2" i key want got status
   for i in "${!PROTECTED_KEYS[@]}"; do
     key="${PROTECTED_KEYS[$i]}"
     want="${PROTECTED_VALUES[$i]}"
-    got="$(printf '%s\n' "$output" | awk -v k="$key" '$1 == k { print $2; exit }')"
-    if [[ -z $got ]]; then
+    status=0
+    got="$(printf '%s\n' "$output" | awk -v k="$key" '$1 == k { print $2; exit }')" ||
+      status=$?
+    if [[ $status -ne 0 ]]; then
+      add_failure "$label: could not read '$key' out of the sshd output (exit $status); failing closed rather than reading an unset value as absent"
+    elif [[ -z $got ]]; then
       add_failure "$label: '$key' is absent from the effective configuration"
     elif [[ $got != "$want" ]]; then
       add_failure "$label: '$key' is '$got', want '$want'"
@@ -517,7 +537,8 @@ scan_config_file() {
 }
 
 check_match_scan() {
-  local file
+  local listing status=0 file old_ifs
+  local -a files
   # Two roots, each walked with Include followed from it. The main config is
   # where sshd starts, so everything sshd reads is reachable from it. The
   # drop-in directory is kept as a second root so a drop-in stays covered even
@@ -528,15 +549,47 @@ check_match_scan() {
   # The include order is lexical byte order; LC_ALL=C sort mirrors it. A
   # config file name containing a newline would break this listing; sshd's
   # own glob handling shares the no-newline assumption.
-  while IFS= read -r file; do
-    [[ -n $file && -f $file ]] || continue
+  #
+  # The listing is CAPTURED, not streamed from a process substitution. A
+  # process substitution discards its exit status, so a failing sort produced
+  # zero files, the loop ran over nothing, and a scan of nothing reported the
+  # tree clean.
+  listing="$(printf '%s\n' "$SSHD_MAIN_CONFIG" "$SSHD_CONFIG_D"/* | LC_ALL=C sort -u)" ||
+    status=$?
+  if [[ $status -ne 0 ]]; then
+    add_failure "match scan: could not list the configuration files to scan (exit $status); failing closed rather than scanning none"
+    return 0
+  fi
+  # Split on newlines only, with globbing off so a file name containing a glob
+  # character is not expanded a second time.
+  old_ifs="$IFS"
+  IFS=$'\n'
+  set -f
+  # shellcheck disable=SC2206  # deliberate newline split of the captured listing
+  files=($listing)
+  set +f
+  IFS="$old_ifs"
+  if [[ ${#files[@]} -eq 0 ]]; then
+    add_failure 'match scan: the configuration file listing came back empty; failing closed rather than scanning none'
+    return 0
+  fi
+  for file in "${files[@]}"; do
+    if [[ -z $file || ! -f $file ]]; then
+      continue
+    fi
     scan_config_file "$file" 0 0 '|'
-  done < <(printf '%s\n' "$SSHD_MAIN_CONFIG" "$SSHD_CONFIG_D"/* | LC_ALL=C sort -u)
+  done
 }
 
 check_connection_specs() {
-  local invoking_user spec output status
-  invoking_user="$(id -un)"
+  local invoking_user spec output status=0
+  # Guarded, not assumed: the status of this substitution used to be visible
+  # only through errexit, which the install path switched off.
+  invoking_user="$(id -un)" || status=$?
+  if [[ $status -ne 0 || -z $invoking_user ]]; then
+    add_failure "connection check: could not determine the invoking user ('id -un' exited $status); failing closed rather than probing a spec built from an empty name"
+    return 0
+  fi
   # Two samples: root (the account PermitRootLogin exists to keep out) and
   # the invoking user (so a 'Match User <name>' aimed at the operator's own
   # account fails RESOLUTION, not only the raw scan). Samples cannot be
@@ -559,10 +612,8 @@ check_connection_specs() {
 
 verify() {
   VERIFY_FAILURES=()
-  VERIFY_SKIPPED=0
   if [[ ! -x $SSHD_BIN ]]; then
-    if [[ -n ${SSH_HARDENING_ALLOW_MISSING_SSHD:-} ]]; then
-      VERIFY_SKIPPED=1
+    if verify_skip_allowed; then
       printf '[ssh-hardening] verify SKIPPED: %s is not executable and the SSH_HARDENING_ALLOW_MISSING_SSHD test seam is set. The configuration was NOT checked.\n' "$SSHD_BIN"
       return 0
     fi
@@ -613,10 +664,29 @@ install_dropin() {
     fi
     printf '[ssh-hardening] removed legacy drop-in %s\n' "$legacy"
   fi
-  if ! verify; then
+  # Verify in a CHILD shell. bash suppresses `set -e` for everything inside an
+  # `if !` or `||` test, and that suppression reaches into called functions and
+  # even into subshells (confirmed on bash 3.2), so calling verify in-process
+  # here ran every check with errexit switched off: a failure mid-flight was
+  # stepped over and the success line still printed. A separate process gets
+  # its own `set -euo pipefail`, so install judges the tree by exactly the
+  # rules --verify applies on its own. The seams are passed explicitly so the
+  # child inspects the tree this install just wrote whether or not the caller
+  # exported them.
+  local verify_status=0
+  SSHD_CONFIG_D="$SSHD_CONFIG_D" \
+    SSHD_MAIN_CONFIG="$SSHD_MAIN_CONFIG" \
+    SSHD_BIN="$SSHD_BIN" \
+    SSH_HARDENING_SUDO="$SSH_HARDENING_SUDO" \
+    SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
+    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify || verify_status=$?
+  if [[ $verify_status -ne 0 ]]; then
     die "wrote '$target' but the effective configuration did NOT verify as fully hardened; refusing to claim success"
   fi
-  if [[ $VERIFY_SKIPPED -eq 1 ]]; then
+  # The child's skip cannot be read out of its exit status, so the same
+  # predicate decides the wording here. One function, two callers, no second
+  # copy of the rule to drift.
+  if [[ ! -x $SSHD_BIN ]] && verify_skip_allowed; then
     printf '[ssh-hardening] wrote %s, but verification was SKIPPED via the test seam; the effective configuration is NOT verified.\n' "$target"
     return 0
   fi

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -10,9 +10,9 @@
 #   --print-path    print the drop-in target path (pure)
 #   --verify        read-only three-way check that the EFFECTIVE sshd
 #                   configuration is fully hardened (see the verify section)
-#   (no argument)   install: write the drop-in, pin mode 0644, migrate the
-#                   legacy 50-no-password-auth.conf away, then run the verify
-#                   and refuse to claim success unless it passes
+#   (no argument)   install: stage the drop-in, publish it with one rename,
+#                   move the legacy 50-no-password-auth.conf aside, verify, and
+#                   roll the whole tree back to what it found if that fails
 #
 # The drop-in file IS the lock; leave it in place permanently. Without it,
 # sshd reverts to its defaults at the next restart.
@@ -127,6 +127,10 @@ DIRECTIVE_ALIAS_TARGETS=(kbdinteractiveauthentication
 die() {
   printf '[ssh-hardening] ERROR: %s\n' "$*" >&2
   exit 1
+}
+
+warn() {
+  printf '[ssh-hardening] WARNING: %s\n' "$*" >&2
 }
 
 run_privileged() {
@@ -635,14 +639,81 @@ verify() {
 
 # --- install -----------------------------------------------------------------
 
+# Install is a TRANSACTION. It stages the new drop-in beside the target,
+# publishes it with one rename, moves the legacy file aside rather than
+# deleting it, and only then verifies. If any step fails the tree goes back
+# exactly as it was found, because refusing to CLAIM success is not the same
+# as refusing to CAUSE harm and the previous version did only the first.
+#
+# The working files are DOT-PREFIXED deliberately: sshd's Include glob does not
+# match a leading dot (glob(3) semantics, verified), so a half-written staging
+# file is never part of the effective configuration and neither is a rollback
+# copy. This scan skips them for the same reason.
+
+# The transaction's state, so rollback undoes what THIS run actually did
+# rather than inferring it from what happens to be on disk. Inferring is how a
+# rollback deletes a drop-in the run never published: the backup copy is
+# absent both before the publish step and when there was nothing to back up.
+INSTALL_TARGET=''
+INSTALL_LEGACY=''
+INSTALL_STAGING=''
+INSTALL_SAVED_TARGET=''
+INSTALL_SAVED_LEGACY=''
+INSTALL_PUBLISHED=0
+
+# rollback_install: undo everything install did, and nothing it did not. Every
+# step reports on its own rather than aborting the rollback, because a rollback
+# that stops half way leaves exactly the state it exists to prevent.
+rollback_install() {
+  if [[ -e $INSTALL_STAGING || -L $INSTALL_STAGING ]]; then
+    run_privileged rm -f -- "$INSTALL_STAGING" ||
+      warn "rollback could not remove the staging file '$INSTALL_STAGING'"
+  fi
+  # Only if this run replaced the target is the target this run's to undo.
+  if [[ $INSTALL_PUBLISHED -eq 1 ]]; then
+    if [[ -e $INSTALL_SAVED_TARGET || -L $INSTALL_SAVED_TARGET ]]; then
+      run_privileged mv -f -- "$INSTALL_SAVED_TARGET" "$INSTALL_TARGET" ||
+        warn "rollback could not restore the previous drop-in from '$INSTALL_SAVED_TARGET'"
+    else
+      # No drop-in existed before this run, so removing the one it created is
+      # what "as it was found" means.
+      run_privileged rm -f -- "$INSTALL_TARGET" ||
+        warn "rollback could not remove the drop-in '$INSTALL_TARGET' this run created"
+    fi
+  fi
+  if [[ -e $INSTALL_SAVED_LEGACY || -L $INSTALL_SAVED_LEGACY ]]; then
+    run_privileged mv -f -- "$INSTALL_SAVED_LEGACY" "$INSTALL_LEGACY" ||
+      warn "rollback could not restore the legacy drop-in from '$INSTALL_SAVED_LEGACY'"
+  fi
+}
+
 install_dropin() {
-  local target legacy
+  local target legacy staging saved_target saved_legacy
   target="$(dropin_path)"
   legacy="$SSHD_CONFIG_D/$LEGACY_DROPIN_NAME"
+  staging="$SSHD_CONFIG_D/.$DROPIN_NAME.staging"
+  saved_target="$SSHD_CONFIG_D/.$DROPIN_NAME.saved"
+  saved_legacy="$SSHD_CONFIG_D/.$LEGACY_DROPIN_NAME.saved"
+  INSTALL_TARGET="$target"
+  INSTALL_LEGACY="$legacy"
+  INSTALL_STAGING="$staging"
+  INSTALL_SAVED_TARGET="$saved_target"
+  INSTALL_SAVED_LEGACY="$saved_legacy"
+  INSTALL_PUBLISHED=0
+
   [[ -d $SSHD_CONFIG_D ]] ||
     die "drop-in directory '$SSHD_CONFIG_D' does not exist"
-  if ! print_config | run_privileged tee -- "$target" >/dev/null; then
-    die "could not write '$target'"
+  if ! run_privileged rm -f -- "$staging" "$saved_target" "$saved_legacy"; then
+    die "could not clear the working files under '$SSHD_CONFIG_D'; refusing to begin an install that could not be rolled back"
+  fi
+
+  # Stage first, publish second. `tee` truncates its target the instant it
+  # opens it, so writing the drop-in directly EMPTIED a perfectly good file
+  # whenever the pipeline feeding it failed afterwards -- which a PATH without
+  # `cat` does, and did.
+  if ! print_config | run_privileged tee -- "$staging" >/dev/null; then
+    rollback_install
+    die "could not stage the new drop-in at '$staging'; '$target' is untouched"
   fi
   # Explicit mode, never the ambient umask: under e.g. umask 0077 tee lands
   # the file 0600, and a root-owned 0600 drop-in makes UNPRIVILEGED `sshd -G`
@@ -650,17 +721,36 @@ install_dropin() {
   # safe: the file holds no credential and sshd must be able to read it.
   # `--` BEFORE the mode: BSD chmod treats a `--` after the mode as a file
   # operand and fails.
-  if ! run_privileged chmod -- 0644 "$target"; then
-    die "could not set mode 0644 on '$target'"
+  if ! run_privileged chmod -- 0644 "$staging"; then
+    rollback_install
+    die "could not set mode 0644 on '$staging'; '$target' is untouched"
   fi
+  # Copy the existing drop-in aside BEFORE replacing it, so the target itself
+  # is never absent: the copy is the backup, and the rename below is atomic.
+  if [[ -e $target || -L $target ]]; then
+    if ! run_privileged cp -p -- "$target" "$saved_target"; then
+      rollback_install
+      die "could not copy the existing '$target' aside; refusing to replace a file that could not then be restored"
+    fi
+  fi
+  if ! run_privileged mv -f -- "$staging" "$target"; then
+    rollback_install
+    die "could not publish the staged drop-in as '$target'"
+  fi
+  INSTALL_PUBLISHED=1
   printf '[ssh-hardening] wrote %s (mode 0644)\n' "$target"
-  # Migrate the legacy drop-in away. Two reasons: one lock in one file (two
-  # files declaring the same policy is drift waiting to happen), and the
-  # legacy file was created 0600 under the umask, which breaks unprivileged
-  # verification for the entire tree (see the chmod comment above).
+
+  # Retire the legacy drop-in, reversibly. Two reasons it has to go: one lock
+  # in one file (two files declaring the same policy is drift waiting to
+  # happen), and the legacy file was created 0600 under the umask, which breaks
+  # unprivileged verification for the entire tree (see the chmod comment
+  # above). It is MOVED, not deleted, until the replacement is proven good --
+  # deleting the only effective policy and then failing verification is exactly
+  # how an install leaves a machine worse than it found it.
   if [[ -e $legacy || -L $legacy ]]; then
-    if ! run_privileged rm -f -- "$legacy"; then
-      die "could not remove the legacy drop-in '$legacy'"
+    if ! run_privileged mv -f -- "$legacy" "$saved_legacy"; then
+      rollback_install
+      die "could not move the legacy drop-in '$legacy' aside"
     fi
     printf '[ssh-hardening] removed legacy drop-in %s\n' "$legacy"
   fi
@@ -681,7 +771,11 @@ install_dropin() {
     SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
     "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify || verify_status=$?
   if [[ $verify_status -ne 0 ]]; then
-    die "wrote '$target' but the effective configuration did NOT verify as fully hardened; refusing to claim success"
+    rollback_install
+    die "the effective configuration did NOT verify as fully hardened; the tree was rolled back to the state this install found it in, and no success is claimed"
+  fi
+  if ! run_privileged rm -f -- "$saved_target" "$saved_legacy"; then
+    warn "could not remove the rollback copies under '$SSHD_CONFIG_D'; they are dot-prefixed and inert, but should be cleaned up"
   fi
   # The child's skip cannot be read out of its exit status, so the same
   # predicate decides the wording here. One function, two callers, no second

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -56,6 +56,26 @@ PROTECTED_KEYS=(passwordauthentication kbdinteractiveauthentication usepam
   pubkeyauthentication permitrootlogin)
 PROTECTED_VALUES=(no no yes yes no)
 
+# Keywords sshd accepts as ALIASES for a protected directive. Enumerated, not
+# recalled: every lowercase keyword string in the sshd binary was extracted and
+# each one set to yes and to no inside a real `Match Address` block over a
+# hardened tree, then resolved with `sshd -G -T -C`. These are the only
+# keywords in the whole binary that move a protected value.
+#
+# Two of them work inside a genuine Match block, and SkeyAuthentication is the
+# dangerous one: sshd_config(5) does not document it at all, and it still
+# flips kbdinteractiveauthentication to yes.
+#
+# DSAAuthentication is GLOBAL-only -- inside a real Match block sshd refuses
+# the entire configuration, which check_global reports as a failed `sshd -G`.
+# It is folded here for the `Match all` form, which sshd does accept and apply
+# globally, so that the scan names the directive it moves instead of passing
+# over a keyword it does not recognize.
+DIRECTIVE_ALIASES=(challengeresponseauthentication skeyauthentication
+  dsaauthentication)
+DIRECTIVE_ALIAS_TARGETS=(kbdinteractiveauthentication
+  kbdinteractiveauthentication pubkeyauthentication)
+
 die() {
   printf '[ssh-hardening] ERROR: %s\n' "$*" >&2
   exit 1
@@ -136,6 +156,21 @@ add_failure() {
 # directive name as one writing it in lowercase.
 MATCHED_PROTECTED_KEY=''
 REQUIRED_VALUE=''
+# canonical_key <keyword>: set CANONICAL_KEY to the protected directive this
+# keyword reaches, folding sshd's aliases onto their target so an alias is
+# reported, and compared, against the directive it actually moves.
+CANONICAL_KEY=''
+canonical_key() {
+  local i
+  CANONICAL_KEY="$1"
+  for i in "${!DIRECTIVE_ALIASES[@]}"; do
+    if [[ $1 == "${DIRECTIVE_ALIASES[$i]}" ]]; then
+      CANONICAL_KEY="${DIRECTIVE_ALIAS_TARGETS[$i]}"
+      return 0
+    fi
+  done
+}
+
 required_value() {
   local i
   for i in "${!PROTECTED_KEYS[@]}"; do
@@ -315,10 +350,8 @@ scan_file_for_match_reenable() {
     else
       value=''
     fi
-    if [[ $key == challengeresponseauthentication ]]; then
-      key=kbdinteractiveauthentication
-    fi
-    if required_value "$key" && [[ $value != "$REQUIRED_VALUE" ]]; then
+    canonical_key "$key"
+    if required_value "$CANONICAL_KEY" && [[ $value != "$REQUIRED_VALUE" ]]; then
       add_failure "match scan: '$file' sets '$MATCHED_PROTECTED_KEY $value' inside a Match block (want '$REQUIRED_VALUE'); a Match-scoped re-enable bypasses the global check"
     fi
   done <"$file" || status=$?

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -70,13 +70,34 @@ LEGACY_DROPIN_NAME="50-no-password-auth.conf"
 # refuses fails check_global anyway.
 MAX_INCLUDE_DEPTH=15
 
-# The five protected directives and their required values, lowercase exactly
-# as `sshd -G` prints them. Parallel arrays because the deployed interpreter
-# is the system bash 3.2, which has no associative arrays; every test drives
-# this script through /bin/bash so a newer-bash-ism fails there.
+# The protected directives and their required values, lowercase exactly as
+# `sshd -G` prints them. Parallel arrays because the deployed interpreter is
+# the system bash 3.2, which has no associative arrays; every test drives this
+# script through /bin/bash so a newer-bash-ism fails there.
+#
+# The set is derived from the userauth methods this sshd actually offers, not
+# from a list of familiar directives. `strings /usr/sbin/sshd` names six:
+# none, password, keyboard-interactive, publickey, gssapi-with-mic, hostbased.
+#
+#   password              closed by passwordauthentication no
+#   keyboard-interactive  closed by kbdinteractiveauthentication no
+#   none                  succeeds only when PasswordAuthentication and
+#                         PermitEmptyPasswords are BOTH on, so the first
+#                         directive closes it
+#   publickey             the one method deliberately left open
+#   gssapi-with-mic       closed by nothing above
+#   hostbased             closed by nothing above
+#
+# The last two are why this list is seven long and not five. Both default to
+# no, and a default is not a policy: both are settable inside a Match block
+# (verified by resolving `sshd -G -T -C` against a tree that sets them there),
+# so with only the first five named, `Match Address *,!127.0.0.1` plus
+# `GSSAPIAuthentication yes` gave a second authentication method on every
+# off-loopback connection while the verify reported the tree fully hardened.
 PROTECTED_KEYS=(passwordauthentication kbdinteractiveauthentication usepam
-  pubkeyauthentication permitrootlogin)
-PROTECTED_VALUES=(no no yes yes no)
+  pubkeyauthentication permitrootlogin gssapiauthentication
+  hostbasedauthentication)
+PROTECTED_VALUES=(no no yes yes no no no)
 
 # Keywords sshd accepts as ALIASES for a protected directive. Enumerated, not
 # recalled: every lowercase keyword string in the sshd binary was extracted and
@@ -133,11 +154,19 @@ print_config() {
 # precisely because no password path remains for PAM to authenticate.
 # PermitRootLogin no is strictly tighter than the without-password default,
 # which still allows root login BY KEY.
+#
+# GSSAPIAuthentication and HostbasedAuthentication are the other two userauth
+# methods this sshd offers. Both default to no, but a default is not a policy:
+# both can be turned on inside a Match block, and none of the directives above
+# constrain them. Naming them is what makes "public-key-only" a statement
+# about this file rather than a hope about the defaults.
 PasswordAuthentication no
 KbdInteractiveAuthentication no
 UsePAM yes
 PubkeyAuthentication yes
 PermitRootLogin no
+GSSAPIAuthentication no
+HostbasedAuthentication no
 EOF
 }
 
@@ -234,7 +263,7 @@ required_value() {
 
 # assert_output_hardened <check-label> <sshd -G output>: every protected
 # directive must be present with its required value. Three outcomes per key,
-# each named: correct, wrong value, absent. All five are asserted
+# each named: correct, wrong value, absent. Every one is asserted
 # individually; completeness beats counting.
 assert_output_hardened() {
   local label="$1" output="$2" i key want got
@@ -548,7 +577,9 @@ verify() {
     printf '  - %s\n' "${VERIFY_FAILURES[@]}" >&2
     return 1
   fi
-  printf '[ssh-hardening] verify: PASS: all five directives hold globally, no Match block re-enables any of them, and both sampled connections resolve hardened.\n'
+  # The count comes from the array, so a directive added to policy cannot
+  # leave the success line claiming a number nobody checked.
+  printf '[ssh-hardening] verify: PASS: all %d protected directives hold globally, no Match block in the include graph re-enables any of them, and both sampled connections resolve hardened.\n' "${#PROTECTED_KEYS[@]}"
 }
 
 # --- install -----------------------------------------------------------------

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1,26 +1,328 @@
 #!/bin/bash
-# Disable SSH password authentication via drop-in config and reload sshd.
-# Manually invoked (no launchd schedule). Run after enabling Remote Login
-# on a fresh Mac to lock the SSH server to public-key auth only.
+# ssh-hardening.sh -- generate, install, and verify a public-key-only sshd
+# drop-in. Everything here is inert for the RUNNING daemon: sshd re-reads its
+# configuration only on restart, so writing the drop-in changes nothing until
+# Remote Login (re)starts sshd. The reload is a deliberately separate,
+# disruptive step and is NOT provided by this script.
 #
-# The drop-in file IS the lock, leave it in place permanently. Without it,
-# sshd reverts to its default of allowing password auth.
+# Modes:
+#   --print-config  print the drop-in content (pure: no privilege, no writes)
+#   --print-path    print the drop-in target path (pure)
+#   --verify        read-only three-way check that the EFFECTIVE sshd
+#                   configuration is fully hardened (see the verify section)
+#   (no argument)   install: write the drop-in, pin mode 0644, migrate the
+#                   legacy 50-no-password-auth.conf away, then run the verify
+#                   and refuse to claim success unless it passes
+#
+# The drop-in file IS the lock; leave it in place permanently. Without it,
+# sshd reverts to its defaults at the next restart.
+#
+# Seams (environment; defaults are the live values):
+#   SSHD_CONFIG_D       drop-in directory      (default /etc/ssh/sshd_config.d)
+#   SSHD_MAIN_CONFIG    main sshd config       (default /etc/ssh/sshd_config)
+#   SSHD_BIN            sshd binary, ABSOLUTE  (default /usr/sbin/sshd) so a
+#                       stripped PATH cannot turn the verifier into a no-op
+#   SSH_HARDENING_SUDO  privilege wrapper for writes; set EMPTY to run
+#                       unprivileged against a sandbox tree (default sudo)
+#   SSH_HARDENING_ALLOW_MISSING_SSHD
+#                       explicit test seam: when set AND $SSHD_BIN cannot run,
+#                       --verify skips (exit 0) WITHOUT a verified claim.
+#                       Never set in the default path; absent it, an
+#                       unrunnable verifier fails closed.
 set -euo pipefail
 
-DROPIN="/etc/ssh/sshd_config.d/50-no-password-auth.conf"
+SSHD_CONFIG_D="${SSHD_CONFIG_D:-/etc/ssh/sshd_config.d}"
+SSHD_MAIN_CONFIG="${SSHD_MAIN_CONFIG:-/etc/ssh/sshd_config}"
+SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
+# `-` not `:-`: set-but-empty means "no wrapper, run the commands directly",
+# which is how tests write into a user-owned sandbox without privilege.
+SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
 
-if [[ ! -f $DROPIN ]] || ! sudo grep -q "PasswordAuthentication no" "$DROPIN" 2>/dev/null; then
-  echo "PasswordAuthentication no" | sudo tee "$DROPIN" >/dev/null
-  echo "[ssh-hardening] Wrote $DROPIN"
-fi
+DROPIN_NAME="000-ssh-hardening.conf"
+LEGACY_DROPIN_NAME="50-no-password-auth.conf"
 
-# Reload sshd via the modern kickstart -k idiom (kill + restart in one call,
-# replaces the deprecated launchctl unload/load pair). Skip silently if sshd
-# isn't currently loaded, the drop-in stays in place and will apply
-# whenever Remote Login is next enabled.
-if sudo launchctl print system/com.openssh.sshd &>/dev/null; then
-  sudo launchctl kickstart -k system/com.openssh.sshd
-  echo "[ssh-hardening] sshd reloaded"
-else
-  echo "[ssh-hardening] sshd not currently running, config will apply when Remote Login is enabled"
-fi
+# The five protected directives and their required values, lowercase exactly
+# as `sshd -G` prints them. Parallel arrays because the deployed interpreter
+# is the system bash 3.2, which has no associative arrays; every test drives
+# this script through /bin/bash so a newer-bash-ism fails there.
+PROTECTED_KEYS=(passwordauthentication kbdinteractiveauthentication usepam
+  pubkeyauthentication permitrootlogin)
+PROTECTED_VALUES=(no no yes yes no)
+
+die() {
+  printf '[ssh-hardening] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+run_privileged() {
+  if [[ -n $SSH_HARDENING_SUDO ]]; then
+    "$SSH_HARDENING_SUDO" "$@"
+  else
+    "$@"
+  fi
+}
+
+dropin_path() {
+  printf '%s/%s\n' "$SSHD_CONFIG_D" "$DROPIN_NAME"
+}
+
+print_config() {
+  cat <<'EOF'
+# 000-ssh-hardening.conf - public-key-only sshd policy, written by
+# ssh-hardening.sh. This file IS the lock: remove it and sshd reverts to its
+# defaults at the next restart.
+#
+# The 000- prefix sorts (LC_ALL=C) before Apple's 100-macos.conf. sshd's
+# Include is lexical and first-value-wins, so sorting first keeps these values
+# authoritative even if a future macOS release adds a competing directive to
+# 100-macos.conf. Today's Apple file sets none of these, so the prefix is
+# insurance, not the repair of a live conflict.
+#
+# PasswordAuthentication and KbdInteractiveAuthentication together close BOTH
+# interactive password channels; either alone leaves one open. UsePAM yes is
+# required on macOS for account and session management, and is safe here
+# precisely because no password path remains for PAM to authenticate.
+# PermitRootLogin no is strictly tighter than the without-password default,
+# which still allows root login BY KEY.
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+UsePAM yes
+PubkeyAuthentication yes
+PermitRootLogin no
+EOF
+}
+
+# --- verify ------------------------------------------------------------------
+# Three independent, read-only, host-key-free checks. All of them run and
+# EVERY failure is reported, so one broken layer cannot mask another:
+#
+#   1. check_global: the pre-Match effective configuration via `sshd -G`.
+#      Catches a global re-enable anywhere in the include chain, including a
+#      sibling that sorts before the drop-in (first-value-wins). It cannot
+#      see Match blocks at all, which is why the next two exist.
+#   2. check_match_scan: a raw scan of the main config and every drop-in for
+#      a Match block that re-enables a protected directive. The completeness
+#      net: it flags ANY Match-scoped re-enable, including forms on subnets
+#      or users the connection samples below never probe.
+#   3. check_connection_specs: per-connection resolution via
+#      `sshd -G -T -C`. Proves Match blocks RESOLVE hardened for concrete
+#      connections (root and the invoking user); samples only, by nature.
+#
+# Any check that cannot run FAILS the verify. A skip exists only behind the
+# SSH_HARDENING_ALLOW_MISSING_SSHD test seam and never claims verified.
+
+VERIFY_FAILURES=()
+VERIFY_SKIPPED=0
+
+add_failure() {
+  VERIFY_FAILURES+=("$1")
+}
+
+# required_value <lowercase-key>: print the required value, or return 1 for a
+# key that is not protected.
+required_value() {
+  local i
+  for i in "${!PROTECTED_KEYS[@]}"; do
+    if [[ $1 == "${PROTECTED_KEYS[$i]}" ]]; then
+      printf '%s\n' "${PROTECTED_VALUES[$i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# assert_output_hardened <check-label> <sshd -G output>: every protected
+# directive must be present with its required value. Three outcomes per key,
+# each named: correct, wrong value, absent. All five are asserted
+# individually; completeness beats counting.
+assert_output_hardened() {
+  local label="$1" output="$2" i key want got
+  for i in "${!PROTECTED_KEYS[@]}"; do
+    key="${PROTECTED_KEYS[$i]}"
+    want="${PROTECTED_VALUES[$i]}"
+    got="$(printf '%s\n' "$output" | awk -v k="$key" '$1 == k { print $2; exit }')"
+    if [[ -z $got ]]; then
+      add_failure "$label: '$key' is absent from the effective configuration"
+    elif [[ $got != "$want" ]]; then
+      add_failure "$label: '$key' is '$got', want '$want'"
+    fi
+  done
+}
+
+check_global() {
+  local output status=0
+  # Capture first, inspect after: the exit status of a piped sshd would be
+  # lost to the pipeline's last element.
+  output="$("$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    add_failure "global check: '$SSHD_BIN -G' exited $status; failing closed rather than assuming the tree is safe (output: $output)"
+    return 0
+  fi
+  assert_output_hardened 'global check' "$output"
+}
+
+# scan_file_for_match_reenable <file>: flag every protected directive set to a
+# non-required value inside a Match block. Normalization mirrors sshd's parser
+# (all verified against OpenSSH 10.0p2): keywords are case-insensitive, one
+# '=' may replace the separating whitespace, arguments may be double-quoted,
+# and the deprecated ChallengeResponseAuthentication alias still flips
+# kbdinteractiveauthentication. A Match block does NOT extend into the next
+# included file (verified empirically), so the in-Match state is per file.
+scan_file_for_match_reenable() {
+  local file="$1" in_match=0 key value _ want content status=0
+  content="$(tr '=\t' '  ' <"$file" | tr '[:upper:]' '[:lower:]')" || status=$?
+  if [[ $status -ne 0 ]]; then
+    add_failure "match scan: cannot read '$file'; failing closed rather than treating it as clean"
+    return 0
+  fi
+  while read -r key value _; do
+    [[ -n $key ]] || continue
+    case $key in '#'*) continue ;; esac
+    if [[ $key == match ]]; then
+      in_match=1
+      continue
+    fi
+    [[ $in_match -eq 1 ]] || continue
+    value="${value#\"}"
+    value="${value%\"}"
+    if [[ $key == challengeresponseauthentication ]]; then
+      key=kbdinteractiveauthentication
+    fi
+    if want="$(required_value "$key")" && [[ $value != "$want" ]]; then
+      add_failure "match scan: '$file' sets '$key $value' inside a Match block (want '$want'); a Match-scoped re-enable bypasses the global check"
+    fi
+  done <<<"$content"
+}
+
+check_match_scan() {
+  local file
+  # The include order is lexical byte order; LC_ALL=C sort mirrors it. A
+  # config file name containing a newline would break this listing; sshd's
+  # own glob handling shares the no-newline assumption.
+  while IFS= read -r file; do
+    [[ -n $file && -f $file ]] || continue
+    scan_file_for_match_reenable "$file"
+  done < <(printf '%s\n' "$SSHD_MAIN_CONFIG" "$SSHD_CONFIG_D"/* | LC_ALL=C sort -u)
+}
+
+check_connection_specs() {
+  local invoking_user spec output status
+  invoking_user="$(id -un)"
+  # Two samples: root (the account PermitRootLogin exists to keep out) and
+  # the invoking user (so a 'Match User <name>' aimed at the operator's own
+  # account fails RESOLUTION, not only the raw scan). Samples cannot be
+  # exhaustive; check_match_scan is the completeness net behind them.
+  for spec in \
+    'user=root,host=localhost,addr=127.0.0.1' \
+    "user=$invoking_user,host=localhost,addr=127.0.0.1"; do
+    status=0
+    # -G -T -C: on OpenSSH 10.0p2, -C without -T is rejected and -T alone
+    # demands host keys; the three together resolve Match blocks for the spec
+    # with no privilege and no host keys (verified empirically).
+    output="$("$SSHD_BIN" -G -T -C "$spec" -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+    if [[ $status -ne 0 ]]; then
+      add_failure "connection check ($spec): '$SSHD_BIN -G -T -C' exited $status; failing closed (output: $output)"
+      continue
+    fi
+    assert_output_hardened "connection check ($spec)" "$output"
+  done
+}
+
+verify() {
+  VERIFY_FAILURES=()
+  VERIFY_SKIPPED=0
+  if [[ ! -x $SSHD_BIN ]]; then
+    if [[ -n ${SSH_HARDENING_ALLOW_MISSING_SSHD:-} ]]; then
+      VERIFY_SKIPPED=1
+      printf '[ssh-hardening] verify SKIPPED: %s is not executable and the SSH_HARDENING_ALLOW_MISSING_SSHD test seam is set. The configuration was NOT checked.\n' "$SSHD_BIN"
+      return 0
+    fi
+    printf '[ssh-hardening] verify: FAILING CLOSED: %s is not executable, so the effective configuration cannot be checked. Refusing to guess.\n' "$SSHD_BIN" >&2
+    return 1
+  fi
+  check_global
+  check_match_scan
+  check_connection_specs
+  if [[ ${#VERIFY_FAILURES[@]} -gt 0 ]]; then
+    printf '[ssh-hardening] verify FAILED, %d problem(s):\n' "${#VERIFY_FAILURES[@]}" >&2
+    printf '  - %s\n' "${VERIFY_FAILURES[@]}" >&2
+    return 1
+  fi
+  printf '[ssh-hardening] verify: PASS: all five directives hold globally, no Match block re-enables any of them, and both sampled connections resolve hardened.\n'
+}
+
+# --- install -----------------------------------------------------------------
+
+install_dropin() {
+  local target legacy
+  target="$(dropin_path)"
+  legacy="$SSHD_CONFIG_D/$LEGACY_DROPIN_NAME"
+  [[ -d $SSHD_CONFIG_D ]] ||
+    die "drop-in directory '$SSHD_CONFIG_D' does not exist"
+  if ! print_config | run_privileged tee -- "$target" >/dev/null; then
+    die "could not write '$target'"
+  fi
+  # Explicit mode, never the ambient umask: under e.g. umask 0077 tee lands
+  # the file 0600, and a root-owned 0600 drop-in makes UNPRIVILEGED `sshd -G`
+  # fail outright, so the whole verification would need elevation. 0644 is
+  # safe: the file holds no credential and sshd must be able to read it.
+  # `--` BEFORE the mode: BSD chmod treats a `--` after the mode as a file
+  # operand and fails.
+  if ! run_privileged chmod -- 0644 "$target"; then
+    die "could not set mode 0644 on '$target'"
+  fi
+  printf '[ssh-hardening] wrote %s (mode 0644)\n' "$target"
+  # Migrate the legacy drop-in away. Two reasons: one lock in one file (two
+  # files declaring the same policy is drift waiting to happen), and the
+  # legacy file was created 0600 under the umask, which breaks unprivileged
+  # verification for the entire tree (see the chmod comment above).
+  if [[ -e $legacy || -L $legacy ]]; then
+    if ! run_privileged rm -f -- "$legacy"; then
+      die "could not remove the legacy drop-in '$legacy'"
+    fi
+    printf '[ssh-hardening] removed legacy drop-in %s\n' "$legacy"
+  fi
+  if ! verify; then
+    die "wrote '$target' but the effective configuration did NOT verify as fully hardened; refusing to claim success"
+  fi
+  if [[ $VERIFY_SKIPPED -eq 1 ]]; then
+    printf '[ssh-hardening] wrote %s, but verification was SKIPPED via the test seam; the effective configuration is NOT verified.\n' "$target"
+    return 0
+  fi
+  printf '[ssh-hardening] install complete: %s is in place and the effective configuration verified fully hardened.\n' "$target"
+}
+
+usage() {
+  cat <<'EOF'
+usage: ssh-hardening.sh [--print-config | --print-path | --verify]
+
+  --print-config  print the generated drop-in content and exit
+  --print-path    print the drop-in target path and exit
+  --verify        read-only check that the effective sshd configuration is
+                  fully hardened; never writes, never escalates
+  (no argument)   install the drop-in and verify
+
+Reloading a running sshd is deliberately not provided here; the drop-in
+takes effect when sshd next starts.
+EOF
+}
+
+main() {
+  if [[ $# -gt 1 ]]; then
+    usage >&2
+    exit 2
+  fi
+  case "${1-}" in
+    --print-config) print_config ;;
+    --print-path) dropin_path ;;
+    --verify) verify ;;
+    '') install_dropin ;;
+    --help | -h) usage ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -45,8 +45,30 @@ SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 # which is how tests write into a user-owned sandbox without privilege.
 SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
 
+# sshd resolves a RELATIVE Include argument against its compiled-in
+# configuration directory, not the working directory (verified two ways: a
+# matching file in the working directory is ignored, and `Include
+# sshd_config.d/*` from a sandbox main config reproduces the live /etc/ssh
+# resolution exactly). That directory is the one holding the default main
+# config, so deriving it from SSHD_MAIN_CONFIG is faithful in production and
+# follows the seam in a sandbox.
+SSHD_CONFIG_DIR="${SSHD_MAIN_CONFIG%/*}"
+if [[ $SSHD_CONFIG_DIR == "$SSHD_MAIN_CONFIG" ]]; then
+  SSHD_CONFIG_DIR='.'
+fi
+
 DROPIN_NAME="000-ssh-hardening.conf"
 LEGACY_DROPIN_NAME="50-no-password-auth.conf"
+
+# sshd refuses a configuration nested deeper than this many Include levels
+# ("Too many recursive configuration includes"; measured: a chain of 16 files
+# below the main config is refused, 15 is accepted). The scan stops at the
+# same depth and FAILS rather than returning quietly, so an include bomb
+# cannot shrink the scanned set into a pass. Drop-in roots are entered at
+# depth 0 where sshd reaches them at depth 1, which makes the scan tolerate
+# one level more than sshd from that root -- harmless, because a tree sshd
+# refuses fails check_global anyway.
+MAX_INCLUDE_DEPTH=15
 
 # The five protected directives and their required values, lowercase exactly
 # as `sshd -G` prints them. Parallel arrays because the deployed interpreter
@@ -127,13 +149,28 @@ EOF
 #      Catches a global re-enable anywhere in the include chain, including a
 #      sibling that sorts before the drop-in (first-value-wins). It cannot
 #      see Match blocks at all, which is why the next two exist.
-#   2. check_match_scan: a raw scan of the main config and every drop-in for
-#      a Match block that re-enables a protected directive. The completeness
-#      net: it flags ANY Match-scoped re-enable, including forms on subnets
-#      or users the connection samples below never probe.
+#   2. check_match_scan: a text scan for a Match block that re-enables a
+#      protected directive, walking the SAME include graph sshd walks.
 #   3. check_connection_specs: per-connection resolution via
 #      `sshd -G -T -C`. Proves Match blocks RESOLVE hardened for concrete
-#      connections (root and the invoking user); samples only, by nature.
+#      connections (root and the invoking user).
+#
+# What these three do and do NOT cover, stated plainly because the comment
+# that used to sit here claimed a completeness the code did not have. It
+# called the scan "the completeness net", and readers stopped checking:
+#
+#   - The connection specs are SAMPLES. Two loopback connections. A Match
+#     block scoped to any other address or user is not resolved by them at
+#     all, by construction, and no number of samples changes that.
+#   - The scan is not a completeness proof either. It is a text scan whose
+#     fidelity is bounded by how exactly the tokenizer matches sshd's own
+#     parser and how exactly the Include walk matches sshd's. Both were
+#     derived from the behaviour of the real binary rather than from the
+#     manual page, and the forms sshd REJECTS are left to check_global: a
+#     file sshd refuses fails `sshd -G`, which is check_global's whole job.
+#   - Where the scan cannot see -- an unreadable file, a listing it could not
+#     build, an Include cycle, a chain deeper than sshd accepts -- it FAILS
+#     rather than scanning a subset and reporting clean.
 #
 # Any check that cannot run FAILS the verify. A skip exists only behind the
 # SSH_HARDENING_ALLOW_MISSING_SSHD test seam and never claims verified.
@@ -141,7 +178,19 @@ EOF
 VERIFY_FAILURES=()
 VERIFY_SKIPPED=0
 
+# add_failure <message>: record a problem once. The include graph is walked
+# from both roots, so a drop-in reached through the main config's Include and
+# again as a root of its own would otherwise report every problem twice and
+# inflate the count the summary prints.
 add_failure() {
+  local existing
+  if [[ ${#VERIFY_FAILURES[@]} -gt 0 ]]; then
+    for existing in "${VERIFY_FAILURES[@]}"; do
+      if [[ $existing == "$1" ]]; then
+        return 0
+      fi
+    done
+  fi
   VERIFY_FAILURES+=("$1")
 }
 
@@ -319,13 +368,83 @@ parse_config_line() {
   return 0
 }
 
-# scan_file_for_match_reenable <file>: flag every protected directive set to a
-# non-required value inside a Match block. The deprecated
-# ChallengeResponseAuthentication alias still flips kbdinteractiveauthentication
-# in sshd, so it is folded onto its target. A Match block does NOT extend into
-# the next included file, so the in-Match state is per file.
-scan_file_for_match_reenable() {
-  local file="$1" in_match=0 key value status=0 line
+# scan_included_files <including file> <in-match> <depth> <chain>: follow the
+# Include whose arguments are sitting in PARSED_ARGS.
+#
+# Include semantics, every one measured against OpenSSH 10.0p2 rather than
+# assumed:
+#
+#   - The Match state in force where the Include appears APPLIES INSIDE the
+#     included file. An `Include` under `Match Address *,!127.0.0.1` really
+#     does re-enable password authentication for off-loopback addresses. The
+#     comment that used to sit here claimed the opposite, and it was wrong:
+#     the probe behind it tested a Match not reaching the NEXT included file,
+#     which is a different question with a different answer.
+#   - A Match opened inside the included file does NOT persist back into the
+#     including file once the Include returns. The state is therefore passed
+#     down by value, and the caller's copy is deliberately left alone.
+#   - One Include line may carry several paths, applied left to right.
+#   - A relative path resolves against sshd's configuration directory, not the
+#     working directory.
+#   - A path matching nothing is ignored, exactly as sshd ignores it. A file
+#     that exists but cannot be read is fatal to sshd, and scan_config_file
+#     treats it as fatal too.
+scan_included_files() {
+  local from="$1" in_match="$2" depth="$3" chain="$4"
+  local pattern resolved old_ifs
+  local -a patterns matches
+  patterns=()
+  if [[ ${#PARSED_ARGS[@]} -gt 0 ]]; then
+    patterns=("${PARSED_ARGS[@]}")
+  fi
+  if [[ ${#patterns[@]} -eq 0 ]]; then
+    add_failure "match scan: '$from' has an Include with no path; failing closed rather than guessing what it pulls in"
+    return 0
+  fi
+  for pattern in "${patterns[@]}"; do
+    case $pattern in
+      /*) ;;
+      *) pattern="$SSHD_CONFIG_DIR/$pattern" ;;
+    esac
+    # IFS=newline so a path containing spaces survives the split while the
+    # glob still expands: pathname expansion produces its own fields whatever
+    # IFS holds. A pattern matching nothing stays literal and is dropped by
+    # the -f test below, which is what sshd does with it.
+    old_ifs="$IFS"
+    IFS=$'\n'
+    # shellcheck disable=SC2206  # deliberate glob expansion of the Include pattern
+    matches=($pattern)
+    IFS="$old_ifs"
+    if [[ ${#matches[@]} -eq 0 ]]; then
+      continue
+    fi
+    for resolved in "${matches[@]}"; do
+      if [[ ! -f $resolved ]]; then
+        continue
+      fi
+      scan_config_file "$resolved" "$in_match" "$((depth + 1))" "$chain"
+    done
+  done
+}
+
+# scan_config_file <file> <in-match> <depth> <chain>: flag every protected
+# directive set to a non-required value inside a Match block, following Include
+# as it goes. <chain> is the '|'-delimited list of files already open on this
+# include path, so a cycle is reported rather than walked.
+scan_config_file() {
+  local file="$1" in_match="$2" depth="$3" chain="$4"
+  local key value status=0 line
+  if [[ $depth -gt $MAX_INCLUDE_DEPTH ]]; then
+    add_failure "match scan: '$file' sits more than $MAX_INCLUDE_DEPTH Include levels deep; sshd refuses a tree that deep and this scan refuses to report on part of one"
+    return 0
+  fi
+  case $chain in
+    *"|$file|"*)
+      add_failure "match scan: Include cycle returning to '$file'; failing closed rather than scanning part of the tree"
+      return 0
+      ;;
+  esac
+  chain="$chain$file|"
   if [[ ! -r $file ]]; then
     add_failure "match scan: cannot read '$file'; failing closed rather than treating it as clean"
     return 0
@@ -333,6 +452,10 @@ scan_file_for_match_reenable() {
   # Read the file directly. No here-string: bash materializes one in a
   # temporary file, so a full or unwritable TMPDIR would feed the loop zero
   # lines and the scan would report a hostile file clean.
+  #
+  # shellcheck disable=SC2094  # $file is passed to the recursive call for the
+  # message it prints; nothing in this verifier ever opens a config file for
+  # writing, and the scan is read-only by design.
   while IFS= read -r line || [[ -n $line ]]; do
     if ! parse_config_line "$line"; then
       continue
@@ -340,6 +463,10 @@ scan_file_for_match_reenable() {
     key="$PARSED_KEYWORD"
     if [[ $key == match ]]; then
       in_match=1
+      continue
+    fi
+    if [[ $key == include ]]; then
+      scan_included_files "$file" "$in_match" "$depth" "$chain"
       continue
     fi
     if [[ $in_match -ne 1 ]]; then
@@ -362,12 +489,19 @@ scan_file_for_match_reenable() {
 
 check_match_scan() {
   local file
+  # Two roots, each walked with Include followed from it. The main config is
+  # where sshd starts, so everything sshd reads is reachable from it. The
+  # drop-in directory is kept as a second root so a drop-in stays covered even
+  # if the main config is unreadable or its Include pattern resolves
+  # differently than this scan computes; a file reached from both roots
+  # reports once (see add_failure).
+  #
   # The include order is lexical byte order; LC_ALL=C sort mirrors it. A
   # config file name containing a newline would break this listing; sshd's
   # own glob handling shares the no-newline assumption.
   while IFS= read -r file; do
     [[ -n $file && -f $file ]] || continue
-    scan_file_for_match_reenable "$file"
+    scan_config_file "$file" 0 0 '|'
   done < <(printf '%s\n' "$SSHD_MAIN_CONFIG" "$SSHD_CONFIG_D"/* | LC_ALL=C sort -u)
 }
 

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -31,6 +31,13 @@
 #                       unrunnable verifier fails closed.
 set -euo pipefail
 
+# sshd matches configuration keywords AND their yes/no arguments
+# case-insensitively: `PASSWORDauthentication YES` inside a Match block
+# resolves to yes on OpenSSH 10.0p2. nocasematch lets every [[ ]] and case
+# comparison below mirror that. The raw line is NEVER case-folded, because
+# Include arguments are filenames and must keep their case.
+shopt -s nocasematch
+
 SSHD_CONFIG_D="${SSHD_CONFIG_D:-/etc/ssh/sshd_config.d}"
 SSHD_MAIN_CONFIG="${SSHD_MAIN_CONFIG:-/etc/ssh/sshd_config}"
 SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
@@ -118,13 +125,23 @@ add_failure() {
   VERIFY_FAILURES+=("$1")
 }
 
-# required_value <lowercase-key>: print the required value, or return 1 for a
-# key that is not protected.
+# required_value <key>: for a protected directive, set MATCHED_PROTECTED_KEY to
+# its canonical lowercase spelling and REQUIRED_VALUE to the value policy
+# demands, then return 0. Return 1 for a key that is not protected.
+#
+# Globals rather than a printed result for two reasons: this runs once per
+# in-Match directive line, and a command substitution per line is a fork per
+# line; and the canonical spelling is what every failure message should name,
+# so a file writing `PASSWORDauthentication` is reported against the same
+# directive name as one writing it in lowercase.
+MATCHED_PROTECTED_KEY=''
+REQUIRED_VALUE=''
 required_value() {
   local i
   for i in "${!PROTECTED_KEYS[@]}"; do
     if [[ $1 == "${PROTECTED_KEYS[$i]}" ]]; then
-      printf '%s\n' "${PROTECTED_VALUES[$i]}"
+      MATCHED_PROTECTED_KEY="${PROTECTED_KEYS[$i]}"
+      REQUIRED_VALUE="${PROTECTED_VALUES[$i]}"
       return 0
     fi
   done
@@ -161,37 +178,153 @@ check_global() {
   assert_output_hardened 'global check' "$output"
 }
 
+# --- sshd configuration tokenizer --------------------------------------------
+# OpenSSH 10.0p2 splits a configuration line the way strdelim() does: space,
+# tab and CARRIAGE RETURN all separate tokens; a token that opens with a
+# double quote runs to its closing quote; and a single '=' may stand in for
+# the whitespace after the keyword. Every one of those forms was confirmed to
+# parse AND to resolve the unsafe value against the real binary, including the
+# two that defeated the previous scanner:
+#
+#   "PasswordAuthentication" yes      quotes around the KEYWORD, not the value
+#   Match<CR>Address *,!127.0.0.1     a carriage return inside the Match line
+#
+# Vertical tab, form feed, a second '=', a quote in the middle of a keyword
+# and a whole-line quote are all REJECTED by sshd (also verified), so they
+# need no handling here: a file carrying them fails `sshd -G`, and reporting
+# that is check_global's job.
+#
+# The line is tokenized rather than bulk-normalized. Bulk normalization is
+# what let the quoted keyword through: quotes were stripped from the value
+# only, and a `tr` that folded case and separators could not tell a keyword
+# from a value in the first place.
+
+CONFIG_TAB=$'\t'
+CONFIG_CR=$'\r'
+TOKEN=''
+REST=''
+
+# next_token <break-on-equals: 0|1>: pull the next token off REST into TOKEN.
+# Returns 1 at end of line and 2 for an unterminated quote (a form sshd
+# rejects outright, so the file fails check_global).
+next_token() {
+  local break_equals="$1" char start_length="${#REST}"
+  while [[ -n $REST ]]; do
+    case $REST in
+      ' '* | "$CONFIG_TAB"* | "$CONFIG_CR"*) REST="${REST:1}" ;;
+      *) break ;;
+    esac
+  done
+  if [[ -z $REST ]]; then
+    return 1
+  fi
+  TOKEN=''
+  if [[ $REST == '"'* ]]; then
+    REST="${REST:1}"
+    case $REST in
+      *'"'*) ;;
+      *) return 2 ;;
+    esac
+    TOKEN="${REST%%\"*}"
+    REST="${REST#*\"}"
+    return 0
+  fi
+  while [[ -n $REST ]]; do
+    char="${REST:0:1}"
+    case $char in
+      ' ' | "$CONFIG_TAB" | "$CONFIG_CR" | '"') break ;;
+    esac
+    if [[ $break_equals -eq 1 && $char == '=' ]]; then
+      break
+    fi
+    TOKEN="$TOKEN$char"
+    REST="${REST:1}"
+  done
+  # A successful token must have consumed input. Reporting success without
+  # advancing REST would spin the caller's loop forever, and a verifier that
+  # HANGS never reports -- strictly worse than one that misreads a line. The
+  # quoted branch above means no input reaches here without advancing, so this
+  # is a guard against a future edit to that branch, not a live condition.
+  if [[ ${#REST} -eq $start_length ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# parse_config_line <raw line>: fill PARSED_KEYWORD (quotes stripped) and
+# PARSED_ARGS. Returns 1 for a blank line, a comment, or a line sshd itself
+# would reject.
+PARSED_KEYWORD=''
+PARSED_ARGS=()
+parse_config_line() {
+  REST="$1"
+  PARSED_KEYWORD=''
+  PARSED_ARGS=()
+  if ! next_token 1; then
+    return 1
+  fi
+  PARSED_KEYWORD="$TOKEN"
+  # Only a '#' at the start of the first token opens a comment.
+  case $PARSED_KEYWORD in
+    '#'*) return 1 ;;
+  esac
+  # A single '=' may replace the whitespace after the keyword.
+  while [[ -n $REST ]]; do
+    case $REST in
+      ' '* | "$CONFIG_TAB"* | "$CONFIG_CR"*) REST="${REST:1}" ;;
+      *) break ;;
+    esac
+  done
+  if [[ $REST == '='* ]]; then
+    REST="${REST:1}"
+  fi
+  while next_token 0; do
+    PARSED_ARGS+=("$TOKEN")
+  done
+  return 0
+}
+
 # scan_file_for_match_reenable <file>: flag every protected directive set to a
-# non-required value inside a Match block. Normalization mirrors sshd's parser
-# (all verified against OpenSSH 10.0p2): keywords are case-insensitive, one
-# '=' may replace the separating whitespace, arguments may be double-quoted,
-# and the deprecated ChallengeResponseAuthentication alias still flips
-# kbdinteractiveauthentication. A Match block does NOT extend into the next
-# included file (verified empirically), so the in-Match state is per file.
+# non-required value inside a Match block. The deprecated
+# ChallengeResponseAuthentication alias still flips kbdinteractiveauthentication
+# in sshd, so it is folded onto its target. A Match block does NOT extend into
+# the next included file, so the in-Match state is per file.
 scan_file_for_match_reenable() {
-  local file="$1" in_match=0 key value _ want content status=0
-  content="$(tr '=\t' '  ' <"$file" | tr '[:upper:]' '[:lower:]')" || status=$?
-  if [[ $status -ne 0 ]]; then
+  local file="$1" in_match=0 key value status=0 line
+  if [[ ! -r $file ]]; then
     add_failure "match scan: cannot read '$file'; failing closed rather than treating it as clean"
     return 0
   fi
-  while read -r key value _; do
-    [[ -n $key ]] || continue
-    case $key in '#'*) continue ;; esac
+  # Read the file directly. No here-string: bash materializes one in a
+  # temporary file, so a full or unwritable TMPDIR would feed the loop zero
+  # lines and the scan would report a hostile file clean.
+  while IFS= read -r line || [[ -n $line ]]; do
+    if ! parse_config_line "$line"; then
+      continue
+    fi
+    key="$PARSED_KEYWORD"
     if [[ $key == match ]]; then
       in_match=1
       continue
     fi
-    [[ $in_match -eq 1 ]] || continue
-    value="${value#\"}"
-    value="${value%\"}"
+    if [[ $in_match -ne 1 ]]; then
+      continue
+    fi
+    if [[ ${#PARSED_ARGS[@]} -gt 0 ]]; then
+      value="${PARSED_ARGS[0]}"
+    else
+      value=''
+    fi
     if [[ $key == challengeresponseauthentication ]]; then
       key=kbdinteractiveauthentication
     fi
-    if want="$(required_value "$key")" && [[ $value != "$want" ]]; then
-      add_failure "match scan: '$file' sets '$key $value' inside a Match block (want '$want'); a Match-scoped re-enable bypasses the global check"
+    if required_value "$key" && [[ $value != "$REQUIRED_VALUE" ]]; then
+      add_failure "match scan: '$file' sets '$MATCHED_PROTECTED_KEY $value' inside a Match block (want '$REQUIRED_VALUE'); a Match-scoped re-enable bypasses the global check"
     fi
-  done <<<"$content"
+  done <"$file" || status=$?
+  if [[ $status -ne 0 ]]; then
+    add_failure "match scan: reading '$file' failed (exit $status); failing closed rather than treating a partial read as clean"
+  fi
 }
 
 check_match_scan() {

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# ssh-hardening-lib.bash - sandbox harness for dot_local/bin/executable_ssh-hardening.sh.
+#
+# Every test drives the script against a scratch sshd_config.d tree through the
+# SSHD_CONFIG_D / SSHD_MAIN_CONFIG / SSH_HARDENING_SUDO seams and NEVER touches
+# /etc/ssh. Two independent guards keep even a regressed script away from the
+# live tree:
+#
+#   1. SSH_HARDENING_SUDO is exported EMPTY, so the script performs its writes
+#      unprivileged inside the user-owned sandbox; a write to /etc/ssh would
+#      need privilege the test never grants.
+#   2. A deliberately FAILING `sudo` stub is prepended to PATH and records every
+#      invocation, so a regressed script that runs a bare `sudo tee
+#      /etc/ssh/...` fails loudly (exit 97) instead of reaching the live tree,
+#      and the spy log convicts it.
+#
+# Every invocation goes through run_ssh_hardening below, which runs the script
+# via /bin/bash: the deployed script runs under the system bash 3.2, so a
+# bashism from a newer bash must fail here, not on the machine.
+
+# Path to the script under test, resolved from this library's location.
+SSH_HARDENING_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dot_local/bin/executable_ssh-hardening.sh"
+
+# ssh_sandbox_setup: build the scratch tree and export the seams.
+# Exports SSH_SANDBOX, SSHD_CONFIG_D, SSHD_MAIN_CONFIG, SSH_HARDENING_SUDO,
+# SSH_SUDO_SPY_LOG; prepends the failing sudo stub to PATH.
+ssh_sandbox_setup() {
+  SSH_SANDBOX="$(mktemp -d)"
+  SSHD_CONFIG_D="$SSH_SANDBOX/sshd_config.d"
+  SSHD_MAIN_CONFIG="$SSH_SANDBOX/sshd_config"
+  SSH_SUDO_SPY_LOG="$SSH_SANDBOX/sudo-spy.log"
+  mkdir -p "$SSHD_CONFIG_D" "$SSH_SANDBOX/bin"
+  printf 'Include %s/*\n' "$SSHD_CONFIG_D" >"$SSHD_MAIN_CONFIG"
+  cat >"$SSH_SANDBOX/bin/sudo" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${SSH_SUDO_SPY_LOG:?}"
+echo 'sudo: blocked by test stub (tests must never escalate)' >&2
+exit 97
+STUB
+  chmod +x "$SSH_SANDBOX/bin/sudo"
+  : >"$SSH_SUDO_SPY_LOG"
+  PATH="$SSH_SANDBOX/bin:$PATH"
+  SSH_HARDENING_SUDO=""
+  export SSH_SANDBOX SSHD_CONFIG_D SSHD_MAIN_CONFIG SSH_HARDENING_SUDO \
+    SSH_SUDO_SPY_LOG PATH
+}
+
+ssh_sandbox_teardown() {
+  [[ -n ${SSH_SANDBOX:-} ]] && rm -rf "$SSH_SANDBOX"
+}
+
+# run_ssh_hardening <args...>: run the script under /bin/bash, capturing
+# stdout, stderr, and the exit status into SSH_RUN_OUT / SSH_RUN_ERR /
+# SSH_RUN_STATUS. Never lets a nonzero status kill the calling test.
+# shellcheck disable=SC2034  # the three run results are read by the sourcing test
+run_ssh_hardening() {
+  local out_file="$SSH_SANDBOX/run.out" err_file="$SSH_SANDBOX/run.err"
+  SSH_RUN_STATUS=0
+  /bin/bash "$SSH_HARDENING_SCRIPT" "$@" >"$out_file" 2>"$err_file" ||
+    SSH_RUN_STATUS=$?
+  SSH_RUN_OUT="$(cat "$out_file")"
+  SSH_RUN_ERR="$(cat "$err_file")"
+}
+
+# write_hostile_apple_conf: a 100-macos.conf that reopens EVERY hole the
+# drop-in closes. Deliberately hostile, unlike the benign file Apple really
+# ships (which sets only UsePAM, AcceptEnv, and the sftp Subsystem): the
+# rename to 000- is insurance against a future Apple file competing on these
+# directives, and the guard must prove precedence against the worst case, not
+# against today's harmless reality.
+write_hostile_apple_conf() {
+  cat >"$SSHD_CONFIG_D/100-macos.conf" <<'EOF'
+PasswordAuthentication yes
+KbdInteractiveAuthentication yes
+UsePAM no
+PubkeyAuthentication no
+PermitRootLogin yes
+EOF
+}
+
+# effective_global_value <lowercase-key>: the test's OWN sshd -G resolution
+# against the sandbox tree, independent of the script under test. Prints the
+# effective value; fails if sshd -G itself fails.
+effective_global_value() {
+  local output
+  output="$(/usr/sbin/sshd -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || {
+    printf 'sshd -G failed: %s\n' "$output" >&2
+    return 1
+  }
+  printf '%s\n' "$output" | awk -v k="$1" '$1 == k { print $2; exit }'
+}
+
+# assert_no_sudo_and_no_sandbox_write <label> <expected-listing>: the sudo spy
+# never fired and the sandbox config tree still matches the given `ls -A`
+# listing (purity check for the print modes).
+assert_no_sudo_and_no_sandbox_write() {
+  local label="$1" expected_listing="$2" actual_listing
+  if [[ -s $SSH_SUDO_SPY_LOG ]]; then
+    printf 'FAIL: %s escalated privilege; sudo spy log: %s\n' \
+      "$label" "$(cat "$SSH_SUDO_SPY_LOG")" >&2
+    return 1
+  fi
+  actual_listing="$(ls -A "$SSHD_CONFIG_D")"
+  if [[ $actual_listing != "$expected_listing" ]]; then
+    printf 'FAIL: %s wrote into the sandbox config dir (before: %s; after: %s)\n' \
+      "$label" "$expected_listing" "$actual_listing" >&2
+    return 1
+  fi
+}

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -69,6 +69,37 @@ run_ssh_hardening() {
   SSH_RUN_ERR="$(cat "$err_file")"
 }
 
+# run_ssh_hardening_bounded <seconds> <args...>: run_ssh_hardening with a wall
+# clock. If the script has not finished inside <seconds> it is killed and
+# SSH_RUN_TIMED_OUT is set to 1, so a test can assert TERMINATION as a
+# property instead of hanging the whole suite.
+#
+# No timeout(1): coreutils is not on a stock macOS runner, and a bound that
+# only holds where Homebrew is installed is not a bound.
+# shellcheck disable=SC2034  # the run results are read by the sourcing test
+run_ssh_hardening_bounded() {
+  local limit="$1"
+  shift
+  local out_file="$SSH_SANDBOX/run.out" err_file="$SSH_SANDBOX/run.err"
+  local child waited=0 deadline=$((limit * 10))
+  SSH_RUN_TIMED_OUT=0
+  SSH_RUN_STATUS=0
+  /bin/bash "$SSH_HARDENING_SCRIPT" "$@" >"$out_file" 2>"$err_file" &
+  child=$!
+  while kill -0 "$child" 2>/dev/null; do
+    if [[ $waited -ge $deadline ]]; then
+      kill -9 "$child" 2>/dev/null || true
+      SSH_RUN_TIMED_OUT=1
+      break
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  wait "$child" 2>/dev/null || SSH_RUN_STATUS=$?
+  SSH_RUN_OUT="$(cat "$out_file")"
+  SSH_RUN_ERR="$(cat "$err_file")"
+}
+
 # write_hostile_apple_conf: a 100-macos.conf that reopens EVERY hole the
 # drop-in closes. Deliberately hostile, unlike the benign file Apple really
 # ships (which sets only UsePAM, AcceptEnv, and the sftp Subsystem): the

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -4,16 +4,29 @@
 #
 # Every test drives the script against a scratch sshd_config.d tree through the
 # SSHD_CONFIG_D / SSHD_MAIN_CONFIG / SSH_HARDENING_SUDO seams and NEVER touches
-# /etc/ssh. Two independent guards keep even a regressed script away from the
-# live tree:
+# /etc/ssh. Three layers keep even a regressed script away from the live tree.
+# They are NOT equivalent, and the difference matters, so each is described by
+# what it actually covers rather than by how reassuring it sounds:
 #
 #   1. SSH_HARDENING_SUDO is exported EMPTY, so the script performs its writes
-#      unprivileged inside the user-owned sandbox; a write to /etc/ssh would
-#      need privilege the test never grants.
-#   2. A deliberately FAILING `sudo` stub is prepended to PATH and records every
-#      invocation, so a regressed script that runs a bare `sudo tee
-#      /etc/ssh/...` fails loudly (exit 97) instead of reaching the live tree,
-#      and the spy log convicts it.
+#      directly instead of through a privilege wrapper. This is what lets the
+#      sandbox be written at all without privilege. It does NOT stop a
+#      regression that hard-codes a path: today every write goes through the
+#      seams, and that is a property of the script, not something this layer
+#      enforces.
+#   2. A deliberately FAILING `sudo` stub is prepended to PATH and records
+#      every invocation, so a regression that runs `sudo tee /etc/ssh/...`
+#      fails loudly (exit 97) and the spy log convicts it. It shadows only a
+#      PATH-RESOLVED `sudo`: a call to `/usr/bin/sudo` by absolute path, or one
+#      made after resetting PATH, walks straight past this layer.
+#   3. The layer that actually holds: the tests run UNPRIVILEGED and /etc/ssh
+#      is root-owned 0755, so a write there fails with EACCES no matter how the
+#      script attempts it. Layers 1 and 2 turn a violation into a loud, named
+#      failure; layer 3 is what makes the violation harmless in the first
+#      place.
+#
+# The spy log is checked after EVERY invocation, not only in the tests that are
+# about purity: escalation is a regression whatever a given test was measuring.
 #
 # Every invocation goes through run_ssh_hardening below, which runs the script
 # via /bin/bash: the deployed script runs under the system bash 3.2, so a
@@ -52,6 +65,16 @@ STUB
     SSH_SUDO_SPY_LOG PATH
 }
 
+# assert_no_escalation <context>: the sudo spy never fired. Called at the end
+# of every runner below, so no invocation can escalate unobserved.
+assert_no_escalation() {
+  if [[ -s ${SSH_SUDO_SPY_LOG:-/dev/null} ]]; then
+    printf 'FAIL: the script escalated privilege during %s; sudo spy log:\n%s\n' \
+      "$1" "$(cat "$SSH_SUDO_SPY_LOG")" >&2
+    exit 1
+  fi
+}
+
 ssh_sandbox_teardown() {
   [[ -n ${SSH_SANDBOX:-} ]] && rm -rf "$SSH_SANDBOX"
 }
@@ -67,6 +90,7 @@ run_ssh_hardening() {
     SSH_RUN_STATUS=$?
   SSH_RUN_OUT="$(cat "$out_file")"
   SSH_RUN_ERR="$(cat "$err_file")"
+  assert_no_escalation "run_ssh_hardening $*"
 }
 
 # run_ssh_hardening_bounded <seconds> <args...>: run_ssh_hardening with a wall
@@ -98,6 +122,7 @@ run_ssh_hardening_bounded() {
   wait "$child" 2>/dev/null || SSH_RUN_STATUS=$?
   SSH_RUN_OUT="$(cat "$out_file")"
   SSH_RUN_ERR="$(cat "$err_file")"
+  assert_no_escalation "run_ssh_hardening_bounded $*"
 }
 
 # run_ssh_hardening_without <command> <args...>: run the script with ONE
@@ -123,6 +148,7 @@ run_ssh_hardening_without() {
   rm -f "$stub_dir/$broken"
   SSH_RUN_OUT="$(cat "$out_file")"
   SSH_RUN_ERR="$(cat "$err_file")"
+  assert_no_escalation "run_ssh_hardening_without $broken $*"
 }
 
 # write_hardened_dropin: put the policy file in place WITHOUT running install,

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -100,28 +100,29 @@ run_ssh_hardening_bounded() {
   SSH_RUN_ERR="$(cat "$err_file")"
 }
 
-# ssh_break_command <name>: shadow one external command with a stub that always
-# exits 91, at the FRONT of PATH, for every later invocation until
-# ssh_restore_commands runs. Used to inject the kind of environmental failure a
-# verifier must never step over.
-ssh_break_command() {
-  SSH_BROKEN_BIN="$SSH_SANDBOX/broken"
-  mkdir -p "$SSH_BROKEN_BIN"
-  printf '#!/bin/bash\nexit 91\n' >"$SSH_BROKEN_BIN/$1"
-  chmod +x "$SSH_BROKEN_BIN/$1"
-  case ":$PATH:" in
-    *":$SSH_BROKEN_BIN:"*) ;;
-    *)
-      PATH="$SSH_BROKEN_BIN:$PATH"
-      export PATH
-      ;;
-  esac
-}
-
-ssh_restore_commands() {
-  if [[ -n ${SSH_BROKEN_BIN:-} && -d ${SSH_BROKEN_BIN:-} ]]; then
-    rm -f "$SSH_BROKEN_BIN"/*
-  fi
+# run_ssh_hardening_without <command> <args...>: run the script with ONE
+# external command shadowed by a stub that always exits 91, so an
+# environmental failure can be injected exactly where it matters.
+#
+# The stub is on PATH only for the script's own invocation. Mutating the
+# test's PATH instead would break the harness itself the moment the injected
+# command is one the harness uses -- `cat`, for instance, which reads the
+# captured output back.
+# shellcheck disable=SC2034  # the run results are read by the sourcing test
+run_ssh_hardening_without() {
+  local broken="$1"
+  shift
+  local stub_dir="$SSH_SANDBOX/broken"
+  local out_file="$SSH_SANDBOX/run.out" err_file="$SSH_SANDBOX/run.err"
+  mkdir -p "$stub_dir"
+  printf '#!/bin/bash\nexit 91\n' >"$stub_dir/$broken"
+  chmod +x "$stub_dir/$broken"
+  SSH_RUN_STATUS=0
+  PATH="$stub_dir:$PATH" /bin/bash "$SSH_HARDENING_SCRIPT" "$@" \
+    >"$out_file" 2>"$err_file" || SSH_RUN_STATUS=$?
+  rm -f "$stub_dir/$broken"
+  SSH_RUN_OUT="$(cat "$out_file")"
+  SSH_RUN_ERR="$(cat "$err_file")"
 }
 
 # write_hardened_dropin: put the policy file in place WITHOUT running install,

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -100,6 +100,38 @@ run_ssh_hardening_bounded() {
   SSH_RUN_ERR="$(cat "$err_file")"
 }
 
+# ssh_break_command <name>: shadow one external command with a stub that always
+# exits 91, at the FRONT of PATH, for every later invocation until
+# ssh_restore_commands runs. Used to inject the kind of environmental failure a
+# verifier must never step over.
+ssh_break_command() {
+  SSH_BROKEN_BIN="$SSH_SANDBOX/broken"
+  mkdir -p "$SSH_BROKEN_BIN"
+  printf '#!/bin/bash\nexit 91\n' >"$SSH_BROKEN_BIN/$1"
+  chmod +x "$SSH_BROKEN_BIN/$1"
+  case ":$PATH:" in
+    *":$SSH_BROKEN_BIN:"*) ;;
+    *)
+      PATH="$SSH_BROKEN_BIN:$PATH"
+      export PATH
+      ;;
+  esac
+}
+
+ssh_restore_commands() {
+  if [[ -n ${SSH_BROKEN_BIN:-} && -d ${SSH_BROKEN_BIN:-} ]]; then
+    rm -f "$SSH_BROKEN_BIN"/*
+  fi
+}
+
+# write_hardened_dropin: put the policy file in place WITHOUT running install,
+# so a test can rebuild a known-good tree between cases without depending on
+# the very install path it is about to examine.
+write_hardened_dropin() {
+  /bin/bash "$SSH_HARDENING_SCRIPT" --print-config \
+    >"$SSHD_CONFIG_D/000-ssh-hardening.conf"
+}
+
 # write_hostile_apple_conf: a 100-macos.conf that reopens EVERY hole the
 # drop-in closes. Deliberately hostile, unlike the benign file Apple really
 # ships (which sets only UsePAM, AcceptEnv, and the sftp Subsystem): the

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -22,6 +22,12 @@
 # Path to the script under test, resolved from this library's location.
 SSH_HARDENING_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dot_local/bin/executable_ssh-hardening.sh"
 
+# A literal carriage return, for fixtures that exercise sshd's whitespace set
+# (misc.c WHITESPACE is " \t\r\n"). Named because a bare $'\r' inside a
+# fixture line is invisible in a diff and in a terminal.
+# shellcheck disable=SC2034  # read by the sourcing test, not by this library
+SSH_CARRIAGE_RETURN=$'\r'
+
 # ssh_sandbox_setup: build the scratch tree and export the seams.
 # Exports SSH_SANDBOX, SSHD_CONFIG_D, SSHD_MAIN_CONFIG, SSH_HARDENING_SUDO,
 # SSH_SUDO_SPY_LOG; prepends the failing sudo stub to PATH.
@@ -89,6 +95,19 @@ effective_global_value() {
     return 1
   }
   printf '%s\n' "$output" | awk -v k="$1" '$1 == k { print $2; exit }'
+}
+
+# effective_spec_value <connection-spec> <lowercase-key>: the same independent
+# resolution, but for one CONNECTION, so a Match block is applied. This is what
+# turns a hostile fixture from an assertion about text into a demonstration:
+# real sshd really does resolve the unsafe value for that spec.
+effective_spec_value() {
+  local output
+  output="$(/usr/sbin/sshd -G -T -C "$1" -f "$SSHD_MAIN_CONFIG" 2>&1)" || {
+    printf 'sshd -G -T -C %s failed: %s\n' "$1" "$output" >&2
+    return 1
+  }
+  printf '%s\n' "$output" | awk -v k="$2" '$1 == k { print $2; exit }'
 }
 
 # assert_no_sudo_and_no_sandbox_write <label> <expected-listing>: the sudo spy

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -113,8 +113,38 @@ KbdInteractiveAuthentication yes
 UsePAM no
 PubkeyAuthentication no
 PermitRootLogin yes
+GSSAPIAuthentication yes
+HostbasedAuthentication yes
 EOF
 }
+
+# The protected directives and the value policy demands, as one list every
+# test iterates. Kept here so adding a directive to the policy cannot leave a
+# guard silently checking the old, shorter set.
+# shellcheck disable=SC2034  # read by the sourcing tests, not by this library
+SSH_HARDENED_PAIRS=(
+  'passwordauthentication no'
+  'kbdinteractiveauthentication no'
+  'usepam yes'
+  'pubkeyauthentication yes'
+  'permitrootlogin no'
+  'gssapiauthentication no'
+  'hostbasedauthentication no'
+)
+
+# The value the hostile 100-macos.conf above sets for each of those, in the
+# same order: the exact opposite, so precedence is proven against the worst
+# case rather than against a file that agrees with policy by accident.
+# shellcheck disable=SC2034  # read by the sourcing tests, not by this library
+SSH_HOSTILE_PAIRS=(
+  'passwordauthentication yes'
+  'kbdinteractiveauthentication yes'
+  'usepam no'
+  'pubkeyauthentication no'
+  'permitrootlogin yes'
+  'gssapiauthentication yes'
+  'hostbasedauthentication yes'
+)
 
 # effective_global_value <lowercase-key>: the test's OWN sshd -G resolution
 # against the sandbox tree, independent of the script under test. Prints the

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -122,7 +122,9 @@ killall 'cfprefsd' 2>/dev/null || true
 GOLDEN_EOF
 
 # The Tier 2 runner's 5774ce0 render plus the firewall-baseline records
-# (global state first; stealth and both signed-software policies after it).
+# (global state first; stealth and both signed-software policies after it),
+# plus the SSH drop-in record the ssh-configuration slice declared (no sudo
+# prefix by design: the script escalates per operation itself).
 # No manual logging record: firewall logging on this macOS version is on by
 # default and cannot be enabled by hand, so nothing renders for it.
 tier2_golden="$work/tier2.golden"
@@ -148,6 +150,8 @@ echo "→ Firewall: auto-allow incoming connections for built-in signed software
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on
 echo "→ Firewall: auto-allow incoming connections for downloaded signed software"
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
+echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
+"$HOME/.local/bin/ssh-hardening.sh"
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 

--- a/test/integration/ssh-hardening-dropin-mode.sh
+++ b/test/integration/ssh-hardening-dropin-mode.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# ssh-hardening-dropin-mode.sh -- install pins the drop-in to mode 0644 even
+# under umask 0077 (slice 7). The mode is not tidiness: a root-owned 0600
+# drop-in makes UNPRIVILEGED `sshd -G` fail outright (permission denied), so
+# the entire three-way verification becomes unrunnable without elevation. An
+# explicit chmod, never the ambient umask, is what makes 0644 deterministic.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; install cannot verify\n'
+  exit 0
+}
+
+file_mode() { # <path> -> octal mode, portable across BSD and GNU stat
+  if stat -f '%Lp' "$1" 2>/dev/null; then
+    return 0
+  fi
+  stat -c '%a' "$1"
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# The hostile umask: without the explicit chmod, tee would land the file 0600.
+umask 0077
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "install must succeed (stderr: $SSH_RUN_ERR)"
+
+dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+[[ -f $dropin ]] || fail "install must write $dropin"
+mode="$(file_mode "$dropin")"
+[[ $mode == '644' ]] ||
+  fail "the drop-in must be pinned to 0644 under umask 0077, got 0$mode"
+
+printf 'ssh-hardening-dropin-mode: OK (0644 pinned by explicit chmod, umask 0077 notwithstanding)\n'

--- a/test/integration/ssh-hardening-dropin-mode.sh
+++ b/test/integration/ssh-hardening-dropin-mode.sh
@@ -23,12 +23,11 @@ fail() {
   exit 0
 }
 
-file_mode() { # <path> -> octal mode, portable across BSD and GNU stat
-  if stat -f '%Lp' "$1" 2>/dev/null; then
-    return 0
-  fi
-  stat -c '%a' "$1"
-}
+# file_mode <path> -> octal mode. GNU form first, BSD form as the fallback:
+# under the nix dev shell GNU coreutils shadows the system stat even on macOS,
+# and GNU's `-f` flag means "filesystem status", which SUCCEEDS with garbage
+# output instead of failing over. See test/test-system/stat-order.sh.
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 
 ssh_sandbox_setup
 trap 'ssh_sandbox_teardown' EXIT

--- a/test/integration/ssh-hardening-include-following.sh
+++ b/test/integration/ssh-hardening-include-following.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# ssh-hardening-include-following.sh -- --verify reads the configuration sshd
+# reads, not the two directories it was pointed at.
+#
+# The scan used to glob $SSHD_MAIN_CONFIG plus $SSHD_CONFIG_D/* and stop
+# there. sshd does not stop there: Include pulls in arbitrary paths, from
+# anywhere, and the Match state in force at the Include point carries INTO the
+# included file. Both shapes below were demonstrated against OpenSSH 10.0p2 as
+# working bypasses, and every case here proves itself the same way -- the test
+# resolves the tree with its own sshd and requires the unsafe value before it
+# asks whether --verify catches it.
+#
+#   a. Include reaching OUTSIDE the scanned set: a drop-in pulls in a file in
+#      another directory that opens a Match block and re-enables two
+#      directives. Nothing in the old scanned set contained a single hostile
+#      byte.
+#   b. Include INSIDE a Match block: the drop-in opens
+#      `Match Address *,!127.0.0.1` and includes a file holding nothing but
+#      `PasswordAuthentication yes`. sshd applies that directive inside the
+#      surrounding Match -- off-loopback resolves yes while loopback stays no,
+#      which is what makes it invisible to both connection samples.
+#   c. The state does NOT bleed back: a Match opened inside an included file
+#      must not leak into the including file after the Include returns. This
+#      one asserts a PASS, because the failure mode is a false positive, and a
+#      verifier that cries wolf is a verifier somebody turns off.
+#   d. An Include CYCLE fails closed, names itself as a cycle, and TERMINATES.
+#   e. A chain deeper than sshd itself accepts fails closed.
+#   f. A RELATIVE Include is resolved against sshd's configuration directory.
+#   g. Several paths on one Include line are all followed.
+#   h. A glob Include is expanded.
+#   i. A quoted Include path containing spaces survives tokenization.
+#
+# Case d is bounded by a wall clock rather than asserted after the fact: an
+# unguarded cycle does not fail, it never returns, and a verifier that hangs
+# reports nothing at all.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "install on a clean sandbox must succeed (stderr: $SSH_RUN_ERR)"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "positive control: --verify must PASS on the clean hardened tree (stderr: $SSH_RUN_ERR)"
+
+off_sample_spec='user=offsample,host=elsewhere.example,addr=198.51.100.23'
+loopback_spec='user=root,host=localhost,addr=127.0.0.1'
+outside_dir="$SSH_SANDBOX/outside"
+mkdir -p "$outside_dir"
+
+# assert_resolves <label> <spec> <key> <expected>: the test's own sshd, so a
+# fixture that sshd ignores cannot masquerade as a bypass.
+assert_resolves() {
+  local label="$1" spec="$2" key="$3" expected="$4" got
+  got="$(effective_spec_value "$spec" "$key")" ||
+    fail "$label: the test's own sshd could not resolve '$key' for '$spec'"
+  [[ $got == "$expected" ]] ||
+    fail "$label: real sshd must resolve '$key' as '$expected' for '$spec', got '$got'"
+}
+
+# assert_verify_fails_naming <label> <needle>...
+assert_verify_fails_naming() {
+  local label="$1" needle
+  shift
+  run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "$label: --verify must exit nonzero (stdout: $SSH_RUN_OUT)"
+  for needle in "$@"; do
+    grep -qF -- "$needle" <<<"$SSH_RUN_ERR" ||
+      fail "$label: stderr must contain '$needle' (stderr: $SSH_RUN_ERR)"
+  done
+}
+
+assert_verify_passes_again() {
+  run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -eq 0 ]] ||
+    fail "$1: --verify must PASS again once the fixture is removed; state leaked (stderr: $SSH_RUN_ERR)"
+}
+
+# --- a: Include reaching outside the scanned set -----------------------------
+
+included_evil="$outside_dir/evil-included"
+printf 'Match Address 198.51.100.0/24\n    PasswordAuthentication yes\n    PermitRootLogin yes\n' \
+  >"$included_evil"
+printf 'Include %s\n' "$included_evil" >"$SSHD_CONFIG_D/999-pull.conf"
+
+assert_resolves 'a: include outside the scanned set' \
+  "$off_sample_spec" passwordauthentication yes
+assert_resolves 'a: include outside the scanned set' \
+  "$off_sample_spec" permitrootlogin yes
+assert_verify_fails_naming 'a: include outside the scanned set' \
+  "match scan: '$included_evil' sets 'passwordauthentication yes'" \
+  "match scan: '$included_evil' sets 'permitrootlogin yes'"
+rm -f "$SSHD_CONFIG_D/999-pull.conf" "$included_evil"
+assert_verify_passes_again 'a'
+
+# --- b: Include inside a Match block ------------------------------------------
+# The included file holds no Match line of its own. It is hostile only because
+# of where it is pulled in, which is exactly why a per-file scan cannot see it.
+
+reopen_inc="$SSH_SANDBOX/reopen.inc"
+printf 'PasswordAuthentication yes\n' >"$reopen_inc"
+printf 'Match Address *,!127.0.0.1\nInclude %s\n' "$reopen_inc" \
+  >"$SSHD_CONFIG_D/500-wrapper.conf"
+
+assert_resolves 'b: include inside a Match block' \
+  "$off_sample_spec" passwordauthentication yes
+# The other half of the demonstration: loopback stays hardened, so neither
+# connection sample --verify probes can see this at all.
+assert_resolves 'b: include inside a Match block (loopback stays hardened)' \
+  "$loopback_spec" passwordauthentication no
+assert_verify_fails_naming 'b: include inside a Match block' \
+  "match scan: '$reopen_inc' sets 'passwordauthentication yes'"
+rm -f "$SSHD_CONFIG_D/500-wrapper.conf" "$reopen_inc"
+assert_verify_passes_again 'b'
+
+# --- c: a Match inside an included file does not bleed back -------------------
+# sshd restores the including file's Match state when the Include returns
+# (verified: a directive after the Include is applied even though the included
+# file ended inside a Match that did not match). A scan that kept the included
+# file's state would read the parent's remaining GLOBAL directives as
+# Match-scoped and report a tree sshd resolves as hardened.
+
+harmless_inc="$SSH_SANDBOX/harmless.inc"
+printf 'Match User no-such-user-for-this-test\nPasswordAuthentication no\n' >"$harmless_inc"
+printf 'Include %s\nPasswordAuthentication yes\n' "$harmless_inc" \
+  >"$SSHD_CONFIG_D/500-parent.conf"
+
+# The parent's global `PasswordAuthentication yes` loses to the 000- drop-in
+# under first-value-wins, so the tree really is hardened and a failure here
+# could only be the scan's own false positive.
+for spec in "$off_sample_spec" "$loopback_spec"; do
+  assert_resolves 'c: no bleed-back' "$spec" passwordauthentication no
+done
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "c: --verify must PASS: the parent's global directive is not inside a Match, and sshd resolves the tree hardened (stderr: $SSH_RUN_ERR)"
+rm -f "$SSHD_CONFIG_D/500-parent.conf" "$harmless_inc"
+assert_verify_passes_again 'c'
+
+# --- d: an Include cycle fails closed, and terminates -------------------------
+
+cycle_b="$SSH_SANDBOX/cycle-b.inc"
+printf 'Include %s\n' "$cycle_b" >"$SSHD_CONFIG_D/700-cycle-a.conf"
+printf 'Include %s/700-cycle-a.conf\n' "$SSHD_CONFIG_D" >"$cycle_b"
+
+run_ssh_hardening_bounded 60 --verify
+[[ $SSH_RUN_TIMED_OUT -eq 0 ]] ||
+  fail 'd: --verify must TERMINATE on an Include cycle; it was still running after 60s'
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail "d: an Include cycle must fail --verify (stdout: $SSH_RUN_OUT)"
+grep -qF 'Include cycle' <<<"$SSH_RUN_ERR" ||
+  fail "d: the failure must name the cycle rather than any other refusal (stderr: $SSH_RUN_ERR)"
+rm -f "$SSHD_CONFIG_D/700-cycle-a.conf" "$cycle_b"
+assert_verify_passes_again 'd'
+
+# --- e: a chain deeper than sshd accepts fails closed -------------------------
+# sshd refuses at 16 files below the main config ("Too many recursive
+# configuration includes"). The scan refuses at the same depth instead of
+# returning quietly with part of the tree unread.
+
+deep_dir="$SSH_SANDBOX/deep"
+mkdir -p "$deep_dir"
+printf 'PasswordAuthentication no\n' >"$deep_dir/deep_end"
+previous="$deep_dir/deep_end"
+for level in $(seq 1 20); do
+  printf 'Include %s\n' "$previous" >"$deep_dir/deep_$level"
+  previous="$deep_dir/deep_$level"
+done
+printf 'Include %s\n' "$previous" >"$SSHD_CONFIG_D/700-deep.conf"
+
+run_ssh_hardening_bounded 60 --verify
+[[ $SSH_RUN_TIMED_OUT -eq 0 ]] ||
+  fail 'e: --verify must TERMINATE on an over-deep include chain'
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail "e: an over-deep include chain must fail --verify (stdout: $SSH_RUN_OUT)"
+grep -qF 'Include levels deep' <<<"$SSH_RUN_ERR" ||
+  fail "e: the failure must name the depth refusal (stderr: $SSH_RUN_ERR)"
+rm -rf "$deep_dir" "$SSHD_CONFIG_D/700-deep.conf"
+assert_verify_passes_again 'e'
+
+# --- f: a relative Include resolves against sshd's configuration directory ----
+# HONESTY NOTE: sshd resolves a relative Include against its COMPILED-IN
+# /etc/ssh, whatever -f points at (verified two ways: a matching file in the
+# working directory is ignored, and `Include sshd_config.d/*` from a sandbox
+# main config reproduces the live /etc/ssh resolution byte for byte). This test
+# must never write to /etc/ssh, so it cannot make real sshd read the fixture
+# below, and this case alone is not proven end to end. It pins the resolution
+# RULE the scan applies -- relative to the directory holding the main config,
+# which IS /etc/ssh in production -- and the scan is deliberately conservative
+# here: reporting a file sshd would not read costs a false alarm, while
+# skipping relative includes would be a hole in the live tree.
+
+relative_evil="$SSH_SANDBOX/relative-evil.inc"
+printf 'Match Address 198.51.100.0/24\nPermitRootLogin yes\n' >"$relative_evil"
+printf 'Include relative-evil.inc\n' >"$SSHD_CONFIG_D/600-relative.conf"
+assert_verify_fails_naming 'f: relative include' \
+  "match scan: '$relative_evil' sets 'permitrootlogin yes'"
+rm -f "$SSHD_CONFIG_D/600-relative.conf" "$relative_evil"
+assert_verify_passes_again 'f'
+
+# --- g: several paths on one Include line -------------------------------------
+
+first_inc="$SSH_SANDBOX/multi-1.inc"
+second_inc="$SSH_SANDBOX/multi-2.inc"
+printf 'Match Address 198.51.100.0/24\nKbdInteractiveAuthentication yes\n' >"$first_inc"
+printf 'Match Address 198.51.100.0/24\nPermitRootLogin yes\n' >"$second_inc"
+printf 'Include %s %s\n' "$first_inc" "$second_inc" >"$SSHD_CONFIG_D/600-multi.conf"
+
+assert_resolves 'g: multiple include paths' \
+  "$off_sample_spec" kbdinteractiveauthentication yes
+assert_resolves 'g: multiple include paths' \
+  "$off_sample_spec" permitrootlogin yes
+# Both needles: a scan that follows only the first path passes the first
+# assertion and fails the second.
+assert_verify_fails_naming 'g: multiple include paths' \
+  "match scan: '$first_inc' sets 'kbdinteractiveauthentication yes'" \
+  "match scan: '$second_inc' sets 'permitrootlogin yes'"
+rm -f "$SSHD_CONFIG_D/600-multi.conf" "$first_inc" "$second_inc"
+assert_verify_passes_again 'g'
+
+# --- h: a glob Include is expanded --------------------------------------------
+
+glob_dir="$SSH_SANDBOX/globdir"
+mkdir -p "$glob_dir"
+printf 'Match Address 198.51.100.0/24\nKbdInteractiveAuthentication yes\n' >"$glob_dir/hostile.inc"
+printf 'Include %s/*.inc\n' "$glob_dir" >"$SSHD_CONFIG_D/600-glob.conf"
+
+assert_resolves 'h: glob include' "$off_sample_spec" kbdinteractiveauthentication yes
+assert_verify_fails_naming 'h: glob include' \
+  "match scan: '$glob_dir/hostile.inc' sets 'kbdinteractiveauthentication yes'"
+rm -rf "$glob_dir" "$SSHD_CONFIG_D/600-glob.conf"
+assert_verify_passes_again 'h'
+
+# --- i: a quoted Include path containing spaces -------------------------------
+# sshd's tokenizer keeps a double-quoted token whole, so this path really is
+# read. A scan that splits the Include arguments on whitespace looks for two
+# directories that do not exist and reports the tree clean.
+
+spaced_dir="$SSH_SANDBOX/dir with spaces"
+mkdir -p "$spaced_dir"
+printf 'Match Address 198.51.100.0/24\nPermitRootLogin yes\n' >"$spaced_dir/evil.inc"
+printf 'Include "%s/evil.inc"\n' "$spaced_dir" >"$SSHD_CONFIG_D/600-quoted.conf"
+
+assert_resolves 'i: quoted include path with spaces' \
+  "$off_sample_spec" permitrootlogin yes
+assert_verify_fails_naming 'i: quoted include path with spaces' \
+  "match scan: '$spaced_dir/evil.inc' sets 'permitrootlogin yes'"
+rm -rf "$spaced_dir" "$SSHD_CONFIG_D/600-quoted.conf"
+assert_verify_passes_again 'i'
+
+printf 'ssh-hardening-include-following: OK (includes followed outside the scanned set, Match state carried across the boundary and not leaked back, cycles and over-deep chains fail closed and terminate, relative/multiple/glob/quoted paths all resolved)\n'

--- a/test/integration/ssh-hardening-include-precedence.sh
+++ b/test/integration/ssh-hardening-include-precedence.sh
@@ -48,12 +48,7 @@ hardened_content="$SSH_RUN_OUT"
 old_name_file="$SSHD_CONFIG_D/50-no-password-auth.conf"
 printf '%s\n' "$hardened_content" >"$old_name_file"
 
-for pair in \
-  'passwordauthentication yes' \
-  'kbdinteractiveauthentication yes' \
-  'usepam no' \
-  'pubkeyauthentication no' \
-  'permitrootlogin yes'; do
+for pair in "${SSH_HOSTILE_PAIRS[@]}"; do
   key="${pair%% *}"
   hostile_value="${pair##* }"
   got="$(effective_global_value "$key")" || fail 'sshd -G failed in phase A'
@@ -72,12 +67,7 @@ new_name_file="$SSH_RUN_OUT"
   fail "--print-path must resolve inside the sandbox tree, got '$new_name_file'"
 printf '%s\n' "$hardened_content" >"$new_name_file"
 
-for pair in \
-  'passwordauthentication no' \
-  'kbdinteractiveauthentication no' \
-  'usepam yes' \
-  'pubkeyauthentication yes' \
-  'permitrootlogin no'; do
+for pair in "${SSH_HARDENED_PAIRS[@]}"; do
   key="${pair%% *}"
   want="${pair##* }"
   got="$(effective_global_value "$key")" || fail 'sshd -G failed in phase B'

--- a/test/integration/ssh-hardening-include-precedence.sh
+++ b/test/integration/ssh-hardening-include-precedence.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ssh-hardening-include-precedence.sh -- the REGRESSION GUARD that documents
+# why the drop-in was renamed 50-no-password-auth.conf -> 000-ssh-hardening.conf
+# (slice 7, acceptance criterion 4). It PROVES the shadowing with a real sshd
+# rather than asserting it in prose.
+#
+# Honesty note: the file Apple ships today sets none of the protected
+# directives, so nothing is shadowed on a real machine right now; the rename
+# is insurance against a future 100-macos.conf that competes. The guard
+# therefore runs against a HOSTILE 100-macos.conf that reopens every hole:
+#
+#   Phase A: the OLD name (50-) carrying the full hardened content IS defeated
+#            by the hostile 100- file, because '1' < '5' in LC_ALL=C order and
+#            sshd's Include is lexical, first-value-wins.
+#   Phase B: the NEW name, taken from the script's own --print-path, wins
+#            against the same hostile file on the same tree.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+write_hostile_apple_conf
+
+# --- Phase A: the old name loses ---------------------------------------------
+
+run_ssh_hardening --print-config
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--print-config must succeed to seed the phases (stderr: $SSH_RUN_ERR)"
+hardened_content="$SSH_RUN_OUT"
+
+old_name_file="$SSHD_CONFIG_D/50-no-password-auth.conf"
+printf '%s\n' "$hardened_content" >"$old_name_file"
+
+for pair in \
+  'passwordauthentication yes' \
+  'kbdinteractiveauthentication yes' \
+  'usepam no' \
+  'pubkeyauthentication no' \
+  'permitrootlogin yes'; do
+  key="${pair%% *}"
+  hostile_value="${pair##* }"
+  got="$(effective_global_value "$key")" || fail 'sshd -G failed in phase A'
+  [[ $got == "$hostile_value" ]] ||
+    fail "phase A: with the OLD 50- name, the hostile value for '$key' must win (got '$got'); if this now fails, the shadowing premise itself has changed"
+done
+rm -f "$old_name_file"
+
+# --- Phase B: the script's name wins -----------------------------------------
+
+run_ssh_hardening --print-path
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--print-path must succeed (stderr: $SSH_RUN_ERR)"
+new_name_file="$SSH_RUN_OUT"
+[[ $new_name_file == "$SSHD_CONFIG_D"/* ]] ||
+  fail "--print-path must resolve inside the sandbox tree, got '$new_name_file'"
+printf '%s\n' "$hardened_content" >"$new_name_file"
+
+for pair in \
+  'passwordauthentication no' \
+  'kbdinteractiveauthentication no' \
+  'usepam yes' \
+  'pubkeyauthentication yes' \
+  'permitrootlogin no'; do
+  key="${pair%% *}"
+  want="${pair##* }"
+  got="$(effective_global_value "$key")" || fail 'sshd -G failed in phase B'
+  [[ $got == "$want" ]] ||
+    fail "phase B: with the script's name '$(basename "$new_name_file")', the hardened value for '$key' must win (got '$got')"
+done
+
+printf 'ssh-hardening-include-precedence: OK (old 50- name provably defeated by a hostile 100-macos.conf; the 000- name wins on the same tree)\n'

--- a/test/integration/ssh-hardening-install-safety.sh
+++ b/test/integration/ssh-hardening-install-safety.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# ssh-hardening-install-safety.sh -- a failed install leaves the machine no
+# worse than it found it.
+#
+# Refusing to CLAIM success is not the same as refusing to CAUSE harm, and the
+# install path did the first while failing the second. Two demonstrations, both
+# reproduced before this guard existed:
+#
+#   a. `tee` truncates its target the instant it opens it. With `cat` missing
+#      from PATH the pipeline feeding it fails -- after the truncation. A valid
+#      1478-byte drop-in came out of that run as 0 bytes, and the run exited
+#      nonzero having destroyed the policy it was there to install.
+#   b. On a main config that includes only `50-*`, install wrote an
+#      unreferenced `000-` file, deleted the legacy `50-` file that was the
+#      ONLY effective policy, failed its verification, and stopped. The machine
+#      went from passwordauthentication no to passwordauthentication yes across
+#      a run that reported failure.
+#
+# So the property is not "install reports honestly" but "install is a
+# transaction": stage, publish, and on any failure put back exactly what was
+# there. Every case below judges the tree with the test's own sshd, not with
+# the script's report of itself.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+file_fingerprint() { # <path> -> size and checksum, or the word absent
+  if [[ -e $1 ]]; then
+    cksum <"$1"
+  else
+    printf 'absent\n'
+  fi
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+legacy="$SSHD_CONFIG_D/50-no-password-auth.conf"
+
+# --- a: a staging failure must not touch the drop-in already in place ---------
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "setup: the first install must succeed (stderr: $SSH_RUN_ERR)"
+before_fingerprint="$(file_fingerprint "$dropin")"
+[[ $before_fingerprint != 'absent' ]] ||
+  fail 'setup: the first install must leave a drop-in behind'
+
+# `cat` is what print_config uses to emit the policy. Losing it fails the
+# pipeline that feeds tee -- which is exactly the ordering that used to empty
+# the target.
+run_ssh_hardening_without cat
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'a: install must fail when it cannot generate the policy'
+after_fingerprint="$(file_fingerprint "$dropin")"
+[[ $after_fingerprint == "$before_fingerprint" ]] ||
+  fail "a: the drop-in already in place must be untouched by a failed staging (before: $before_fingerprint; after: $after_fingerprint)"
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  'a: a failed staging must not claim success'
+
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "a: the tree must still verify after the failed install (stderr: $SSH_RUN_ERR)"
+
+# --- b: a failed verification restores the tree it found ----------------------
+# The main config here includes ONLY 50-*, so the drop-in install writes is
+# inert and the legacy file is the whole policy. Install therefore cannot
+# succeed, and the question is what it leaves behind.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || true
+printf 'Include %s/50-*\n' "$SSHD_CONFIG_D" >"$SSHD_MAIN_CONFIG"
+/bin/bash "$SSH_HARDENING_SCRIPT" --print-config >"$legacy"
+legacy_fingerprint="$(file_fingerprint "$legacy")"
+
+for pair in "${SSH_HARDENED_PAIRS[@]}"; do
+  key="${pair%% *}"
+  want="${pair##* }"
+  got="$(effective_global_value "$key")" || fail 'b: sshd -G failed before the install'
+  [[ $got == "$want" ]] ||
+    fail "b: the tree must be hardened BEFORE the install, '$key' is '$got'; otherwise this case cannot show install making it worse"
+done
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'b: install cannot succeed when the drop-in it writes is not included'
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  'b: a failed verification must not claim success'
+
+# The whole point. Every directive must still resolve hardened.
+for pair in "${SSH_HARDENED_PAIRS[@]}"; do
+  key="${pair%% *}"
+  want="${pair##* }"
+  got="$(effective_global_value "$key")" || fail 'b: sshd -G failed after the install'
+  [[ $got == "$want" ]] ||
+    fail "b: after a FAILED install the tree must be exactly as hardened as before, but '$key' is now '$got' (want '$want'); the install made the machine worse"
+done
+
+[[ "$(file_fingerprint "$legacy")" == "$legacy_fingerprint" ]] ||
+  fail 'b: the legacy drop-in was the only effective policy and must be back, byte for byte'
+[[ ! -e $dropin ]] ||
+  fail 'b: the drop-in this run created must be removed again; there was none before it'
+
+# --- c: no working files are left behind, on either outcome -------------------
+# The staging and rollback files are dot-prefixed so sshd's Include glob cannot
+# match them (glob(3) does not match a leading dot), but leaving them lying
+# around is still litter in a directory that is supposed to hold policy only.
+
+leftovers="$(ls -A "$SSHD_CONFIG_D" | grep -E '\.(staging|saved)$' || true)"
+[[ -z $leftovers ]] ||
+  fail "c: a failed install left working files behind: $leftovers"
+
+printf 'Include %s/*\n' "$SSHD_CONFIG_D" >"$SSHD_MAIN_CONFIG"
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || true
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "c: install on a clean tree must succeed (stderr: $SSH_RUN_ERR)"
+leftovers="$(ls -A "$SSHD_CONFIG_D" | grep -E '\.(staging|saved)$' || true)"
+[[ -z $leftovers ]] ||
+  fail "c: a successful install left working files behind: $leftovers"
+
+# --- d: the legacy file survives a failed run, and only a failed run ----------
+# On success the legacy file really must go: two files declaring the same
+# policy is drift waiting to happen, and the legacy one is 0600, which breaks
+# unprivileged verification for the whole tree.
+
+printf 'PasswordAuthentication no\n' >"$legacy"
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "d: install must succeed on this tree (stderr: $SSH_RUN_ERR)"
+[[ ! -e $legacy ]] ||
+  fail 'd: a SUCCESSFUL install must still retire the legacy drop-in'
+
+# --- e: the rollback copies are invisible to sshd -----------------------------
+# The legacy file here carries a Match-scoped re-enable, so retiring it is the
+# whole reason the tree can verify at all. install keeps a copy of it until the
+# replacement is proven good -- and if that copy were visible to sshd's Include
+# glob, the re-enable would still be in the effective configuration and the
+# install would fail. glob(3) does not match a leading dot, which is exactly
+# why the copy is dot-prefixed and not, say, suffixed.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || true
+printf 'Include %s/*\n' "$SSHD_CONFIG_D" >"$SSHD_MAIN_CONFIG"
+printf 'Match Address 198.51.100.0/24\nPasswordAuthentication yes\n' >"$legacy"
+
+off_sample_spec='user=offsample,host=elsewhere.example,addr=198.51.100.23'
+got="$(effective_spec_value "$off_sample_spec" passwordauthentication)" ||
+  fail 'e: sshd -G -T -C failed before the install'
+[[ $got == 'yes' ]] ||
+  fail "e: the legacy file must really re-enable password authentication off-loopback (got '$got'); otherwise retiring it proves nothing"
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "e: retiring a legacy file that carried the re-enable must let the install SUCCEED; a rollback copy still visible to sshd's Include glob would keep the re-enable in the effective configuration (stderr: $SSH_RUN_ERR)"
+
+got="$(effective_spec_value "$off_sample_spec" passwordauthentication)" ||
+  fail 'e: sshd -G -T -C failed after the install'
+[[ $got == 'no' ]] ||
+  fail "e: after the install the re-enable must be gone from the effective configuration, got '$got'"
+
+printf 'ssh-hardening-install-safety: OK (a failed staging leaves the existing drop-in byte-identical, a failed verification restores the tree sshd resolves as hardened along with the legacy file, no working files survive either outcome, and a successful install still retires the legacy file)\n'

--- a/test/integration/ssh-hardening-install-safety.sh
+++ b/test/integration/ssh-hardening-install-safety.sh
@@ -45,6 +45,20 @@ refute_contains() { # <haystack> <fixed-string> <message>
   exit 0
 }
 
+# working_file_leftovers: any staging or rollback file still sitting in the
+# drop-in directory, dot-prefixed or not. Globs rather than `ls | grep`, so a
+# file name containing anything unusual is still matched by the shell.
+working_file_leftovers() {
+  local candidate found=''
+  for candidate in "$SSHD_CONFIG_D"/*.staging "$SSHD_CONFIG_D"/*.saved \
+    "$SSHD_CONFIG_D"/.*.staging "$SSHD_CONFIG_D"/.*.saved; do
+    if [[ -e $candidate ]]; then
+      found="$found $candidate"
+    fi
+  done
+  printf '%s\n' "$found"
+}
+
 file_fingerprint() { # <path> -> size and checksum, or the word absent
   if [[ -e $1 ]]; then
     cksum <"$1"
@@ -127,7 +141,7 @@ done
 # match them (glob(3) does not match a leading dot), but leaving them lying
 # around is still litter in a directory that is supposed to hold policy only.
 
-leftovers="$(ls -A "$SSHD_CONFIG_D" | grep -E '\.(staging|saved)$' || true)"
+leftovers="$(working_file_leftovers)"
 [[ -z $leftovers ]] ||
   fail "c: a failed install left working files behind: $leftovers"
 
@@ -136,7 +150,7 @@ rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || true
 run_ssh_hardening
 [[ $SSH_RUN_STATUS -eq 0 ]] ||
   fail "c: install on a clean tree must succeed (stderr: $SSH_RUN_ERR)"
-leftovers="$(ls -A "$SSHD_CONFIG_D" | grep -E '\.(staging|saved)$' || true)"
+leftovers="$(working_file_leftovers)"
 [[ -z $leftovers ]] ||
   fail "c: a successful install left working files behind: $leftovers"
 

--- a/test/integration/ssh-hardening-install-strictness.sh
+++ b/test/integration/ssh-hardening-install-strictness.sh
@@ -59,18 +59,20 @@ assert_install_no_weaker_than_verify() {
 
   reset_tree
   if [[ -n $broken ]]; then
-    ssh_break_command "$broken"
+    run_ssh_hardening_without "$broken" --verify
+  else
+    run_ssh_hardening --verify
   fi
-
-  run_ssh_hardening --verify
   verify_status=$SSH_RUN_STATUS
 
   reset_tree
-  run_ssh_hardening
+  if [[ -n $broken ]]; then
+    run_ssh_hardening_without "$broken"
+  else
+    run_ssh_hardening
+  fi
   install_status=$SSH_RUN_STATUS
   install_output="$SSH_RUN_OUT"
-
-  ssh_restore_commands
 
   if [[ $verify_status -eq 0 ]]; then
     [[ $install_status -eq 0 ]] ||

--- a/test/integration/ssh-hardening-install-strictness.sh
+++ b/test/integration/ssh-hardening-install-strictness.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ssh-hardening-install-strictness.sh -- install judges the tree by exactly the
+# rules --verify applies on its own.
+#
+# bash suppresses `set -e` for every command inside an `if !` or `||` test, and
+# that suppression reaches into called functions and even into subshells
+# (confirmed on the bash 3.2 this script is deployed under). install called
+# `if ! verify`, so every check inside ran with errexit switched off: a command
+# whose failure aborts --verify on its own was stepped over in the install
+# path, execution carried on past it, and install printed its success line.
+#
+# Demonstrated with a failing `id`: standalone --verify exited 91 while install
+# exited 0 and claimed "install complete" on the same tree.
+#
+# The assertion here is DIFFERENTIAL, not mechanism-specific. For every
+# injected environmental fault: if standalone --verify fails, install must fail
+# too and must not claim success. That holds a future unguarded command to the
+# same rule without this file having to know which command it is, and it fails
+# in both directions -- an install that refused everything would break the
+# control row.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# reset_tree: a known-good hardened tree, built WITHOUT install, so each case
+# starts from the same place regardless of what the previous install did.
+reset_tree() {
+  rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || true
+  write_hardened_dropin
+}
+
+# assert_install_no_weaker_than_verify <label> <command to break, or ''>
+assert_install_no_weaker_than_verify() {
+  local label="$1" broken="$2" verify_status install_status install_output
+
+  reset_tree
+  if [[ -n $broken ]]; then
+    ssh_break_command "$broken"
+  fi
+
+  run_ssh_hardening --verify
+  verify_status=$SSH_RUN_STATUS
+
+  reset_tree
+  run_ssh_hardening
+  install_status=$SSH_RUN_STATUS
+  install_output="$SSH_RUN_OUT"
+
+  ssh_restore_commands
+
+  if [[ $verify_status -eq 0 ]]; then
+    [[ $install_status -eq 0 ]] ||
+      fail "$label: standalone --verify passed but install exited $install_status; install must not be STRICTER than the verify it runs"
+    grep -qF 'install complete' <<<"$install_output" ||
+      fail "$label: a passing verify must let install claim success (stdout: $install_output)"
+    return 0
+  fi
+
+  [[ $install_status -ne 0 ]] ||
+    fail "$label: standalone --verify exited $verify_status but install exited 0; the install path is running the checks with errexit disabled"
+  refute_contains "$install_output" 'install complete' \
+    "$label: install claimed success over a fault that fails --verify on its own"
+}
+
+# The control row. Without it, an install that refused every tree would pass
+# every other row in this table.
+assert_install_no_weaker_than_verify 'control: no injected fault' ''
+
+# The demonstrated one. `id -un` builds the connection spec; its failure used
+# to be stepped over, leaving a spec built from an empty user name.
+assert_install_no_weaker_than_verify 'failing id' id
+
+# The file listing for the scan.
+assert_install_no_weaker_than_verify 'failing sort' sort
+
+# The text extraction each protected value is read with.
+assert_install_no_weaker_than_verify 'failing awk' awk
+
+# A fault the script cannot guard away, so this row stays meaningful however
+# thoroughly the individual commands are checked: the verifier itself refuses
+# to run.
+reset_tree
+verify_status=0
+SSHD_BIN="$SSH_SANDBOX/no-such-sshd" run_ssh_hardening --verify || true
+verify_status=$SSH_RUN_STATUS
+[[ $verify_status -ne 0 ]] ||
+  fail 'unrunnable verifier: standalone --verify must fail closed'
+reset_tree
+SSHD_BIN="$SSH_SANDBOX/no-such-sshd" run_ssh_hardening
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'unrunnable verifier: install must fail closed too'
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  'unrunnable verifier: install must not claim success'
+
+printf 'ssh-hardening-install-strictness: OK (install is never weaker than standalone --verify under an injected id, sort or awk failure, nor with an unrunnable verifier; the control row keeps a blanket refusal from passing)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -236,4 +236,36 @@ run_reenable_case 'o: HostbasedAuthentication inside a Match block' \
   "$off_sample_spec" hostbasedauthentication yes \
   'Match Address *,!127.0.0.1' 'HostbasedAuthentication yes'
 
+# p. The ROOT connection sample, pinned the way case d pins the invoking-user
+# sample. Without this, deleting the root spec from the connection check broke
+# nothing: every other case is caught by the scan or by the invoking-user
+# sample. root is the account PermitRootLogin exists to keep out, so it is the
+# one sample that must not quietly disappear.
+run_reenable_case 'p: Match User root' \
+  'connection check (user=root' \
+  'user=root,host=localhost,addr=127.0.0.1' passwordauthentication yes \
+  'Match User root' 'PasswordAuthentication yes'
+
+# q. The re-enable in the MAIN CONFIG rather than a drop-in. Every other
+# hostile fixture in this file writes into the drop-in directory, so dropping
+# $SSHD_MAIN_CONFIG from the scan roots broke nothing at all -- and the main
+# config is the one file sshd is guaranteed to read.
+main_config_backup="$SSH_SANDBOX/sshd_config.backup"
+cp "$SSHD_MAIN_CONFIG" "$main_config_backup"
+printf 'Match Address 198.51.100.0/24\nPasswordAuthentication yes\n' >>"$SSHD_MAIN_CONFIG"
+
+resolved="$(effective_spec_value "$off_sample_spec" passwordauthentication)" ||
+  fail 'q: the test sshd could not resolve the main-config fixture'
+[[ $resolved == 'yes' ]] ||
+  fail "q: real sshd must resolve passwordauthentication yes off-loopback, got '$resolved'"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail "q: a Match re-enable in the MAIN config must fail --verify (stdout: $SSH_RUN_OUT)"
+grep -qF -- "match scan: '$SSHD_MAIN_CONFIG' sets 'passwordauthentication yes'" <<<"$SSH_RUN_ERR" ||
+  fail "q: the scan must name the main config itself (stderr: $SSH_RUN_ERR)"
+cp "$main_config_backup" "$SSHD_MAIN_CONFIG"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "q: --verify must PASS again once the main config is restored (stderr: $SSH_RUN_ERR)"
+
 printf 'ssh-hardening-match-reenable: OK (every Match bypass form resolves unsafe under real sshd and fails --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ssh-hardening-match-reenable.sh -- --verify catches every Match-shaped
+# bypass (slice 7, acceptance criterion 5). `sshd -G` without a connection
+# spec dumps only the pre-Match configuration, so a Match block re-enabling a
+# protected directive passes it while the machine is wide open; that is the
+# most idiomatic sshd bypass and each form below must fail the verify, loudly
+# and nonzero.
+#
+# The cases, each on an otherwise fully hardened tree:
+#   a. Match Address 0.0.0.0/0 re-enable        (raw scan names the file)
+#   b. Match User * re-enable                   (raw scan names the file)
+#   c. Match all re-enable, PermitRootLogin     (raw scan names the file)
+#   d. Match User <invoking user> re-enable     (the CONNECTION-SPEC check
+#      must catch it: asserted on the connection check's own attribution)
+#   e. sibling that sorts FIRST (00-evil.conf) globally re-enabling UsePAM
+#      and PubkeyAuthentication (the GLOBAL check catches first-value-wins)
+#   f. Match Address on a subnet NO connection sample hits (only the raw scan
+#      can catch this one; it pins the scan as the completeness net)
+#   g. '=' separator form: Match=all with PasswordAuthentication=yes (sshd
+#      parses it, verified on OpenSSH 10.0p2, so the scan must too)
+#   h. ChallengeResponseAuthentication alias re-enable inside Match (sshd
+#      still honors the deprecated alias, verified on OpenSSH 10.0p2)
+#
+# Between cases the hostile file is removed and --verify must PASS again, so
+# a pass after a fail proves no state leaks and every failure is the hostile
+# file's own doing. The tree starts clean and verifies clean (positive
+# control), so "fails" is asserted on the right dimension.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# Harden the sandbox tree through the script's own install, then the positive
+# control: a clean tree must PASS.
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "install on a clean sandbox must succeed (stderr: $SSH_RUN_ERR)"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "positive control: --verify must PASS on the clean hardened tree (stderr: $SSH_RUN_ERR)"
+
+hostile_file="$SSHD_CONFIG_D/500-hostile.conf"
+
+# run_reenable_case <label> <expected-stderr-needle> <hostile-content...>
+# Writes the hostile file, expects --verify to fail naming the needle, then
+# removes it and expects --verify to pass again (no state leak).
+run_reenable_case() {
+  local label="$1" needle="$2"
+  shift 2
+  printf '%s\n' "$@" >"$hostile_file"
+  run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "$label: --verify must exit nonzero (stdout: $SSH_RUN_OUT)"
+  grep -qF -- "$needle" <<<"$SSH_RUN_ERR" ||
+    fail "$label: stderr must contain '$needle' (stderr: $SSH_RUN_ERR)"
+  rm -f "$hostile_file"
+  run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -eq 0 ]] ||
+    fail "$label: --verify must PASS again once the hostile file is removed; state leaked (stderr: $SSH_RUN_ERR)"
+}
+
+# a. The idiomatic bypass. The raw scan must name the offending file.
+run_reenable_case 'a: Match Address 0.0.0.0/0' "$hostile_file" \
+  'Match Address 0.0.0.0/0' 'PasswordAuthentication yes'
+
+# b. Match User * catches every user; scan names the file.
+run_reenable_case 'b: Match User *' "$hostile_file" \
+  'Match User *' 'KbdInteractiveAuthentication yes'
+
+# c. Match all; also pins permitrootlogin as a protected directive.
+run_reenable_case 'c: Match all PermitRootLogin' "$hostile_file" \
+  'Match all' 'PermitRootLogin yes'
+
+# d. Match User <invoking user>: the connection-spec resolution must catch it.
+# The raw scan fires too; the assertion pins the CONNECTION check's own
+# attribution so removing that check fails here even with the scan intact.
+invoking_user="$(id -un)"
+run_reenable_case 'd: Match User (invoking user)' \
+  "connection check (user=$invoking_user" \
+  "Match User $invoking_user" 'PasswordAuthentication yes'
+
+# e. A sibling sorting BEFORE 000- with GLOBAL re-enables: first-value-wins
+# hands these two directives to the sibling, and only the global check sees
+# it (no Match block anywhere). Pins usepam and pubkeyauthentication.
+sibling="$SSHD_CONFIG_D/00-evil.conf"
+printf 'UsePAM no\nPubkeyAuthentication no\n' >"$sibling"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'e: a first-sorting sibling with global re-enables must fail --verify'
+grep -qF 'usepam' <<<"$SSH_RUN_ERR" ||
+  fail "e: stderr must name usepam (stderr: $SSH_RUN_ERR)"
+grep -qF 'pubkeyauthentication' <<<"$SSH_RUN_ERR" ||
+  fail "e: stderr must name pubkeyauthentication (stderr: $SSH_RUN_ERR)"
+rm -f "$sibling"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail 'e: --verify must PASS again once the sibling is removed'
+
+# f. A subnet neither connection sample hits: the raw scan is the ONLY net.
+run_reenable_case 'f: Match Address off-sample subnet' "$hostile_file" \
+  'Match Address 198.51.100.0/24' 'PermitRootLogin yes'
+
+# g. The '=' separator form sshd accepts must not slip past the scan.
+run_reenable_case "g: '=' separator form" "$hostile_file" \
+  'Match=all' 'PasswordAuthentication=yes'
+
+# h. The deprecated alias still flips kbdinteractiveauthentication in sshd.
+run_reenable_case 'h: ChallengeResponseAuthentication alias' "$hostile_file" \
+  'Match Address 198.51.100.0/24' 'ChallengeResponseAuthentication yes'
+
+printf 'ssh-hardening-match-reenable: OK (all Match bypass forms fail --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -218,4 +218,22 @@ run_reenable_case 'm: DSAAuthentication alias' \
   "$off_sample_spec" pubkeyauthentication no \
   'Match all' 'DSAAuthentication no'
 
+# n and o. The two userauth methods the password-and-key directives do not
+# reach. `strings /usr/sbin/sshd` lists six methods this binary offers -- none,
+# password, keyboard-interactive, publickey, gssapi-with-mic, hostbased -- and
+# the first four are settled by PasswordAuthentication,
+# KbdInteractiveAuthentication and PubkeyAuthentication. gssapi-with-mic and
+# hostbased are settled by nothing, and both default to no. A default is not a
+# policy: both are settable inside a Match block, which is exactly what these
+# two cases do.
+run_reenable_case 'n: GSSAPIAuthentication inside a Match block' \
+  "match scan: '$hostile_file' sets 'gssapiauthentication yes'" \
+  "$off_sample_spec" gssapiauthentication yes \
+  'Match Address *,!127.0.0.1' 'GSSAPIAuthentication yes'
+
+run_reenable_case 'o: HostbasedAuthentication inside a Match block' \
+  "match scan: '$hostile_file' sets 'hostbasedauthentication yes'" \
+  "$off_sample_spec" hostbasedauthentication yes \
+  'Match Address *,!127.0.0.1' 'HostbasedAuthentication yes'
+
 printf 'ssh-hardening-match-reenable: OK (every Match bypass form resolves unsafe under real sshd and fails --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -6,6 +6,12 @@
 # most idiomatic sshd bypass and each form below must fail the verify, loudly
 # and nonzero.
 #
+# EVERY case proves itself against real sshd first: the test resolves the
+# hostile tree with its own `sshd -G -T -C` and requires the unsafe value to
+# come back before it asks whether --verify catches it. A fixture that sshd
+# quietly ignores would pin nothing, and three of the forms below were
+# originally believed to be non-bypasses until the resolution was run.
+#
 # The cases, each on an otherwise fully hardened tree:
 #   a. Match Address 0.0.0.0/0 re-enable        (raw scan names the file)
 #   b. Match User * re-enable                   (raw scan names the file)
@@ -15,11 +21,25 @@
 #   e. sibling that sorts FIRST (00-evil.conf) globally re-enabling UsePAM
 #      and PubkeyAuthentication (the GLOBAL check catches first-value-wins)
 #   f. Match Address on a subnet NO connection sample hits (only the raw scan
-#      can catch this one; it pins the scan as the completeness net)
+#      can catch this one)
 #   g. '=' separator form: Match=all with PasswordAuthentication=yes (sshd
 #      parses it, verified on OpenSSH 10.0p2, so the scan must too)
 #   h. ChallengeResponseAuthentication alias re-enable inside Match (sshd
 #      still honors the deprecated alias, verified on OpenSSH 10.0p2)
+#   i. a QUOTED KEYWORD: `"PasswordAuthentication" yes`. sshd strips the
+#      quotes around the keyword just as it does around a value, so this
+#      re-enables password authentication while a scanner that only strips
+#      quotes from the VALUE never recognizes the keyword at all.
+#   j. a QUOTED VALUE: `PasswordAuthentication "yes"`. The mirror of i, and
+#      the case that makes the value-side quote stripping non-removable.
+#   k. a CARRIAGE RETURN inside the Match line: `Match<CR>Address ...`. CR is
+#      whitespace to sshd, so the line opens a Match block, but a scanner
+#      that only knows spaces and tabs never sees a Match at all and treats
+#      every directive under it as global.
+#
+# Cases i, j and k assert on the SCAN's own attribution string, not merely on
+# the file name, so each pins the scan rather than any other layer that
+# happens to also fire.
 #
 # Between cases the hostile file is removed and --verify must PASS again, so
 # a pass after a fail proves no state leaks and every failure is the hostile
@@ -58,13 +78,25 @@ run_ssh_hardening --verify
 
 hostile_file="$SSHD_CONFIG_D/500-hostile.conf"
 
-# run_reenable_case <label> <expected-stderr-needle> <hostile-content...>
-# Writes the hostile file, expects --verify to fail naming the needle, then
-# removes it and expects --verify to pass again (no state leak).
+# An address in TEST-NET-2 (RFC 5737): routable-looking, reserved for
+# documentation, and deliberately NOT one of the loopback samples --verify
+# probes, so a case scoped away from loopback is genuinely off-sample.
+off_sample_spec='user=offsample,host=elsewhere.example,addr=198.51.100.23'
+
+# run_reenable_case <label> <needle> <spec> <key> <unsafe-value> <line>...
+# Writes the hostile file, PROVES with the test's own sshd that <key> really
+# resolves to <unsafe-value> for <spec>, requires --verify to fail naming
+# <needle>, then removes it and requires --verify to pass again.
 run_reenable_case() {
-  local label="$1" needle="$2"
-  shift 2
+  local label="$1" needle="$2" spec="$3" key="$4" unsafe="$5" resolved
+  shift 5
   printf '%s\n' "$@" >"$hostile_file"
+
+  resolved="$(effective_spec_value "$spec" "$key")" ||
+    fail "$label: the test's own sshd could not resolve '$key' for '$spec'"
+  [[ $resolved == "$unsafe" ]] ||
+    fail "$label: real sshd must resolve '$key' as '$unsafe' for '$spec', got '$resolved'; this fixture is not a bypass and would pin nothing"
+
   run_ssh_hardening --verify
   [[ $SSH_RUN_STATUS -ne 0 ]] ||
     fail "$label: --verify must exit nonzero (stdout: $SSH_RUN_OUT)"
@@ -78,14 +110,17 @@ run_reenable_case() {
 
 # a. The idiomatic bypass. The raw scan must name the offending file.
 run_reenable_case 'a: Match Address 0.0.0.0/0' "$hostile_file" \
+  "$off_sample_spec" passwordauthentication yes \
   'Match Address 0.0.0.0/0' 'PasswordAuthentication yes'
 
 # b. Match User * catches every user; scan names the file.
 run_reenable_case 'b: Match User *' "$hostile_file" \
+  "$off_sample_spec" kbdinteractiveauthentication yes \
   'Match User *' 'KbdInteractiveAuthentication yes'
 
 # c. Match all; also pins permitrootlogin as a protected directive.
 run_reenable_case 'c: Match all PermitRootLogin' "$hostile_file" \
+  "$off_sample_spec" permitrootlogin yes \
   'Match all' 'PermitRootLogin yes'
 
 # d. Match User <invoking user>: the connection-spec resolution must catch it.
@@ -94,6 +129,7 @@ run_reenable_case 'c: Match all PermitRootLogin' "$hostile_file" \
 invoking_user="$(id -un)"
 run_reenable_case 'd: Match User (invoking user)' \
   "connection check (user=$invoking_user" \
+  "user=$invoking_user,host=localhost,addr=127.0.0.1" passwordauthentication yes \
   "Match User $invoking_user" 'PasswordAuthentication yes'
 
 # e. A sibling sorting BEFORE 000- with GLOBAL re-enables: first-value-wins
@@ -101,6 +137,13 @@ run_reenable_case 'd: Match User (invoking user)' \
 # it (no Match block anywhere). Pins usepam and pubkeyauthentication.
 sibling="$SSHD_CONFIG_D/00-evil.conf"
 printf 'UsePAM no\nPubkeyAuthentication no\n' >"$sibling"
+for pair in 'usepam no' 'pubkeyauthentication no'; do
+  key="${pair%% *}"
+  want="${pair##* }"
+  got="$(effective_global_value "$key")" || fail 'e: sshd -G failed'
+  [[ $got == "$want" ]] ||
+    fail "e: the first-sorting sibling must win '$key' globally (got '$got'); the fixture is not a bypass"
+done
 run_ssh_hardening --verify
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail 'e: a first-sorting sibling with global re-enables must fail --verify'
@@ -115,14 +158,43 @@ run_ssh_hardening --verify
 
 # f. A subnet neither connection sample hits: the raw scan is the ONLY net.
 run_reenable_case 'f: Match Address off-sample subnet' "$hostile_file" \
+  "$off_sample_spec" permitrootlogin yes \
   'Match Address 198.51.100.0/24' 'PermitRootLogin yes'
 
 # g. The '=' separator form sshd accepts must not slip past the scan.
 run_reenable_case "g: '=' separator form" "$hostile_file" \
+  "$off_sample_spec" passwordauthentication yes \
   'Match=all' 'PasswordAuthentication=yes'
 
 # h. The deprecated alias still flips kbdinteractiveauthentication in sshd.
 run_reenable_case 'h: ChallengeResponseAuthentication alias' "$hostile_file" \
+  "$off_sample_spec" kbdinteractiveauthentication yes \
   'Match Address 198.51.100.0/24' 'ChallengeResponseAuthentication yes'
 
-printf 'ssh-hardening-match-reenable: OK (all Match bypass forms fail --verify loudly; clean tree passes before and after every case)\n'
+# i. A quoted KEYWORD. sshd strips the quotes and honours the directive; a
+# scanner that carries the quotes into its keyword comparison never matches.
+# Asserted on the scan's own attribution, so it pins the scan.
+run_reenable_case 'i: quoted keyword' \
+  "match scan: '$hostile_file' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  'Match Address *,!127.0.0.1' '"PasswordAuthentication" yes'
+
+# j. A quoted VALUE, the mirror of i: without value-side quote stripping the
+# scan reads the value as '"yes"' and compares it against 'no' -- which does
+# fail, but for the wrong reason. Pinned on the attribution, which names the
+# STRIPPED value, so a scan that stops stripping quotes fails this case.
+run_reenable_case 'j: quoted value' \
+  "match scan: '$hostile_file' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  'Match Address *,!127.0.0.1' 'PasswordAuthentication "yes"'
+
+# k. A carriage return between Match and its criteria. CR is whitespace to
+# sshd (misc.c WHITESPACE is " \t\r\n"), so the block opens normally; a
+# scanner that splits on spaces and tabs only sees one token, never matches
+# 'match', and reads every directive below it as global configuration.
+run_reenable_case 'k: carriage return inside the Match line' \
+  "match scan: '$hostile_file' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  "Match${SSH_CARRIAGE_RETURN}Address *,!127.0.0.1" 'PasswordAuthentication yes'
+
+printf 'ssh-hardening-match-reenable: OK (every Match bypass form resolves unsafe under real sshd and fails --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -197,4 +197,25 @@ run_reenable_case 'k: carriage return inside the Match line' \
   "$off_sample_spec" passwordauthentication yes \
   "Match${SSH_CARRIAGE_RETURN}Address *,!127.0.0.1" 'PasswordAuthentication yes'
 
+# l. SkeyAuthentication: an alias sshd_config(5) does not document at all,
+# still wired to kbdinteractiveauthentication in the parser. The needle names
+# the CANONICAL directive, so a scan that does not fold the alias cannot
+# produce it.
+run_reenable_case 'l: SkeyAuthentication alias' \
+  "match scan: '$hostile_file' sets 'kbdinteractiveauthentication yes'" \
+  "$off_sample_spec" kbdinteractiveauthentication yes \
+  'Match Address *,!127.0.0.1' 'SkeyAuthentication yes'
+
+# m. DSAAuthentication, the third alias, aimed at pubkeyauthentication. Unlike
+# the other two it is GLOBAL-only: put it under `Match Address ...` and sshd
+# refuses the whole configuration ("Directive 'DSAAuthentication' is not
+# allowed within a Match block"). Under `Match all` sshd accepts it and
+# applies it globally, which is the form used here. The needle is the SCAN's
+# attribution naming pubkeyauthentication, so the case pins the alias fold
+# even though the global check independently sees the same value move.
+run_reenable_case 'm: DSAAuthentication alias' \
+  "match scan: '$hostile_file' sets 'pubkeyauthentication no'" \
+  "$off_sample_spec" pubkeyauthentication no \
+  'Match all' 'DSAAuthentication no'
+
 printf 'ssh-hardening-match-reenable: OK (every Match bypass form resolves unsafe under real sshd and fails --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-sshd-validate.sh
+++ b/test/integration/ssh-hardening-sshd-validate.sh
@@ -61,12 +61,7 @@ grep -qi 'verified' <<<"$SSH_RUN_OUT" ||
   fail "install must report the effective configuration verified (stdout: $SSH_RUN_OUT)"
 
 # The independent judge: the test's own sshd -G, not the script's verifier.
-for pair in \
-  'passwordauthentication no' \
-  'kbdinteractiveauthentication no' \
-  'usepam yes' \
-  'pubkeyauthentication yes' \
-  'permitrootlogin no'; do
+for pair in "${SSH_HARDENED_PAIRS[@]}"; do
   key="${pair%% *}"
   want="${pair##* }"
   got="$(effective_global_value "$key")" ||

--- a/test/integration/ssh-hardening-sshd-validate.sh
+++ b/test/integration/ssh-hardening-sshd-validate.sh
@@ -10,9 +10,11 @@
 #   2. The judge is not the script: the test's own `/usr/sbin/sshd -G` on the
 #      same tree confirms all five effective values, one by one.
 #   3. Install REFUSES to claim success when verification cannot pass: with a
-#      hostile `Match all` re-enable present, install still writes the drop-in
-#      but exits nonzero and does not print its success line, because the
-#      effective configuration is not fully hardened.
+#      hostile `Match all` re-enable present it exits nonzero and does not
+#      print its success line, because the effective configuration is not fully
+#      hardened. The tree is rolled back to what that run found, which here is
+#      the drop-in the previous run left; ssh-hardening-install-safety.sh is
+#      where the rollback itself is pinned.
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this

--- a/test/integration/ssh-hardening-sshd-validate.sh
+++ b/test/integration/ssh-hardening-sshd-validate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ssh-hardening-sshd-validate.sh -- default install against a hostile tree
+# (slice 7, acceptance criterion 3), judged by an INDEPENDENT sshd -G.
+#
+# The properties pinned:
+#   1. Against a sandbox tree containing a hostile 100-macos.conf that reopens
+#      every hole, install writes the 000- drop-in, REMOVES a seeded legacy
+#      50-no-password-auth.conf, and reports the effective configuration
+#      verified.
+#   2. The judge is not the script: the test's own `/usr/sbin/sshd -G` on the
+#      same tree confirms all five effective values, one by one.
+#   3. Install REFUSES to claim success when verification cannot pass: with a
+#      hostile `Match all` re-enable present, install still writes the drop-in
+#      but exits nonzero and does not print its success line, because the
+#      effective configuration is not fully hardened.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot resolve effective configuration\n'
+  exit 0
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# --- 1 + 2: hostile tree, install, independent judge -------------------------
+
+write_hostile_apple_conf
+legacy="$SSHD_CONFIG_D/50-no-password-auth.conf"
+printf 'PasswordAuthentication no\n' >"$legacy"
+chmod 600 "$legacy"
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "install must succeed on the hostile tree, got exit $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+
+dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+[[ -f $dropin ]] ||
+  fail "install must write $dropin"
+[[ ! -e $legacy ]] ||
+  fail "install must REMOVE the seeded legacy $legacy (a 0600 root-owned legacy file breaks unprivileged verification for the whole tree)"
+grep -qi 'verified' <<<"$SSH_RUN_OUT" ||
+  fail "install must report the effective configuration verified (stdout: $SSH_RUN_OUT)"
+
+# The independent judge: the test's own sshd -G, not the script's verifier.
+for pair in \
+  'passwordauthentication no' \
+  'kbdinteractiveauthentication no' \
+  'usepam yes' \
+  'pubkeyauthentication yes' \
+  'permitrootlogin no'; do
+  key="${pair%% *}"
+  want="${pair##* }"
+  got="$(effective_global_value "$key")" ||
+    fail "independent sshd -G failed on the installed tree"
+  [[ $got == "$want" ]] ||
+    fail "independent sshd -G: '$key' is '$got', want '$want' (the hostile 100-macos.conf must lose to the 000- drop-in)"
+done
+
+# --- 3: install refuses success when verify cannot pass ----------------------
+
+cat >"$SSHD_CONFIG_D/700-hostile-match.conf" <<'EOF'
+Match all
+PasswordAuthentication yes
+EOF
+
+run_ssh_hardening
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'with a Match-block re-enable present, install must exit nonzero'
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  'a failed verification must suppress the install success line'
+grep -qi 'not' <<<"$SSH_RUN_ERR" ||
+  fail "the refusal must say the configuration is not fully hardened (stderr: $SSH_RUN_ERR)"
+
+printf 'ssh-hardening-sshd-validate: OK (hostile tree installed and independently verified; legacy removed; install refuses success when verification fails)\n'

--- a/test/test-system/stat-order.sh
+++ b/test/test-system/stat-order.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
-# stat-order.sh. test/validate-tests.sh must reject a BSD-first stat
-# fallback chain in a scanned test file. The BSD form (the `-f` variant) placed
-# first in a chain runs before the GNU form (the `-c` variant); on Linux CI (GNU
-# coreutils) the `-f` variant means "filesystem status" and SUCCEEDS with the
-# wrong output, so the fallback never fires and the test silently reads garbage.
-# This broke CI twice. The portable idiom is
-# GNU-first (the `-c` variant first). A capability-gated bare BSD form with no
-# chain (e.g. a find-exec in a GNU-probed else-branch) is not a fallback chain
-# and must stay allowed. This drives the guard against a scratch fixture tree.
+# stat-order.sh. test/validate-tests.sh must reject any control flow that
+# tries a BSD-form stat before a GNU-form stat in a scanned test file. The BSD
+# form (the `-f` variant) reached first runs before the GNU form (the `-c`
+# variant); on Linux CI (GNU coreutils), and on macOS whenever the nix dev
+# shell puts GNU coreutils first on PATH, the `-f` variant means "filesystem
+# status" and SUCCEEDS with the wrong output, so the GNU form never runs and
+# the test silently reads garbage. This broke CI twice as a `||` fallback
+# chain, then a third time as an `if`-gated probe the chain-only scan could
+# not see. The property is ORDER, not one syntax: the portable idiom is
+# GNU-first (the `-c` variant first) in any shape -- chain, `if` probe, `&&`
+# probe, case branch, or a variable holding the command. A capability-gated
+# bare BSD form with no GNU form after it in scope (e.g. a find-exec in a
+# GNU-probed else-branch) must stay allowed. This drives the guard against a
+# scratch fixture tree.
 #
 # Self-immunity trick: the two stat tokens are assembled from the variables
-# below, never written as a literal BSD-first chain in THIS file. `just test`
-# runs the real guard over test/, which scans this very file; keeping every line
-# that also carries `||` off the literal tokens lets the fixtures stay honest
-# without the guard flagging its own test.
+# below, GNU token declared FIRST, and never written as a literal BSD-first
+# sequence in THIS file. `just test` runs the real guard over test/, which
+# scans this very file in raw-text order, so declaring the GNU token before
+# the BSD token is what keeps the fixtures honest without the guard flagging
+# its own test. The gnu-token-first boundary fixture below pins this exact
+# escape hatch.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -68,9 +75,10 @@ run_guard() {
 # create_flagged_tree_fixtures <associative-array-name>
 # Build the flagged tree's fixtures under $flagged_root and record each fixture
 # path in the caller-named associative array (nameref), keyed by fixture name,
-# for the assertions that grep the guard's rejection output. The chain always
-# starts on physical line 2 (right after the shebang), so a flagged file is
-# reported at ":2".
+# for the assertions that grep the guard's rejection output. The offending
+# line usually sits on physical line 2 (right after the shebang), so most
+# flagged files are reported at ":2"; the case and masked-function fixtures
+# place it deeper and assert their own line number.
 # shellcheck disable=SC2034 # nameref: every write lands in the caller's array
 create_flagged_tree_fixtures() {
   local -n flagged_fixture_destination="$1"
@@ -115,6 +123,63 @@ create_flagged_tree_fixtures() {
     printf '%s\n' "perms() { $bsd_form '%Lp' \"\$1\" || $gnu_form '%a' \"\$1\"; }"
   } >"$fixtures_lib"
   flagged_fixture_destination["fixtures_lib"]="$fixtures_lib"
+
+  # An `if`-gated BSD probe with the GNU form after the `fi` -- MUST be
+  # flagged. This is the exact shape that broke CI a third time: no `||`
+  # anywhere, yet the BSD form is tried first and its SUCCESS short-circuits
+  # the GNU form.
+  flagged_fixture_destination["if_gated"]="$(probe "$flagged_root" if-gated \
+    "if $bsd_form '%Lp' . 2>/dev/null; then" \
+    "  exit 0" \
+    "fi" \
+    "$gnu_form '%a' .")"
+
+  # A `&&`-early-exit BSD probe with the GNU form on the next line -- MUST be
+  # flagged (same order, third spelling).
+  flagged_fixture_destination["and_exit"]="$(probe "$flagged_root" and-exit \
+    "$bsd_form '%Lp' . 2>/dev/null && exit 0" \
+    "$gnu_form '%a' .")"
+
+  # A case dispatch whose BSD branch precedes its GNU branch -- MUST be
+  # flagged: a uname gate still picks the BSD form on macOS while the nix
+  # shell has put GNU stat first on PATH. Reported at the BSD branch, line 3.
+  # shellcheck disable=SC2016 # the fixture wants a literal $(uname), run-time expanded
+  flagged_fixture_destination["case_dispatch"]="$(probe "$flagged_root" case-dispatch \
+    'case "$(uname)" in' \
+    "  Darwin) $bsd_form '%Lp' . ;;" \
+    "  *) $gnu_form '%a' . ;;" \
+    "esac")"
+
+  # A variable assigned the BSD command, used in a chain with a GNU fallback
+  # -- MUST be flagged at the assignment: the token declaration is where the
+  # BSD form enters the file first.
+  flagged_fixture_destination["variable_token"]="$(probe "$flagged_root" variable-token \
+    "stat_command='$bsd_form'" \
+    "\$stat_command '%Lp' . || $gnu_form '%a' .")"
+
+  # The same BSD token feeding eval / sh -c assembled chains -- MUST be
+  # flagged at the assignment. (Formerly documented out of scope; the ordered
+  # raw-text scan sees the token declaration precede the GNU form. A token
+  # file that declares the GNU token FIRST remains the documented escape
+  # hatch; see the boundary tree.)
+  flagged_fixture_destination["eval_assembled"]="$(probe "$flagged_root" eval-assembled \
+    "bsd_token='$bsd_form'" \
+    "eval \"\$bsd_token '%Lp' . || $gnu_form '%a' .\"")"
+  flagged_fixture_destination["sh_c_assembled"]="$(probe "$flagged_root" sh-c-assembled \
+    "gated_command='$bsd_form'" \
+    "sh -c \"\$gated_command '%Lp' . || $gnu_form '%a' .\"")"
+
+  # A GNU-first function must NOT absolve a BSD-first probe in a LATER
+  # function: scopes reset at each function definition line, so the second
+  # function is judged on its own and MUST be flagged at its BSD line (4).
+  flagged_fixture_destination["masked_function"]="$(probe "$flagged_root" masked-function \
+    "good() { $gnu_form '%a' .; }" \
+    "bad() {" \
+    "  if $bsd_form '%Lp' . 2>/dev/null; then" \
+    "    return 0" \
+    "  fi" \
+    "  $gnu_form '%a' ." \
+    "}")"
 
   # The flagged tree also carries passing single-line and split GNU-first
   # fixtures so one guard run proves the scan flags only the BSD-first chains
@@ -173,8 +238,28 @@ create_clean_tree_fixtures() {
   gnu_long_separate="$(probe "$clean_root" gnu-long-separate \
     "size() { $gnu_printf_form '%s' \"\$1\" || $bsd_form '%z' \"\$1\"; }")"
 
+  # An `if`-gated GNU probe with the BSD form after the `fi` -- MUST pass:
+  # the correct order in the same shape the flagged if-gated fixture uses.
+  local gnu_first_if
+  gnu_first_if="$(probe "$clean_root" gnu-first-if \
+    "if $gnu_form '%a' . 2>/dev/null; then" \
+    "  exit 0" \
+    "fi" \
+    "$bsd_form '%Lp' .")"
+
+  # A GNU capability probe gating a bare BSD call in the else-branch -- MUST
+  # pass: this is the allowed capability-gate pattern (the GNU form appears
+  # first, and the BSD call carries no chain).
+  local gnu_probe_gated_bsd
+  gnu_probe_gated_bsd="$(probe "$clean_root" gnu-probe-gated-bsd \
+    "if $gnu_form '%n' . >/dev/null 2>&1; then" \
+    "  find . -exec $gnu_form '%n %a' {} +" \
+    "else" \
+    "  find . -exec $bsd_form '%N %Lp' {} +" \
+    "fi")"
+
   : "$gnu_single" "$gnu_split" "$bare_bsd" "$clean_file" "$double_safe" "$gnu_wide"
-  : "$gnu_long_attached" "$gnu_long_separate"
+  : "$gnu_long_attached" "$gnu_long_separate" "$gnu_first_if" "$gnu_probe_gated_bsd"
 }
 
 # Build the no-candidate tree (not a single stat call) under $no_candidate_root.
@@ -185,21 +270,49 @@ create_no_candidate_fixture() {
   : "$no_candidate_probe"
 }
 
-# Build the documented out-of-scope fixtures under $eval_boundary_root: chains
-# assembled at run time (eval, sh -c) and a same-segment mask. These exist so a
-# future "improvement" that silently widens the scan's scope shows up as a test
-# change.
+# Build the documented out-of-scope fixtures under $eval_boundary_root: the
+# shapes the scan is KNOWN not to catch, pinned so a future "improvement" that
+# silently widens or narrows the scan's scope shows up as a test change.
 create_boundary_tree_fixtures() {
-  local eval_probe sh_c_probe same_segment_mask
-  eval_probe="$(probe "$eval_boundary_root" eval-assembled \
-    "bsd_token='$bsd_form'" \
-    "eval \"\$bsd_token '%Lp' . || $gnu_form '%a' .\"")"
-  sh_c_probe="$(probe "$eval_boundary_root" sh-c-assembled \
-    "gated_command='$bsd_form'" \
-    "sh -c \"\$gated_command '%Lp' . || $gnu_form '%a' .\"")"
+  # A masking GNU call inside the same unseparated segment: the ordered scan
+  # sees the GNU form first and absolves the BSD-first chain after it.
+  local same_segment_mask
   same_segment_mask="$(probe "$eval_boundary_root" same-segment-mask \
     "a=\$($gnu_form '%a' .) b=\$($bsd_form '%Lp' . || $gnu_form '%a' .)")"
-  : "$eval_probe" "$sh_c_probe" "$same_segment_mask"
+
+  # An UNRELATED GNU call earlier in the same scope absolves a later
+  # BSD-first probe: the scan tracks form order, not data flow, so it cannot
+  # tell a real capability gate from a coincidental earlier GNU call. This is
+  # the scope-level analog of the same-segment mask.
+  local scope_mask
+  scope_mask="$(probe "$eval_boundary_root" scope-mask \
+    "a=\"\$($gnu_form '%s' .)\"" \
+    "if $bsd_form '%Lp' . 2>/dev/null; then exit 0; fi" \
+    "$gnu_form '%a' .")"
+
+  # Runtime assembly with the GNU token declared FIRST: the raw-text scan
+  # reads declaration order, so a BSD-first chain assembled at run time from
+  # GNU-token-first declarations is invisible. This is the exact escape hatch
+  # THIS test file relies on for self-immunity; pinned so it cannot silently
+  # close (closing it means this test flags itself).
+  local gnu_token_first_assembly
+  gnu_token_first_assembly="$(probe "$eval_boundary_root" gnu-token-first-assembly \
+    "gnu_token='$gnu_form'" \
+    "bsd_token='$bsd_form'" \
+    "eval \"\$bsd_token '%Lp' . || \$gnu_token '%a' .\"")"
+
+  # A case dispatch listing the GNU branch BEFORE a BSD fallback branch: the
+  # scan does not understand dispatch conditions, so this passes even though
+  # the `*)` branch still runs the BSD form on macOS under a GNU-first PATH.
+  local reversed_case_dispatch
+  # shellcheck disable=SC2016 # the fixture wants a literal $(uname), run-time expanded
+  reversed_case_dispatch="$(probe "$eval_boundary_root" reversed-case-dispatch \
+    'case "$(uname)" in' \
+    "  Linux) $gnu_form '%a' . ;;" \
+    "  *) $bsd_form '%Lp' . ;;" \
+    "esac")"
+
+  : "$same_segment_mask" "$scope_mask" "$gnu_token_first_assembly" "$reversed_case_dispatch"
 }
 
 # assert_flagged_tree_rejected <associative-array-name>
@@ -229,6 +342,20 @@ assert_flagged_tree_rejected() {
     record_failure "BSD-first chain inside a comment not reported at :2: $guard_output"
   grep -qF "${flagged_fixture_paths_reference["fixtures_lib"]}:2" <<<"$guard_output" ||
     record_failure "BSD-first chain inside fixtures/ not reported at :2: $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["if_gated"]}:2" <<<"$guard_output" ||
+    record_failure "if-gated BSD probe (the third CI breakage shape) not reported at :2: $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["and_exit"]}:2" <<<"$guard_output" ||
+    record_failure "and-exit BSD probe not reported at :2: $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["case_dispatch"]}:3" <<<"$guard_output" ||
+    record_failure "case dispatch with the BSD branch first not reported at :3: $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["variable_token"]}:2" <<<"$guard_output" ||
+    record_failure "BSD command held in a variable not reported at its assignment (:2): $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["eval_assembled"]}:2" <<<"$guard_output" ||
+    record_failure "eval-assembled chain fed by a BSD token not reported at the assignment (:2): $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["sh_c_assembled"]}:2" <<<"$guard_output" ||
+    record_failure "sh -c assembled chain fed by a BSD token not reported at the assignment (:2): $guard_output"
+  grep -qF "${flagged_fixture_paths_reference["masked_function"]}:4" <<<"$guard_output" ||
+    record_failure "BSD-first probe in a later function masked by an earlier GNU-first function not reported at :4: $guard_output"
   grep -qF "${flagged_fixture_paths_reference["gnu_single_mixed"]}" <<<"$guard_output" &&
     record_failure "GNU-first single-line chain was wrongly reported: $guard_output"
   grep -qF "${flagged_fixture_paths_reference["gnu_split_mixed"]}" <<<"$guard_output" &&
@@ -299,13 +426,14 @@ assert_awk_failure_fails_guard() {
   fi
 }
 
-# The documented boundary: runtime-assembled chains and a same-segment mask are
-# out of scope and MUST pass.
+# The documented boundary: the same-segment mask, the scope-level mask, the
+# gnu-token-first assembly, and the reversed case dispatch are out of scope
+# and MUST pass.
 assert_out_of_scope_cases_pass() {
   local guard_output guard_status
   run_guard guard_output guard_status "$eval_boundary_root/test"
   [[ $guard_status -eq 0 ]] ||
-    record_failure "documented out-of-scope cases (eval, sh -c, same-segment mask) must pass: $guard_output"
+    record_failure "documented out-of-scope cases (same-segment mask, scope mask, gnu-token-first assembly, reversed case dispatch) must pass: $guard_output"
 }
 
 main() {

--- a/test/unit/ssh-hardening-dropin.sh
+++ b/test/unit/ssh-hardening-dropin.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ssh-hardening-dropin.sh -- the two pure modes of ssh-hardening.sh, the test
+# seam everything else stands on (slice 7).
+#
+# The properties pinned, one per acceptance criterion:
+#   1. --print-config emits ALL FIVE accepted directives (asserted one by one:
+#      completeness over counting), each exactly once among the non-comment
+#      lines with its accepted value, so no conflicting directive can hide.
+#      No privilege escalation, no write.
+#   2. --print-path names 000-ssh-hardening.conf under the configured drop-in
+#      directory, and an LC_ALL=C sort places that name before Apple's
+#      100-macos.conf (sshd's Include is lexical and first-value-wins, so
+#      sorting first is what keeps the drop-in authoritative). No privilege
+#      escalation, no write.
+#
+# Runs through the sandbox harness: seams point at a scratch tree, a failing
+# sudo stub on PATH blocks escalation, and the script runs under /bin/bash so
+# a bash 3.2 regression fails here.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-commit and pre-push hooks.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# The sandbox drop-in dir starts EMPTY; both pure modes must leave it so.
+baseline_listing="$(ls -A "$SSHD_CONFIG_D")"
+
+# --- Criterion 1: --print-config -------------------------------------------
+
+run_ssh_hardening --print-config
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--print-config must exit 0, got $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+
+# All five accepted lines, each asserted individually.
+for accepted_line in \
+  'PasswordAuthentication no' \
+  'KbdInteractiveAuthentication no' \
+  'UsePAM yes' \
+  'PubkeyAuthentication yes' \
+  'PermitRootLogin no'; do
+  grep -qxF "$accepted_line" <<<"$SSH_RUN_OUT" ||
+    fail "--print-config must emit '$accepted_line' (got: $SSH_RUN_OUT)"
+done
+
+# No conflicting directive: among non-comment lines, each protected keyword
+# appears EXACTLY once (case-insensitive, '=' separator counted too), so a
+# second occurrence with a hostile value cannot ride along.
+noncomment_lines="$(grep -Ev '^[[:space:]]*(#|$)' <<<"$SSH_RUN_OUT")"
+for keyword in PasswordAuthentication KbdInteractiveAuthentication UsePAM \
+  PubkeyAuthentication PermitRootLogin; do
+  occurrences="$(grep -icE "^[[:space:]]*${keyword}([[:space:]=]|$)" \
+    <<<"$noncomment_lines")" || true
+  [[ $occurrences -eq 1 ]] ||
+    fail "--print-config must set '$keyword' exactly once among non-comment lines, found $occurrences"
+done
+
+assert_no_sudo_and_no_sandbox_write '--print-config' "$baseline_listing" ||
+  fail '--print-config must be pure'
+
+# --- Criterion 2: --print-path ----------------------------------------------
+
+run_ssh_hardening --print-path
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--print-path must exit 0, got $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+
+dropin_name="$(basename "$SSH_RUN_OUT")"
+[[ $dropin_name == '000-ssh-hardening.conf' ]] ||
+  fail "--print-path must name 000-ssh-hardening.conf, got '$SSH_RUN_OUT'"
+[[ $SSH_RUN_OUT == "$SSHD_CONFIG_D/$dropin_name" ]] ||
+  fail "--print-path must resolve under the SSHD_CONFIG_D seam, got '$SSH_RUN_OUT'"
+
+# The precedence property itself: in sshd's lexical (LC_ALL=C) include order
+# the drop-in must sort BEFORE Apple's file, or first-value-wins hands every
+# directive to Apple.
+first_sorted="$(printf '%s\n%s\n' "$dropin_name" '100-macos.conf' |
+  LC_ALL=C sort | head -n 1)"
+[[ $first_sorted == "$dropin_name" ]] ||
+  fail "the drop-in name '$dropin_name' must sort before 100-macos.conf in LC_ALL=C order"
+
+assert_no_sudo_and_no_sandbox_write '--print-path' "$baseline_listing" ||
+  fail '--print-path must be pure'
+
+printf 'ssh-hardening-dropin: OK (both pure modes: five directives exactly once, 000- name sorts before 100-macos.conf, no escalation, no writes)\n'

--- a/test/unit/ssh-hardening-dropin.sh
+++ b/test/unit/ssh-hardening-dropin.sh
@@ -3,7 +3,7 @@
 # seam everything else stands on (slice 7).
 #
 # The properties pinned, one per acceptance criterion:
-#   1. --print-config emits ALL FIVE accepted directives (asserted one by one:
+#   1. --print-config emits EVERY accepted directive (asserted one by one:
 #      completeness over counting), each exactly once among the non-comment
 #      lines with its accepted value, so no conflicting directive can hide.
 #      No privilege escalation, no write.
@@ -42,13 +42,16 @@ run_ssh_hardening --print-config
 [[ $SSH_RUN_STATUS -eq 0 ]] ||
   fail "--print-config must exit 0, got $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
 
-# All five accepted lines, each asserted individually.
+# Every accepted line, each asserted individually. The list is the shared one,
+# so a directive added to policy cannot leave this guard checking a short set.
 for accepted_line in \
   'PasswordAuthentication no' \
   'KbdInteractiveAuthentication no' \
   'UsePAM yes' \
   'PubkeyAuthentication yes' \
-  'PermitRootLogin no'; do
+  'PermitRootLogin no' \
+  'GSSAPIAuthentication no' \
+  'HostbasedAuthentication no'; do
   grep -qxF "$accepted_line" <<<"$SSH_RUN_OUT" ||
     fail "--print-config must emit '$accepted_line' (got: $SSH_RUN_OUT)"
 done
@@ -58,7 +61,8 @@ done
 # second occurrence with a hostile value cannot ride along.
 noncomment_lines="$(grep -Ev '^[[:space:]]*(#|$)' <<<"$SSH_RUN_OUT")"
 for keyword in PasswordAuthentication KbdInteractiveAuthentication UsePAM \
-  PubkeyAuthentication PermitRootLogin; do
+  PubkeyAuthentication PermitRootLogin GSSAPIAuthentication \
+  HostbasedAuthentication; do
   occurrences="$(grep -icE "^[[:space:]]*${keyword}([[:space:]=]|$)" \
     <<<"$noncomment_lines")" || true
   [[ $occurrences -eq 1 ]] ||
@@ -91,4 +95,4 @@ first_sorted="$(printf '%s\n%s\n' "$dropin_name" '100-macos.conf' |
 assert_no_sudo_and_no_sandbox_write '--print-path' "$baseline_listing" ||
   fail '--print-path must be pure'
 
-printf 'ssh-hardening-dropin: OK (both pure modes: five directives exactly once, 000- name sorts before 100-macos.conf, no escalation, no writes)\n'
+printf 'ssh-hardening-dropin: OK (both pure modes: every directive exactly once, 000- name sorts before 100-macos.conf, no escalation, no writes)\n'

--- a/test/unit/ssh-hardening-verify-failclosed.sh
+++ b/test/unit/ssh-hardening-verify-failclosed.sh
@@ -88,4 +88,83 @@ grep -qi 'cannot read' <<<"$SSH_RUN_ERR" ||
 refute_contains "$SSH_RUN_OUT" 'verify: PASS' \
   'an unreadable drop-in must never produce a pass claim'
 
-printf 'ssh-hardening-verify-failclosed: OK (missing verifier fails closed, seam skips without a verified claim, unreadable drop-in fails and is named)\n'
+# --- 4: the skip seam is ON only for a TRUE-ish value ------------------------
+# The seam was tested for being NONEMPTY, so every value enabled it -- setting
+# it to `0`, the value that reads as "off", switched verification off. Both
+# directions are asserted, because "ignore the seam entirely" would satisfy
+# only half of this.
+
+for off_value in 0 false no off FALSE Off; do
+  SSHD_BIN="$SSH_SANDBOX/no-such-sshd" \
+    SSH_HARDENING_ALLOW_MISSING_SSHD="$off_value" run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "seam='$off_value' reads as OFF and must NOT enable the skip; --verify exited 0 (stdout: $SSH_RUN_OUT)"
+  grep -qi 'failing closed' <<<"$SSH_RUN_ERR" ||
+    fail "seam='$off_value': the failure must say it is failing closed (stderr: $SSH_RUN_ERR)"
+  refute_contains "$SSH_RUN_OUT" 'skip' \
+    "seam='$off_value' must not report a skip"
+done
+
+for on_value in 1 true yes on TRUE On; do
+  SSHD_BIN="$SSH_SANDBOX/no-such-sshd" \
+    SSH_HARDENING_ALLOW_MISSING_SSHD="$on_value" run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -eq 0 ]] ||
+    fail "seam='$on_value' reads as ON and must still skip cleanly, got $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+  grep -qi 'skip' <<<"$SSH_RUN_OUT" ||
+    fail "seam='$on_value': the seam path must say it skipped (stdout: $SSH_RUN_OUT)"
+  refute_contains "$SSH_RUN_OUT" 'verified' \
+    "seam='$on_value' must not print a verified claim"
+done
+
+# --- 5: a file listing that could not be built is not an empty tree ----------
+# The list of files to scan was produced by a pipeline inside a process
+# substitution, whose exit status nothing can observe. A failing `sort` there
+# yields ZERO files, and a scan of nothing finds nothing wrong: --verify
+# printed PASS over a tree it had never read. The tree here is fully hardened
+# on purpose, so the listing failure is the only thing that can fail it.
+
+write_hardened_dropin
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "positive control: the hardened sandbox must verify before the listing is broken (stderr: $SSH_RUN_ERR)"
+
+ssh_break_command sort
+run_ssh_hardening --verify
+ssh_restore_commands
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'a configuration listing that could not be built must FAIL the verify, not pass it as an empty tree'
+grep -qi 'list the configuration files' <<<"$SSH_RUN_ERR" ||
+  fail "the failure must name the listing it could not build (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'verify: PASS' \
+  'a scan that read no files must never produce a pass claim'
+
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--verify must PASS again once the listing works; state leaked (stderr: $SSH_RUN_ERR)"
+
+# --- 6: every command the verify depends on is checked BY NAME ---------------
+# Each of these used to be visible only through errexit, which the install path
+# switched off. Asserting the WORDING and not merely the exit status is what
+# pins the individual guard: without it the run still fails, but for a reason
+# nobody can act on -- a spec built from an empty user name, or an unset value
+# read as an absent directive.
+
+assert_named_failure() { # <broken command> <message needle>
+  ssh_break_command "$1"
+  run_ssh_hardening --verify
+  ssh_restore_commands
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "a failing '$1' must FAIL the verify (stdout: $SSH_RUN_OUT)"
+  grep -qi -- "$2" <<<"$SSH_RUN_ERR" ||
+    fail "a failing '$1' must be reported as '$2' rather than left to surface as some downstream confusion (stderr: $SSH_RUN_ERR)"
+  refute_contains "$SSH_RUN_OUT" 'verify: PASS' \
+    "a failing '$1' must never produce a pass claim"
+  run_ssh_hardening --verify
+  [[ $SSH_RUN_STATUS -eq 0 ]] ||
+    fail "--verify must PASS again once '$1' works (stderr: $SSH_RUN_ERR)"
+}
+
+assert_named_failure id 'could not determine the invoking user'
+assert_named_failure awk 'could not read'
+
+printf 'ssh-hardening-verify-failclosed: OK (missing verifier fails closed, the skip seam honours only true-ish values, an unreadable drop-in and an unbuildable listing both fail and are named)\n'

--- a/test/unit/ssh-hardening-verify-failclosed.sh
+++ b/test/unit/ssh-hardening-verify-failclosed.sh
@@ -128,9 +128,7 @@ run_ssh_hardening --verify
 [[ $SSH_RUN_STATUS -eq 0 ]] ||
   fail "positive control: the hardened sandbox must verify before the listing is broken (stderr: $SSH_RUN_ERR)"
 
-ssh_break_command sort
-run_ssh_hardening --verify
-ssh_restore_commands
+run_ssh_hardening_without sort --verify
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail 'a configuration listing that could not be built must FAIL the verify, not pass it as an empty tree'
 grep -qi 'list the configuration files' <<<"$SSH_RUN_ERR" ||
@@ -150,9 +148,7 @@ run_ssh_hardening --verify
 # read as an absent directive.
 
 assert_named_failure() { # <broken command> <message needle>
-  ssh_break_command "$1"
-  run_ssh_hardening --verify
-  ssh_restore_commands
+  run_ssh_hardening_without "$1" --verify
   [[ $SSH_RUN_STATUS -ne 0 ]] ||
     fail "a failing '$1' must FAIL the verify (stdout: $SSH_RUN_OUT)"
   grep -qi -- "$2" <<<"$SSH_RUN_ERR" ||

--- a/test/unit/ssh-hardening-verify-failclosed.sh
+++ b/test/unit/ssh-hardening-verify-failclosed.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# ssh-hardening-verify-failclosed.sh -- --verify fails CLOSED whenever it
+# cannot actually check anything (slice 7, acceptance criterion 6). Fail-open
+# is the cardinal sin: "cannot run the verifier" and "cannot read a drop-in"
+# must both resolve to FAILURE, never to a verified claim.
+#
+# The properties pinned:
+#   1. SSHD_BIN pointing at a nonexistent path, no test seam: --verify exits
+#      nonzero and says it is failing closed.
+#   2. Same broken SSHD_BIN with the SSH_HARDENING_ALLOW_MISSING_SSHD seam
+#      set: --verify skips cleanly (exit 0) and does NOT print a verified
+#      claim.
+#   3. An unreadable drop-in in the tree: --verify exits nonzero and names the
+#      unreadable file, from the raw scan's own "cannot read" branch (distinct
+#      from sshd's Permission denied wording, so the scan's fail-closed branch
+#      is pinned even though sshd -G also refuses).
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-commit and pre-push hooks.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it is the last statement, so
+# every negative goes through this helper.
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# --- 1: missing verifier, no seam -> nonzero, says failing closed -----------
+
+SSHD_BIN="$SSH_SANDBOX/no-such-sshd" run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'with SSHD_BIN nonexistent and no seam, --verify must exit nonzero'
+grep -qi 'failing closed' <<<"$SSH_RUN_ERR" ||
+  fail "the failure must say it is failing closed (stderr: $SSH_RUN_ERR)"
+grep -qF "$SSH_SANDBOX/no-such-sshd" <<<"$SSH_RUN_ERR" ||
+  fail "the failure must name the unrunnable verifier (stderr: $SSH_RUN_ERR)"
+
+# --- 2: missing verifier, seam set -> clean skip, no verified claim ---------
+
+SSHD_BIN="$SSH_SANDBOX/no-such-sshd" SSH_HARDENING_ALLOW_MISSING_SSHD=1 \
+  run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "with the seam set, --verify must skip cleanly (exit 0), got $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+grep -qi 'skip' <<<"$SSH_RUN_OUT" ||
+  fail "the seam path must say it skipped (stdout: $SSH_RUN_OUT)"
+refute_contains "$SSH_RUN_OUT" 'verified' \
+  'the seam path must not print a verified claim'
+refute_contains "$SSH_RUN_OUT" 'PASS' \
+  'the seam path must not print a PASS claim'
+
+# --- 3: unreadable drop-in -> nonzero, names the file ------------------------
+
+[[ -x /usr/sbin/sshd ]] || {
+  printf 'SKIP: /usr/sbin/sshd not present; cannot exercise the unreadable-drop-in case\n'
+  exit 0
+}
+
+# A fully hardened tree, then one unreadable sibling: the tree WOULD verify,
+# so only the fail-closed handling of the unreadable file can fail it.
+/bin/bash "$SSH_HARDENING_SCRIPT" --print-config \
+  >"$SSHD_CONFIG_D/000-ssh-hardening.conf" 2>/dev/null || true
+unreadable="$SSHD_CONFIG_D/060-unreadable.conf"
+printf '# contents beside the point; the mode is the case\n' >"$unreadable"
+chmod 000 "$unreadable"
+
+run_ssh_hardening --verify
+chmod 644 "$unreadable" # so teardown can remove it regardless of the verdict
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 'with an unreadable drop-in, --verify must exit nonzero'
+grep -qF "$unreadable" <<<"$SSH_RUN_ERR" ||
+  fail "the failure must name the unreadable file (stderr: $SSH_RUN_ERR)"
+grep -qi 'cannot read' <<<"$SSH_RUN_ERR" ||
+  fail "the raw scan's own cannot-read branch must fire, not only sshd's refusal (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'verify: PASS' \
+  'an unreadable drop-in must never produce a pass claim'
+
+printf 'ssh-hardening-verify-failclosed: OK (missing verifier fails closed, seam skips without a verified claim, unreadable drop-in fails and is named)\n'

--- a/test/validate-tests.sh
+++ b/test/validate-tests.sh
@@ -109,38 +109,103 @@ check_placement() { # <root> <workdir>
   return 0
 }
 
-# BSD-first stat fallback chains. The BSD form of stat (the `-f` variant) placed
-# first in a fallback chain does not fail on Linux (GNU coreutils), where that
-# flag means "filesystem status": it succeeds with the wrong output, the GNU
-# fallback never fires, and the caller silently reads garbage (this broke CI
-# twice). The scan's contract, applied per chain segment (physical lines joined
-# across backslash continuations, then split on `;` and `&&`):
+# BSD-first stat usage. The BSD form of stat (the `-f` variant) tried before
+# the GNU form does not fail on Linux (GNU coreutils), or on macOS whenever
+# the nix dev shell puts GNU coreutils first on PATH: there that flag means
+# "filesystem status", so it succeeds with the wrong output, the GNU form
+# never runs, and the caller silently reads garbage (this broke CI twice as a
+# `||` chain, then a third time as an `if`-gated probe the chain-only scan
+# could not see). The property enforced is ORDER, not one syntax: no control
+# flow may try the BSD form before a GNU form (`-c`, `--format`, `--printf`)
+# has appeared. Two analyses over raw text (comments and fixture prose count;
+# the scan reads raw text on purpose, since examples get copy-pasted), both on
+# chain segments (physical lines joined across backslash continuations, then
+# split on `;` and `&&`):
 #
-#   - FLAGGED: a segment whose BSD-form stat sits in a `||` chain with no
-#     GNU-form stat (`-c`, `--format`, `--printf`) before it. Comments and
-#     fixture prose count; the scan reads raw text on purpose (copy-paste risk).
-#   - ALLOWED: GNU-first chains, and capability-gated bare BSD-form calls.
-#   - Boundary: literal chains in raw text only. Runtime-assembled chains and a
-#     masking GNU call inside the same unseparated segment are out of scope.
+#   - Per segment: a BSD-form stat sitting in a `||` chain with no GNU-form
+#     stat before it in the same segment is FLAGGED (catches a chain masked
+#     by an earlier GNU call elsewhere in the file).
+#   - Per scope, reading every segment's stat forms in raw-text order (two
+#     scopes: the whole file, and afresh from each function-definition line):
+#     a BSD form seen before any GNU form is FLAGGED at its line as soon as a
+#     GNU form follows in the same scope. This catches `if`-gated probes,
+#     `&&`-early-exit probes, a case dispatch with the BSD branch first, and
+#     a variable assigned the BSD command before the GNU form appears.
+#   - ALLOWED: GNU-first order in any shape, and a bare BSD-form call with no
+#     GNU form after it in scope (capability-gated, darwin-only use).
+#   - Boundary (documented misses): an unrelated GNU call earlier in the same
+#     segment or scope absolves a later BSD-first construct (order, not data
+#     flow); runtime-assembled commands whose tokens are declared GNU-first
+#     are invisible; dispatch conditions are not understood, so a case
+#     listing a GNU branch before a BSD fallback branch passes; function
+#     scopes reset at each function-definition line, not at closing braces.
 #   - Fail closed: a grep or awk error fails the guard, never a silent pass.
 #
 # Each rule and boundary here is pinned as a named fixture + assertion in
 # test/test-system/stat-order.sh; that test is the authoritative documentation
 # and cannot drift. (The guard lives inside its own scan root, so no comment
-# here may spell a literal BSD-first chain; hence this phrasing.)
-# find_bsd_first_chains_in_file <file> -- print the starting line number of
-# every BSD-first stat fallback chain in the file, one per line. Physical lines
-# are joined across backslash continuations, then split on `;` and `&&`; each
-# segment is judged on its own. Returns awk's exit status so the caller can
-# fail closed on a tool error.
+# here may spell a literal BSD-first sequence; hence this phrasing.)
+# find_bsd_first_chains_in_file <file> -- print the line number of every
+# BSD-first stat usage in the file, one per line, ascending, deduplicated.
+# Returns awk's exit status so the caller can fail closed on a tool error.
 #
 # awk idiom: awk has no `local`; extra function parameters ARE the locals, and
-# the wide gap in flush()'s parameter list separates real arguments (none here)
-# from those locals.
+# the wide gap in each parameter list separates real arguments from those
+# locals.
 find_bsd_first_chains_in_file() { # <file>
   LC_ALL=C awk '
+    BEGIN {
+      bsd_regex = "stat[[:space:]]+-f"
+      gnu_regex = "stat[[:space:]]+(-c|--(format|printf)[=[:space:]])"
+      function_definition_regex = "^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\\(\\)[[:space:]]*\\{"
+    }
+    function report(line_number) {
+      if (line_number in reported) return
+      reported[line_number] = 1
+      reported_lines[++reported_count] = line_number
+    }
+    # One stat-form occurrence, in raw-text order, feeding two identical
+    # state machines: file scope (never resets) and function scope (reset at
+    # each function-definition line). A GNU form flags any pending BSD form
+    # and absolves every later one; a BSD form seen before any GNU form
+    # becomes the pending line of each scope that has not seen a GNU form.
+    function process_occurrence(is_gnu_form, line_number) {
+      if (is_gnu_form) {
+        if (file_pending) { report(file_pending); file_pending = 0 }
+        if (func_pending) { report(func_pending); func_pending = 0 }
+        file_gnu_seen = 1
+        func_gnu_seen = 1
+        return
+      }
+      if (!file_gnu_seen && !file_pending) file_pending = line_number
+      if (!func_gnu_seen && !func_pending) func_pending = line_number
+    }
+    # Feed the stat forms of one segment to process_occurrence in position
+    # order (a segment may hold both forms in either order).
+    function scan_segment_forms(segment, line_number,   gnu_position, gnu_length, bsd_position, bsd_length) {
+      while (1) {
+        gnu_position = 0
+        bsd_position = 0
+        if (match(segment, gnu_regex)) { gnu_position = RSTART; gnu_length = RLENGTH }
+        if (match(segment, bsd_regex)) { bsd_position = RSTART; bsd_length = RLENGTH }
+        if (!gnu_position && !bsd_position) return
+        if (gnu_position && (!bsd_position || gnu_position < bsd_position)) {
+          process_occurrence(1, line_number)
+          segment = substr(segment, gnu_position + gnu_length)
+        } else {
+          process_occurrence(0, line_number)
+          segment = substr(segment, bsd_position + bsd_length)
+        }
+      }
+    }
     function flush(   line_copy, segment_count, segment_number, segment, bsd_index, gnu_index) {
       if (joined == "") return
+      # Function boundary: a function-definition line starts a fresh function
+      # scope, judged on its own even when an earlier function was GNU-first.
+      if (joined ~ function_definition_regex) {
+        func_gnu_seen = 0
+        func_pending = 0
+      }
       # Segment split: `;` and `&&` both terminate a chain, so rewrite
       # `&&` to `;` and split the logical line once.
       line_copy = joined
@@ -148,18 +213,16 @@ find_bsd_first_chains_in_file() { # <file>
       segment_count = split(line_copy, segments, ";")
       for (segment_number = 1; segment_number <= segment_count; segment_number++) {
         segment = segments[segment_number]
-        # BSD hit: skip any segment without the BSD form.
-        bsd_index = match(segment, /stat[[:space:]]+-f/)
-        if (bsd_index == 0) continue
-        # Chain check: a bare capability-gated call is not a fallback chain.
-        if (index(segment, "||") == 0) continue
-        # GNU-before check: a GNU form earlier in the SAME segment means the
-        # chain is GNU-first, the portable order.
-        gnu_index = match(segment, /stat[[:space:]]+(-c|--(format|printf)[=[:space:]])/)
-        if (!(gnu_index > 0 && gnu_index < bsd_index)) {
-          print start_line
-          break
+        # Per-segment chain analysis: a BSD form in a `||` chain with no GNU
+        # form earlier in the SAME segment is BSD-first regardless of scope
+        # state (an earlier GNU call elsewhere must not mask it).
+        bsd_index = match(segment, bsd_regex)
+        if (bsd_index > 0 && index(segment, "||") > 0) {
+          gnu_index = match(segment, gnu_regex)
+          if (!(gnu_index > 0 && gnu_index < bsd_index)) report(start_line)
         }
+        # Scope analysis: every stat form feeds the ordered state machines.
+        scan_segment_forms(segment, start_line)
       }
       joined = ""
     }
@@ -172,7 +235,17 @@ find_bsd_first_chains_in_file() { # <file>
       joined = joined line
       flush()
     }
-    END { flush() }
+    END {
+      flush()
+      for (i = 1; i <= reported_count; i++)
+        for (j = i + 1; j <= reported_count; j++)
+          if (reported_lines[j] + 0 < reported_lines[i] + 0) {
+            swap = reported_lines[i]
+            reported_lines[i] = reported_lines[j]
+            reported_lines[j] = swap
+          }
+      for (i = 1; i <= reported_count; i++) print reported_lines[i]
+    }
   ' "$1"
 }
 
@@ -208,7 +281,7 @@ check_stat_order() { # <root> <workdir>
   bsd_first_chains="${bsd_first_chains%$'\n'}"
 
   if [[ -n $bsd_first_chains ]]; then
-    printf 'FAIL: BSD-first stat fallback chain(s) below %s/ (break on Linux CI; put the GNU -c form first, the BSD -f form as the fallback):\n' "$root" >&2
+    printf 'FAIL: BSD-first stat usage(s) below %s/ (the BSD form does not fail under GNU coreutils, it succeeds with garbage; try the GNU -c form first, in any control flow, and fall back to the BSD -f form):\n' "$root" >&2
     printf '%s\n' "$bsd_first_chains" | sed 's/^/  /' >&2
     return 1
   fi


### PR DESCRIPTION
## Context

Remote login on this machine should accept keys and nothing else. The existing setup got part of the way
there: password logins were already off, but a second interactive password channel was still open and root
could still log in by key. A small drop-in file said so, and nothing checked whether it was still true.

This rewrites the script that manages that file so it generates the policy, installs it safely, and then
proves the machine actually resolves the way the policy says. Nothing here touches the running daemon: a
new configuration file changes nothing until sshd restarts, which is the next change, not this one.

## Summary

- Closes the second password channel and removes root login, the only two settings that were still open.
- Renames the drop-in so it takes precedence over anything the system ships, and retires the old file.
- Verifies the result three independent ways, all read-only, and refuses to claim success otherwise.
- Installs as a transaction, so a failure at any point leaves the machine exactly as it was.
- Adds tests that prove each of eight ways a determined configuration could have slipped past.

Key files: `dot_local/bin/executable_ssh-hardening.sh`, `.chezmoidata/macos_system_setup.yaml`, six test
files.

## What was actually unhardened, measured rather than assumed

Reading the live effective configuration before writing anything:

```
passwordauthentication       no                  already correct
pubkeyauthentication         yes                 already correct
usepam                       yes                 already correct
kbdinteractiveauthentication yes                 open
permitrootlogin              without-password    open
```

So turning off password authentication was never sufficient on its own, and the second channel had been
open the whole time. Root login was at the upstream default, which permits it by key.

One claim in the plan turned out to be overstated and is corrected here: the old file was said to be
overridden by a file the system ships. It sorts later, and the system's file is read first, but that file
never mentions the setting in question, so nothing was actually being overridden. The rename is still
worth doing as insurance for the day it does, and the tests prove it against a deliberately hostile
version of that file rather than against the harmless real one.

## Why three checks, and why that still was not enough

The natural way to ask "what is my effective configuration" reports only the part that applies before any
conditional block. A conditional block that re-opens password authentication for every address except the
loopback is therefore invisible to it, while the machine is wide open. That is the most idiomatic way to
defeat this kind of check, so two more were added: a direct scan of the configuration text, and resolution
against specific sample connections.

Two independent reviews then defeated all three together, five different ways, each demonstrated against
the real daemon rather than argued:

A quoted keyword. A rarely-used alias for one of the protected settings. A carriage return inside the
conditional line. A file pulled in from outside the scanned directory. And a file pulled in from inside a
conditional block, which the daemon applies within that block's scope.

The first three are text-matching gaps: the daemon tokenises its configuration more liberally than a
simple pattern does. The last two share a deeper cause. All three checks assumed the set of files was
fixed, and a configuration can change that set while being read. Three checks, one shared blind spot, and
independence was the whole premise.

The scan now tokenises the way the daemon does, folds every alias that reaches a protected setting
(enumerated from the daemon's own strings rather than guessed), and follows included files recursively
while carrying conditional context across the boundary. Cycles, excessive depth, and unreadable files each
fail closed and say which.

## Failing safely, in both senses

Several paths reported success when they should have refused: a switch meant to skip verification in tests
turned on for any value at all, including one that reads as off; a failed listing left the scan examining
nothing while still reporting a pass; and calling the verifier from the install path silently disabled the
shell's error handling inside it.

Installation could also leave the machine worse than it found it. The write truncated the destination
before the content had been produced, so an interrupted install emptied a valid file. It also removed the
old policy before the new one had been proven. Installation is now a transaction: stage, publish, set the
old file aside, verify, and roll everything back on any failure.

## One thing deliberately kept despite a test not requiring it

The verifier now runs in a child shell when called from install. A mutation that reverts this to an
in-process call passes every test, because each individual fault is now guarded separately. It was kept
anyway: separate guards make the property true by enumerating faults, and a child shell makes it true by
construction. Enumeration is exactly what failed the first time. Not every correct structure is detectable
by breaking it.

## What is not proven here

The daemon is never reloaded, restarted, or contacted; every check is read-only, and the tests run against
temporary directories with three separate barriers preventing them from reaching the real configuration.
One of those barriers turned out to be weaker than its comment claimed, and the comment now says what each
one does and does not cover.

One case is proven by inspection rather than end to end: the daemon resolves relative includes against its
compiled-in directory regardless of which configuration file it is pointed at, so a relative include
cannot be exercised without writing to the real one.

## Effect of merging

Advances `main` only. Writing this file changes nothing for the running daemon, and the live machine
follows another branch. The reload, and the recovery path that goes with it, are the next change.
