### PR TITLE
feat(ssh): add --reload and --rollback, the sshd apply-safety modes

### DIFF
--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -61,6 +61,25 @@ Do not resurrect the legacy `defaults write /Library/Preferences/com.apple.alf l
 nothing on 26.2 documents that the daemon still reads it, and a preference written under a subsystem that
 ignores it reads back as configured while doing nothing.
 
+### SSH hardening: reload and the way back in
+
+`ssh-hardening.sh` writes `/etc/ssh/sshd_config.d/000-ssh-hardening.conf` (public-key-only sshd policy)
+and verifies it, but never restarts sshd. The running daemon picks the drop-in up only via the separate,
+deliberately disruptive `ssh-hardening.sh --reload`, which validates the complete configuration first,
+restarts the launchd service, and refuses to report success until an SSH banner exchange completes on the
+resolved port.
+
+Before running `--reload` on a machine you are not sitting at:
+
+1. Keep an existing SSH session open until a brand-new session has succeeded.
+1. Confirm Screen Sharing over the tailnet works BEFORE the reload, not during the incident.
+
+If `--reload` fails, warns about a possible lockout, or a new session cannot connect: from the physical
+console or Screen Sharing over the tailnet, run `ssh-hardening.sh --rollback` (or
+`sudo rm /etc/ssh/sshd_config.d/000-ssh-hardening.conf`), then turn Remote Login off and back on in
+System Settings > General > Sharing. `--rollback` removes the drop-in and confirms the hardening is out
+of the effective configuration; the next sshd start accepts password authentication again.
+
 ### Hardware pairing
 
 - **Bluetooth**: pair AirPods, mice, keyboards via System Settings → Bluetooth.

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -66,12 +66,14 @@ ignores it reads back as configured while doing nothing.
 `ssh-hardening.sh` writes `/etc/ssh/sshd_config.d/000-ssh-hardening.conf` (public-key-only sshd policy)
 and verifies it, but never restarts sshd. The running daemon picks the drop-in up only via the separate,
 deliberately disruptive `ssh-hardening.sh --reload`, which validates the complete configuration first,
-restarts the launchd service, and refuses to report success until an SSH banner exchange completes on the
-resolved port.
+restarts the launchd service, and refuses to report a restart as successful until an SSH banner exchange
+completes on the resolved port. One documented exception: when Remote Login is off (the launchd service
+is confirmed absent), `--reload` exits 0 as a clean no-op, with no restart and no banner; the drop-in
+applies when Remote Login is next enabled.
 
 Before running `--reload` on a machine you are not sitting at:
 
-1. Keep an existing SSH session open until a brand-new session has succeeded.
+1. Above all, keep any SSH session you still have OPEN until a new login succeeds.
 1. Confirm Screen Sharing over the tailnet works BEFORE the reload, not during the incident.
 
 If `--reload` fails, warns about a possible lockout, or a new session cannot connect: from the physical

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1207,6 +1207,20 @@ main() {
     usage >&2
     exit 2
   fi
+  # Dispatch is CASE-SENSITIVE. nocasematch is on at file scope because the
+  # sshd keyword matching needs it, and left alone it reaches this case too:
+  # measured, a mistyped `--RELOAD` invoked the one disruptive mode in the
+  # script. The flag is validated with matching off, then switched back on
+  # before any mode function runs, because the verify machinery depends on it.
+  shopt -u nocasematch
+  case "${1-}" in
+    --print-config | --print-path | --verify | --reload | --rollback | '' | --help | -h) ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shopt -s nocasematch
   case "${1-}" in
     --print-config) print_config ;;
     --print-path) dropin_path ;;

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -994,8 +994,113 @@ validate_readiness_knobs() {
   esac
 }
 
+# resolve_probe_ports: every `Port` the effective configuration declares,
+# validated and deduplicated, into the PROBE_PORTS array.
+#
+# A NOTE ON AUTHORITY, and why this is a best effort rather than the truth:
+# macOS Remote Login is launchd SOCKET ACTIVATION. ssh.plist declares
+# inetdCompatibility with Sockets.Listeners.SockServiceName = ssh, so launchd
+# owns the listening socket and sshd never binds one; the Port directive that
+# `sshd -G` reports is inert for the live listener. On a machine whose
+# configuration carries a nonstandard Port, every port resolved here can be
+# wrong while the daemon is healthy on launchd's socket (normally 22).
+# Deriving the probe target from launchd instead was considered and rejected:
+# `launchctl print` output is an undocumented human-oriented format with no
+# stability guarantee, and parsing it in the one path that must not misfire
+# is a worse risk than an honest diagnosis. So the resolved ports stay the
+# probe target (on a stock machine the two authorities agree), and the
+# LOCKOUT failure names the launchd-socket possibility so a port mismatch
+# reads as a diagnosis rather than a false emergency.
+#
+# Every declared Port is kept: two Port directives produce two `port` lines
+# from the real binary (measured), and probing only the first would prove
+# readiness for one listener while the success message speaks for the
+# daemon. Each value is checked as a canonical integer and range-bounded on
+# BOTH sides (1-65535) before it reaches arithmetic or a probe argv.
+PROBE_PORTS=()
+resolve_probe_ports() {
+  local status=0 output listing port existing duplicate
+  PROBE_PORTS=()
+  output="$("$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    die "could not resolve the effective sshd port ('$SSHD_BIN -G' exited $status); refusing to restart a daemon whose readiness could not then be probed. sshd was not touched. Output: $output"
+  fi
+  status=0
+  listing="$(printf '%s\n' "$output" | awk '$1 == "port" { print $2 }')" ||
+    status=$?
+  if [[ $status -ne 0 ]]; then
+    die "could not read the port out of the sshd -G output (exit $status); failing closed before the disruptive step. sshd was not touched."
+  fi
+  if [[ -z $listing ]]; then
+    die "the effective configuration resolved NO port at all; refusing to probe readiness blind. sshd was not touched."
+  fi
+  # A here-string materializes in TMPDIR; if that fails the loop reads zero
+  # lines, PROBE_PORTS stays empty, and the guard below refuses -- the
+  # failure direction is closed either way.
+  while IFS= read -r port; do
+    case $port in
+      '' | *[!0-9]* | 0*)
+        die "the effective sshd port resolved to '$port', which is not a canonical port number; refusing to probe readiness blind. sshd was not touched."
+        ;;
+    esac
+    if [[ ${#port} -gt 5 || $port -gt 65535 ]]; then
+      die "the effective sshd port resolved to '$port', which is outside 1-65535; refusing to probe readiness blind. sshd was not touched."
+    fi
+    duplicate=0
+    if [[ ${#PROBE_PORTS[@]} -gt 0 ]]; then
+      for existing in "${PROBE_PORTS[@]}"; do
+        if [[ $existing == "$port" ]]; then
+          duplicate=1
+          break
+        fi
+      done
+    fi
+    if [[ $duplicate -eq 0 ]]; then
+      PROBE_PORTS+=("$port")
+    fi
+  done <<<"$listing"
+  if [[ ${#PROBE_PORTS[@]} -eq 0 ]]; then
+    die "the effective configuration resolved no usable port; refusing to probe readiness blind. sshd was not touched."
+  fi
+}
+
+# wait_for_ssh_banner: the readiness loop. One attempt probes EVERY resolved
+# port once; the bound is SSH_HARDENING_READY_ATTEMPTS attempts (see the seam
+# comment for what that bound does and does not promise). On success sets
+# READY_PORT to the port that answered and returns 0; after the bound is
+# exhausted returns 1 with READY_PORT empty. Success requires the probe's
+# exit status AND a banner on stdout: the status alone is a proxy, and a
+# probe that printed no key line proved nothing, whatever it exited. Every
+# child status is captured explicitly, so the loop's answer does not depend
+# on errexit (callers judging it inside `if !` have errexit off).
+READY_PORT=''
+wait_for_ssh_banner() {
+  local attempt=1 keyscan_status banner_output port status
+  READY_PORT=''
+  while [[ $attempt -le $SSH_HARDENING_READY_ATTEMPTS ]]; do
+    for port in "${PROBE_PORTS[@]}"; do
+      keyscan_status=0
+      banner_output="$("$KEYSCAN_BIN" -T "$SSH_HARDENING_PROBE_TIMEOUT" -p "$port" 127.0.0.1 2>/dev/null)" ||
+        keyscan_status=$?
+      if [[ $keyscan_status -eq 0 && -n $banner_output ]]; then
+        READY_PORT="$port"
+        return 0
+      fi
+    done
+    if [[ $attempt -lt $SSH_HARDENING_READY_ATTEMPTS && $SSH_HARDENING_READY_INTERVAL != 0 ]]; then
+      status=0
+      "$SLEEP_BIN" "$SSH_HARDENING_READY_INTERVAL" || status=$?
+      if [[ $status -ne 0 ]]; then
+        die "the retry delay '$SLEEP_BIN $SSH_HARDENING_READY_INTERVAL' failed (exit $status) between readiness probes, so readiness cannot be awaited; the restart HAS already happened. $(recovery_instructions)"
+      fi
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
 reload_sshd() {
-  local status output port
+  local status output
 
   validate_readiness_knobs
 
@@ -1040,23 +1145,10 @@ reload_sshd() {
     die "the effective configuration is not fully hardened (the verify failures are above); refusing to restart sshd onto it. sshd was not touched."
   fi
 
-  # 5. Resolve the port now, while nothing has been disturbed: a reload that
-  # cannot name the port to probe must fail BEFORE the kickstart, not after.
-  status=0
-  output="$("$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
-  if [[ $status -ne 0 ]]; then
-    die "could not resolve the effective sshd port ('$SSHD_BIN -G' exited $status); refusing to restart a daemon whose readiness could not then be probed. sshd was not touched. Output: $output"
-  fi
-  status=0
-  port="$(printf '%s\n' "$output" | awk '$1 == "port" { print $2; exit }')" || status=$?
-  if [[ $status -ne 0 ]]; then
-    die "could not read the port out of the sshd -G output (exit $status); failing closed before the disruptive step. sshd was not touched."
-  fi
-  case $port in
-    '' | *[!0-9]*)
-      die "the effective sshd port resolved to '$port', which is not a port number; refusing to probe readiness blind. sshd was not touched."
-      ;;
-  esac
+  # 5. Resolve the probe ports now, while nothing has been disturbed: a
+  # reload that cannot name what to probe must fail BEFORE the kickstart,
+  # not after.
+  resolve_probe_ports
 
   # 6. Probe the service, separating THREE outcomes, not two.
   probe_sshd_service
@@ -1083,35 +1175,15 @@ reload_sshd() {
     die "the sshd launchd service did not reload: after the kickstart, '$LAUNCHCTL_BIN print' exited $SERVICE_PROBE_STATUS instead of confirming a loaded job. $(recovery_instructions)"
   fi
 
-  # 9. The artifact: a completed SSH banner exchange on the resolved port.
-  # ssh-keyscan's exit status alone is not trusted either; a probe that
-  # produced no key line proved nothing, whatever it exited. The probe
-  # targets loopback, so a green result proves the daemon answers, NOT that a
-  # remote client can reach it (the application firewall does not filter
-  # loopback); the runbook's keep-a-session-open step is what covers that
-  # gap.
-  local attempt=1 ready=0 keyscan_status banner_output
-  while [[ $attempt -le $SSH_HARDENING_READY_ATTEMPTS ]]; do
-    keyscan_status=0
-    banner_output="$("$KEYSCAN_BIN" -T "$SSH_HARDENING_PROBE_TIMEOUT" -p "$port" 127.0.0.1 2>/dev/null)" ||
-      keyscan_status=$?
-    if [[ $keyscan_status -eq 0 && -n $banner_output ]]; then
-      ready=1
-      break
-    fi
-    if [[ $attempt -lt $SSH_HARDENING_READY_ATTEMPTS && $SSH_HARDENING_READY_INTERVAL != 0 ]]; then
-      status=0
-      "$SLEEP_BIN" "$SSH_HARDENING_READY_INTERVAL" || status=$?
-      if [[ $status -ne 0 ]]; then
-        die "the retry delay '$SLEEP_BIN $SSH_HARDENING_READY_INTERVAL' failed (exit $status) between readiness probes, so readiness cannot be awaited; the restart HAS already happened. $(recovery_instructions)"
-      fi
-    fi
-    attempt=$((attempt + 1))
-  done
-  if [[ $ready -ne 1 ]]; then
-    die "POSSIBLE LOCKOUT: the launchd job reports loaded, but no SSH banner arrived on port $port after $SSH_HARDENING_READY_ATTEMPTS attempt(s). A loaded job with a silent listener is what a crashed sshd looks like, so this is a failure, not a maybe. $(recovery_instructions)"
+  # 9. The artifact: a completed SSH banner exchange on a resolved port (see
+  # wait_for_ssh_banner for what counts). The probe targets loopback, so a
+  # green result proves the daemon answers, NOT that a remote client can
+  # reach it (the application firewall does not filter loopback); the
+  # runbook's keep-a-session-open step is what covers that gap.
+  if ! wait_for_ssh_banner; then
+    die "POSSIBLE LOCKOUT: the launchd job reports loaded, but no SSH banner arrived on port(s) ${PROBE_PORTS[*]} after $SSH_HARDENING_READY_ATTEMPTS attempt(s). A loaded job with a silent listener is what a crashed sshd looks like, so treat this as a failure. One more possibility BEFORE assuming an outage: on macOS, launchd owns Remote Login's listening socket (ssh.plist inetdCompatibility) and sshd's Port directive does not move it, so if this configuration carries a nonstandard Port the daemon may be healthy on launchd's socket (normally 22) while every probe watched the wrong port; check with '$KEYSCAN_BIN -p 22 127.0.0.1' before treating this as a lockout. $(recovery_instructions)"
   fi
-  printf '[ssh-hardening] reload complete: sshd restarted and is accepting connections on port %s (SSH banner exchange completed).\n' "$port"
+  printf '[ssh-hardening] reload complete: sshd restarted and is accepting connections on port %s (SSH banner exchange completed).\n' "$READY_PORT"
 }
 
 # --- rollback ----------------------------------------------------------------

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -36,11 +36,16 @@
 #                       the readiness prover, only --reload uses it
 #   SSH_HARDENING_SUDO  privilege wrapper for writes; set EMPTY to run
 #                       unprivileged against a sandbox tree (default sudo)
-#   SSH_HARDENING_READY_ATTEMPTS / SSH_HARDENING_READY_INTERVAL
-#                       how many banner probes --reload makes and the seconds
-#                       between them (defaults 30 and 1); the bound is by
-#                       ATTEMPT COUNT, so a probe that never answers cannot
-#                       hang the reload forever
+#   SSH_HARDENING_READY_ATTEMPTS / SSH_HARDENING_READY_INTERVAL /
+#   SSH_HARDENING_PROBE_TIMEOUT
+#                       how many banner probes --reload makes, the seconds
+#                       between them, and each probe's connection timeout
+#                       (defaults 30, 1 and 5). The bound is by ATTEMPT
+#                       COUNT, not wall clock: with the real ssh-keyscan each
+#                       attempt is capped by the connection timeout, but an
+#                       overridden KEYSCAN_BIN that never returns holds the
+#                       reload for as long as it blocks -- the bound limits
+#                       how many times a probe runs, not how long one takes.
 #   SSH_HARDENING_ALLOW_MISSING_SSHD
 #                       explicit test seam: when set to a TRUE-ish value AND
 #                       $SSHD_BIN cannot run, --verify skips (exit 0) WITHOUT a
@@ -64,8 +69,14 @@ SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
 LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-/bin/launchctl}"
 KEYSCAN_BIN="${KEYSCAN_BIN:-/usr/bin/ssh-keyscan}"
-SSH_HARDENING_READY_ATTEMPTS="${SSH_HARDENING_READY_ATTEMPTS:-30}"
-SSH_HARDENING_READY_INTERVAL="${SSH_HARDENING_READY_INTERVAL:-1}"
+# `-` not `:-` for the three readiness knobs, matching SSH_HARDENING_SUDO
+# above: unset means "use the default", but SET-BUT-EMPTY is an operator
+# statement and validate_readiness_knobs REFUSES it rather than silently
+# rewriting it to the default (`:-` did exactly that, which also made the
+# empty-string arm of the old validation unreachable dead code).
+SSH_HARDENING_READY_ATTEMPTS="${SSH_HARDENING_READY_ATTEMPTS-30}"
+SSH_HARDENING_READY_INTERVAL="${SSH_HARDENING_READY_INTERVAL-1}"
+SSH_HARDENING_PROBE_TIMEOUT="${SSH_HARDENING_PROBE_TIMEOUT-5}"
 
 # The launchd service behind macOS Remote Login. `launchctl print` on it exits
 # 0 when the job is loaded and 113 when the service is genuinely absent
@@ -934,19 +945,49 @@ probe_sshd_service() {
 # just failed to restart cleanly is exactly the machine that must not receive
 # a second unattended state change; the failure names the recovery path and
 # leaves the operator in control.
+# validate_readiness_knobs: refuse every knob shape that would not mean what
+# the operator asked, BEFORE anything else runs. The property, not a list of
+# last time's bad examples:
+#
+#   - attempts and the probe timeout: one canonical base-10 positive integer,
+#     short enough for safe bash arithmetic. No leading zero, because bash
+#     arithmetic reads one as base-8 (measured on bash 3.2: ATTEMPTS=010 made
+#     8 probes, ATTEMPTS=08 died mid-loop with "value too great for base",
+#     and ATTEMPTS=00 bounded the loop at ZERO probes and reported POSSIBLE
+#     LOCKOUT on a healthy machine).
+#   - the interval: a canonical non-negative decimal number of seconds
+#     (fractions are legal; the delay tool accepts them). It never enters
+#     bash arithmetic -- it is only compared to the literal 0 and handed to
+#     the delay tool -- so it needs no length bound, but leading-zero integer
+#     forms are refused for the same one-canonical-spelling rule.
+validate_readiness_knobs() {
+  case $SSH_HARDENING_READY_ATTEMPTS in
+    '' | *[!0-9]* | 0*)
+      die "SSH_HARDENING_READY_ATTEMPTS must be a positive base-10 integer with no leading zero, got '$SSH_HARDENING_READY_ATTEMPTS'; refusing to run with a readiness bound that does not mean what it says"
+      ;;
+  esac
+  if [[ ${#SSH_HARDENING_READY_ATTEMPTS} -gt 9 ]]; then
+    die "SSH_HARDENING_READY_ATTEMPTS ('$SSH_HARDENING_READY_ATTEMPTS') is too long to stay inside safe bash arithmetic; refusing to run with it"
+  fi
+  case $SSH_HARDENING_PROBE_TIMEOUT in
+    '' | *[!0-9]* | 0*)
+      die "SSH_HARDENING_PROBE_TIMEOUT must be a positive base-10 integer number of seconds with no leading zero, got '$SSH_HARDENING_PROBE_TIMEOUT'"
+      ;;
+  esac
+  if [[ ${#SSH_HARDENING_PROBE_TIMEOUT} -gt 9 ]]; then
+    die "SSH_HARDENING_PROBE_TIMEOUT ('$SSH_HARDENING_PROBE_TIMEOUT') is too long to stay inside safe bash arithmetic; refusing to run with it"
+  fi
+  case $SSH_HARDENING_READY_INTERVAL in
+    '' | . | *.*.* | *[!0-9.]* | 0[0-9]*)
+      die "SSH_HARDENING_READY_INTERVAL must be a canonical non-negative decimal number of seconds, got '$SSH_HARDENING_READY_INTERVAL'"
+      ;;
+  esac
+}
+
 reload_sshd() {
   local status output port
 
-  case $SSH_HARDENING_READY_ATTEMPTS in
-    '' | 0 | *[!0-9]*)
-      die "SSH_HARDENING_READY_ATTEMPTS must be a positive integer, got '$SSH_HARDENING_READY_ATTEMPTS'; refusing to run with a readiness bound that means nothing"
-      ;;
-  esac
-  case $SSH_HARDENING_READY_INTERVAL in
-    '' | . | *.*.* | *[!0-9.]*)
-      die "SSH_HARDENING_READY_INTERVAL must be a non-negative number of seconds, got '$SSH_HARDENING_READY_INTERVAL'"
-      ;;
-  esac
+  validate_readiness_knobs
 
   # 1. Privilege first, VISIBLY (a password prompt, if any, lands on the
   # terminal). Everything disruptive below runs through the wrapper, so a
@@ -1032,11 +1073,11 @@ reload_sshd() {
   # targets loopback, so a green result proves the daemon answers, NOT that a
   # remote client can reach it (the application firewall does not filter
   # loopback); the runbook's keep-a-session-open step is what covers that
-  # gap. The 5 is ssh-keyscan's per-attempt connection timeout in seconds.
+  # gap.
   local attempt=1 ready=0 keyscan_status banner_output
   while [[ $attempt -le $SSH_HARDENING_READY_ATTEMPTS ]]; do
     keyscan_status=0
-    banner_output="$("$KEYSCAN_BIN" -T 5 -p "$port" 127.0.0.1 2>/dev/null)" ||
+    banner_output="$("$KEYSCAN_BIN" -T "$SSH_HARDENING_PROBE_TIMEOUT" -p "$port" 127.0.0.1 2>/dev/null)" ||
       keyscan_status=$?
     if [[ $keyscan_status -eq 0 && -n $banner_output ]]; then
       ready=1

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -215,6 +215,24 @@ EOF
 
 VERIFY_FAILURES=()
 
+# run_verify_child: re-run this script's --verify in a CHILD shell. bash
+# suppresses `set -e` for everything inside an `if !` or `||` test, and that
+# suppression reaches into called functions and even into subshells (confirmed
+# on bash 3.2), so a caller judging the tree from inside such a test would run
+# every check with errexit switched off: a failure mid-flight would be stepped
+# over and the success line still printed. A separate process gets its own
+# `set -euo pipefail`, so every caller judges the tree by exactly the rules
+# --verify applies on its own. The seams are passed explicitly so the child
+# inspects the tree the caller just changed whether or not they were exported.
+run_verify_child() {
+  SSHD_CONFIG_D="$SSHD_CONFIG_D" \
+    SSHD_MAIN_CONFIG="$SSHD_MAIN_CONFIG" \
+    SSHD_BIN="$SSHD_BIN" \
+    SSH_HARDENING_SUDO="$SSH_HARDENING_SUDO" \
+    SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
+    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify
+}
+
 # verify_skip_allowed: the SSH_HARDENING_ALLOW_MISSING_SSHD seam is ON only for
 # an explicitly TRUE-ish value. It used to be tested for being NONEMPTY, so
 # every value turned it on -- including `0`, the one value a reader would
@@ -754,22 +772,10 @@ install_dropin() {
     fi
     printf '[ssh-hardening] removed legacy drop-in %s\n' "$legacy"
   fi
-  # Verify in a CHILD shell. bash suppresses `set -e` for everything inside an
-  # `if !` or `||` test, and that suppression reaches into called functions and
-  # even into subshells (confirmed on bash 3.2), so calling verify in-process
-  # here ran every check with errexit switched off: a failure mid-flight was
-  # stepped over and the success line still printed. A separate process gets
-  # its own `set -euo pipefail`, so install judges the tree by exactly the
-  # rules --verify applies on its own. The seams are passed explicitly so the
-  # child inspects the tree this install just wrote whether or not the caller
-  # exported them.
+  # Verify in a child shell (see run_verify_child for why in-process
+  # verification under an `if !` or `||` test would run with errexit off).
   local verify_status=0
-  SSHD_CONFIG_D="$SSHD_CONFIG_D" \
-    SSHD_MAIN_CONFIG="$SSHD_MAIN_CONFIG" \
-    SSHD_BIN="$SSHD_BIN" \
-    SSH_HARDENING_SUDO="$SSH_HARDENING_SUDO" \
-    SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
-    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify || verify_status=$?
+  run_verify_child || verify_status=$?
   if [[ $verify_status -ne 0 ]]; then
     rollback_install
     die "the effective configuration did NOT verify as fully hardened; the tree was rolled back to the state this install found it in, and no success is claimed"

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1055,23 +1055,118 @@ reload_sshd() {
 
 # --- rollback ----------------------------------------------------------------
 
+# The recovery gate's three outcomes, named because the caller must branch on
+# all three: collapsing "still blocked" and "errored" into one nonzero status
+# is how the previous rollback read an sshd crash as proof of restored access.
+PASSWORD_CHANNEL_OPEN=0
+PASSWORD_CHANNEL_BLOCKED=1
+PASSWORD_CHANNEL_ERROR=2
+
+# check_password_channel: the recovery gate's question, asked of the real
+# binary. "Access restored" is DEFINED as: for each sampled connection (the
+# invoking user at loopback, and the invoking user at an off-loopback
+# documentation address, because the locked-out operator this gate exists for
+# connects from OFF the machine), `sshd -G -T -C` reports
+# passwordauthentication yes OR kbdinteractiveauthentication yes -- the two
+# interactive password channels; either one open means a password prompt can
+# be reached. Negating --verify would not do: "not fully hardened" is true
+# the moment ANY of the seven directives drifts, which proves nothing about
+# whether a password login can now succeed.
+#
+# The samples are samples: a Match block scoped to an address neither sample
+# hits can still block one specific network path, and the runbook's
+# keep-a-session-open step covers what sampling cannot. Every anomaly (a
+# failed `id`, a failed resolution, an unreadable output, a value that is
+# neither yes nor no) is the ERROR outcome, never a quiet pass, and every
+# command's status is captured explicitly so the answer does not depend on
+# errexit, which callers judging a status have switched off.
+check_password_channel() {
+  local invoking_user status=0 output spec key value channel_open
+  invoking_user="$(id -un)" || status=$?
+  if [[ $status -ne 0 || -z $invoking_user ]]; then
+    return "$PASSWORD_CHANNEL_ERROR"
+  fi
+  for spec in \
+    "user=$invoking_user,host=localhost,addr=127.0.0.1" \
+    "user=$invoking_user,host=recovery.invalid,addr=198.51.100.23"; do
+    status=0
+    output="$("$SSHD_BIN" -G -T -C "$spec" -f "$SSHD_MAIN_CONFIG" 2>&1)" ||
+      status=$?
+    if [[ $status -ne 0 ]]; then
+      return "$PASSWORD_CHANNEL_ERROR"
+    fi
+    channel_open=0
+    for key in passwordauthentication kbdinteractiveauthentication; do
+      status=0
+      value="$(printf '%s\n' "$output" | awk -v k="$key" '$1 == k { print $2; exit }')" ||
+        status=$?
+      if [[ $status -ne 0 ]]; then
+        return "$PASSWORD_CHANNEL_ERROR"
+      fi
+      case $value in
+        yes) channel_open=1 ;;
+        no) ;;
+        *) return "$PASSWORD_CHANNEL_ERROR" ;;
+      esac
+    done
+    if [[ $channel_open -ne 1 ]]; then
+      return "$PASSWORD_CHANNEL_BLOCKED"
+    fi
+  done
+  return "$PASSWORD_CHANNEL_OPEN"
+}
+
+# confirm_password_access_restored <target>: rollback's success gate, run on
+# BOTH paths (after a removal, and when the drop-in was already absent --
+# "nothing to remove" is not "access is back": a sibling file or the main
+# config can enforce the policy with the managed drop-in long gone). Success
+# is claimed only on the OPEN outcome; BLOCKED and ERROR are distinct, loud,
+# nonzero failures.
+confirm_password_access_restored() {
+  local target="$1" channel_status=0
+  if [[ ! -x $SSHD_BIN ]]; then
+    if verify_skip_allowed; then
+      printf '[ssh-hardening] rollback: %s is absent, but verification was SKIPPED via the test seam; whether password access is restored was NOT checked.\n' "$target"
+      return 0
+    fi
+    die "'$target' is absent, but '$SSHD_BIN' cannot run, so whether password access is really restored cannot be checked; failing closed rather than claiming the way back in is open"
+  fi
+  check_password_channel || channel_status=$?
+  case $channel_status in
+    "$PASSWORD_CHANNEL_OPEN")
+      # The restart guidance names only routes that can actually run:
+      # --reload refuses a tree that is not fully hardened, which is exactly
+      # the state a successful rollback leaves, so advertising it here would
+      # send the operator down a path that refuses on arrival.
+      printf '[ssh-hardening] rollback complete: %s is absent and an interactive password channel (PasswordAuthentication or KbdInteractiveAuthentication) resolves ON for the sampled loopback and off-loopback connections, so password access is restored at the next sshd start. The running daemon keeps its current configuration until sshd restarts: toggle Remote Login off and back on in System Settings > General > Sharing (or reboot). --reload cannot perform this restart, because it refuses to restart onto a tree that is no longer hardened; reinstall first if the hardened policy should return.\n' "$target"
+      ;;
+    "$PASSWORD_CHANNEL_BLOCKED")
+      die "'$target' is absent, but the interactive password channels (PasswordAuthentication and KbdInteractiveAuthentication) still resolve OFF for a sampled connection, so something else under '$SSHD_CONFIG_D' (or the main config) is still enforcing the policy and password access is NOT restored. Inspect the remaining files there."
+      ;;
+    *)
+      die "could not verify that password access is restored: the recovery check errored (sshd resolution or its parsing failed) instead of answering; refusing to guess either way"
+      ;;
+  esac
+}
+
 # rollback_dropin: the way back in, as code. Remove the managed drop-in, then
-# prove the hardening is GONE from the effective configuration, because a
-# rollback exists for exactly one moment: the operator is locked out and needs
-# password authentication back at the next sshd start. Every step it cannot
-# prove is a nonzero failure. The removal itself still happens before any
-# verification, so even a failing rollback has already done the one thing the
-# locked-out operator needs.
+# PROVE password access is restored, because a rollback exists for exactly
+# one moment: the operator is locked out and needs password authentication
+# back at the next sshd start. Every step it cannot prove is a nonzero
+# failure. The removal itself still happens before any verification, so even
+# a failing rollback has already done the one thing the locked-out operator
+# needs.
 #
 # Deliberately NOT here: restarting sshd. Rollback changes the tree only; the
-# RUNNING daemon keeps its configuration until sshd restarts (--reload, a
-# Remote Login toggle, or a reboot), and pairing an automatic restart with an
-# emergency path would make the emergency path disruptive too.
+# RUNNING daemon keeps its configuration until sshd restarts (a Remote Login
+# toggle, or a reboot), and pairing an automatic restart with an emergency
+# path would make the emergency path disruptive too.
 rollback_dropin() {
   local target
   target="$(dropin_path)"
   if [[ ! -e $target && ! -L $target ]]; then
     printf '[ssh-hardening] rollback: %s is already absent; nothing to remove.\n' "$target"
+    confirm_password_access_restored "$target"
     return 0
   fi
   if ! run_privileged rm -f -- "$target"; then
@@ -1081,24 +1176,7 @@ rollback_dropin() {
     die "'$target' still exists after the removal command reported success; refusing to claim the hardening is gone"
   fi
   printf '[ssh-hardening] rollback: removed %s\n' "$target"
-  if [[ ! -x $SSHD_BIN ]]; then
-    if verify_skip_allowed; then
-      printf '[ssh-hardening] rollback: %s is removed, but verification was SKIPPED via the test seam; the effective configuration was NOT checked.\n' "$target"
-      return 0
-    fi
-    die "removed '$target', but '$SSHD_BIN' cannot run, so whether the hardening is really gone from the effective configuration cannot be checked; failing closed rather than claiming it is"
-  fi
-  # The child verify is EXPECTED to fail here: a tree without the drop-in must
-  # no longer verify fully hardened. Its (noisy, failure-listing) output is
-  # discarded because failure is the good outcome; only the unexpected PASS is
-  # reported, loudly, since it means a sibling file still enforces the policy
-  # and password access is NOT back.
-  local verify_status=0
-  run_verify_child >/dev/null 2>&1 || verify_status=$?
-  if [[ $verify_status -eq 0 ]]; then
-    die "the effective configuration still verifies fully hardened after removing '$target'; something else under '$SSHD_CONFIG_D' (or the main config) is enforcing the policy, and password access is NOT restored"
-  fi
-  printf '[ssh-hardening] rollback complete: the drop-in is removed and the effective configuration no longer verifies fully hardened. The running daemon keeps the old configuration until sshd restarts (--reload, or toggle Remote Login).\n'
+  confirm_password_access_restored "$target"
 }
 
 usage() {

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -34,6 +34,10 @@
 #                       stripped-PATH rationale; only --reload uses it
 #   KEYSCAN_BIN         ssh-keyscan, ABSOLUTE  (default /usr/bin/ssh-keyscan);
 #                       the readiness prover, only --reload uses it
+#   SLEEP_BIN           the retry delay, ABSOLUTE (default /bin/sleep); only
+#                       --reload uses it, BETWEEN readiness probes, which is
+#                       AFTER the disruptive step -- exactly where a bare
+#                       `sleep` under a stripped PATH aborted with no message
 #   SSH_HARDENING_SUDO  privilege wrapper for writes; set EMPTY to run
 #                       unprivileged against a sandbox tree (default sudo)
 #   SSH_HARDENING_READY_ATTEMPTS / SSH_HARDENING_READY_INTERVAL /
@@ -69,6 +73,12 @@ SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
 LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-/bin/launchctl}"
 KEYSCAN_BIN="${KEYSCAN_BIN:-/usr/bin/ssh-keyscan}"
+# ABSOLUTE like the other seams, and doubly so: sleep is NOT a bash builtin
+# (measured: /bin/sleep), it is the only tool the readiness loop runs after
+# the kickstart, and under `set -e` a PATH-resolved `sleep` that is missing
+# kills the script mid-loop with no output at all -- the one failure mode
+# where the operator most needs the recovery text printed none.
+SLEEP_BIN="${SLEEP_BIN:-/bin/sleep}"
 # `-` not `:-` for the three readiness knobs, matching SSH_HARDENING_SUDO
 # above: unset means "use the default", but SET-BUT-EMPTY is an operator
 # statement and validate_readiness_knobs REFUSES it rather than silently
@@ -1003,11 +1013,17 @@ reload_sshd() {
     fi
   fi
 
-  # 2. The readiness prover must exist BEFORE anything disruptive happens. A
-  # reload that cannot prove the daemon came back is a reload that leaves the
-  # operator guessing, so its absence is a refusal, not a warning.
+  # 2. The readiness prover AND the retry delay must exist BEFORE anything
+  # disruptive happens. A reload that cannot prove the daemon came back
+  # leaves the operator guessing, so the prover's absence is a refusal; and
+  # the delay tool runs only BETWEEN probes, after the kickstart, so ITS
+  # absence would surface as a silent post-restart abort unless it is
+  # validated here, where nothing has been disturbed yet.
   if [[ ! -x $KEYSCAN_BIN ]]; then
     die "the readiness prover '$KEYSCAN_BIN' is not runnable, so there would be no way to prove sshd came back after a restart; refusing to kickstart blind. sshd was not touched."
+  fi
+  if [[ ! -x $SLEEP_BIN ]]; then
+    die "the retry delay tool '$SLEEP_BIN' is not runnable, so the readiness loop could only abort after the restart; refusing to kickstart. sshd was not touched."
   fi
 
   # 3. Syntax: never restart onto a configuration sshd cannot parse.
@@ -1084,7 +1100,11 @@ reload_sshd() {
       break
     fi
     if [[ $attempt -lt $SSH_HARDENING_READY_ATTEMPTS && $SSH_HARDENING_READY_INTERVAL != 0 ]]; then
-      sleep "$SSH_HARDENING_READY_INTERVAL"
+      status=0
+      "$SLEEP_BIN" "$SSH_HARDENING_READY_INTERVAL" || status=$?
+      if [[ $status -ne 0 ]]; then
+        die "the retry delay '$SLEEP_BIN $SSH_HARDENING_READY_INTERVAL' failed (exit $status) between readiness probes, so readiness cannot be awaited; the restart HAS already happened. $(recovery_instructions)"
+      fi
     fi
     attempt=$((attempt + 1))
   done

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1174,7 +1174,11 @@ reload_sshd() {
     die "could not determine the state of the sshd launchd service: '$LAUNCHCTL_BIN print $SSHD_LAUNCHD_SERVICE' exited $SERVICE_PROBE_STATUS, which is neither 0 (loaded) nor $LAUNCHCTL_STATUS_SERVICE_ABSENT (confirmed absent). A probe error is not evidence the daemon is stopped; refusing to guess. sshd was not touched. Output: $SERVICE_PROBE_OUTPUT"
   fi
 
-  # 7. The disruptive step.
+  # 7. The disruptive step. The keep-open warning and the COMPLETE recovery
+  # command are printed FIRST: the kickstart is the step that can kill the
+  # SSH session carrying this output, so anything printed only after it may
+  # never arrive. Every failure path below repeats the same instructions.
+  printf '[ssh-hardening] reload: about to restart sshd; on a remote machine this can drop the SSH session carrying this output. %s\n' "$(recovery_instructions)"
   status=0
   output="$(run_privileged "$LAUNCHCTL_BIN" kickstart -k "$SSHD_LAUNCHD_SERVICE" 2>&1)" || status=$?
   if [[ $status -ne 0 ]]; then

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -10,6 +10,9 @@
 #   --print-path    print the drop-in target path (pure)
 #   --verify        read-only three-way check that the EFFECTIVE sshd
 #                   configuration is fully hardened (see the verify section)
+#   --rollback      remove the managed drop-in and prove the hardening is gone
+#                   from the effective configuration (the way back in); never
+#                   restarts sshd
 #   (no argument)   install: stage the drop-in, publish it with one rename,
 #                   move the legacy 50-no-password-auth.conf aside, verify, and
 #                   roll the whole tree back to what it found if that fails
@@ -793,14 +796,65 @@ install_dropin() {
   printf '[ssh-hardening] install complete: %s is in place and the effective configuration verified fully hardened.\n' "$target"
 }
 
+# --- rollback ----------------------------------------------------------------
+
+# rollback_dropin: the way back in, as code. Remove the managed drop-in, then
+# prove the hardening is GONE from the effective configuration, because a
+# rollback exists for exactly one moment: the operator is locked out and needs
+# password authentication back at the next sshd start. Every step it cannot
+# prove is a nonzero failure. The removal itself still happens before any
+# verification, so even a failing rollback has already done the one thing the
+# locked-out operator needs.
+#
+# Deliberately NOT here: restarting sshd. Rollback changes the tree only; the
+# RUNNING daemon keeps its configuration until sshd restarts (--reload, a
+# Remote Login toggle, or a reboot), and pairing an automatic restart with an
+# emergency path would make the emergency path disruptive too.
+rollback_dropin() {
+  local target
+  target="$(dropin_path)"
+  if [[ ! -e $target && ! -L $target ]]; then
+    printf '[ssh-hardening] rollback: %s is already absent; nothing to remove.\n' "$target"
+    return 0
+  fi
+  if ! run_privileged rm -f -- "$target"; then
+    die "could not remove '$target'; the hardening is still in place. Remove it by hand (sudo rm $target) and re-run --rollback to confirm."
+  fi
+  if [[ -e $target || -L $target ]]; then
+    die "'$target' still exists after the removal command reported success; refusing to claim the hardening is gone"
+  fi
+  printf '[ssh-hardening] rollback: removed %s\n' "$target"
+  if [[ ! -x $SSHD_BIN ]]; then
+    if verify_skip_allowed; then
+      printf '[ssh-hardening] rollback: %s is removed, but verification was SKIPPED via the test seam; the effective configuration was NOT checked.\n' "$target"
+      return 0
+    fi
+    die "removed '$target', but '$SSHD_BIN' cannot run, so whether the hardening is really gone from the effective configuration cannot be checked; failing closed rather than claiming it is"
+  fi
+  # The child verify is EXPECTED to fail here: a tree without the drop-in must
+  # no longer verify fully hardened. Its (noisy, failure-listing) output is
+  # discarded because failure is the good outcome; only the unexpected PASS is
+  # reported, loudly, since it means a sibling file still enforces the policy
+  # and password access is NOT back.
+  local verify_status=0
+  run_verify_child >/dev/null 2>&1 || verify_status=$?
+  if [[ $verify_status -eq 0 ]]; then
+    die "the effective configuration still verifies fully hardened after removing '$target'; something else under '$SSHD_CONFIG_D' (or the main config) is enforcing the policy, and password access is NOT restored"
+  fi
+  printf '[ssh-hardening] rollback complete: the drop-in is removed and the effective configuration no longer verifies fully hardened. The running daemon keeps the old configuration until sshd restarts (--reload, or toggle Remote Login).\n'
+}
+
 usage() {
   cat <<'EOF'
-usage: ssh-hardening.sh [--print-config | --print-path | --verify]
+usage: ssh-hardening.sh [--print-config | --print-path | --verify | --rollback]
 
   --print-config  print the generated drop-in content and exit
   --print-path    print the drop-in target path and exit
   --verify        read-only check that the effective sshd configuration is
                   fully hardened; never writes, never escalates
+  --rollback      remove the managed drop-in and confirm the hardening is
+                  gone from the effective configuration (the way back in);
+                  never restarts sshd
   (no argument)   install the drop-in and verify
 
 Reloading a running sshd is deliberately not provided here; the drop-in
@@ -817,6 +871,7 @@ main() {
     --print-config) print_config ;;
     --print-path) dropin_path ;;
     --verify) verify ;;
+    --rollback) rollback_dropin ;;
     '') install_dropin ;;
     --help | -h) usage ;;
     *)

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -933,16 +933,24 @@ recovery_instructions() {
   printf 'Recovery: keep any SSH session you still have OPEN until a new login succeeds. From the physical console, or Screen Sharing over the tailnet, run: ssh-hardening.sh --rollback (or: sudo rm %s), then turn Remote Login off and back on in System Settings > General > Sharing.' "$(dropin_path)"
 }
 
-# probe_sshd_service: one `launchctl print` of the sshd service, through the
-# privilege wrapper. Results land in globals rather than an exit status,
-# because the caller needs the EXACT status to separate three outcomes:
-# loaded (0), confirmed absent (113), and everything else, which is a probe
-# error and must never be read as "the daemon is stopped".
+# probe_sshd_service: one `launchctl print` of the sshd service, run DIRECTLY
+# and not through the privilege wrapper -- deliberately. Measured on macOS
+# 26.2: unprivileged `launchctl print system/<service>` exits 0 for a loaded
+# job and 113 for an absent one, the same statuses the privileged probe
+# returns. Running it bare removes the wrapper's own exit status from this
+# channel entirely, so a wrapper failing with 113 cannot masquerade as
+# "Remote Login is off": every status seen here is launchctl's own answer
+# (or bash's 126/127 for an unrunnable LAUNCHCTL_BIN, neither of which is 0
+# or 113, so both land in the probe-error branch). Results land in globals
+# rather than an exit status, because the caller needs the EXACT status to
+# separate three outcomes: loaded (0), confirmed absent (113), and
+# everything else, which is a probe error and must never be read as "the
+# daemon is stopped".
 SERVICE_PROBE_STATUS=0
 SERVICE_PROBE_OUTPUT=''
 probe_sshd_service() {
   SERVICE_PROBE_STATUS=0
-  SERVICE_PROBE_OUTPUT="$(run_privileged "$LAUNCHCTL_BIN" print "$SSHD_LAUNCHD_SERVICE" 2>&1)" ||
+  SERVICE_PROBE_OUTPUT="$("$LAUNCHCTL_BIN" print "$SSHD_LAUNCHD_SERVICE" 2>&1)" ||
     SERVICE_PROBE_STATUS=$?
 }
 

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1064,15 +1064,28 @@ resolve_probe_ports() {
   fi
 }
 
+# banner_output_names_host_key <output>: at least one stdout line shaped like
+# a host-key record: three or more fields (host, key type, key material), not
+# opening a comment. The real ssh-keyscan prints exactly that shape for a
+# completed exchange and sends its chatter to stderr, so this is a
+# seam-contract check: an overridden KEYSCAN_BIN exiting 0 with arbitrary
+# text must not satisfy readiness. Deliberately loose beyond the shape (no
+# key-type allowlist): the artifact required is "a host-key record arrived",
+# not a catalogue of algorithms.
+banner_output_names_host_key() {
+  printf '%s\n' "$1" |
+    awk 'NF >= 3 && $1 !~ /^#/ { found = 1 } END { exit found ? 0 : 1 }'
+}
+
 # wait_for_ssh_banner: the readiness loop. One attempt probes EVERY resolved
 # port once; the bound is SSH_HARDENING_READY_ATTEMPTS attempts (see the seam
 # comment for what that bound does and does not promise). On success sets
 # READY_PORT to the port that answered and returns 0; after the bound is
 # exhausted returns 1 with READY_PORT empty. Success requires the probe's
-# exit status AND a banner on stdout: the status alone is a proxy, and a
-# probe that printed no key line proved nothing, whatever it exited. Every
-# child status is captured explicitly, so the loop's answer does not depend
-# on errexit (callers judging it inside `if !` have errexit off).
+# exit status AND a host-key record on stdout: the status alone is a proxy,
+# and a probe that printed no key record proved nothing, whatever it exited.
+# Every child status is captured explicitly, so the loop's answer does not
+# depend on errexit (callers judging it inside `if !` have errexit off).
 READY_PORT=''
 wait_for_ssh_banner() {
   local attempt=1 keyscan_status banner_output port status
@@ -1082,7 +1095,8 @@ wait_for_ssh_banner() {
       keyscan_status=0
       banner_output="$("$KEYSCAN_BIN" -T "$SSH_HARDENING_PROBE_TIMEOUT" -p "$port" 127.0.0.1 2>/dev/null)" ||
         keyscan_status=$?
-      if [[ $keyscan_status -eq 0 && -n $banner_output ]]; then
+      if [[ $keyscan_status -eq 0 ]] &&
+        banner_output_names_host_key "$banner_output"; then
         READY_PORT="$port"
         return 0
       fi

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -362,20 +362,42 @@ check_global() {
 }
 
 # --- sshd configuration tokenizer --------------------------------------------
-# OpenSSH 10.0p2 splits a configuration line the way strdelim() does: space,
-# tab and CARRIAGE RETURN all separate tokens; a token that opens with a
-# double quote runs to its closing quote; and a single '=' may stand in for
-# the whitespace after the keyword. Every one of those forms was confirmed to
-# parse AND to resolve the unsafe value against the real binary, including the
-# two that defeated the previous scanner:
+# OpenSSH 10.0p2 tokenizes the KEYWORD and the ARGUMENTS of a configuration
+# line with two DIFFERENT rules. Every claim below was measured against the
+# real binary (`sshd -G` accepts/rejects, `sshd -G -T -C` resolves), not read
+# out of the manual page:
 #
-#   "PasswordAuthentication" yes      quotes around the KEYWORD, not the value
-#   Match<CR>Address *,!127.0.0.1     a carriage return inside the Match line
+#   KEYWORD (strdelim semantics): space, tab and CARRIAGE RETURN separate
+#   tokens; a single '=' may end the keyword; and ONE double-quoted segment
+#   may sit anywhere in the token -- the unquoted prefix and the quoted
+#   content CONCATENATE, and the token ENDS at the closing quote. Measured:
+#     Ma"tch" Address ...        reads as Match                    (accepted)
+#     Pubkey"Authentication" no  reads as the full keyword         (accepted)
+#     "PasswordAuthentication"   reads as the full keyword         (accepted)
+#     Pass"word"Authentication   reads as Password + a stray token (rejected:
+#                                unknown keyword)
+#     Ma'tch'                    single quotes are NOT special in keywords
+#                                (rejected: unknown keyword)
+#   The previous tokenizer treated '"' as a terminator in the middle of a
+#   token, so it read `Ma"tch"` as `Ma`, never entered Match state, and
+#   certified a tree whose off-loopback clients had no authentication method
+#   at all. The comment that stood here claiming a mid-keyword quote is
+#   rejected by sshd was FALSE.
 #
-# Vertical tab, form feed, a second '=', a quote in the middle of a keyword
-# and a whole-line quote are all REJECTED by sshd (also verified), so they
-# need no handling here: a file carrying them fails `sshd -G`, and reporting
-# that is check_global's job.
+#   ARGUMENTS (argv_split semantics): any number of double- OR single-quoted
+#   segments concatenate with unquoted text into one token ("y"e"s" and
+#   ye's' both read as yes, measured); an unquoted '#' OPENING a token
+#   comments out the rest of the line, while a mid-token '#' stays literal
+#   (measured with an Include path carrying one); the token ends only at
+#   unquoted whitespace.
+#
+# Forms sshd REJECTS outright, re-measured for this list: a single-quoted
+# keyword, a whole-line quote, an unterminated quote, vertical tab or form
+# feed in the keyword, a second '=', and '"Keyword"=value' (no '=' is
+# consumed after a quote-terminated keyword). A file carrying one fails
+# `sshd -G`, and reporting that is check_global's job, so this scan may read
+# those lines any way it likes; what it must NEVER do is read an ACCEPTED
+# line differently from sshd.
 #
 # The line is tokenized rather than bulk-normalized. Bulk normalization is
 # what let the quoted keyword through: quotes were stripped from the value
@@ -386,39 +408,51 @@ CONFIG_TAB=$'\t'
 CONFIG_CR=$'\r'
 TOKEN=''
 REST=''
+# Set by next_keyword_token when the keyword was ENDED by a closing double
+# quote: sshd consumes no '=' after such a keyword (measured:
+# `"PasswordAuthentication"=yes` is rejected as `unsupported option "=yes"`),
+# so parse_config_line must not strip one either.
+TOKEN_ENDED_AT_QUOTE=0
 
-# next_token <break-on-equals: 0|1>: pull the next token off REST into TOKEN.
-# Returns 1 at end of line and 2 for an unterminated quote (a form sshd
-# rejects outright, so the file fails check_global).
-next_token() {
-  local break_equals="$1" char start_length="${#REST}"
+# skip_leading_whitespace: drop sshd's token separators (space, tab, CR) off
+# the front of REST.
+skip_leading_whitespace() {
   while [[ -n $REST ]]; do
     case $REST in
       ' '* | "$CONFIG_TAB"* | "$CONFIG_CR"*) REST="${REST:1}" ;;
       *) break ;;
     esac
   done
+}
+
+# next_keyword_token: pull the KEYWORD off REST into TOKEN with strdelim
+# semantics (prefix plus at most one double-quoted segment; the token ends at
+# the closing quote). Returns 1 at end of line and 2 for an unterminated
+# quote (a form sshd rejects outright, so the file fails check_global).
+next_keyword_token() {
+  local char start_length
+  skip_leading_whitespace
+  start_length="${#REST}"
   if [[ -z $REST ]]; then
     return 1
   fi
   TOKEN=''
-  if [[ $REST == '"'* ]]; then
-    REST="${REST:1}"
-    case $REST in
-      *'"'*) ;;
-      *) return 2 ;;
-    esac
-    TOKEN="${REST%%\"*}"
-    REST="${REST#*\"}"
-    return 0
-  fi
+  TOKEN_ENDED_AT_QUOTE=0
   while [[ -n $REST ]]; do
     char="${REST:0:1}"
     case $char in
-      ' ' | "$CONFIG_TAB" | "$CONFIG_CR" | '"') break ;;
+      ' ' | "$CONFIG_TAB" | "$CONFIG_CR" | '=') break ;;
     esac
-    if [[ $break_equals -eq 1 && $char == '=' ]]; then
-      break
+    if [[ $char == '"' ]]; then
+      REST="${REST:1}"
+      case $REST in
+        *'"'*) ;;
+        *) return 2 ;;
+      esac
+      TOKEN="$TOKEN${REST%%\"*}"
+      REST="${REST#*\"}"
+      TOKEN_ENDED_AT_QUOTE=1
+      return 0
     fi
     TOKEN="$TOKEN$char"
     REST="${REST:1}"
@@ -426,10 +460,57 @@ next_token() {
   # A successful token must have consumed input. Reporting success without
   # advancing REST would spin the caller's loop forever, and a verifier that
   # HANGS never reports -- strictly worse than one that misreads a line. The
-  # quoted branch above means no input reaches here without advancing, so this
-  # is a guard against a future edit to that branch, not a live condition.
+  # quoted branch above always advances, so this is a guard against a future
+  # edit, not a live condition.
   if [[ ${#REST} -eq $start_length ]]; then
     return 1
+  fi
+  return 0
+}
+
+# next_argument_token: pull one ARGUMENT off REST into TOKEN with argv_split
+# semantics (any number of single- or double-quoted segments concatenate with
+# unquoted text; an unquoted '#' opening a token ends the argument list).
+# Returns 1 at end of line or at a comment and 2 for an unterminated quote (a
+# form sshd rejects outright, so the file fails check_global). Every loop
+# iteration consumes one character, so this cannot spin.
+next_argument_token() {
+  local char quote=''
+  skip_leading_whitespace
+  if [[ -z $REST ]]; then
+    return 1
+  fi
+  case $REST in
+    '#'*)
+      REST=''
+      return 1
+      ;;
+  esac
+  TOKEN=''
+  while [[ -n $REST ]]; do
+    char="${REST:0:1}"
+    if [[ -n $quote ]]; then
+      REST="${REST:1}"
+      if [[ $char == "$quote" ]]; then
+        quote=''
+      else
+        TOKEN="$TOKEN$char"
+      fi
+      continue
+    fi
+    case $char in
+      ' ' | "$CONFIG_TAB" | "$CONFIG_CR") break ;;
+      '"' | "'")
+        quote="$char"
+        REST="${REST:1}"
+        continue
+        ;;
+    esac
+    TOKEN="$TOKEN$char"
+    REST="${REST:1}"
+  done
+  if [[ -n $quote ]]; then
+    return 2
   fi
   return 0
 }
@@ -440,10 +521,12 @@ next_token() {
 PARSED_KEYWORD=''
 PARSED_ARGS=()
 parse_config_line() {
+  local keyword_status=0
   REST="$1"
   PARSED_KEYWORD=''
   PARSED_ARGS=()
-  if ! next_token 1; then
+  next_keyword_token || keyword_status=$?
+  if [[ $keyword_status -ne 0 ]]; then
     return 1
   fi
   PARSED_KEYWORD="$TOKEN"
@@ -451,17 +534,15 @@ parse_config_line() {
   case $PARSED_KEYWORD in
     '#'*) return 1 ;;
   esac
-  # A single '=' may replace the whitespace after the keyword.
-  while [[ -n $REST ]]; do
-    case $REST in
-      ' '* | "$CONFIG_TAB"* | "$CONFIG_CR"*) REST="${REST:1}" ;;
-      *) break ;;
-    esac
-  done
-  if [[ $REST == '='* ]]; then
-    REST="${REST:1}"
+  # A single '=' may replace the whitespace after the keyword -- but not
+  # after a quote-terminated keyword (see TOKEN_ENDED_AT_QUOTE above).
+  if [[ $TOKEN_ENDED_AT_QUOTE -ne 1 ]]; then
+    skip_leading_whitespace
+    if [[ $REST == '='* ]]; then
+      REST="${REST:1}"
+    fi
   fi
-  while next_token 0; do
+  while next_argument_token; do
     PARSED_ARGS+=("$TOKEN")
   done
   return 0

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -12,9 +12,13 @@
 #   --verify        read-only three-way check that the EFFECTIVE sshd
 #                   configuration is fully hardened (see the verify section)
 #   --reload        validate the complete configuration, then restart the sshd
-#                   launchd service and refuse to claim success until a real
-#                   SSH banner exchange proves the listener answers; the ONLY
-#                   mode that restarts anything, and it never writes
+#                   launchd service and refuse to claim a RESTART succeeded
+#                   until a real SSH banner exchange proves the listener
+#                   answers; the ONLY mode that restarts anything, and it
+#                   never writes. One documented exception to "no success
+#                   without a banner": a CONFIRMED-ABSENT service (Remote
+#                   Login off) exits 0 as a clean no-op, with no restart and
+#                   no banner (spec-mandated)
 #   --rollback      remove the managed drop-in and prove the hardening is gone
 #                   from the effective configuration (the way back in); never
 #                   restarts sshd

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1186,6 +1186,15 @@ reload_sshd() {
     die "could not determine the state of the sshd launchd service: '$LAUNCHCTL_BIN print $SSHD_LAUNCHD_SERVICE' exited $SERVICE_PROBE_STATUS, which is neither 0 (loaded) nor $LAUNCHCTL_STATUS_SERVICE_ABSENT (confirmed absent). A probe error is not evidence the daemon is stopped; refusing to guess. sshd was not touched. Output: $SERVICE_PROBE_OUTPUT"
   fi
 
+  # KNOWN RESIDUAL RACE, deliberately not closed in this change: the syntax
+  # check, the verify, and the port resolution above all read the
+  # configuration BEFORE this point, and nothing stops another writer from
+  # changing the tree between those reads and the kickstart below, so the
+  # daemon could restart onto a tree the preflight never saw. Closing it
+  # needs a re-read-and-compare design (fingerprint the tree at step 3,
+  # recheck it here) that is its own piece of work; a follow-up task carries
+  # it.
+  #
   # 7. The disruptive step. The keep-open warning and the COMPLETE recovery
   # command are printed FIRST: the kickstart is the step that can kill the
   # SSH session carrying this output, so anything printed only after it may

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
-# ssh-hardening.sh -- generate, install, and verify a public-key-only sshd
-# drop-in. Everything here is inert for the RUNNING daemon: sshd re-reads its
-# configuration only on restart, so writing the drop-in changes nothing until
-# Remote Login (re)starts sshd. The reload is a deliberately separate,
-# disruptive step and is NOT provided by this script.
+# ssh-hardening.sh -- generate, install, verify, reload, and roll back a
+# public-key-only sshd drop-in. Install is INERT for the running service: it
+# only writes files, and nothing here ever restarts sshd behind the operator's
+# back. Restarting the service so it demonstrably serves the new policy is its
+# own explicit, disruptive mode (--reload), removing the policy is another
+# (--rollback), and neither ever happens as a side effect of install.
 #
 # Modes:
 #   --print-config  print the drop-in content (pure: no privilege, no writes)
 #   --print-path    print the drop-in target path (pure)
 #   --verify        read-only three-way check that the EFFECTIVE sshd
 #                   configuration is fully hardened (see the verify section)
+#   --reload        validate the complete configuration, then restart the sshd
+#                   launchd service and refuse to claim success until a real
+#                   SSH banner exchange proves the listener answers; the ONLY
+#                   mode that restarts anything, and it never writes
 #   --rollback      remove the managed drop-in and prove the hardening is gone
 #                   from the effective configuration (the way back in); never
 #                   restarts sshd
@@ -25,8 +30,17 @@
 #   SSHD_MAIN_CONFIG    main sshd config       (default /etc/ssh/sshd_config)
 #   SSHD_BIN            sshd binary, ABSOLUTE  (default /usr/sbin/sshd) so a
 #                       stripped PATH cannot turn the verifier into a no-op
+#   LAUNCHCTL_BIN       launchctl, ABSOLUTE    (default /bin/launchctl), same
+#                       stripped-PATH rationale; only --reload uses it
+#   KEYSCAN_BIN         ssh-keyscan, ABSOLUTE  (default /usr/bin/ssh-keyscan);
+#                       the readiness prover, only --reload uses it
 #   SSH_HARDENING_SUDO  privilege wrapper for writes; set EMPTY to run
 #                       unprivileged against a sandbox tree (default sudo)
+#   SSH_HARDENING_READY_ATTEMPTS / SSH_HARDENING_READY_INTERVAL
+#                       how many banner probes --reload makes and the seconds
+#                       between them (defaults 30 and 1); the bound is by
+#                       ATTEMPT COUNT, so a probe that never answers cannot
+#                       hang the reload forever
 #   SSH_HARDENING_ALLOW_MISSING_SSHD
 #                       explicit test seam: when set to a TRUE-ish value AND
 #                       $SSHD_BIN cannot run, --verify skips (exit 0) WITHOUT a
@@ -48,6 +62,17 @@ SSHD_BIN="${SSHD_BIN:-/usr/sbin/sshd}"
 # `-` not `:-`: set-but-empty means "no wrapper, run the commands directly",
 # which is how tests write into a user-owned sandbox without privilege.
 SSH_HARDENING_SUDO="${SSH_HARDENING_SUDO-sudo}"
+LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-/bin/launchctl}"
+KEYSCAN_BIN="${KEYSCAN_BIN:-/usr/bin/ssh-keyscan}"
+SSH_HARDENING_READY_ATTEMPTS="${SSH_HARDENING_READY_ATTEMPTS:-30}"
+SSH_HARDENING_READY_INTERVAL="${SSH_HARDENING_READY_INTERVAL:-1}"
+
+# The launchd service behind macOS Remote Login. `launchctl print` on it exits
+# 0 when the job is loaded and 113 when the service is genuinely absent
+# (Remote Login off); both measured on macOS 26.2. Any OTHER status is a probe
+# ERROR, and the reload path refuses to read one as "the daemon is stopped".
+SSHD_LAUNCHD_SERVICE='system/com.openssh.sshd'
+LAUNCHCTL_STATUS_SERVICE_ABSENT=113
 
 # This file, for the install path's strict child verify. BASH_SOURCE and not
 # $0, so a caller that rewrites $0 cannot redirect the re-invocation.
@@ -796,6 +821,157 @@ install_dropin() {
   printf '[ssh-hardening] install complete: %s is in place and the effective configuration verified fully hardened.\n' "$target"
 }
 
+# --- reload ------------------------------------------------------------------
+
+# recovery_instructions: the way back in, in one sentence, printed verbatim in
+# every failure after the disruptive step. The exact wording is pinned by a
+# test against the runbook's copy, so shortening it to "investigate" (or
+# letting the two drift apart) fails the suite.
+recovery_instructions() {
+  printf 'Recovery: keep any SSH session you still have OPEN until a new login succeeds. From the physical console, or Screen Sharing over the tailnet, run: ssh-hardening.sh --rollback (or: sudo rm %s), then turn Remote Login off and back on in System Settings > General > Sharing.' "$(dropin_path)"
+}
+
+# probe_sshd_service: one `launchctl print` of the sshd service, through the
+# privilege wrapper. Results land in globals rather than an exit status,
+# because the caller needs the EXACT status to separate three outcomes:
+# loaded (0), confirmed absent (113), and everything else, which is a probe
+# error and must never be read as "the daemon is stopped".
+SERVICE_PROBE_STATUS=0
+SERVICE_PROBE_OUTPUT=''
+probe_sshd_service() {
+  SERVICE_PROBE_STATUS=0
+  SERVICE_PROBE_OUTPUT="$(run_privileged "$LAUNCHCTL_BIN" print "$SSHD_LAUNCHD_SERVICE" 2>&1)" ||
+    SERVICE_PROBE_STATUS=$?
+}
+
+# reload_sshd: restart the sshd launchd service so it demonstrably serves the
+# drop-in. This is the one disruptive mode in the script: on a remote machine
+# the daemon being restarted is the daemon carrying the session, so every step
+# fails CLOSED, everything that can be validated is validated BEFORE the
+# restart, and success is claimed only after a real SSH banner exchange. What
+# is deliberately NOT here: any automatic rollback on failure. A machine that
+# just failed to restart cleanly is exactly the machine that must not receive
+# a second unattended state change; the failure names the recovery path and
+# leaves the operator in control.
+reload_sshd() {
+  local status output port
+
+  case $SSH_HARDENING_READY_ATTEMPTS in
+    '' | 0 | *[!0-9]*)
+      die "SSH_HARDENING_READY_ATTEMPTS must be a positive integer, got '$SSH_HARDENING_READY_ATTEMPTS'; refusing to run with a readiness bound that means nothing"
+      ;;
+  esac
+  case $SSH_HARDENING_READY_INTERVAL in
+    '' | . | *.*.* | *[!0-9.]*)
+      die "SSH_HARDENING_READY_INTERVAL must be a non-negative number of seconds, got '$SSH_HARDENING_READY_INTERVAL'"
+      ;;
+  esac
+
+  # 1. Privilege first, VISIBLY (a password prompt, if any, lands on the
+  # terminal). Everything disruptive below runs through the wrapper, so a
+  # sudo failure aborts here, named as what it is: without this, a failed
+  # `sudo launchctl print` exits nonzero and reads exactly like a service
+  # problem. An empty wrapper means the caller already runs with whatever
+  # privilege it has (the sandbox case), so there is nothing to prime.
+  if [[ -n $SSH_HARDENING_SUDO ]]; then
+    status=0
+    "$SSH_HARDENING_SUDO" -v || status=$?
+    if [[ $status -ne 0 ]]; then
+      die "privilege escalation is unavailable ('$SSH_HARDENING_SUDO -v' exited $status), and the reload needs it before it can do anything, so nothing was attempted. This is a sudo failure, not a statement about the sshd service."
+    fi
+  fi
+
+  # 2. The readiness prover must exist BEFORE anything disruptive happens. A
+  # reload that cannot prove the daemon came back is a reload that leaves the
+  # operator guessing, so its absence is a refusal, not a warning.
+  if [[ ! -x $KEYSCAN_BIN ]]; then
+    die "the readiness prover '$KEYSCAN_BIN' is not runnable, so there would be no way to prove sshd came back after a restart; refusing to kickstart blind. sshd was not touched."
+  fi
+
+  # 3. Syntax: never restart onto a configuration sshd cannot parse.
+  # Privileged, because -t reads the root-owned host keys.
+  status=0
+  output="$(run_privileged "$SSHD_BIN" -t -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    die "the configuration failed sshd's syntax check ('$SSHD_BIN -t' exited $status); refusing to restart onto it. sshd was not touched. Output: $output"
+  fi
+
+  # 4. The full three-way verify: never restart onto a configuration that
+  # parses but has lost the hardening.
+  if ! run_verify_child; then
+    die "the effective configuration is not fully hardened (the verify failures are above); refusing to restart sshd onto it. sshd was not touched."
+  fi
+
+  # 5. Resolve the port now, while nothing has been disturbed: a reload that
+  # cannot name the port to probe must fail BEFORE the kickstart, not after.
+  status=0
+  output="$("$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    die "could not resolve the effective sshd port ('$SSHD_BIN -G' exited $status); refusing to restart a daemon whose readiness could not then be probed. sshd was not touched. Output: $output"
+  fi
+  status=0
+  port="$(printf '%s\n' "$output" | awk '$1 == "port" { print $2; exit }')" || status=$?
+  if [[ $status -ne 0 ]]; then
+    die "could not read the port out of the sshd -G output (exit $status); failing closed before the disruptive step. sshd was not touched."
+  fi
+  case $port in
+    '' | *[!0-9]*)
+      die "the effective sshd port resolved to '$port', which is not a port number; refusing to probe readiness blind. sshd was not touched."
+      ;;
+  esac
+
+  # 6. Probe the service, separating THREE outcomes, not two.
+  probe_sshd_service
+  if [[ $SERVICE_PROBE_STATUS -eq $LAUNCHCTL_STATUS_SERVICE_ABSENT ]]; then
+    printf '[ssh-hardening] reload: the sshd launchd service is confirmed absent, which is what Remote Login being off looks like, so there is no daemon to restart. The installed drop-in applies when Remote Login is next enabled.\n'
+    return 0
+  fi
+  if [[ $SERVICE_PROBE_STATUS -ne 0 ]]; then
+    die "could not determine the state of the sshd launchd service: '$LAUNCHCTL_BIN print $SSHD_LAUNCHD_SERVICE' exited $SERVICE_PROBE_STATUS, which is neither 0 (loaded) nor $LAUNCHCTL_STATUS_SERVICE_ABSENT (confirmed absent). A probe error is not evidence the daemon is stopped; refusing to guess. sshd was not touched. Output: $SERVICE_PROBE_OUTPUT"
+  fi
+
+  # 7. The disruptive step.
+  status=0
+  output="$(run_privileged "$LAUNCHCTL_BIN" kickstart -k "$SSHD_LAUNCHD_SERVICE" 2>&1)" || status=$?
+  if [[ $status -ne 0 ]]; then
+    die "'launchctl kickstart -k $SSHD_LAUNCHD_SERVICE' failed (exit $status), so sshd may now be in any state between untouched and stopped. $(recovery_instructions) Output: $output"
+  fi
+
+  # 8. The job must be loaded again. FIRST SIGNAL ONLY: `launchctl print`
+  # returns 0 for a loaded-but-crashed service, so this can refute success
+  # but never establish it.
+  probe_sshd_service
+  if [[ $SERVICE_PROBE_STATUS -ne 0 ]]; then
+    die "the sshd launchd service did not reload: after the kickstart, '$LAUNCHCTL_BIN print' exited $SERVICE_PROBE_STATUS instead of confirming a loaded job. $(recovery_instructions)"
+  fi
+
+  # 9. The artifact: a completed SSH banner exchange on the resolved port.
+  # ssh-keyscan's exit status alone is not trusted either; a probe that
+  # produced no key line proved nothing, whatever it exited. The probe
+  # targets loopback, so a green result proves the daemon answers, NOT that a
+  # remote client can reach it (the application firewall does not filter
+  # loopback); the runbook's keep-a-session-open step is what covers that
+  # gap. The 5 is ssh-keyscan's per-attempt connection timeout in seconds.
+  local attempt=1 ready=0 keyscan_status banner_output
+  while [[ $attempt -le $SSH_HARDENING_READY_ATTEMPTS ]]; do
+    keyscan_status=0
+    banner_output="$("$KEYSCAN_BIN" -T 5 -p "$port" 127.0.0.1 2>/dev/null)" ||
+      keyscan_status=$?
+    if [[ $keyscan_status -eq 0 && -n $banner_output ]]; then
+      ready=1
+      break
+    fi
+    if [[ $attempt -lt $SSH_HARDENING_READY_ATTEMPTS && $SSH_HARDENING_READY_INTERVAL != 0 ]]; then
+      sleep "$SSH_HARDENING_READY_INTERVAL"
+    fi
+    attempt=$((attempt + 1))
+  done
+  if [[ $ready -ne 1 ]]; then
+    die "POSSIBLE LOCKOUT: the launchd job reports loaded, but no SSH banner arrived on port $port after $SSH_HARDENING_READY_ATTEMPTS attempt(s). A loaded job with a silent listener is what a crashed sshd looks like, so this is a failure, not a maybe. $(recovery_instructions)"
+  fi
+  printf '[ssh-hardening] reload complete: sshd restarted and is accepting connections on port %s (SSH banner exchange completed).\n' "$port"
+}
+
 # --- rollback ----------------------------------------------------------------
 
 # rollback_dropin: the way back in, as code. Remove the managed drop-in, then
@@ -846,19 +1022,24 @@ rollback_dropin() {
 
 usage() {
   cat <<'EOF'
-usage: ssh-hardening.sh [--print-config | --print-path | --verify | --rollback]
+usage: ssh-hardening.sh [--print-config | --print-path | --verify | --reload | --rollback]
 
   --print-config  print the generated drop-in content and exit
   --print-path    print the drop-in target path and exit
   --verify        read-only check that the effective sshd configuration is
                   fully hardened; never writes, never escalates
+  --reload        validate the complete configuration, then restart the sshd
+                  launchd service and prove it answers with an SSH banner
+                  before claiming success; DISRUPTIVE, and fails closed at
+                  every step
   --rollback      remove the managed drop-in and confirm the hardening is
                   gone from the effective configuration (the way back in);
                   never restarts sshd
   (no argument)   install the drop-in and verify
 
-Reloading a running sshd is deliberately not provided here; the drop-in
-takes effect when sshd next starts.
+--reload is the only mode that restarts sshd, and it never writes; install
+writes and never restarts. The disruptive step only ever happens because an
+operator typed it.
 EOF
 }
 
@@ -871,6 +1052,7 @@ main() {
     --print-config) print_config ;;
     --print-path) dropin_path ;;
     --verify) verify ;;
+    --reload) reload_sshd ;;
     --rollback) rollback_dropin ;;
     '') install_dropin ;;
     --help | -h) usage ;;

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -35,6 +35,27 @@
 # Path to the script under test, resolved from this library's location.
 SSH_HARDENING_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dot_local/bin/executable_ssh-hardening.sh"
 
+# The managed drop-in's file name, in ONE place (exported: the reload lib's
+# sshd stub reads it at run time). Must match DROPIN_NAME in the script.
+SSH_DROPIN_NAME='000-ssh-hardening.conf'
+export SSH_DROPIN_NAME
+
+# fail <message...>: print and abort the test. Shared by every suite that
+# sources this library.
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# refute_contains <haystack> <fixed-string> <message>: a bare `! grep` is
+# dead under `set -e` unless it is the last statement, so every negative
+# assertion goes through this helper.
+refute_contains() {
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
 # A literal carriage return, for fixtures that exercise sshd's whitespace set
 # (misc.c WHITESPACE is " \t\r\n"). Named because a bare $'\r' inside a
 # fixture line is invisible in a diff and in a terminal.
@@ -156,7 +177,7 @@ run_ssh_hardening_without() {
 # the very install path it is about to examine.
 write_hardened_dropin() {
   /bin/bash "$SSH_HARDENING_SCRIPT" --print-config \
-    >"$SSHD_CONFIG_D/000-ssh-hardening.conf"
+    >"$SSHD_CONFIG_D/$SSH_DROPIN_NAME"
 }
 
 # write_hostile_apple_conf: a 100-macos.conf that reopens EVERY hole the

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -34,10 +34,14 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #                                            at SSH_SUDO_DENY_STUB for the
 #                                            privilege-failure case
 # and the spy logs:
-#   LAUNCHCTL_SPY_LOG, KEYSCAN_SPY_LOG, SLEEP_SPY_LOG, SUDO_OK_SPY_LOG,
-#   SUDO_DENY_SPY_LOG, SSH_BARE_TOOL_SPY_LOG (the PATH tripwires for bare
-#   sshd / launchctl / ssh-keyscan; bare sudo keeps slice 7's
-#   SSH_SUDO_SPY_LOG).
+#   SSHD_SPY_LOG, LAUNCHCTL_SPY_LOG, KEYSCAN_SPY_LOG, SLEEP_SPY_LOG,
+#   SUDO_OK_SPY_LOG, SUDO_DENY_SPY_LOG, SSH_BARE_TOOL_SPY_LOG (the PATH
+#   tripwires for bare sshd / launchctl / ssh-keyscan; bare sudo keeps slice
+#   7's SSH_SUDO_SPY_LOG), and SSH_SEAM_CALL_LOG, one SHARED ordered log
+#   every controlled stub appends `<tool> <argv>` to, so tests can assert
+#   the exact sequence of seam calls across tools (a spy that records THAT a
+#   call happened but not WHAT it asked lets a dropped flag, a typo'd label,
+#   a wrong -f target, or a reordered step survive).
 #
 # Stub behavior knobs, all exported and overridable per invocation:
 #   SSHD_STUB_SYNTAX_STATUS          exit status of `sshd -t` (default 0)
@@ -79,18 +83,22 @@ reload_sandbox_setup() {
   SSH_STUB_DIR="$SSH_SANDBOX/stubs"
   SSH_STUB_STATE="$SSH_SANDBOX/stub-state"
   mkdir -p "$SSH_STUB_DIR" "$SSH_STUB_STATE"
+  SSHD_SPY_LOG="$SSH_SANDBOX/sshd-spy.log"
   LAUNCHCTL_SPY_LOG="$SSH_SANDBOX/launchctl-spy.log"
   KEYSCAN_SPY_LOG="$SSH_SANDBOX/keyscan-spy.log"
   SLEEP_SPY_LOG="$SSH_SANDBOX/sleep-spy.log"
   SUDO_OK_SPY_LOG="$SSH_SANDBOX/sudo-ok-spy.log"
   SUDO_DENY_SPY_LOG="$SSH_SANDBOX/sudo-deny-spy.log"
   SSH_BARE_TOOL_SPY_LOG="$SSH_SANDBOX/bare-tool-spy.log"
+  SSH_SEAM_CALL_LOG="$SSH_SANDBOX/seam-call.log"
+  : >"$SSHD_SPY_LOG"
   : >"$LAUNCHCTL_SPY_LOG"
   : >"$KEYSCAN_SPY_LOG"
   : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
   : >"$SSH_BARE_TOOL_SPY_LOG"
+  : >"$SSH_SEAM_CALL_LOG"
 
   # PATH tripwires: a bare-name call to any tool the reload modes touch must
   # fail loudly, never reach the real tool. $SSH_SANDBOX/bin is already first
@@ -113,6 +121,8 @@ STUB
   cat >"$SSH_STUB_DIR/sshd" <<'STUB'
 #!/bin/bash
 set -euo pipefail
+printf '%s\n' "$*" >>"${SSHD_SPY_LOG:?}"
+printf 'sshd %s\n' "$*" >>"${SSH_SEAM_CALL_LOG:?}"
 case " $* " in
   *' -t '*)
     if [[ ${SSHD_STUB_SYNTAX_STATUS:-0} -ne 0 ]]; then
@@ -164,6 +174,7 @@ STUB
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${LAUNCHCTL_SPY_LOG:?}"
+printf 'launchctl %s\n' "$*" >>"${SSH_SEAM_CALL_LOG:?}"
 case "${1:-}" in
   print)
     count_file="${SSH_STUB_STATE:?}/launchctl-print-count"
@@ -219,6 +230,7 @@ STUB
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${KEYSCAN_SPY_LOG:?}"
+printf 'ssh-keyscan %s\n' "$*" >>"${SSH_SEAM_CALL_LOG:?}"
 requested_port=''
 previous=''
 for argument in "$@"; do
@@ -266,6 +278,7 @@ STUB
   cat >"$SSH_STUB_DIR/sleep" <<'STUB'
 #!/bin/bash
 printf '%s\n' "$*" >>"${SLEEP_SPY_LOG:?}"
+printf 'sleep %s\n' "$*" >>"${SSH_SEAM_CALL_LOG:?}"
 exit 0
 STUB
   chmod +x "$SSH_STUB_DIR/sleep"
@@ -331,8 +344,9 @@ STUB
   KEYSCAN_STUB_ANSWER_PORT=""
   export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
     SSH_SUDO_LAUNCHCTL_113_STUB \
-    LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG SUDO_OK_SPY_LOG \
-    SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
+    SSHD_SPY_LOG LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG \
+    SUDO_OK_SPY_LOG SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
+    SSH_SEAM_CALL_LOG \
     SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SLEEP_BIN SSH_HARDENING_SUDO \
     SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUSES SSHD_STUB_PORT \
     SSHD_STUB_FORCE_HARDENED SSHD_STUB_PARTIAL_HARDENED \
@@ -344,11 +358,13 @@ STUB
 # then assert no bare-name tripwire fired. Every reload/rollback invocation
 # goes through here so no run can reach a real tool unobserved.
 run_ssh_reload() {
+  : >"$SSHD_SPY_LOG"
   : >"$LAUNCHCTL_SPY_LOG"
   : >"$KEYSCAN_SPY_LOG"
   : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
+  : >"$SSH_SEAM_CALL_LOG"
   rm -f "$SSH_STUB_STATE/launchctl-print-count" "$SSH_STUB_STATE/sshd-resolve-count" \
     "$SSH_STUB_STATE/stdout-at-kickstart" "$SSH_STUB_STATE/stderr-at-kickstart"
   run_ssh_hardening "$@"
@@ -361,11 +377,31 @@ run_ssh_reload() {
 
 # assert_kickstart_attempted <label> / assert_no_kickstart <label>: whether
 # `launchctl kickstart` was invoked during the LAST run_ssh_reload, judged by
-# the stub's own spy log, never by the script's output.
+# the stub's own spy log, never by the script's output. The attempted form
+# asserts the EXACT argv: without -k a running instance is never terminated
+# (a reload "succeeds" while sshd serves the old configuration), and a
+# typo'd label makes real launchctl exit 113, which the reload reads as
+# Remote Login being off.
 assert_kickstart_attempted() {
-  if ! grep -q '^kickstart ' "$LAUNCHCTL_SPY_LOG"; then
-    printf 'FAIL: %s: expected a kickstart attempt; launchctl spy log:\n%s\n' \
+  if ! grep -qxF 'kickstart -k system/com.openssh.sshd' "$LAUNCHCTL_SPY_LOG"; then
+    printf 'FAIL: %s: expected exactly `kickstart -k system/com.openssh.sshd`; launchctl spy log:\n%s\n' \
       "$1" "$(cat "$LAUNCHCTL_SPY_LOG")" >&2
+    exit 1
+  fi
+}
+
+# assert_seam_calls <label> <expected-line>...: the ORDERED argv of every
+# seam call in the last run, diffed whole against the shared seam log. One
+# assertion covers the argument of every call AND the order between them
+# (syntax check before verify before port resolution before the kickstart
+# before the probes), so none of those can regress individually.
+assert_seam_calls() {
+  local label="$1" expected_file="$SSH_SANDBOX/expected-seam-calls"
+  shift
+  printf '%s\n' "$@" >"$expected_file"
+  if ! diff -u "$expected_file" "$SSH_SEAM_CALL_LOG" >&2; then
+    printf 'FAIL: %s: seam calls differ from expected (diff above: - expected, + actual)\n' \
+      "$label" >&2
     exit 1
   fi
 }

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -35,10 +35,19 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #
 # Stub behavior knobs, all exported and overridable per invocation:
 #   SSHD_STUB_SYNTAX_STATUS          exit status of `sshd -t` (default 0)
+#   SSHD_STUB_RESOLVE_STATUS         exit status of every `sshd -G` call
+#                                    (default 0; nonzero models a verifier
+#                                    binary that runs but ERRORS)
 #   SSHD_STUB_PORT                   the `port` line `sshd -G` prints (2222)
 #   SSHD_STUB_FORCE_HARDENED         nonempty: -G prints hardened values even
 #                                    with the drop-in absent (models a second
 #                                    file still enforcing the policy)
+#   SSHD_STUB_PARTIAL_HARDENED       nonempty: -G keeps BOTH interactive
+#                                    password channels closed but leaves the
+#                                    rest at defaults (models a sibling that
+#                                    still blocks passwords after the drop-in
+#                                    is gone, without verifying fully
+#                                    hardened)
 #   LAUNCHCTL_STUB_PRINT_STATUSES    space-separated exit statuses for
 #                                    successive `launchctl print` calls within
 #                                    one run; the last entry repeats
@@ -94,10 +103,18 @@ case " $* " in
     exit 0
     ;;
 esac
+if [[ ${SSHD_STUB_RESOLVE_STATUS:-0} -ne 0 ]]; then
+  echo 'sshd stub: -G resolution failure injected' >&2
+  exit "${SSHD_STUB_RESOLVE_STATUS}"
+fi
 printf 'port %s\n' "${SSHD_STUB_PORT:-2222}"
 if [[ -f "${SSHD_CONFIG_D:?}/000-ssh-hardening.conf" || -n ${SSHD_STUB_FORCE_HARDENED:-} ]]; then
   printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
     'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin no' \
+    'gssapiauthentication no' 'hostbasedauthentication no'
+elif [[ -n ${SSHD_STUB_PARTIAL_HARDENED:-} ]]; then
+  printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
+    'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin prohibit-password' \
     'gssapiauthentication no' 'hostbasedauthentication no'
 else
   printf '%s\n' 'passwordauthentication yes' 'kbdinteractiveauthentication yes' \
@@ -209,8 +226,10 @@ STUB
   KEYSCAN_BIN="$SSH_STUB_DIR/ssh-keyscan"
   SSH_HARDENING_SUDO="$SSH_STUB_DIR/sudo-ok"
   SSHD_STUB_SYNTAX_STATUS=0
+  SSHD_STUB_RESOLVE_STATUS=0
   SSHD_STUB_PORT=2222
   SSHD_STUB_FORCE_HARDENED=""
+  SSHD_STUB_PARTIAL_HARDENED=""
   LAUNCHCTL_STUB_PRINT_STATUSES='0'
   LAUNCHCTL_STUB_KICKSTART_STATUS=0
   KEYSCAN_STUB_MODE=banner
@@ -218,7 +237,8 @@ STUB
     LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SUDO_OK_SPY_LOG SUDO_DENY_SPY_LOG \
     SSH_BARE_TOOL_SPY_LOG \
     SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SSH_HARDENING_SUDO \
-    SSHD_STUB_SYNTAX_STATUS SSHD_STUB_PORT SSHD_STUB_FORCE_HARDENED \
+    SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUS SSHD_STUB_PORT \
+    SSHD_STUB_FORCE_HARDENED SSHD_STUB_PARTIAL_HARDENED \
     LAUNCHCTL_STUB_PRINT_STATUSES LAUNCHCTL_STUB_KICKSTART_STATUS \
     KEYSCAN_STUB_MODE
 }

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -417,7 +417,7 @@ run_ssh_reload() {
 # Remote Login being off.
 assert_kickstart_attempted() {
   if ! grep -qxF 'kickstart -k system/com.openssh.sshd' "$LAUNCHCTL_SPY_LOG"; then
-    printf 'FAIL: %s: expected exactly `kickstart -k system/com.openssh.sshd`; launchctl spy log:\n%s\n' \
+    printf 'FAIL: %s: expected exactly "kickstart -k system/com.openssh.sshd"; launchctl spy log:\n%s\n' \
       "$1" "$(cat "$LAUNCHCTL_SPY_LOG")" >&2
     exit 1
   fi

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -283,6 +283,27 @@ exec "$@"
 STUB
   chmod +x "$SSH_STUB_DIR/sudo-ok"
 
+  # A wrapper that primes fine but fails ONLY for launchctl, with the exact
+  # status the reload reads as "service absent", without ever running it:
+  # the shape of a wrapper failure masquerading as a confirmed-absent
+  # service. Everything else it is asked to run passes through.
+  cat >"$SSH_STUB_DIR/sudo-launchctl-113" <<'STUB'
+#!/bin/bash
+if [[ ${1:-} == '-v' ]]; then
+  exit 0
+fi
+case "${1:-}" in
+  *launchctl*)
+    printf '%s\n' "$*" >>"${SUDO_DENY_SPY_LOG:?}"
+    printf 'sudo stub: refusing to run launchctl (exit 113 without executing it)\n' >&2
+    exit 113
+    ;;
+esac
+exec "$@"
+STUB
+  chmod +x "$SSH_STUB_DIR/sudo-launchctl-113"
+  SSH_SUDO_LAUNCHCTL_113_STUB="$SSH_STUB_DIR/sudo-launchctl-113"
+
   # Denying sudo: logs and fails the way a passwordless-sudo revocation or a
   # missing terminal does. Nothing it is asked to run ever runs.
   cat >"$SSH_STUB_DIR/sudo-deny" <<'STUB'
@@ -309,6 +330,7 @@ STUB
   KEYSCAN_STUB_MODE=banner
   KEYSCAN_STUB_ANSWER_PORT=""
   export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
+    SSH_SUDO_LAUNCHCTL_113_STUB \
     LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG SUDO_OK_SPY_LOG \
     SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
     SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SLEEP_BIN SSH_HARDENING_SUDO \

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -41,10 +41,16 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #
 # Stub behavior knobs, all exported and overridable per invocation:
 #   SSHD_STUB_SYNTAX_STATUS          exit status of `sshd -t` (default 0)
-#   SSHD_STUB_RESOLVE_STATUS         exit status of every `sshd -G` call
-#                                    (default 0; nonzero models a verifier
-#                                    binary that runs but ERRORS)
-#   SSHD_STUB_PORT                   the `port` line `sshd -G` prints (2222)
+#   SSHD_STUB_RESOLVE_STATUSES       space-separated exit statuses for
+#                                    successive `sshd -G` calls within one
+#                                    run; the last entry repeats (default 0;
+#                                    a uniform nonzero models a verifier
+#                                    binary that runs but ERRORS, a trailing
+#                                    nonzero fails only a later call such as
+#                                    the reload's port resolution)
+#   SSHD_STUB_PORT                   space-separated list of `port` lines
+#                                    `sshd -G` prints (default 2222; empty
+#                                    prints NO port line)
 #   SSHD_STUB_FORCE_HARDENED         nonempty: -G prints hardened values even
 #                                    with the drop-in absent (models a second
 #                                    file still enforcing the policy)
@@ -59,6 +65,8 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #                                    one run; the last entry repeats
 #   LAUNCHCTL_STUB_KICKSTART_STATUS  exit status of `launchctl kickstart` (0)
 #   KEYSCAN_STUB_MODE                banner | refuse | silent-zero
+#   KEYSCAN_STUB_ANSWER_PORT         banner mode only: refuse every requested
+#                                    port except this one (empty: answer any)
 #
 # The sshd stub keys its -G output off the PRESENCE of the sandbox drop-in, so
 # --verify (which the reload and rollback paths re-run in a child) tracks what
@@ -111,11 +119,23 @@ case " $* " in
     exit 0
     ;;
 esac
-if [[ ${SSHD_STUB_RESOLVE_STATUS:-0} -ne 0 ]]; then
-  echo 'sshd stub: -G resolution failure injected' >&2
-  exit "${SSHD_STUB_RESOLVE_STATUS}"
+count_file="${SSH_STUB_STATE:?}/sshd-resolve-count"
+count="$(cat "$count_file" 2>/dev/null || printf '0')"
+count=$((count + 1))
+printf '%s' "$count" >"$count_file"
+# shellcheck disable=SC2206  # deliberate word split of the status list
+statuses=(${SSHD_STUB_RESOLVE_STATUSES:-0})
+index=$((count - 1))
+if [[ $index -ge ${#statuses[@]} ]]; then
+  index=$((${#statuses[@]} - 1))
 fi
-printf 'port %s\n' "${SSHD_STUB_PORT:-2222}"
+if [[ ${statuses[$index]} -ne 0 ]]; then
+  echo 'sshd stub: -G resolution failure injected' >&2
+  exit "${statuses[$index]}"
+fi
+for stub_port in ${SSHD_STUB_PORT-2222}; do
+  printf 'port %s\n' "$stub_port"
+done
 if [[ -f "${SSHD_CONFIG_D:?}/000-ssh-hardening.conf" || -n ${SSHD_STUB_FORCE_HARDENED:-} ]]; then
   printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
     'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin no' \
@@ -177,17 +197,32 @@ STUB
   chmod +x "$SSH_STUB_DIR/launchctl"
 
   # Controlled ssh-keyscan: `banner` completes the exchange (a key line on
-  # stdout, exit 0); `refuse` models connection refused (exit 1, nothing on
-  # stdout); `silent-zero` exits 0 with NO output, the shape of a probe that
-  # ran but proved nothing, so a reload that trusts the exit status alone and
-  # not the banner itself is convicted by it.
+  # stdout naming the REQUESTED port, exit 0), unless KEYSCAN_STUB_ANSWER_PORT
+  # names a different port, in which case the request is refused (multi-port
+  # cases prove the probe walks every resolved port); `refuse` models
+  # connection refused (exit 1, nothing on stdout); `silent-zero` exits 0
+  # with NO output, the shape of a probe that ran but proved nothing, so a
+  # reload that trusts the exit status alone and not the banner itself is
+  # convicted by it.
   cat >"$SSH_STUB_DIR/ssh-keyscan" <<'STUB'
 #!/bin/bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${KEYSCAN_SPY_LOG:?}"
+requested_port=''
+previous=''
+for argument in "$@"; do
+  if [[ $previous == '-p' ]]; then
+    requested_port="$argument"
+  fi
+  previous="$argument"
+done
 case "${KEYSCAN_STUB_MODE:-banner}" in
   banner)
-    printf '[127.0.0.1]:%s ssh-ed25519 AAAA-stub-host-key\n' "${SSHD_STUB_PORT:-2222}"
+    if [[ -n ${KEYSCAN_STUB_ANSWER_PORT:-} && $requested_port != "${KEYSCAN_STUB_ANSWER_PORT}" ]]; then
+      printf 'ssh-keyscan stub: connect to 127.0.0.1 port %s: Connection refused\n' "$requested_port" >&2
+      exit 1
+    fi
+    printf '[127.0.0.1]:%s ssh-ed25519 AAAA-stub-host-key\n' "$requested_port"
     exit 0
     ;;
   refuse)
@@ -246,21 +281,22 @@ STUB
   SLEEP_BIN="$SSH_STUB_DIR/sleep"
   SSH_HARDENING_SUDO="$SSH_STUB_DIR/sudo-ok"
   SSHD_STUB_SYNTAX_STATUS=0
-  SSHD_STUB_RESOLVE_STATUS=0
+  SSHD_STUB_RESOLVE_STATUSES=0
   SSHD_STUB_PORT=2222
   SSHD_STUB_FORCE_HARDENED=""
   SSHD_STUB_PARTIAL_HARDENED=""
   LAUNCHCTL_STUB_PRINT_STATUSES='0'
   LAUNCHCTL_STUB_KICKSTART_STATUS=0
   KEYSCAN_STUB_MODE=banner
+  KEYSCAN_STUB_ANSWER_PORT=""
   export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
     LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG SUDO_OK_SPY_LOG \
     SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
     SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SLEEP_BIN SSH_HARDENING_SUDO \
-    SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUS SSHD_STUB_PORT \
+    SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUSES SSHD_STUB_PORT \
     SSHD_STUB_FORCE_HARDENED SSHD_STUB_PARTIAL_HARDENED \
     LAUNCHCTL_STUB_PRINT_STATUSES LAUNCHCTL_STUB_KICKSTART_STATUS \
-    KEYSCAN_STUB_MODE
+    KEYSCAN_STUB_MODE KEYSCAN_STUB_ANSWER_PORT
 }
 
 # run_ssh_reload <args...>: run_ssh_hardening with fresh per-run spy state,
@@ -272,7 +308,7 @@ run_ssh_reload() {
   : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
-  rm -f "$SSH_STUB_STATE/launchctl-print-count"
+  rm -f "$SSH_STUB_STATE/launchctl-print-count" "$SSH_STUB_STATE/sshd-resolve-count"
   run_ssh_hardening "$@"
   if [[ -s $SSH_BARE_TOOL_SPY_LOG ]]; then
     printf 'FAIL: the script called a tool by bare name instead of its seam during %s; tripwire log:\n%s\n' \

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# ssh-reload-lib.bash - stub harness for the disruptive modes (--reload,
+# --rollback) of dot_local/bin/executable_ssh-hardening.sh, layered on
+# ssh-hardening-lib.bash (which supplies the sandbox tree and the failing
+# PATH `sudo` tripwire).
+#
+# Every tool the disruptive modes drive is a FULLY CONTROLLED stub reached
+# through the SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN
+# seams, and every seam is MIRRORED on PATH by a tripwire that always fails
+# loudly (exit 96) and records the call: a regressed script that drops a seam
+# and calls a bare tool name hits the tripwire, never the real tool. No test
+# sourcing this library requires a real sshd, launchctl, ssh-keyscan, or sudo,
+# so none can skip, and none can reach the live daemon. On top of the seams
+# and the tripwires, the tests run UNPRIVILEGED: even if every layer above
+# regressed at once, launchd refuses an unprivileged kickstart of the real
+# system/com.openssh.sshd, and /etc/ssh is root-owned, so the violation would
+# be loud and harmless rather than a live restart.
+
+# shellcheck source=./ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
+
+# reload_sandbox_setup: ssh_sandbox_setup plus the reload seams.
+#
+# Exports the seams (all absolute paths into the sandbox):
+#   SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN   controlled stubs
+#   SSH_HARDENING_SUDO                       passthrough sudo stub (logs the
+#                                            call, then executes it); point it
+#                                            at SSH_SUDO_DENY_STUB for the
+#                                            privilege-failure case
+# and the spy logs:
+#   LAUNCHCTL_SPY_LOG, KEYSCAN_SPY_LOG, SUDO_OK_SPY_LOG, SUDO_DENY_SPY_LOG,
+#   SSH_BARE_TOOL_SPY_LOG (the PATH tripwires for bare sshd / launchctl /
+#   ssh-keyscan; bare sudo keeps slice 7's SSH_SUDO_SPY_LOG).
+#
+# Stub behavior knobs, all exported and overridable per invocation:
+#   SSHD_STUB_SYNTAX_STATUS          exit status of `sshd -t` (default 0)
+#   SSHD_STUB_PORT                   the `port` line `sshd -G` prints (2222)
+#   SSHD_STUB_FORCE_HARDENED         nonempty: -G prints hardened values even
+#                                    with the drop-in absent (models a second
+#                                    file still enforcing the policy)
+#   LAUNCHCTL_STUB_PRINT_STATUSES    space-separated exit statuses for
+#                                    successive `launchctl print` calls within
+#                                    one run; the last entry repeats
+#   LAUNCHCTL_STUB_KICKSTART_STATUS  exit status of `launchctl kickstart` (0)
+#   KEYSCAN_STUB_MODE                banner | refuse | silent-zero
+#
+# The sshd stub keys its -G output off the PRESENCE of the sandbox drop-in, so
+# --verify (which the reload and rollback paths re-run in a child) tracks what
+# install or rollback actually did to the tree, the way the real sshd would.
+reload_sandbox_setup() {
+  ssh_sandbox_setup
+  SSH_STUB_DIR="$SSH_SANDBOX/stubs"
+  SSH_STUB_STATE="$SSH_SANDBOX/stub-state"
+  mkdir -p "$SSH_STUB_DIR" "$SSH_STUB_STATE"
+  LAUNCHCTL_SPY_LOG="$SSH_SANDBOX/launchctl-spy.log"
+  KEYSCAN_SPY_LOG="$SSH_SANDBOX/keyscan-spy.log"
+  SUDO_OK_SPY_LOG="$SSH_SANDBOX/sudo-ok-spy.log"
+  SUDO_DENY_SPY_LOG="$SSH_SANDBOX/sudo-deny-spy.log"
+  SSH_BARE_TOOL_SPY_LOG="$SSH_SANDBOX/bare-tool-spy.log"
+  : >"$LAUNCHCTL_SPY_LOG"
+  : >"$KEYSCAN_SPY_LOG"
+  : >"$SUDO_OK_SPY_LOG"
+  : >"$SUDO_DENY_SPY_LOG"
+  : >"$SSH_BARE_TOOL_SPY_LOG"
+
+  # PATH tripwires: a bare-name call to any tool the reload modes touch must
+  # fail loudly, never reach the real tool. $SSH_SANDBOX/bin is already first
+  # on PATH (ssh_sandbox_setup put the failing `sudo` there).
+  local tool
+  for tool in sshd launchctl ssh-keyscan; do
+    cat >"$SSH_SANDBOX/bin/$tool" <<STUB
+#!/bin/bash
+printf '%s %s\n' '$tool' "\$*" >>"\${SSH_BARE_TOOL_SPY_LOG:?}"
+echo '$tool: bare-name call blocked by test tripwire (the script must use its seam)' >&2
+exit 96
+STUB
+    chmod +x "$SSH_SANDBOX/bin/$tool"
+  done
+
+  # Controlled sshd: -t exits SSHD_STUB_SYNTAX_STATUS; -G (with or without
+  # -T -C) prints a `port` line plus the seven protected directives, hardened
+  # exactly when the sandbox drop-in exists (or SSHD_STUB_FORCE_HARDENED is
+  # set), unhardened defaults otherwise.
+  cat >"$SSH_STUB_DIR/sshd" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+case " $* " in
+  *' -t '*)
+    if [[ ${SSHD_STUB_SYNTAX_STATUS:-0} -ne 0 ]]; then
+      echo 'sshd stub: bad configuration option (syntax failure injected)' >&2
+      exit "${SSHD_STUB_SYNTAX_STATUS}"
+    fi
+    exit 0
+    ;;
+esac
+printf 'port %s\n' "${SSHD_STUB_PORT:-2222}"
+if [[ -f "${SSHD_CONFIG_D:?}/000-ssh-hardening.conf" || -n ${SSHD_STUB_FORCE_HARDENED:-} ]]; then
+  printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
+    'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin no' \
+    'gssapiauthentication no' 'hostbasedauthentication no'
+else
+  printf '%s\n' 'passwordauthentication yes' 'kbdinteractiveauthentication yes' \
+    'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin prohibit-password' \
+    'gssapiauthentication no' 'hostbasedauthentication no'
+fi
+STUB
+  chmod +x "$SSH_STUB_DIR/sshd"
+
+  # Controlled launchctl: `print` walks LAUNCHCTL_STUB_PRINT_STATUSES one call
+  # at a time (a per-run counter file keeps the position, so the pre- and
+  # post-kickstart probes can answer differently); `kickstart` exits
+  # LAUNCHCTL_STUB_KICKSTART_STATUS. Everything is logged first, so a test can
+  # assert whether a kickstart was ATTEMPTED independently of how it exited.
+  cat >"$SSH_STUB_DIR/launchctl" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${LAUNCHCTL_SPY_LOG:?}"
+case "${1:-}" in
+  print)
+    count_file="${SSH_STUB_STATE:?}/launchctl-print-count"
+    count="$(cat "$count_file" 2>/dev/null || printf '0')"
+    count=$((count + 1))
+    printf '%s' "$count" >"$count_file"
+    # shellcheck disable=SC2206  # deliberate word split of the status list
+    statuses=(${LAUNCHCTL_STUB_PRINT_STATUSES:-0})
+    index=$((count - 1))
+    if [[ $index -ge ${#statuses[@]} ]]; then
+      index=$((${#statuses[@]} - 1))
+    fi
+    status="${statuses[$index]}"
+    if [[ $status -eq 0 ]]; then
+      printf 'system/com.openssh.sshd = { state (stub) }\n'
+    else
+      printf 'launchctl stub: print exiting %s\n' "$status" >&2
+    fi
+    exit "$status"
+    ;;
+  kickstart)
+    status="${LAUNCHCTL_STUB_KICKSTART_STATUS:-0}"
+    if [[ $status -ne 0 ]]; then
+      printf 'launchctl stub: kickstart refused (exit %s)\n' "$status" >&2
+    fi
+    exit "$status"
+    ;;
+  *)
+    printf 'launchctl stub: unexpected subcommand: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod +x "$SSH_STUB_DIR/launchctl"
+
+  # Controlled ssh-keyscan: `banner` completes the exchange (a key line on
+  # stdout, exit 0); `refuse` models connection refused (exit 1, nothing on
+  # stdout); `silent-zero` exits 0 with NO output, the shape of a probe that
+  # ran but proved nothing, so a reload that trusts the exit status alone and
+  # not the banner itself is convicted by it.
+  cat >"$SSH_STUB_DIR/ssh-keyscan" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${KEYSCAN_SPY_LOG:?}"
+case "${KEYSCAN_STUB_MODE:-banner}" in
+  banner)
+    printf '[127.0.0.1]:%s ssh-ed25519 AAAA-stub-host-key\n' "${SSHD_STUB_PORT:-2222}"
+    exit 0
+    ;;
+  refuse)
+    printf 'ssh-keyscan stub: connect to 127.0.0.1: Connection refused\n' >&2
+    exit 1
+    ;;
+  silent-zero)
+    exit 0
+    ;;
+  *)
+    printf 'ssh-keyscan stub: unknown KEYSCAN_STUB_MODE %s\n' "${KEYSCAN_STUB_MODE}" >&2
+    exit 70
+    ;;
+esac
+STUB
+  chmod +x "$SSH_STUB_DIR/ssh-keyscan"
+
+  # Passthrough sudo: logs, handles the -v priming call, then executes the
+  # wrapped command directly (the sandbox is user-owned, so no privilege is
+  # needed or taken).
+  cat >"$SSH_STUB_DIR/sudo-ok" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${SUDO_OK_SPY_LOG:?}"
+if [[ ${1:-} == '-v' ]]; then
+  exit 0
+fi
+exec "$@"
+STUB
+  chmod +x "$SSH_STUB_DIR/sudo-ok"
+
+  # Denying sudo: logs and fails the way a passwordless-sudo revocation or a
+  # missing terminal does. Nothing it is asked to run ever runs.
+  cat >"$SSH_STUB_DIR/sudo-deny" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${SUDO_DENY_SPY_LOG:?}"
+printf 'sudo: a password is required and no terminal is available\n' >&2
+exit 1
+STUB
+  chmod +x "$SSH_STUB_DIR/sudo-deny"
+  SSH_SUDO_DENY_STUB="$SSH_STUB_DIR/sudo-deny"
+
+  SSHD_BIN="$SSH_STUB_DIR/sshd"
+  LAUNCHCTL_BIN="$SSH_STUB_DIR/launchctl"
+  KEYSCAN_BIN="$SSH_STUB_DIR/ssh-keyscan"
+  SSH_HARDENING_SUDO="$SSH_STUB_DIR/sudo-ok"
+  SSHD_STUB_SYNTAX_STATUS=0
+  SSHD_STUB_PORT=2222
+  SSHD_STUB_FORCE_HARDENED=""
+  LAUNCHCTL_STUB_PRINT_STATUSES='0'
+  LAUNCHCTL_STUB_KICKSTART_STATUS=0
+  KEYSCAN_STUB_MODE=banner
+  export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
+    LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SUDO_OK_SPY_LOG SUDO_DENY_SPY_LOG \
+    SSH_BARE_TOOL_SPY_LOG \
+    SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SSH_HARDENING_SUDO \
+    SSHD_STUB_SYNTAX_STATUS SSHD_STUB_PORT SSHD_STUB_FORCE_HARDENED \
+    LAUNCHCTL_STUB_PRINT_STATUSES LAUNCHCTL_STUB_KICKSTART_STATUS \
+    KEYSCAN_STUB_MODE
+}
+
+# run_ssh_reload <args...>: run_ssh_hardening with fresh per-run spy state,
+# then assert no bare-name tripwire fired. Every reload/rollback invocation
+# goes through here so no run can reach a real tool unobserved.
+run_ssh_reload() {
+  : >"$LAUNCHCTL_SPY_LOG"
+  : >"$KEYSCAN_SPY_LOG"
+  : >"$SUDO_OK_SPY_LOG"
+  : >"$SUDO_DENY_SPY_LOG"
+  rm -f "$SSH_STUB_STATE/launchctl-print-count"
+  run_ssh_hardening "$@"
+  if [[ -s $SSH_BARE_TOOL_SPY_LOG ]]; then
+    printf 'FAIL: the script called a tool by bare name instead of its seam during %s; tripwire log:\n%s\n' \
+      "run_ssh_reload $*" "$(cat "$SSH_BARE_TOOL_SPY_LOG")" >&2
+    exit 1
+  fi
+}
+
+# assert_kickstart_attempted <label> / assert_no_kickstart <label>: whether
+# `launchctl kickstart` was invoked during the LAST run_ssh_reload, judged by
+# the stub's own spy log, never by the script's output.
+assert_kickstart_attempted() {
+  if ! grep -q '^kickstart ' "$LAUNCHCTL_SPY_LOG"; then
+    printf 'FAIL: %s: expected a kickstart attempt; launchctl spy log:\n%s\n' \
+      "$1" "$(cat "$LAUNCHCTL_SPY_LOG")" >&2
+    exit 1
+  fi
+}
+
+assert_no_kickstart() {
+  if grep -q '^kickstart ' "$LAUNCHCTL_SPY_LOG"; then
+    printf 'FAIL: %s: a kickstart was attempted; launchctl spy log:\n%s\n' \
+      "$1" "$(cat "$LAUNCHCTL_SPY_LOG")" >&2
+    exit 1
+  fi
+}
+
+# config_tree_fingerprint: every file under the sandbox drop-in directory with
+# its checksum, so "this mode wrote nothing" is judged byte-for-byte rather
+# than by file count.
+config_tree_fingerprint() {
+  local file
+  find "$SSHD_CONFIG_D" -type f -print0 | LC_ALL=C sort -z |
+    while IFS= read -r -d '' file; do
+      printf '%s ' "$file"
+      cksum <"$file"
+    done
+}

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -64,7 +64,10 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #                                    successive `launchctl print` calls within
 #                                    one run; the last entry repeats
 #   LAUNCHCTL_STUB_KICKSTART_STATUS  exit status of `launchctl kickstart` (0)
-#   KEYSCAN_STUB_MODE                banner | refuse | silent-zero
+#   KEYSCAN_STUB_MODE                banner | refuse | silent-zero |
+#                                    garbage-zero (exit 0 with output that is
+#                                    NOT a host-key record) | banner-nonzero
+#                                    (a real record but a nonzero status)
 #   KEYSCAN_STUB_ANSWER_PORT         banner mode only: refuse every requested
 #                                    port except this one (empty: answer any)
 #
@@ -231,6 +234,14 @@ case "${KEYSCAN_STUB_MODE:-banner}" in
     ;;
   silent-zero)
     exit 0
+    ;;
+  garbage-zero)
+    printf 'stub-noise-not-a-key-record\n'
+    exit 0
+    ;;
+  banner-nonzero)
+    printf '[127.0.0.1]:%s ssh-ed25519 AAAA-stub-host-key\n' "$requested_port"
+    exit 1
     ;;
   *)
     printf 'ssh-keyscan stub: unknown KEYSCAN_STUB_MODE %s\n' "${KEYSCAN_STUB_MODE}" >&2

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -6,16 +6,25 @@
 # PATH `sudo` tripwire).
 #
 # Every tool the disruptive modes drive is a FULLY CONTROLLED stub reached
-# through the SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN
-# seams, and every seam is MIRRORED on PATH by a tripwire that always fails
-# loudly (exit 96) and records the call: a regressed script that drops a seam
-# and calls a bare tool name hits the tripwire, never the real tool. No test
-# sourcing this library requires a real sshd, launchctl, ssh-keyscan, or sudo,
-# so none can skip, and none can reach the live daemon. On top of the seams
-# and the tripwires, the tests run UNPRIVILEGED: even if every layer above
-# regressed at once, launchd refuses an unprivileged kickstart of the real
-# system/com.openssh.sshd, and /etc/ssh is root-owned, so the violation would
-# be loud and harmless rather than a live restart.
+# through the SSH_HARDENING_SUDO / SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN /
+# SLEEP_BIN seams, and every seam is MIRRORED on PATH by a tripwire that
+# always fails loudly (exit 96) and records the call: a regressed script that
+# drops a seam and calls a bare tool name hits the tripwire, never the real
+# tool. No test sourcing this library requires a real sshd, launchctl,
+# ssh-keyscan, or sudo, so none can skip, and none can reach the live daemon
+# through those routes.
+#
+# What the barriers do NOT guarantee, stated so nobody leans on more than is
+# there: the tripwires shadow only PATH-RESOLVED bare names, so a regression
+# that hard-codes /usr/bin/sudo or /bin/launchctl walks straight past them,
+# and if the developer's sudo timestamp happens to be cached (or sudo is
+# passwordless) such a call could really escalate. The backstop is narrower
+# than "unprivileged execution makes violations impossible": it is that the
+# specific dangerous actions here are root-gated by the OS itself -- launchd
+# refuses an unprivileged kickstart of system/com.openssh.sshd and /etc/ssh
+# is root-owned 0755 -- so THOSE fail loudly even if every layer above
+# regressed at once. Keeping absolute-path escalation out of the script is a
+# review property, not something this harness can enforce.
 
 # shellcheck source=./ssh-hardening-lib.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
@@ -149,7 +158,7 @@ fi
 for stub_port in ${SSHD_STUB_PORT-2222}; do
   printf 'port %s\n' "$stub_port"
 done
-if [[ -f "${SSHD_CONFIG_D:?}/000-ssh-hardening.conf" || -n ${SSHD_STUB_FORCE_HARDENED:-} ]]; then
+if [[ -f "${SSHD_CONFIG_D:?}/${SSH_DROPIN_NAME:?}" || -n ${SSHD_STUB_FORCE_HARDENED:-} ]]; then
   printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
     'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin no' \
     'gssapiauthentication no' 'hostbasedauthentication no'
@@ -438,9 +447,12 @@ assert_no_kickstart() {
   fi
 }
 
-# config_tree_fingerprint: every file under the sandbox drop-in directory with
-# its checksum, so "this mode wrote nothing" is judged byte-for-byte rather
-# than by file count.
+# config_tree_fingerprint: every REGULAR FILE under the sandbox drop-in
+# directory with its checksum, so "this mode wrote nothing" is judged by
+# content rather than by file count. Stated coverage: paths and contents of
+# regular files only -- not modes, ownership, symlinks, directories, the
+# main config, or Include targets outside the drop-in directory -- and the
+# suites compare it on the happy path, not after every case.
 config_tree_fingerprint() {
   local file
   find "$SSHD_CONFIG_D" -type f -print0 | LC_ALL=C sort -z |

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -317,6 +317,22 @@ STUB
   chmod +x "$SSH_STUB_DIR/sudo-launchctl-113"
   SSH_SUDO_LAUNCHCTL_113_STUB="$SSH_STUB_DIR/sudo-launchctl-113"
 
+  # A wrapper that SWALLOWS rm: reports success without executing it, the
+  # shape of a removal command that lies. Everything else passes through.
+  cat >"$SSH_STUB_DIR/sudo-swallow-rm" <<'STUB'
+#!/bin/bash
+if [[ ${1:-} == '-v' ]]; then
+  exit 0
+fi
+if [[ ${1:-} == 'rm' ]]; then
+  printf '%s\n' "$*" >>"${SUDO_DENY_SPY_LOG:?}"
+  exit 0
+fi
+exec "$@"
+STUB
+  chmod +x "$SSH_STUB_DIR/sudo-swallow-rm"
+  SSH_SUDO_SWALLOW_RM_STUB="$SSH_STUB_DIR/sudo-swallow-rm"
+
   # Denying sudo: logs and fails the way a passwordless-sudo revocation or a
   # missing terminal does. Nothing it is asked to run ever runs.
   cat >"$SSH_STUB_DIR/sudo-deny" <<'STUB'
@@ -343,7 +359,7 @@ STUB
   KEYSCAN_STUB_MODE=banner
   KEYSCAN_STUB_ANSWER_PORT=""
   export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
-    SSH_SUDO_LAUNCHCTL_113_STUB \
+    SSH_SUDO_LAUNCHCTL_113_STUB SSH_SUDO_SWALLOW_RM_STUB \
     SSHD_SPY_LOG LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG \
     SUDO_OK_SPY_LOG SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
     SSH_SEAM_CALL_LOG \

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -185,6 +185,14 @@ case "${1:-}" in
     exit "$status"
     ;;
   kickstart)
+    # Snapshot the script's captured output AT the moment of the disruptive
+    # step: the kickstart is what can kill the session carrying the output,
+    # so anything that must reach the operator has to be in these files
+    # BEFORE this call. The runners redirect the script's stdout/stderr to
+    # $SSH_SANDBOX/run.out and run.err, so copying them here gives tests a
+    # pre-kickstart view to assert against.
+    cat "${SSH_SANDBOX:?}/run.out" >"${SSH_STUB_STATE:?}/stdout-at-kickstart" 2>/dev/null || :
+    cat "${SSH_SANDBOX:?}/run.err" >"${SSH_STUB_STATE:?}/stderr-at-kickstart" 2>/dev/null || :
     status="${LAUNCHCTL_STUB_KICKSTART_STATUS:-0}"
     if [[ $status -ne 0 ]]; then
       printf 'launchctl stub: kickstart refused (exit %s)\n' "$status" >&2
@@ -319,7 +327,8 @@ run_ssh_reload() {
   : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
-  rm -f "$SSH_STUB_STATE/launchctl-print-count" "$SSH_STUB_STATE/sshd-resolve-count"
+  rm -f "$SSH_STUB_STATE/launchctl-print-count" "$SSH_STUB_STATE/sshd-resolve-count" \
+    "$SSH_STUB_STATE/stdout-at-kickstart" "$SSH_STUB_STATE/stderr-at-kickstart"
   run_ssh_hardening "$@"
   if [[ -s $SSH_BARE_TOOL_SPY_LOG ]]; then
     printf 'FAIL: the script called a tool by bare name instead of its seam during %s; tripwire log:\n%s\n' \

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -354,9 +354,12 @@ STUB
     KEYSCAN_STUB_MODE KEYSCAN_STUB_ANSWER_PORT
 }
 
-# run_ssh_reload <args...>: run_ssh_hardening with fresh per-run spy state,
-# then assert no bare-name tripwire fired. Every reload/rollback invocation
-# goes through here so no run can reach a real tool unobserved.
+# run_ssh_reload <args...>: run_ssh_hardening_bounded with fresh per-run spy
+# state, then assert no bare-name tripwire fired. Every reload/rollback
+# invocation goes through here so no run can reach a real tool unobserved,
+# and every run is WALL-CLOCK BOUNDED (SSH_RELOAD_TIME_LIMIT seconds,
+# default 30): a regression that makes the readiness loop infinite fails the
+# gate instead of hanging it.
 run_ssh_reload() {
   : >"$SSHD_SPY_LOG"
   : >"$LAUNCHCTL_SPY_LOG"
@@ -367,7 +370,12 @@ run_ssh_reload() {
   : >"$SSH_SEAM_CALL_LOG"
   rm -f "$SSH_STUB_STATE/launchctl-print-count" "$SSH_STUB_STATE/sshd-resolve-count" \
     "$SSH_STUB_STATE/stdout-at-kickstart" "$SSH_STUB_STATE/stderr-at-kickstart"
-  run_ssh_hardening "$@"
+  run_ssh_hardening_bounded "${SSH_RELOAD_TIME_LIMIT:-30}" "$@"
+  if [[ ${SSH_RUN_TIMED_OUT:-0} -eq 1 ]]; then
+    printf 'FAIL: run_ssh_reload %s exceeded its %ss wall clock; a reload that can hang is itself a regression\n' \
+      "$*" "${SSH_RELOAD_TIME_LIMIT:-30}" >&2
+    exit 1
+  fi
   if [[ -s $SSH_BARE_TOOL_SPY_LOG ]]; then
     printf 'FAIL: the script called a tool by bare name instead of its seam during %s; tripwire log:\n%s\n' \
       "run_ssh_reload $*" "$(cat "$SSH_BARE_TOOL_SPY_LOG")" >&2

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -24,14 +24,20 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #
 # Exports the seams (all absolute paths into the sandbox):
 #   SSHD_BIN / LAUNCHCTL_BIN / KEYSCAN_BIN   controlled stubs
+#   SLEEP_BIN                                a sleep spy that logs the delay
+#                                            and returns immediately, so
+#                                            nonzero-interval cases observe
+#                                            their pacing without slowing the
+#                                            suite
 #   SSH_HARDENING_SUDO                       passthrough sudo stub (logs the
 #                                            call, then executes it); point it
 #                                            at SSH_SUDO_DENY_STUB for the
 #                                            privilege-failure case
 # and the spy logs:
-#   LAUNCHCTL_SPY_LOG, KEYSCAN_SPY_LOG, SUDO_OK_SPY_LOG, SUDO_DENY_SPY_LOG,
-#   SSH_BARE_TOOL_SPY_LOG (the PATH tripwires for bare sshd / launchctl /
-#   ssh-keyscan; bare sudo keeps slice 7's SSH_SUDO_SPY_LOG).
+#   LAUNCHCTL_SPY_LOG, KEYSCAN_SPY_LOG, SLEEP_SPY_LOG, SUDO_OK_SPY_LOG,
+#   SUDO_DENY_SPY_LOG, SSH_BARE_TOOL_SPY_LOG (the PATH tripwires for bare
+#   sshd / launchctl / ssh-keyscan; bare sudo keeps slice 7's
+#   SSH_SUDO_SPY_LOG).
 #
 # Stub behavior knobs, all exported and overridable per invocation:
 #   SSHD_STUB_SYNTAX_STATUS          exit status of `sshd -t` (default 0)
@@ -64,11 +70,13 @@ reload_sandbox_setup() {
   mkdir -p "$SSH_STUB_DIR" "$SSH_STUB_STATE"
   LAUNCHCTL_SPY_LOG="$SSH_SANDBOX/launchctl-spy.log"
   KEYSCAN_SPY_LOG="$SSH_SANDBOX/keyscan-spy.log"
+  SLEEP_SPY_LOG="$SSH_SANDBOX/sleep-spy.log"
   SUDO_OK_SPY_LOG="$SSH_SANDBOX/sudo-ok-spy.log"
   SUDO_DENY_SPY_LOG="$SSH_SANDBOX/sudo-deny-spy.log"
   SSH_BARE_TOOL_SPY_LOG="$SSH_SANDBOX/bare-tool-spy.log"
   : >"$LAUNCHCTL_SPY_LOG"
   : >"$KEYSCAN_SPY_LOG"
+  : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
   : >"$SSH_BARE_TOOL_SPY_LOG"
@@ -197,6 +205,17 @@ esac
 STUB
   chmod +x "$SSH_STUB_DIR/ssh-keyscan"
 
+  # Controlled sleep: logs the requested delay and returns immediately. The
+  # script's SLEEP_BIN default is the real /bin/sleep; tests point the seam
+  # here so pacing is observable and a regression back to a bare `sleep`
+  # (ignoring the seam) shows up as an empty spy log.
+  cat >"$SSH_STUB_DIR/sleep" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${SLEEP_SPY_LOG:?}"
+exit 0
+STUB
+  chmod +x "$SSH_STUB_DIR/sleep"
+
   # Passthrough sudo: logs, handles the -v priming call, then executes the
   # wrapped command directly (the sandbox is user-owned, so no privilege is
   # needed or taken).
@@ -224,6 +243,7 @@ STUB
   SSHD_BIN="$SSH_STUB_DIR/sshd"
   LAUNCHCTL_BIN="$SSH_STUB_DIR/launchctl"
   KEYSCAN_BIN="$SSH_STUB_DIR/ssh-keyscan"
+  SLEEP_BIN="$SSH_STUB_DIR/sleep"
   SSH_HARDENING_SUDO="$SSH_STUB_DIR/sudo-ok"
   SSHD_STUB_SYNTAX_STATUS=0
   SSHD_STUB_RESOLVE_STATUS=0
@@ -234,9 +254,9 @@ STUB
   LAUNCHCTL_STUB_KICKSTART_STATUS=0
   KEYSCAN_STUB_MODE=banner
   export SSH_STUB_DIR SSH_STUB_STATE SSH_SUDO_DENY_STUB \
-    LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SUDO_OK_SPY_LOG SUDO_DENY_SPY_LOG \
-    SSH_BARE_TOOL_SPY_LOG \
-    SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SSH_HARDENING_SUDO \
+    LAUNCHCTL_SPY_LOG KEYSCAN_SPY_LOG SLEEP_SPY_LOG SUDO_OK_SPY_LOG \
+    SUDO_DENY_SPY_LOG SSH_BARE_TOOL_SPY_LOG \
+    SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SLEEP_BIN SSH_HARDENING_SUDO \
     SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUS SSHD_STUB_PORT \
     SSHD_STUB_FORCE_HARDENED SSHD_STUB_PARTIAL_HARDENED \
     LAUNCHCTL_STUB_PRINT_STATUSES LAUNCHCTL_STUB_KICKSTART_STATUS \
@@ -249,6 +269,7 @@ STUB
 run_ssh_reload() {
   : >"$LAUNCHCTL_SPY_LOG"
   : >"$KEYSCAN_SPY_LOG"
+  : >"$SLEEP_SPY_LOG"
   : >"$SUDO_OK_SPY_LOG"
   : >"$SUDO_DENY_SPY_LOG"
   rm -f "$SSH_STUB_STATE/launchctl-print-count"

--- a/test/integration/ssh-hardening-match-reenable.sh
+++ b/test/integration/ssh-hardening-match-reenable.sh
@@ -36,6 +36,15 @@
 #      whitespace to sshd, so the line opens a Match block, but a scanner
 #      that only knows spaces and tabs never sees a Match at all and treats
 #      every directive under it as global.
+#   r-w. MIXED-QUOTE keywords: `Ma"tch"`, `Pubkey"Authentication"`,
+#      `Inc"lude"`, and friends. sshd CONCATENATES an unquoted prefix with
+#      one double-quoted segment and ends the keyword at the closing quote
+#      (measured; the previous scanner believed a mid-keyword quote was
+#      rejected, and that belief certified a tree with no usable off-loopback
+#      authentication method at all). Each protected directive that sshd
+#      allows inside a Match block gets its own mixed-quote case; UsePAM is
+#      global-only in sshd, so its mixed-quote case is asserted through the
+#      global check instead.
 #
 # Cases i, j and k assert on the SCAN's own attribution string, not merely on
 # the file name, so each pins the scan rather than any other layer that
@@ -267,5 +276,89 @@ cp "$main_config_backup" "$SSHD_MAIN_CONFIG"
 run_ssh_hardening --verify
 [[ $SSH_RUN_STATUS -eq 0 ]] ||
   fail "q: --verify must PASS again once the main config is restored (stderr: $SSH_RUN_ERR)"
+
+# r. Match ITSELF with a mid-keyword quote. sshd reads `Ma"tch"` as `Match`
+# (unquoted prefix + quoted segment concatenate, measured on OpenSSH 10.0p2),
+# so the block opens and the directive under it applies off-loopback. A
+# scanner that treats '"' as a token terminator reads `Ma`, never enters
+# Match state, and certifies the tree.
+run_reenable_case 'r: mid-quote Match keyword' \
+  "match scan: '$hostile_file' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  'Ma"tch" Address *,!127.0.0.1' 'PasswordAuthentication yes'
+
+# s. Every protected directive sshd allows inside a Match block, each with a
+# mid-keyword quote closing at the keyword's end (the only mixed-quote shape
+# sshd accepts: the token ENDS at the closing quote, so `Pass"word"Auth...`
+# is the unknown keyword `Password` and is rejected, while `Password"Authentication"`
+# is the full keyword). UsePAM is absent here because sshd refuses it inside
+# any Match block; its mixed-quote form is case t below.
+run_reenable_case 's: mid-quote PasswordAuthentication' \
+  "match scan: '$hostile_file' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  'Match Address *,!127.0.0.1' 'Password"Authentication" yes'
+run_reenable_case 's: mid-quote KbdInteractiveAuthentication' \
+  "match scan: '$hostile_file' sets 'kbdinteractiveauthentication yes'" \
+  "$off_sample_spec" kbdinteractiveauthentication yes \
+  'Match Address *,!127.0.0.1' 'KbdInteractive"Authentication" yes'
+run_reenable_case 's: mid-quote PubkeyAuthentication' \
+  "match scan: '$hostile_file' sets 'pubkeyauthentication no'" \
+  "$off_sample_spec" pubkeyauthentication no \
+  'Match Address *,!127.0.0.1' 'Pubkey"Authentication" no'
+run_reenable_case 's: mid-quote PermitRootLogin' \
+  "match scan: '$hostile_file' sets 'permitrootlogin yes'" \
+  "$off_sample_spec" permitrootlogin yes \
+  'Match Address *,!127.0.0.1' 'PermitRoot"Login" yes'
+run_reenable_case 's: mid-quote GSSAPIAuthentication' \
+  "match scan: '$hostile_file' sets 'gssapiauthentication yes'" \
+  "$off_sample_spec" gssapiauthentication yes \
+  'Match Address *,!127.0.0.1' 'GSSAPI"Authentication" yes'
+run_reenable_case 's: mid-quote HostbasedAuthentication' \
+  "match scan: '$hostile_file' sets 'hostbasedauthentication yes'" \
+  "$off_sample_spec" hostbasedauthentication yes \
+  'Match Address *,!127.0.0.1' 'Hostbased"Authentication" yes'
+
+# t. UsePAM with a mid-keyword quote, GLOBAL (sshd refuses it in Match
+# blocks). Real sshd resolves `Use"PAM" no` as usepam no, so the global
+# check must flag it; this pins the mixed-quote form on the one protected
+# directive the scan can never see inside a Match block.
+printf '%s\n' 'Use"PAM" no' >"$SSHD_CONFIG_D/00-quoted-usepam.conf"
+got="$(effective_global_value usepam)" || fail 't: sshd -G failed on the quoted-UsePAM fixture'
+[[ $got == no ]] ||
+  fail "t: real sshd must resolve 'Use\"PAM\" no' as usepam no globally, got '$got'; the fixture proves nothing"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail 't: a mixed-quote global UsePAM re-enable must fail --verify'
+grep -qF 'usepam' <<<"$SSH_RUN_ERR" ||
+  fail "t: stderr must name usepam (stderr: $SSH_RUN_ERR)"
+rm -f "$SSHD_CONFIG_D/00-quoted-usepam.conf"
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail 't: --verify must PASS again once the quoted-UsePAM fixture is removed'
+
+# u. An ALIAS with a mid-keyword quote: sshd reads `Skey"Authentication"` as
+# the undocumented SkeyAuthentication alias and flips
+# kbdinteractiveauthentication (measured). The needle names the CANONICAL
+# directive, so this pins the alias fold THROUGH the mixed-quote tokenizer.
+run_reenable_case 'u: mid-quote SkeyAuthentication alias' \
+  "match scan: '$hostile_file' sets 'kbdinteractiveauthentication yes'" \
+  "$off_sample_spec" kbdinteractiveauthentication yes \
+  'Match Address *,!127.0.0.1' 'Skey"Authentication" yes'
+
+# v and w. Include through the mixed-quote tokenizer, with the hostile file
+# OUTSIDE both scan roots so ONLY following the Include can reach it: v puts
+# the quote in the Include keyword itself, w puts it inside the path argument
+# (argument tokens concatenate any number of quoted segments, measured).
+outside_dir="$SSH_SANDBOX/outside"
+mkdir -p "$outside_dir"
+printf 'Match Address *,!127.0.0.1\nPasswordAuthentication yes\n' >"$outside_dir/evil.conf"
+run_reenable_case 'v: mid-quote Include keyword' \
+  "match scan: '$outside_dir/evil.conf' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  "Inc\"lude\" $outside_dir/evil.conf"
+run_reenable_case 'w: quoted fragment inside the Include path' \
+  "match scan: '$outside_dir/evil.conf' sets 'passwordauthentication yes'" \
+  "$off_sample_spec" passwordauthentication yes \
+  "Include $SSH_SANDBOX/out\"side\"/evil.conf"
 
 printf 'ssh-hardening-match-reenable: OK (every Match bypass form resolves unsafe under real sshd and fails --verify loudly; clean tree passes before and after every case)\n'

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -242,6 +242,35 @@ grep -qF -- '-p 2222' "$KEYSCAN_SPY_LOG" ||
 [[ "$(config_tree_fingerprint)" == "$baseline_fingerprint" ]] ||
   fail '10: a reload must leave the configuration tree byte-for-byte untouched (criterion 12)'
 
+# The complete ordered argv of every seam call in the happy path, diffed as
+# one list: the syntax check names the REAL main config (sshd -G -f
+# /dev/null exits 0, measured, so a wrong -f target passes the gate), the
+# child verify resolves both connection samples, port resolution happens
+# BEFORE the kickstart, the kickstart carries -k and the exact service
+# label, and the readiness probe targets loopback on the resolved port with
+# the configured timeout.
+invoking_user="$(id -un)"
+assert_seam_calls '10' \
+  "sshd -t -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -T -C user=root,host=localhost,addr=127.0.0.1 -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -T -C user=$invoking_user,host=localhost,addr=127.0.0.1 -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -f $SSHD_MAIN_CONFIG" \
+  'launchctl print system/com.openssh.sshd' \
+  'launchctl kickstart -k system/com.openssh.sshd' \
+  'launchctl print system/com.openssh.sshd' \
+  'ssh-keyscan -T 5 -p 2222 127.0.0.1'
+
+# What ran through the privilege wrapper, exactly and in order: the priming
+# -v, the syntax check, and the kickstart. The service probes are absent
+# deliberately (they run unprivileged so their status is launchctl's own).
+expected_sudo_calls="$SSH_SANDBOX/expected-sudo-calls"
+printf '%s\n' '-v' \
+  "$SSHD_BIN -t -f $SSHD_MAIN_CONFIG" \
+  "$LAUNCHCTL_BIN kickstart -k system/com.openssh.sshd" >"$expected_sudo_calls"
+diff -u "$expected_sudo_calls" "$SUDO_OK_SPY_LOG" >&2 ||
+  fail '10: the privileged calls (or their order/argv) differ from expected (diff above)'
+
 # --- 11: the keep-open warning is printed BEFORE the kickstart ----------------
 # The kickstart is the step that can kill the SSH session carrying the
 # output, so the warning and the COMPLETE recovery command must already be

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -131,7 +131,8 @@ refute_contains "$SSH_RUN_ERR" 'not running' \
 SSH_HARDENING_SUDO="$SSH_SUDO_LAUNCHCTL_113_STUB" run_ssh_reload --reload
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '5b: a wrapper exiting 113 without running launchctl must not produce the clean no-op'
-refute_contains "$SSH_RUN_OUT" 'no daemon to restart'   '5b: a wrapper failure must never be reported as Remote Login being off'
+refute_contains "$SSH_RUN_OUT" 'no daemon to restart' \
+  '5b: a wrapper failure must never be reported as Remote Login being off'
 
 # --- 6: kickstart fails: nonzero, kickstart WAS attempted, named --------------
 

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -182,6 +182,27 @@ KEYSCAN_STUB_MODE=silent-zero run_ssh_reload --reload
 grep -qi 'possible lockout' <<<"$SSH_RUN_ERR" ||
   fail "8: the silent-success probe must also warn about a possible lockout (stderr: $SSH_RUN_ERR)"
 
+# A probe that exits 0 printing text that is NOT a host-key record proved
+# nothing either: the real tool prints host/type/key lines for a completed
+# exchange, so arbitrary output through an overridden seam must not satisfy
+# readiness.
+KEYSCAN_STUB_MODE=garbage-zero run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: a keyscan that exits 0 with non-record output must still fail the reload'
+grep -qi 'possible lockout' <<<"$SSH_RUN_ERR" ||
+  fail "8: the garbage-output probe must also warn about a possible lockout (stderr: $SSH_RUN_ERR)"
+
+# The STATUS half of the readiness conjunction: a valid-looking record with a
+# nonzero exit must not count. This shape is HYPOTHETICAL for the real tool
+# (measured: a reachable host prints 8 lines and exits 0, an unreachable one
+# prints 0 lines and exits 1; no output-plus-nonzero combination could be
+# produced), so this pins the seam contract, not a live defect.
+KEYSCAN_STUB_MODE=banner-nonzero run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: a keyscan that prints a record but exits nonzero must still fail the reload'
+grep -qi 'possible lockout' <<<"$SSH_RUN_ERR" ||
+  fail "8: the nonzero-status probe must also warn about a possible lockout (stderr: $SSH_RUN_ERR)"
+
 # --- 9: readiness prover unavailable: refuse BEFORE anything disruptive -------
 
 KEYSCAN_BIN="$SSH_SANDBOX/no-such-keyscan" run_ssh_reload --reload

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -42,6 +42,8 @@ RECOVERY_PHRASES=(
   'ssh-hardening.sh --rollback'
   'Screen Sharing over the tailnet'
   'Remote Login off and back on'
+  'keep any SSH session you still have OPEN until a new login succeeds'
+  'sudo rm'
 )
 
 # The reload's retry loop is attempt-bounded through these knobs; every case
@@ -183,6 +185,10 @@ keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
 # emergency.
 grep -qi 'launchd' <<<"$SSH_RUN_ERR" ||
   fail "8: the lockout failure must name the launchd-socket possibility so a port mismatch reads as a diagnosis, not a false emergency (stderr: $SSH_RUN_ERR)"
+# The sudo rm fallback must name the CONCRETE file, so it works when the
+# script itself is broken.
+grep -qF "sudo rm $SSHD_CONFIG_D/000-ssh-hardening.conf" <<<"$SSH_RUN_ERR" ||
+  fail "8: the sudo rm fallback must name the exact drop-in path (stderr: $SSH_RUN_ERR)"
 
 # A probe that exits 0 with NO banner output proved nothing: the exit status
 # is a proxy, the banner is the artifact, and trusting the proxy would report
@@ -479,5 +485,7 @@ for phrase in "${RECOVERY_PHRASES[@]}"; do
   grep -qF -- "$phrase" <<<"$runbook_content" ||
     fail "13: the runbook must carry the recovery instruction '$phrase'"
 done
+grep -qF 'sudo rm /etc/ssh/sshd_config.d/000-ssh-hardening.conf' <<<"$runbook_content" ||
+  fail '13: the runbook sudo rm fallback must name the LIVE drop-in path'
 
 printf 'ssh-hardening-reload-failclosed: OK (every unprovable step refuses before the kickstart, every failure after it names the way back in)\n'

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -231,6 +231,21 @@ grep -qF -- '-p 2222' "$KEYSCAN_SPY_LOG" ||
 [[ "$(config_tree_fingerprint)" == "$baseline_fingerprint" ]] ||
   fail '10: a reload must leave the configuration tree byte-for-byte untouched (criterion 12)'
 
+# --- 11: the keep-open warning is printed BEFORE the kickstart ----------------
+# The kickstart is the step that can kill the SSH session carrying the
+# output, so the warning and the COMPLETE recovery command must already be
+# out before it runs. Asserted against the launchctl stub's snapshot of the
+# script's output taken AT the kickstart call, so moving the warning back
+# after the kickstart fails here even though the final output still carries
+# it.
+pre_kickstart_output="$( (cat "$SSH_STUB_STATE/stdout-at-kickstart" && cat "$SSH_STUB_STATE/stderr-at-kickstart") 2>/dev/null || :)"
+grep -qi 'about to restart sshd' <<<"$pre_kickstart_output" ||
+  fail "11: the warning must be printed before the kickstart (snapshot: $pre_kickstart_output)"
+for phrase in "${RECOVERY_PHRASES[@]}"; do
+  grep -qF -- "$phrase" <<<"$pre_kickstart_output" ||
+    fail "11: the recovery instruction '$phrase' must be printed before the kickstart (snapshot: $pre_kickstart_output)"
+done
+
 # --- 12: the default install mode never reloads -------------------------------
 
 rm -f "$dropin"

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -216,6 +216,28 @@ run_ssh_reload
 [[ ! -s $KEYSCAN_SPY_LOG ]] ||
   fail "12: install must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
 
+# --- 14: mode dispatch is case-sensitive --------------------------------------
+# nocasematch is on at file scope for sshd keyword matching; if it reaches
+# main's case, a mistyped `--RELOAD` invokes the ONE disruptive mode in the
+# script. Both disruptive spellings must be refused as unknown flags while
+# the exact lowercase spelling keeps working (the happy-path case above pins
+# that side).
+
+run_ssh_reload --RELOAD
+[[ $SSH_RUN_STATUS -eq 2 ]] ||
+  fail "14: --RELOAD must be an unknown-flag usage error (exit 2), got $SSH_RUN_STATUS"
+assert_no_kickstart '14'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail "14: --RELOAD must not touch the service at all (spy: $(cat "$LAUNCHCTL_SPY_LOG"))"
+grep -qi 'usage' <<<"$SSH_RUN_ERR" ||
+  fail "14: --RELOAD must print usage (stderr: $SSH_RUN_ERR)"
+
+run_ssh_reload --Rollback
+[[ $SSH_RUN_STATUS -eq 2 ]] ||
+  fail "14: --Rollback must be an unknown-flag usage error (exit 2), got $SSH_RUN_STATUS"
+grep -qi 'usage' <<<"$SSH_RUN_ERR" ||
+  fail "14: --Rollback must print usage (stderr: $SSH_RUN_ERR)"
+
 # --- 13: the recovery path lives in the runbook, as the same literal text -----
 
 [[ -f $RUNBOOK ]] ||

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -175,8 +175,10 @@ keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
 # nonstandard Port makes this exact alarm fire against a HEALTHY daemon. The
 # lockout text must hand the operator that diagnosis instead of only an
 # emergency.
-grep -qi 'launchd' <<<"$SSH_RUN_ERR" ||
+grep -qi 'launchd owns Remote Login' <<<"$SSH_RUN_ERR" ||
   fail "8: the lockout failure must name the launchd-socket possibility so a port mismatch reads as a diagnosis, not a false emergency (stderr: $SSH_RUN_ERR)"
+grep -qF -- '-p 22 127.0.0.1' <<<"$SSH_RUN_ERR" ||
+  fail "8: the lockout failure must hand the operator the exact port-22 check command (stderr: $SSH_RUN_ERR)"
 # The sudo rm fallback must name the CONCRETE file, so it works when the
 # script itself is broken.
 grep -qF "sudo rm $SSHD_CONFIG_D/$SSH_DROPIN_NAME" <<<"$SSH_RUN_ERR" ||

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -216,6 +216,53 @@ run_ssh_reload
 [[ ! -s $KEYSCAN_SPY_LOG ]] ||
   fail "12: install must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
 
+# --- 16: the retry delay is a validated seam, never a bare sleep --------------
+# sleep is /bin/sleep on this platform, an external binary and not a builtin,
+# so under a stripped PATH a bare `sleep` is exit 127 INSIDE the readiness
+# loop: an abort AFTER the disruptive step, under set -e, printing nothing.
+# The delay tool must be resolved and validated BEFORE the kickstart, and a
+# nonzero interval must pace through the seam, observably.
+
+# 16a: a nonzero interval paces through SLEEP_BIN: three refused probes make
+# exactly two inter-probe delays of the requested length.
+SSH_HARDENING_READY_ATTEMPTS=3 SSH_HARDENING_READY_INTERVAL=1 \
+  KEYSCAN_STUB_MODE=refuse run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '16a: three refused probes must still be a lockout failure'
+keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
+[[ $keyscan_attempts -eq 3 ]] ||
+  fail "16a: expected 3 probes, got $keyscan_attempts"
+sleep_calls="$(grep -c . "$SLEEP_SPY_LOG")" || true
+[[ $sleep_calls -eq 2 ]] ||
+  fail "16a: 3 attempts must sleep exactly twice through the seam, got $sleep_calls (spy: $(cat "$SLEEP_SPY_LOG"))"
+grep -qx '1' "$SLEEP_SPY_LOG" ||
+  fail "16a: the delay must be the requested interval (spy: $(cat "$SLEEP_SPY_LOG"))"
+
+# 16b: an unavailable delay tool must refuse BEFORE the kickstart, not abort
+# silently after it.
+SSH_HARDENING_READY_INTERVAL=1 SLEEP_BIN="$SSH_SANDBOX/no-such-sleep" \
+  run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '16b: a missing delay tool must fail the reload'
+assert_no_kickstart '16b'
+grep -qF "$SSH_SANDBOX/no-such-sleep" <<<"$SSH_RUN_ERR" ||
+  fail "16b: the refusal must name the missing delay tool (stderr: $SSH_RUN_ERR)"
+
+# 16c: a delay tool that fails MID-loop (after the kickstart) must die
+# NAMING the delay failure and carrying the recovery text, never abort bare.
+failing_sleep="$SSH_SANDBOX/failing-sleep"
+printf '#!/bin/bash\nexit 9\n' >"$failing_sleep"
+chmod +x "$failing_sleep"
+SSH_HARDENING_READY_ATTEMPTS=2 SSH_HARDENING_READY_INTERVAL=1 \
+  SLEEP_BIN="$failing_sleep" KEYSCAN_STUB_MODE=refuse run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '16c: a mid-loop delay failure must fail the reload'
+assert_kickstart_attempted '16c'
+grep -qi 'retry delay' <<<"$SSH_RUN_ERR" ||
+  fail "16c: the failure must be attributed to the retry delay (stderr: $SSH_RUN_ERR)"
+grep -qF 'ssh-hardening.sh --rollback' <<<"$SSH_RUN_ERR" ||
+  fail "16c: a failure after the disruptive step must carry the recovery path (stderr: $SSH_RUN_ERR)"
+
 # --- 15: readiness knobs are validated BEFORE anything runs -------------------
 # The property: attempts and the probe timeout are one canonical base-10
 # positive integer (bash arithmetic reads a leading zero as base-8, so 010

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# ssh-hardening-reload-failclosed.sh -- --reload fails closed at EVERY step
+# (slice 8, acceptance criteria 1-10, 12, 13). The reload is the first
+# genuinely disruptive mode in this program: it restarts the daemon that
+# serves remote access, so every "cannot determine" below must resolve to
+# FAILURE before the disruptive step, and every failure after it must warn
+# and name the way back in. Everything drives the stub seams from
+# ssh-reload-lib.bash; no case can reach the live daemon or /etc/ssh.
+#
+# Each case asserts three dimensions: the exit status, whether a kickstart
+# was ATTEMPTED (judged by the launchctl stub's spy log, never by the
+# script's output), and the message content.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-reload-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib.bash"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it is the last statement, so
+# every negative goes through this helper.
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+# The recovery instruction, pinned as LITERAL text in both the script's
+# lockout failure and the runbook (criterion 13). One list, asserted against
+# both, so the two cannot drift apart without this test failing.
+RECOVERY_PHRASES=(
+  'ssh-hardening.sh --rollback'
+  'Screen Sharing over the tailnet'
+  'Remote Login off and back on'
+)
+
+# The reload's retry loop is attempt-bounded through these knobs; every case
+# that expects failure keeps the suite fast by using two attempts with no
+# sleep between them.
+export SSH_HARDENING_READY_ATTEMPTS=2
+export SSH_HARDENING_READY_INTERVAL=0
+
+reload_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+write_hardened_dropin
+baseline_fingerprint="$(config_tree_fingerprint)"
+
+# --- 1: sudo failure: named as sudo, never mistaken for a stopped daemon -----
+
+SSH_HARDENING_SUDO="$SSH_SUDO_DENY_STUB" run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '1: a sudo failure must fail the reload'
+assert_no_kickstart '1'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail "1: with sudo unavailable, the service must not even be probed (spy: $(cat "$LAUNCHCTL_SPY_LOG"))"
+grep -q '^-v$' "$SUDO_DENY_SPY_LOG" ||
+  fail '1: privilege must be primed visibly via sudo -v before anything else'
+[[ "$(grep -c . "$SUDO_DENY_SPY_LOG")" -eq 1 ]] ||
+  fail "1: after the failed priming NOTHING else may run through the wrapper (deny spy: $(cat "$SUDO_DENY_SPY_LOG"))"
+grep -qi 'sudo' <<<"$SSH_RUN_ERR" ||
+  fail "1: the failure must name sudo (stderr: $SSH_RUN_ERR)"
+grep -qi 'privilege escalation' <<<"$SSH_RUN_ERR" ||
+  fail "1: the failure must be ATTRIBUTED to privilege escalation, not to a downstream step that happened to mention sudo (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_ERR" 'not loaded' \
+  '1: a sudo failure must never be reported as the service not loaded'
+refute_contains "$SSH_RUN_ERR" 'not running' \
+  '1: a sudo failure must never be reported as sshd not running'
+
+# --- 2: sshd -t failure: nonzero, no kickstart, names syntax ------------------
+
+SSHD_STUB_SYNTAX_STATUS=78 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '2: a failed syntax check must fail the reload'
+assert_no_kickstart '2'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail '2: validation must fail BEFORE the service is probed'
+grep -qi 'syntax' <<<"$SSH_RUN_ERR" ||
+  fail "2: the failure must name syntax (stderr: $SSH_RUN_ERR)"
+
+# --- 3: hardening lost: nonzero, no kickstart, not fully hardened -------------
+
+rm -f "$dropin"
+run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '3: a tree that lost the hardening must fail the reload'
+assert_no_kickstart '3'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail '3: verification must fail BEFORE the service is probed'
+grep -qi 'not fully hardened' <<<"$SSH_RUN_ERR" ||
+  fail "3: the failure must say the configuration is not fully hardened (stderr: $SSH_RUN_ERR)"
+[[ ! -e $dropin ]] ||
+  fail '3: --reload must never write the drop-in (criterion 12)'
+write_hardened_dropin
+
+# --- 4: service confirmed absent (113): exit 0, no kickstart, explained -------
+
+LAUNCHCTL_STUB_PRINT_STATUSES=113 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "4: a confirmed-absent service is a clean no-op, got exit $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)"
+assert_no_kickstart '4'
+grep -qi 'Remote Login' <<<"$SSH_RUN_OUT" ||
+  fail "4: stdout must explain the service follows Remote Login (stdout: $SSH_RUN_OUT)"
+grep -qi 'next enabled' <<<"$SSH_RUN_OUT" ||
+  fail "4: stdout must explain the drop-in applies when Remote Login is next enabled (stdout: $SSH_RUN_OUT)"
+
+# --- 5: probe error (neither 0 nor 113): nonzero, no kickstart ----------------
+
+LAUNCHCTL_STUB_PRINT_STATUSES=150 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '5: an errored probe must fail the reload, never pass as a stopped service'
+assert_no_kickstart '5'
+grep -qi 'could not determine' <<<"$SSH_RUN_ERR" ||
+  fail "5: the failure must say the state could not be determined (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_ERR" 'not loaded' \
+  '5: an errored probe must never be reported as not loaded'
+refute_contains "$SSH_RUN_ERR" 'not running' \
+  '5: an errored probe must never be reported as not running'
+
+# --- 6: kickstart fails: nonzero, kickstart WAS attempted, named --------------
+
+LAUNCHCTL_STUB_KICKSTART_STATUS=9 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '6: a failed kickstart must fail the reload'
+assert_kickstart_attempted '6'
+grep -qi 'kickstart' <<<"$SSH_RUN_ERR" ||
+  fail "6: the failure must name kickstart (stderr: $SSH_RUN_ERR)"
+grep -qF 'ssh-hardening.sh --rollback' <<<"$SSH_RUN_ERR" ||
+  fail "6: a failure AFTER the disruptive step began must name the recovery path (stderr: $SSH_RUN_ERR)"
+
+# --- 7: job does not reload after kickstart: nonzero, says so -----------------
+
+LAUNCHCTL_STUB_PRINT_STATUSES='0 113' run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '7: a job that does not come back loaded must fail the reload'
+assert_kickstart_attempted '7'
+grep -qi 'did not reload' <<<"$SSH_RUN_ERR" ||
+  fail "7: the failure must say the job did not reload (stderr: $SSH_RUN_ERR)"
+grep -qF 'ssh-hardening.sh --rollback' <<<"$SSH_RUN_ERR" ||
+  fail "7: a failure AFTER the disruptive step must name the recovery path (stderr: $SSH_RUN_ERR)"
+
+# --- 8: loaded but no banner: nonzero, lockout warning, recovery path ---------
+
+KEYSCAN_STUB_MODE=refuse run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: a listener that never answers must fail the reload'
+assert_kickstart_attempted '8'
+grep -qi 'possible lockout' <<<"$SSH_RUN_ERR" ||
+  fail "8: the failure must warn about a possible lockout (stderr: $SSH_RUN_ERR)"
+for phrase in "${RECOVERY_PHRASES[@]}"; do
+  grep -qF -- "$phrase" <<<"$SSH_RUN_ERR" ||
+    fail "8: the lockout failure must carry the recovery instruction '$phrase' (stderr: $SSH_RUN_ERR)"
+done
+keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
+[[ $keyscan_attempts -eq $SSH_HARDENING_READY_ATTEMPTS ]] ||
+  fail "8: the probe must retry to the attempt bound and then STOP, got $keyscan_attempts attempts (want $SSH_HARDENING_READY_ATTEMPTS)"
+
+# A probe that exits 0 with NO banner output proved nothing: the exit status
+# is a proxy, the banner is the artifact, and trusting the proxy would report
+# green over a crashed sshd.
+KEYSCAN_STUB_MODE=silent-zero run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: a keyscan that exits 0 with no banner output must still fail the reload'
+grep -qi 'possible lockout' <<<"$SSH_RUN_ERR" ||
+  fail "8: the silent-success probe must also warn about a possible lockout (stderr: $SSH_RUN_ERR)"
+
+# --- 9: readiness prover unavailable: refuse BEFORE anything disruptive -------
+
+KEYSCAN_BIN="$SSH_SANDBOX/no-such-keyscan" run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '9: with no way to prove the daemon came back, --reload must refuse to run'
+assert_no_kickstart '9'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail '9: the refusal must come before the service is even probed'
+grep -qi 'refusing' <<<"$SSH_RUN_ERR" ||
+  fail "9: the refusal must be explicit (stderr: $SSH_RUN_ERR)"
+grep -qF "$SSH_SANDBOX/no-such-keyscan" <<<"$SSH_RUN_ERR" ||
+  fail "9: the refusal must name the missing prover (stderr: $SSH_RUN_ERR)"
+
+# --- 10: happy path: kickstart attempted, banner proven, port named -----------
+
+run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "10: the happy path must succeed (stderr: $SSH_RUN_ERR)"
+assert_kickstart_attempted '10'
+grep -qi 'accepting connections' <<<"$SSH_RUN_OUT" ||
+  fail "10: stdout must confirm sshd is accepting connections (stdout: $SSH_RUN_OUT)"
+grep -qF 'port 2222' <<<"$SSH_RUN_OUT" ||
+  fail "10: stdout must name the RESOLVED port, 2222 from the stub's sshd -G (stdout: $SSH_RUN_OUT)"
+grep -qF -- '-p 2222' "$KEYSCAN_SPY_LOG" ||
+  fail "10: the readiness probe must target the resolved port (keyscan spy: $(cat "$KEYSCAN_SPY_LOG"))"
+[[ "$(config_tree_fingerprint)" == "$baseline_fingerprint" ]] ||
+  fail '10: a reload must leave the configuration tree byte-for-byte untouched (criterion 12)'
+
+# --- 12: the default install mode never reloads -------------------------------
+
+rm -f "$dropin"
+run_ssh_reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "12: install must succeed in the sandbox (stderr: $SSH_RUN_ERR)"
+[[ -f $dropin ]] ||
+  fail '12: install must write the drop-in'
+[[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+  fail "12: install must never touch launchctl (spy: $(cat "$LAUNCHCTL_SPY_LOG"))"
+[[ ! -s $KEYSCAN_SPY_LOG ]] ||
+  fail "12: install must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+
+# --- 13: the recovery path lives in the runbook, as the same literal text -----
+
+[[ -f $RUNBOOK ]] ||
+  fail "13: the runbook is missing at $RUNBOOK"
+runbook_content="$(cat "$RUNBOOK")"
+for phrase in "${RECOVERY_PHRASES[@]}"; do
+  grep -qF -- "$phrase" <<<"$runbook_content" ||
+    fail "13: the runbook must carry the recovery instruction '$phrase'"
+done
+
+printf 'ssh-hardening-reload-failclosed: OK (every unprovable step refuses before the kickstart, every failure after it names the way back in)\n'

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -22,22 +22,14 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
 
-fail() {
-  printf 'FAIL: %s\n' "$*" >&2
-  exit 1
-}
+# fail and refute_contains come from ssh-hardening-lib.bash (via the reload
+# lib).
 
-# A bare `! grep` is dead under `set -e` unless it is the last statement, so
-# every negative goes through this helper.
-refute_contains() { # <haystack> <fixed-string> <message>
-  if grep -qiF -- "$2" <<<"$1"; then
-    fail "$3"
-  fi
-}
-
-# The recovery instruction, pinned as LITERAL text in both the script's
-# lockout failure and the runbook (criterion 13). One list, asserted against
-# both, so the two cannot drift apart without this test failing.
+# Fragments of the recovery instruction, pinned as LITERAL text that must
+# appear in the script's lockout failure AND somewhere in the runbook
+# (criterion 13). Honest scope: this keeps each fragment from being dropped
+# or reworded on either side; it does not prove the two render one identical
+# complete sentence.
 RECOVERY_PHRASES=(
   'ssh-hardening.sh --rollback'
   'Screen Sharing over the tailnet'
@@ -55,7 +47,7 @@ export SSH_HARDENING_READY_INTERVAL=0
 reload_sandbox_setup
 trap 'ssh_sandbox_teardown' EXIT
 
-dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+dropin="$SSHD_CONFIG_D/$SSH_DROPIN_NAME"
 write_hardened_dropin
 baseline_fingerprint="$(config_tree_fingerprint)"
 
@@ -187,7 +179,7 @@ grep -qi 'launchd' <<<"$SSH_RUN_ERR" ||
   fail "8: the lockout failure must name the launchd-socket possibility so a port mismatch reads as a diagnosis, not a false emergency (stderr: $SSH_RUN_ERR)"
 # The sudo rm fallback must name the CONCRETE file, so it works when the
 # script itself is broken.
-grep -qF "sudo rm $SSHD_CONFIG_D/000-ssh-hardening.conf" <<<"$SSH_RUN_ERR" ||
+grep -qF "sudo rm $SSHD_CONFIG_D/$SSH_DROPIN_NAME" <<<"$SSH_RUN_ERR" ||
   fail "8: the sudo rm fallback must name the exact drop-in path (stderr: $SSH_RUN_ERR)"
 
 # A probe that exits 0 with NO banner output proved nothing: the exit status
@@ -246,7 +238,7 @@ grep -qF 'port 2222' <<<"$SSH_RUN_OUT" ||
 grep -qF -- '-p 2222' "$KEYSCAN_SPY_LOG" ||
   fail "10: the readiness probe must target the resolved port (keyscan spy: $(cat "$KEYSCAN_SPY_LOG"))"
 [[ "$(config_tree_fingerprint)" == "$baseline_fingerprint" ]] ||
-  fail '10: a reload must leave the configuration tree byte-for-byte untouched (criterion 12)'
+  fail '10: a reload must leave every regular file under the drop-in directory unchanged in path and content (criterion 12; see config_tree_fingerprint for what this does not cover)'
 
 # The complete ordered argv of every seam call in the happy path, diffed as
 # one list: the syntax check names the REAL main config (sshd -G -f

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -128,6 +128,17 @@ refute_contains "$SSH_RUN_ERR" 'not loaded' \
 refute_contains "$SSH_RUN_ERR" 'not running' \
   '5: an errored probe must never be reported as not running'
 
+# --- 5b: a wrapper failure must never read as "Remote Login is off" -----------
+# A privilege wrapper that exits 113 for launchctl WITHOUT running it used to
+# be read as the confirmed-absent status: the reload printed its clean no-op
+# and exited 0 having restarted nothing. Only a status proven to come from
+# launchctl may mean absent.
+
+SSH_HARDENING_SUDO="$SSH_SUDO_LAUNCHCTL_113_STUB" run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '5b: a wrapper exiting 113 without running launchctl must not produce the clean no-op'
+refute_contains "$SSH_RUN_OUT" 'no daemon to restart'   '5b: a wrapper failure must never be reported as Remote Login being off'
+
 # --- 6: kickstart fails: nonzero, kickstart WAS attempted, named --------------
 
 LAUNCHCTL_STUB_KICKSTART_STATUS=9 run_ssh_reload --reload

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -165,6 +165,13 @@ done
 keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
 [[ $keyscan_attempts -eq $SSH_HARDENING_READY_ATTEMPTS ]] ||
   fail "8: the probe must retry to the attempt bound and then STOP, got $keyscan_attempts attempts (want $SSH_HARDENING_READY_ATTEMPTS)"
+# The probe port comes from `sshd -G`, but on macOS launchd owns Remote
+# Login's listening socket and the Port directive does not move it, so a
+# nonstandard Port makes this exact alarm fire against a HEALTHY daemon. The
+# lockout text must hand the operator that diagnosis instead of only an
+# emergency.
+grep -qi 'launchd' <<<"$SSH_RUN_ERR" ||
+  fail "8: the lockout failure must name the launchd-socket possibility so a port mismatch reads as a diagnosis, not a false emergency (stderr: $SSH_RUN_ERR)"
 
 # A probe that exits 0 with NO banner output proved nothing: the exit status
 # is a proxy, the banner is the artifact, and trusting the proxy would report
@@ -215,6 +222,51 @@ run_ssh_reload
   fail "12: install must never touch launchctl (spy: $(cat "$LAUNCHCTL_SPY_LOG"))"
 [[ ! -s $KEYSCAN_SPY_LOG ]] ||
   fail "12: install must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+
+# --- 17: port resolution fails closed BEFORE the kickstart --------------------
+# The port branch had no test at all; every shape that cannot be probed must
+# refuse while nothing has been disturbed, and every DECLARED port must be
+# probed rather than silently the first (two Port directives produce two
+# `port` lines from the real binary, measured).
+
+# 17a: `sshd -G` itself fails at the port-resolution call (the fourth -G of
+# the run; the three before it belong to the child verify and must succeed).
+SSHD_STUB_RESOLVE_STATUSES='0 0 0 3' run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '17a: a failed port resolution must fail the reload'
+assert_no_kickstart '17a'
+grep -qi 'could not resolve the effective sshd port' <<<"$SSH_RUN_ERR" ||
+  fail "17a: the failure must name the port resolution (stderr: $SSH_RUN_ERR)"
+
+# 17b: -G output with NO port line at all.
+SSHD_STUB_PORT='' run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '17b: portless -G output must fail the reload'
+assert_no_kickstart '17b'
+grep -qi 'no port' <<<"$SSH_RUN_ERR" ||
+  fail "17b: the failure must say no port resolved (stderr: $SSH_RUN_ERR)"
+
+# 17c: ports outside the valid range, both sides, plus a non-number.
+for bad_port in 0 70000 007 abc; do
+  SSHD_STUB_PORT="$bad_port" run_ssh_reload --reload
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "17c: port '$bad_port' must be refused"
+  assert_no_kickstart "17c: port '$bad_port'"
+  grep -qF "'$bad_port'" <<<"$SSH_RUN_ERR" ||
+    fail "17c: the refusal must name the bad port '$bad_port' (stderr: $SSH_RUN_ERR)"
+done
+
+# 17d: TWO declared ports, only the second answering: the probe must walk
+# both and succeed, naming the port that answered.
+SSHD_STUB_PORT='2222 2223' KEYSCAN_STUB_ANSWER_PORT=2223 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "17d: with the second declared port answering, the reload must succeed (stderr: $SSH_RUN_ERR)"
+grep -qF -- '-p 2222' "$KEYSCAN_SPY_LOG" ||
+  fail "17d: the first declared port must have been probed (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+grep -qF -- '-p 2223' "$KEYSCAN_SPY_LOG" ||
+  fail "17d: the second declared port must have been probed (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+grep -qF 'port 2223' <<<"$SSH_RUN_OUT" ||
+  fail "17d: success must name the port that actually answered (stdout: $SSH_RUN_OUT)"
 
 # --- 16: the retry delay is a validated seam, never a bare sleep --------------
 # sleep is /bin/sleep on this platform, an external binary and not a builtin,

--- a/test/integration/ssh-hardening-reload-failclosed.sh
+++ b/test/integration/ssh-hardening-reload-failclosed.sh
@@ -216,6 +216,63 @@ run_ssh_reload
 [[ ! -s $KEYSCAN_SPY_LOG ]] ||
   fail "12: install must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
 
+# --- 15: readiness knobs are validated BEFORE anything runs -------------------
+# The property: attempts and the probe timeout are one canonical base-10
+# positive integer (bash arithmetic reads a leading zero as base-8, so 010
+# meant 8 probes and 08 died mid-loop; 0 and 00 bounded the loop at zero
+# probes and reported POSSIBLE LOCKOUT on a healthy machine); the interval is
+# a canonical non-negative decimal. Set-but-EMPTY is an operator statement
+# and is refused, never silently rewritten to the default.
+
+for bad_attempts in '' '0' '00' '08' '010' '+1' '1x' '1 0'; do
+  SSH_HARDENING_READY_ATTEMPTS="$bad_attempts" run_ssh_reload --reload
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "15: SSH_HARDENING_READY_ATTEMPTS='$bad_attempts' must be refused"
+  assert_no_kickstart "15: attempts '$bad_attempts'"
+  [[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+    fail "15: attempts '$bad_attempts' must be refused before the service is probed"
+  grep -q 'SSH_HARDENING_READY_ATTEMPTS' <<<"$SSH_RUN_ERR" ||
+    fail "15: the refusal of attempts '$bad_attempts' must name the knob (stderr: $SSH_RUN_ERR)"
+done
+
+for bad_interval in '' '.' '1.2.3' 'abc' '00' '01'; do
+  SSH_HARDENING_READY_INTERVAL="$bad_interval" run_ssh_reload --reload
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "15: SSH_HARDENING_READY_INTERVAL='$bad_interval' must be refused"
+  assert_no_kickstart "15: interval '$bad_interval'"
+  grep -q 'SSH_HARDENING_READY_INTERVAL' <<<"$SSH_RUN_ERR" ||
+    fail "15: the refusal of interval '$bad_interval' must name the knob (stderr: $SSH_RUN_ERR)"
+done
+
+for bad_timeout in '' '0' '05' '5x'; do
+  SSH_HARDENING_PROBE_TIMEOUT="$bad_timeout" run_ssh_reload --reload
+  [[ $SSH_RUN_STATUS -ne 0 ]] ||
+    fail "15: SSH_HARDENING_PROBE_TIMEOUT='$bad_timeout' must be refused"
+  assert_no_kickstart "15: timeout '$bad_timeout'"
+  grep -q 'SSH_HARDENING_PROBE_TIMEOUT' <<<"$SSH_RUN_ERR" ||
+    fail "15: the refusal of timeout '$bad_timeout' must name the knob (stderr: $SSH_RUN_ERR)"
+done
+
+# Accepted shapes. attempts=10 must mean TEN probes (base-10, not base-8);
+# the probe timeout must reach the keyscan argv; a fractional interval is
+# legal (the global interval stays 0 elsewhere so the suite never sleeps).
+SSH_HARDENING_READY_ATTEMPTS=10 KEYSCAN_STUB_MODE=refuse run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '15: ten refused probes must still be a lockout failure'
+keyscan_attempts="$(grep -c . "$KEYSCAN_SPY_LOG")" || true
+[[ $keyscan_attempts -eq 10 ]] ||
+  fail "15: SSH_HARDENING_READY_ATTEMPTS=10 must probe exactly 10 times, got $keyscan_attempts"
+
+SSH_HARDENING_PROBE_TIMEOUT=7 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "15: a legal probe timeout must not break the happy path (stderr: $SSH_RUN_ERR)"
+grep -qF -- '-T 7' "$KEYSCAN_SPY_LOG" ||
+  fail "15: the probe timeout knob must reach the keyscan argv (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+
+SSH_HARDENING_READY_INTERVAL=0.5 run_ssh_reload --reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "15: a fractional interval is legal and must not be refused (stderr: $SSH_RUN_ERR)"
+
 # --- 14: mode dispatch is case-sensitive --------------------------------------
 # nocasematch is on at file scope for sshd keyword matching; if it reaches
 # main's case, a mistyped `--RELOAD` invokes the ONE disruptive mode in the

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -7,9 +7,12 @@
 # /etc/ssh.
 #
 # Properties pinned:
-#   1. rollback removes the drop-in and a following --verify reports the
-#      hardening absent
-#   2. a second rollback is a clean no-op (exit 0, nothing to remove)
+#   1. rollback removes the drop-in, PROVES an interactive password channel
+#      resolves ON for the sampled connections, and says which restart route
+#      actually works (--reload refuses an unhardened tree, so it is never
+#      advertised)
+#   2. a second rollback re-runs the same proof on the already-absent path:
+#      "nothing to remove" is never "access is back" by itself
 #   3. rollback never restarts anything: no launchctl call, no keyscan call
 #   4. a removal that fails leaves a loud nonzero failure, not a success claim
 #   5. a tree that STILL verifies hardened after the removal is a loud
@@ -17,6 +20,12 @@
 #      password access is NOT back
 #   6. an unrunnable verifier after the removal fails closed: the file is
 #      gone, but rollback refuses to CLAIM the hardening is gone unchecked
+#   7. a PARTIAL policy that still closes both password channels fails loudly
+#      even though the tree no longer verifies fully hardened (negating
+#      --verify is not proof of access)
+#   8. a verifier that runs but ERRORS is the error outcome, distinct from
+#      "still blocked" and never a success
+#   9. the already-absent path with the policy still in force fails loudly
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -65,21 +74,33 @@ run_ssh_reload --rollback
   fail '1: rollback must remove the drop-in'
 grep -qF "$dropin" <<<"$SSH_RUN_OUT" ||
   fail "1: rollback must name the file it removed (stdout: $SSH_RUN_OUT)"
-grep -qi 'no longer verifies fully hardened' <<<"$SSH_RUN_OUT" ||
-  fail "1: rollback must report the hardening gone from the effective configuration (stdout: $SSH_RUN_OUT)"
+grep -qi 'password access is restored' <<<"$SSH_RUN_OUT" ||
+  fail "1: rollback must claim success as PROVEN password access, not as policy drift (stdout: $SSH_RUN_OUT)"
+grep -qi 'resolves ON' <<<"$SSH_RUN_OUT" ||
+  fail "1: the success claim must name what was proven, a password channel resolving ON (stdout: $SSH_RUN_OUT)"
+# The restart guidance must name a route that can actually run: --reload
+# refuses a tree that is not fully hardened, which is exactly the state a
+# successful rollback leaves, so it must only ever appear as the thing that
+# CANNOT perform this restart.
+grep -qi 'toggle Remote Login off and back on' <<<"$SSH_RUN_OUT" ||
+  fail "1: the success message must name the reachable restart route (stdout: $SSH_RUN_OUT)"
+grep -qF -- '--reload cannot perform this restart' <<<"$SSH_RUN_OUT" ||
+  fail "1: the success message must explain that --reload refuses an unhardened tree (stdout: $SSH_RUN_OUT)"
 assert_no_reload_side_effects '1'
 
 run_ssh_reload --verify
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '1: after rollback, --verify must report the hardening ABSENT (it exited 0)'
 
-# --- 2: a second rollback is a clean no-op ------------------------------------
+# --- 2: a second rollback re-proves access on the already-absent path ---------
 
 run_ssh_reload --rollback
 [[ $SSH_RUN_STATUS -eq 0 ]] ||
   fail "2: a second rollback must be a clean no-op (stderr: $SSH_RUN_ERR)"
 grep -qi 'already absent' <<<"$SSH_RUN_OUT" ||
   fail "2: the no-op must say there was nothing to remove (stdout: $SSH_RUN_OUT)"
+grep -qi 'password access is restored' <<<"$SSH_RUN_OUT" ||
+  fail "2: even with nothing to remove, success must rest on the SAME access proof (stdout: $SSH_RUN_OUT)"
 [[ ! -e $dropin ]] ||
   fail '2: the second rollback must leave the drop-in absent'
 assert_no_reload_side_effects '2'
@@ -108,8 +129,8 @@ SSHD_STUB_FORCE_HARDENED=1 run_ssh_reload --rollback
   fail '4: rollback must fail when the tree still verifies hardened after the removal'
 [[ ! -e $dropin ]] ||
   fail '4: the drop-in itself must still have been removed'
-grep -qi 'still verifies fully hardened' <<<"$SSH_RUN_ERR" ||
-  fail "4: the failure must say the hardening is still in effect (stderr: $SSH_RUN_ERR)"
+grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
+  fail "4: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
 refute_contains "$SSH_RUN_OUT" 'rollback complete' \
   '4: a still-hardened tree must not produce a completion claim'
 assert_no_reload_side_effects '4'
@@ -128,4 +149,58 @@ refute_contains "$SSH_RUN_OUT" 'rollback complete' \
   '5: an unverified removal must not claim completion'
 assert_no_reload_side_effects '5'
 
-printf 'ssh-hardening-rollback: OK (removal proven, no-op idempotent, every unprovable step fails closed)\n'
+# --- 6: partial policy still closes both channels -> loud failure -------------
+# The drop-in is gone and the tree no longer verifies fully hardened
+# (permitrootlogin drifted back to its default), yet PasswordAuthentication
+# and KbdInteractiveAuthentication both still resolve no. The previous
+# rollback treated ANY failed child verify as proof of restored access and
+# claimed success here; the exact fail-open this case exists to keep dead.
+
+write_hardened_dropin
+SSHD_STUB_PARTIAL_HARDENED=1 run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '6: with both password channels still OFF, rollback must fail even though the tree no longer verifies fully hardened'
+[[ ! -e $dropin ]] ||
+  fail '6: the removal itself must still happen'
+grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
+  fail "6: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '6: a blocked password path must not produce a completion claim'
+assert_no_reload_side_effects '6'
+
+# --- 7: verifier runs but ERRORS -> the error outcome, never success ----------
+# Distinct from case 5: the binary IS executable and its failure is an exit
+# status, not a missing file. The previous rollback read this nonzero child
+# status as "the hardening is gone" and claimed success.
+
+write_hardened_dropin
+SSHD_STUB_RESOLVE_STATUS=1 run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '7: an ERRORING verifier must fail the rollback, not pass as proof of access'
+[[ ! -e $dropin ]] ||
+  fail '7: the removal itself must still happen'
+grep -qi 'errored' <<<"$SSH_RUN_ERR" ||
+  fail "7: the failure must name the ERROR outcome, distinct from a blocked channel (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_ERR" 'NOT restored' \
+  '7: an errored check must not claim to know the channels are blocked'
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '7: an errored check must not produce a completion claim'
+assert_no_reload_side_effects '7'
+
+# --- 8: already absent, policy still in force -> loud failure -----------------
+# The exact scenario the old already-absent branch fail-opened on: nothing to
+# remove, but a sibling (modeled by SSHD_STUB_FORCE_HARDENED) still enforces
+# the full policy, so the operator is told "nothing to remove" while password
+# access is NOT back.
+
+rm -f "$dropin"
+SSHD_STUB_FORCE_HARDENED=1 run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: an already-absent drop-in with the policy still in force must fail the rollback'
+grep -qi 'already absent' <<<"$SSH_RUN_OUT" ||
+  fail "8: the run must still report there was nothing to remove (stdout: $SSH_RUN_OUT)"
+grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
+  fail "8: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
+assert_no_reload_side_effects '8'
+
+printf 'ssh-hardening-rollback: OK (success means a PROVEN password channel, on both the removal and the already-absent path; blocked, errored, and unverifiable are three distinct loud failures)\n'

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ssh-hardening-rollback.sh -- --rollback is the way back in, expressed as
+# code (slice 8, acceptance criterion 11). It removes the managed drop-in,
+# re-verifies that the hardening is GONE from the effective configuration, and
+# fails closed on every step it cannot prove. Everything here drives the stub
+# seams from ssh-reload-lib.bash; no case can reach the live daemon or
+# /etc/ssh.
+#
+# Properties pinned:
+#   1. rollback removes the drop-in and a following --verify reports the
+#      hardening absent
+#   2. a second rollback is a clean no-op (exit 0, nothing to remove)
+#   3. rollback never restarts anything: no launchctl call, no keyscan call
+#   4. a removal that fails leaves a loud nonzero failure, not a success claim
+#   5. a tree that STILL verifies hardened after the removal is a loud
+#      failure: the drop-in was not the (only) thing enforcing the policy, so
+#      password access is NOT back
+#   6. an unrunnable verifier after the removal fails closed: the file is
+#      gone, but rollback refuses to CLAIM the hardening is gone unchecked
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-reload-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it is the last statement, so
+# every negative goes through this helper.
+refute_contains() { # <haystack> <fixed-string> <message>
+  if grep -qiF -- "$2" <<<"$1"; then
+    fail "$3"
+  fi
+}
+
+assert_no_reload_side_effects() { # <label>
+  [[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
+    fail "$1: rollback must never touch launchctl (spy: $(cat "$LAUNCHCTL_SPY_LOG"))"
+  [[ ! -s $KEYSCAN_SPY_LOG ]] ||
+    fail "$1: rollback must never probe the listener (spy: $(cat "$KEYSCAN_SPY_LOG"))"
+}
+
+reload_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+
+# --- 1: remove, and the hardening really is gone ------------------------------
+
+write_hardened_dropin
+run_ssh_reload --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "setup: the hardened tree must verify before the rollback (stderr: $SSH_RUN_ERR)"
+
+run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "1: rollback must succeed on a hardened tree (stderr: $SSH_RUN_ERR)"
+[[ ! -e $dropin ]] ||
+  fail '1: rollback must remove the drop-in'
+grep -qF "$dropin" <<<"$SSH_RUN_OUT" ||
+  fail "1: rollback must name the file it removed (stdout: $SSH_RUN_OUT)"
+grep -qi 'no longer verifies fully hardened' <<<"$SSH_RUN_OUT" ||
+  fail "1: rollback must report the hardening gone from the effective configuration (stdout: $SSH_RUN_OUT)"
+assert_no_reload_side_effects '1'
+
+run_ssh_reload --verify
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '1: after rollback, --verify must report the hardening ABSENT (it exited 0)'
+
+# --- 2: a second rollback is a clean no-op ------------------------------------
+
+run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "2: a second rollback must be a clean no-op (stderr: $SSH_RUN_ERR)"
+grep -qi 'already absent' <<<"$SSH_RUN_OUT" ||
+  fail "2: the no-op must say there was nothing to remove (stdout: $SSH_RUN_OUT)"
+[[ ! -e $dropin ]] ||
+  fail '2: the second rollback must leave the drop-in absent'
+assert_no_reload_side_effects '2'
+
+# --- 3: a failed removal is a loud failure, never a success claim -------------
+
+write_hardened_dropin
+SSH_HARDENING_SUDO="$SSH_SUDO_DENY_STUB" run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '3: rollback must fail when the removal command fails'
+[[ -e $dropin ]] ||
+  fail '3: with the removal refused, the drop-in must still be in place'
+grep -qi 'could not remove' <<<"$SSH_RUN_ERR" ||
+  fail "3: the failure must name the removal (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '3: a failed removal must not claim completion'
+assert_no_reload_side_effects '3'
+
+# --- 4: still hardened after removal -> loud failure --------------------------
+# SSHD_STUB_FORCE_HARDENED models a sibling file still enforcing the policy:
+# the drop-in is gone, yet the effective configuration still verifies
+# hardened, so the way back in is NOT restored and rollback must say so.
+
+SSHD_STUB_FORCE_HARDENED=1 run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '4: rollback must fail when the tree still verifies hardened after the removal'
+[[ ! -e $dropin ]] ||
+  fail '4: the drop-in itself must still have been removed'
+grep -qi 'still verifies fully hardened' <<<"$SSH_RUN_ERR" ||
+  fail "4: the failure must say the hardening is still in effect (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '4: a still-hardened tree must not produce a completion claim'
+assert_no_reload_side_effects '4'
+
+# --- 5: unrunnable verifier after removal -> fail closed ----------------------
+
+write_hardened_dropin
+SSHD_BIN="$SSH_SANDBOX/no-such-sshd" run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '5: rollback must fail closed when the removal cannot be verified'
+[[ ! -e $dropin ]] ||
+  fail '5: the removal itself must still happen (it is the way back in)'
+grep -qi 'failing closed' <<<"$SSH_RUN_ERR" ||
+  fail "5: the failure must say it is failing closed (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '5: an unverified removal must not claim completion'
+assert_no_reload_side_effects '5'
+
+printf 'ssh-hardening-rollback: OK (removal proven, no-op idempotent, every unprovable step fails closed)\n'

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -203,4 +203,23 @@ grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
   fail "8: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
 assert_no_reload_side_effects '8'
 
+# --- 9: a removal command that LIES produces no success claim -----------------
+# The wrapper reports rm succeeded without running it; the post-removal
+# existence re-check must convict the lie by looking at the file itself,
+# BEFORE any recovery proof runs against a tree that still carries the
+# drop-in.
+
+write_hardened_dropin
+SSH_HARDENING_SUDO="$SSH_SUDO_SWALLOW_RM_STUB" run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '9: a swallowed rm must fail the rollback'
+[[ -e $dropin ]] ||
+  fail '9: the drop-in must still be in place (the stub never removed it)'
+grep -qi 'still exists after the removal command reported success' <<<"$SSH_RUN_ERR" ||
+  fail "9: the failure must convict the lying removal specifically (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '9: a swallowed removal must not produce a completion claim'
+assert_no_reload_side_effects '9'
+rm -f "$dropin"
+
 printf 'ssh-hardening-rollback: OK (success means a PROVEN password channel, on both the removal and the already-absent path; blocked, errored, and unverifiable are three distinct loud failures)\n'

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -35,18 +35,8 @@ unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
 # shellcheck source=../fixtures/ssh-reload-lib.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib.bash"
 
-fail() {
-  printf 'FAIL: %s\n' "$*" >&2
-  exit 1
-}
-
-# A bare `! grep` is dead under `set -e` unless it is the last statement, so
-# every negative goes through this helper.
-refute_contains() { # <haystack> <fixed-string> <message>
-  if grep -qiF -- "$2" <<<"$1"; then
-    fail "$3"
-  fi
-}
+# fail and refute_contains come from ssh-hardening-lib.bash (via the reload
+# lib).
 
 assert_no_reload_side_effects() { # <label>
   [[ ! -s $LAUNCHCTL_SPY_LOG ]] ||
@@ -58,7 +48,7 @@ assert_no_reload_side_effects() { # <label>
 reload_sandbox_setup
 trap 'ssh_sandbox_teardown' EXIT
 
-dropin="$SSHD_CONFIG_D/000-ssh-hardening.conf"
+dropin="$SSHD_CONFIG_D/$SSH_DROPIN_NAME"
 
 # --- 1: remove, and the hardening really is gone ------------------------------
 

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -174,7 +174,7 @@ assert_no_reload_side_effects '6'
 # status as "the hardening is gone" and claimed success.
 
 write_hardened_dropin
-SSHD_STUB_RESOLVE_STATUS=1 run_ssh_reload --rollback
+SSHD_STUB_RESOLVE_STATUSES=1 run_ssh_reload --rollback
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '7: an ERRORING verifier must fail the rollback, not pass as proof of access'
 [[ ! -e $dropin ]] ||


### PR DESCRIPTION
## Context

This machine's remote login accepts keys and nothing else. The previous change wrote the file that says
so and proved the machine resolves that way, but it never touched the running daemon: a new
configuration file changes nothing until sshd restarts.

This adds the two modes that touch the running world. `--reload` restarts the service and refuses to
report success until a real login handshake proves the listener answers. `--rollback` removes the policy
file and proves password access is genuinely back, which is what someone locked out actually needs. The
apply path still runs neither: it installs the file and stops, so nothing restarts unless a person types
it.

## Summary

- Adds a restart mode that proves the daemon answers before claiming success.
- Adds a rollback mode that proves password access is restored, not merely that a file is gone.
- Every step that cannot be proven refuses, and refuses before anything is disturbed.
- Closes a hole where the configuration reader disagreed with the daemon and certified a locked-out
  machine.
- Failures name the way back in, and the warning now prints before the disruptive step, not after.
- Deliberately no automatic recovery: a machine that just failed to restart gets no second unattended
  change.

Key files: `dot_local/bin/executable_ssh-hardening.sh`, three test files, and the fresh-machine runbook.

## What proves the daemon came back

The obvious check is to ask the service manager whether the job is loaded. It answers yes for a job that
loaded and then crashed, so the most authoritative-looking check reports green on exactly the failure it
exists to catch. It is kept, but only to refute: it can prove the restart failed, never that it worked.

The proof is a completed login handshake on the port. Not "is it loaded" but "does it answer."

This machine turned out to make that distinction sharper than expected. Remote login here is not a
conventional daemon at all: the system holds the listening socket itself and starts a fresh server for
each connection. A healthy, enabled machine therefore reports its service as not running, with zero
active copies. Reading that as failure would have broken every restart on a perfectly good machine. The
code judges the probe by its result code and never reads that text, so it does not.

The same fact cuts the other way in one place, and is recorded rather than fixed: the port is resolved
from the daemon's own configuration, but the system owns the socket, so a machine configured for a
non-default port would probe one nothing listens on and cry lockout about a healthy service. Latent
here, since no such setting exists on this machine.

## The hole that was found, and why it mattered

The configuration reader models the daemon's own parsing so it can find a rule that re-opens password
access for some addresses but not the one being tested from. Two reviews found that model was wrong
about quoting: the daemon joins quoted and unquoted pieces of a word, the reader split on them. A file
using that form was read by the daemon as a rule and by the checker as nothing at all.

Demonstrated end to end before the fix, against the real daemon: a file that parses cleanly, resolves
every login method closed for any address off this machine, and still made the checker print that all
seven protected settings hold. Every remote client locked out, certified healthy.

The parsing rules were then re-derived from the daemon's actual behaviour rather than from its manual,
and the comment that had asserted the wrong rule was corrected along with the code. A new test drives
every one of those forms through the real daemon.

The rollback path had the mirror problem. It reported success whenever the checker failed for any
reason, but "not all seven settings hold" is not "a password login will now work": a partly-applied
policy, an unreadable file, or a crash all produced the same cheerful answer. It now proves the specific
condition an operator needs, distinguishes still-blocked from could-not-tell, and runs that proof even
when the file was already gone.

## How it was reviewed

Two independent reviews plus a separate pass, then a fix round, then a re-review by a fresh reviewer.

The first review returned a block-merge verdict with two findings of the highest severity, both
reproduced against the real daemon before being accepted. The second ran thirty-one deliberate breakages
against the tests and found twelve that no assertion caught, nearly all tracing to one cause: the test
doubles recorded that a command ran but never what it asked for, so nothing checked which service was
restarted, which file was validated, or which host was probed.

The re-review ran thirty-one further breakages against the new code specifically and found no regression
from the fix round. It did find one more instance of the original class, arrived at from the other
direction: a word that begins empty is discarded by the daemon and the next word becomes the setting
name. That was measured to behave identically on the current branch and on the base, so it predates this
change entirely and is filed rather than fixed here.

One reviewer finding was downgraded rather than accepted. A readiness probe that prints output while
reporting failure would be trusted wrongly, but the real tool could not be made to do that under any
input tried, so it is pinned as a coverage gap rather than treated as a defect.

## What is not proven here

No daemon was restarted and nothing under the system's configuration directory was touched; the
directory listing and file timestamps are unchanged, and the service has never been started. Every test
runs against temporary directories and controlled stand-ins, with a tripwire that fails the test if the
script ever reaches for a real tool by name.

One thing genuinely remains: the acceptance drill wants a connection from a second machine. Verifying
readiness over the local loopback passes while a firewall blocks real remote access, so a green local
check is compatible with a machine no remote client can reach. That is tracked as a prerequisite for the
cutover rather than done here, because merging changes no running service.

## Effect of merging

Advances `main` only. The live machine follows another branch, the apply path installs a file and
restarts nothing, and both new modes run only when someone types them.
