### PR TITLE
chore(atuin): disable Atuin AI so new shells stop prompting for Hub login

### DIFF
--- a/dot_config/atuin/config.toml.tmpl
+++ b/dot_config/atuin/config.toml.tmpl
@@ -22,7 +22,12 @@ auto_sync = false
 records = true
 
 [ai]
-enabled = true
+# enabled=false: with this on, `atuin init bash` wires an `atuin ai inline --hook`
+# call, and that hook prompts for Atuin Hub authentication on every new shell when
+# no Hub session exists. The features it gates (natural-language command generation
+# on the `?` key) are not in use. Revisit via issue #91, which records what the
+# feature does and the self-hosted-endpoint option.
+enabled = false
 
 [daemon]
 enabled = true


### PR DESCRIPTION
## Context

Every new terminal pane was printing a login prompt for an account service, waiting on a keypress before
the shell settled. The cause was a shell-history setting that had quietly grown an assistant feature: with
it on, the tool's shell integration wires in an extra hook, and that hook asks to authenticate whenever no
account session exists.

The feature it gates generates shell commands from plain language on a keypress. It is not in use here,
and it needs an account, so this turns it off. Nothing else about shell history changes.

## Summary

- Stops the account login prompt that appeared in every new pane.
- Turns off one setting; history recording, search, and the daemon are untouched.
- Records why in a comment, so the next reader does not have to rediscover it.
- Points at issue #91, which holds the full evaluation for when this is revisited.

## What was verified

Turning the setting off removes the hook wiring entirely rather than merely silencing it: generating the
shell integration with the feature enabled emits one reference to the assistant hook, and with it disabled
emits none. The file still parses, and the neighbouring history-sync and daemon settings are unchanged.

## What this does not do

History recording, search, and the background daemon are separate systems and are not touched. Sync was
already off and stays off. The account itself is neither created nor used.

Nothing changes on this machine until the settings are applied, which needs an interactive session because
the file pulls a secret from the password manager at render time.

## Effect of merging

Advances `main` only, and the live machine follows another branch. Issue #91 carries the wider question of
what to use for this, including a self-hosted option that would keep everything local.
