### PR TITLE
feat(macos): verify the OverSight monitor is running, and track its real manual step

### DIFF
--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -103,7 +103,8 @@ macos:
     # verify, not enforce: OverSight is a login item the operator may quit on
     # purpose, and silently restarting it is not a read-only poller's (or an
     # apply-time runner's) business; the deviation pages instead. Its
-    # interactive permission grants are a separate manual record in
+    # Notification Center delivery (the alert channel, the one interactive
+    # authorization it has) is a separate manual record in
     # macos_system_setup.yaml.
     - id: oversight
       description: "The OverSight microphone and camera monitor process"

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -70,9 +70,11 @@
 #     disk whether or not the monitor is watching anything, so presence
 #     would report healthy for a quit monitor (verify the artifact, never a
 #     proxy for it). Classification follows pgrep's documented exit
-#     statuses: 0 with pids on stdout is running; the no-match exit 1 with
-#     no output at all is stopped; every other outcome (usage or internal
-#     error, a timeout kill, a status/output mismatch) is indeterminate.
+#     statuses, and the status/output pairing is symmetric: 0 with a
+#     well-formed pid list on stdout (digits, one pid per line, pgrep's only
+#     success output) is running; the no-match exit 1 with no output at all
+#     is stopped; every other outcome (usage or internal error, a timeout
+#     kill, a status/output mismatch in either direction) is indeterminate.
 
 macos:
   posture_controls:

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -29,6 +29,7 @@
 #                            #   csrutil_status      -> enabled|disabled
 #                            #   defaults_autologin  -> on|off
 #                            #   sysadminctl_guest   -> enabled|disabled
+#                            #   pgrep_oversight     -> running|stopped
 #     expect:      <value>   # the value the control must hold, inside the
 #                            # reader's domain; ANY in-domain deviation pages
 #     remedy:      <string>  # OPTIONAL: the page's fix-it line. Keep it
@@ -57,6 +58,21 @@
 #     silently activated.
 #   - sysadminctl_guest runs `sysadminctl -guestAccount status`, which reports
 #     the state on stderr and exits 0 in both states.
+#   - pgrep_oversight runs `pgrep -x -U <uid> OverSight`, a live process-table
+#     read scoped to the poller's own user session. The identity is pinned
+#     from the installed bundle (verified 2026-07-27): /Applications/
+#     OverSight.app carries exactly one executable, Contents/MacOS/OverSight
+#     (CFBundleExecutable "OverSight", CFBundleIdentifier
+#     com.objective-see.oversight), and no LoginItems/ or XPCServices/
+#     helpers, so the application process IS the monitor and its exact
+#     process name is OverSight (ps -o ucomm= on the live pid agrees).
+#     Deliberately NOT a bundle-presence check: the .app directory sits on
+#     disk whether or not the monitor is watching anything, so presence
+#     would report healthy for a quit monitor (verify the artifact, never a
+#     proxy for it). Classification follows pgrep's documented exit
+#     statuses: 0 with pids on stdout is running; the no-match exit 1 with
+#     no output at all is stopped; every other outcome (usage or internal
+#     error, a timeout kill, a status/output mismatch) is indeterminate.
 
 macos:
   posture_controls:
@@ -84,3 +100,14 @@ macos:
       reader: sysadminctl_guest
       expect: "disabled"
       remedy: "Disable it: System Settings → Users & Groups → Guest User"
+    # verify, not enforce: OverSight is a login item the operator may quit on
+    # purpose, and silently restarting it is not a read-only poller's (or an
+    # apply-time runner's) business; the deviation pages instead. Its
+    # interactive permission grants are a separate manual record in
+    # macos_system_setup.yaml.
+    - id: oversight
+      description: "The OverSight microphone and camera monitor process"
+      tier: verify
+      reader: pgrep_oversight
+      expect: "running"
+      remedy: "Relaunch it: open -a OverSight, and keep it in System Settings → General → Login Items so it returns at login"

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -95,16 +95,21 @@ macos:
     - description: "SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
       command: '"$HOME/.local/bin/ssh-hardening.sh"'
       tier: enforce
-    # OverSight (the microphone and camera activation monitor) only identifies
-    # which process is using a device once macOS grants it the matching
-    # recording permissions, and those grants are interactive-only: System
-    # Settings prompts per application and no supported command line writes
-    # them. Declared manual so the runbook owns the steps; whether the monitor
+    # OverSight (the microphone and camera activation monitor) needs NO
+    # privacy permission: the installed 2.4.0 bundle declares no
+    # NS*UsageDescription keys and no entitlements, so macOS never presents a
+    # Microphone or Camera grant for it, and it never asks for one. It
+    # observes device ACTIVATION EVENTS through CoreMediaIO property
+    # listeners, never device content. What IS interactive-only is
+    # Notification Center delivery, its single output channel: with delivery
+    # denied the monitor observes correctly and tells nobody, a dead alert
+    # channel that reads as healthy. No supported command line writes that
+    # authorization, so the runbook owns the steps; whether the monitor
     # process is RUNNING is a separate verify control in
     # macos_posture_controls.yaml.
-    - description: "OverSight: grant the microphone and camera permissions its monitoring needs"
+    - description: "OverSight: allow its Notification Center alerts (its only output channel)"
       tier: manual
-      runbook: "OverSight microphone and camera permission grants"
+      runbook: "OverSight notification delivery"
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -95,6 +95,16 @@ macos:
     - description: "SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
       command: '"$HOME/.local/bin/ssh-hardening.sh"'
       tier: enforce
+    # OverSight (the microphone and camera activation monitor) only identifies
+    # which process is using a device once macOS grants it the matching
+    # recording permissions, and those grants are interactive-only: System
+    # Settings prompts per application and no supported command line writes
+    # them. Declared manual so the runbook owns the steps; whether the monitor
+    # process is RUNNING is a separate verify control in
+    # macos_posture_controls.yaml.
+    - description: "OverSight: grant the microphone and camera permissions its monitoring needs"
+      tier: manual
+      runbook: "OverSight microphone and camera permission grants"
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -42,6 +42,19 @@ System Settings → Privacy & Security → grant the following:
 Each grant requires opening the Privacy sheet and dragging the app into the listed sheet. There's no CLI
 surface.
 
+### OverSight microphone and camera permission grants
+
+OverSight (the Objective-See microphone and camera activation monitor, installed as a cask) can only
+identify which process is using a device once macOS grants it the matching recording permissions. The
+grants are interactive-only; no supported command line writes them:
+
+1. Launch OverSight once (`open -a OverSight`) so it registers with the privacy database and prompts.
+1. System Settings → Privacy & Security → Microphone: enable OverSight.
+1. System Settings → Privacy & Security → Camera: enable OverSight.
+1. Confirm the monitor is running: `pgrep -x OverSight` prints a PID. The security-posture poller
+   verifies this continuously (the `oversight` record in `.chezmoidata/macos_posture_controls.yaml`) and
+   pages if the process stops.
+
 ### Firewall log diagnostics
 
 Nothing to enable here, this section is view-only. Firewall logging is on by default on macOS 26.2 and

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -56,8 +56,8 @@ interactive-only; no supported command line writes it:
    screen (banners dismiss themselves).
 1. Grant nothing under Privacy & Security. OverSight watches device activation events (CoreMediaIO
    property listeners), never microphone or camera content; the installed 2.4.0 bundle declares no
-   usage-description keys and no entitlements, so macOS never lists it under Microphone or Camera and
-   no such grant exists to give.
+   usage-description keys and no entitlements, so macOS never lists it under Microphone or Camera and no
+   such grant exists to give.
 1. Confirm the monitor is running: `pgrep -x -U "$(id -u)" OverSight` prints a PID. User-scoped (`-U`)
    exactly like the security-posture poller's probe, so another user's OverSight cannot mask a stopped
    one here; the poller verifies this continuously (the `oversight` record in

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -42,15 +42,22 @@ System Settings → Privacy & Security → grant the following:
 Each grant requires opening the Privacy sheet and dragging the app into the listed sheet. There's no CLI
 surface.
 
-### OverSight microphone and camera permission grants
+### OverSight notification delivery
 
-OverSight (the Objective-See microphone and camera activation monitor, installed as a cask) can only
-identify which process is using a device once macOS grants it the matching recording permissions. The
-grants are interactive-only; no supported command line writes them:
+OverSight (the Objective-See microphone and camera activation monitor, installed as a cask) alerts
+through Notification Center, and that alert is its ONLY output: with delivery denied the monitor still
+observes correctly and tells nobody, so a dead alert channel reads as healthy. The authorization is
+interactive-only; no supported command line writes it:
 
-1. Launch OverSight once (`open -a OverSight`) so it registers with the privacy database and prompts.
-1. System Settings → Privacy & Security → Microphone: enable OverSight.
-1. System Settings → Privacy & Security → Camera: enable OverSight.
+1. Launch OverSight once (`open -a OverSight`). First launch registers it with Notification Center and
+   prompts to allow notifications; click Allow.
+1. If the prompt was dismissed or denied: System Settings → Notifications → OverSight → turn on Allow
+   notifications, and pick the Alerts style so an activation that fires while you are away stays on
+   screen (banners dismiss themselves).
+1. Grant nothing under Privacy & Security. OverSight watches device activation events (CoreMediaIO
+   property listeners), never microphone or camera content; the installed 2.4.0 bundle declares no
+   usage-description keys and no entitlements, so macOS never lists it under Microphone or Camera and
+   no such grant exists to give.
 1. Confirm the monitor is running: `pgrep -x OverSight` prints a PID. The security-posture poller
    verifies this continuously (the `oversight` record in `.chezmoidata/macos_posture_controls.yaml`) and
    pages if the process stops.

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -58,9 +58,10 @@ interactive-only; no supported command line writes it:
    property listeners), never microphone or camera content; the installed 2.4.0 bundle declares no
    usage-description keys and no entitlements, so macOS never lists it under Microphone or Camera and
    no such grant exists to give.
-1. Confirm the monitor is running: `pgrep -x OverSight` prints a PID. The security-posture poller
-   verifies this continuously (the `oversight` record in `.chezmoidata/macos_posture_controls.yaml`) and
-   pages if the process stops.
+1. Confirm the monitor is running: `pgrep -x -U "$(id -u)" OverSight` prints a PID. User-scoped (`-U`)
+   exactly like the security-posture poller's probe, so another user's OverSight cannot mask a stopped
+   one here; the poller verifies this continuously (the `oversight` record in
+   `.chezmoidata/macos_posture_controls.yaml`) and pages if the process stops.
 
 ### Firewall log diagnostics
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -255,14 +255,18 @@ read_control() {
       # presence would report healthy for a quit monitor. classify_probe
       # cannot express pgrep, whose documented healthy-off form is a status,
       # not a needle (man page: exit 0 matched, 1 no match, 2 invalid
-      # options): exit 0 with pids on stdout is running; the no-match exit 1
-      # with no output at all is stopped; every other outcome (usage or
-      # internal error, a timeout kill, a status/output mismatch) is
-      # indeterminate, the same untrustworthy-failure discipline as the
-      # readers above -- a failed probe is never believed, whatever it
-      # printed.
+      # options): exit 0 with a WELL-FORMED pid list on stdout (digits, one
+      # pid per line, nothing else -- pgrep's only success output) is
+      # running; the no-match exit 1 with no output at all is stopped; every
+      # other outcome (usage or internal error, a timeout kill, a
+      # status/output mismatch in either direction) is indeterminate, the
+      # same untrustworthy-failure discipline as the readers above -- a
+      # probe whose status and output disagree is never believed, whatever
+      # it printed. The pairing is symmetric: exit 0 requires well-formed
+      # pid output exactly as exit 1 requires empty output.
+      local pid_list_pattern=$'^[0-9]+(\n[0-9]+)*$'
       output=$(run_bounded "$PGREP" -x -U "$UID" OverSight 2>&1) || rc=$?
-      if [[ $rc -eq 0 && -n $output ]]; then
+      if [[ $rc -eq 0 && $output =~ $pid_list_pattern ]]; then
         printf 'running'
       elif [[ $rc -eq 1 && -z $output ]]; then
         printf 'stopped'

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -35,6 +35,7 @@ FDESETUP="${OSQUERY_POSTURE_FDESETUP:-/usr/bin/fdesetup}"
 CSRUTIL="${OSQUERY_POSTURE_CSRUTIL:-/usr/bin/csrutil}"
 SYSADMINCTL="${OSQUERY_POSTURE_SYSADMINCTL:-/usr/sbin/sysadminctl}"
 DEFAULTS="${OSQUERY_POSTURE_DEFAULTS:-/usr/bin/defaults}"
+PGREP="${OSQUERY_POSTURE_PGREP:-/usr/bin/pgrep}"
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -132,6 +133,7 @@ reader_domain() {
   case "$1" in
     fdesetup_status | defaults_autologin) printf 'on off' ;;
     csrutil_status | sysadminctl_guest) printf 'enabled disabled' ;;
+    pgrep_oversight) printf 'running stopped' ;;
   esac
 }
 
@@ -240,6 +242,33 @@ read_control() {
     sysadminctl_guest)
       output=$(run_bounded "$SYSADMINCTL" -guestAccount status 2>&1) || rc=$?
       classify_probe "$output" "$rc" "Guest account enabled." enabled "Guest account disabled." disabled
+      ;;
+    pgrep_oversight)
+      # A live process-table read: OverSight's monitor is the application
+      # process itself. The installed bundle carries exactly one executable,
+      # Contents/MacOS/OverSight (CFBundleExecutable "OverSight",
+      # CFBundleIdentifier com.objective-see.oversight), and no LoginItems/
+      # or XPCServices/ helpers (verified 2026-07-27), so an exact-name match
+      # scoped to this user's session (-x -U) IS the running state.
+      # Deliberately NOT a bundle-presence check: /Applications/OverSight.app
+      # sits on disk whether or not the monitor is watching anything, so
+      # presence would report healthy for a quit monitor. classify_probe
+      # cannot express pgrep, whose documented healthy-off form is a status,
+      # not a needle (man page: exit 0 matched, 1 no match, 2 invalid
+      # options): exit 0 with pids on stdout is running; the no-match exit 1
+      # with no output at all is stopped; every other outcome (usage or
+      # internal error, a timeout kill, a status/output mismatch) is
+      # indeterminate, the same untrustworthy-failure discipline as the
+      # readers above -- a failed probe is never believed, whatever it
+      # printed.
+      output=$(run_bounded "$PGREP" -x -U "$UID" OverSight 2>&1) || rc=$?
+      if [[ $rc -eq 0 && -n $output ]]; then
+        printf 'running'
+      elif [[ $rc -eq 1 && -z $output ]]; then
+        printf 'stopped'
+      else
+        printf 'indeterminate'
+      fi
       ;;
     *)
       # Unreachable behind load_controls' reader validation; fail closed

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -27,7 +27,8 @@ function; the poller-vs-data agreement test holds the two together. */ -}}
       "fdesetup_status" (list "on" "off")
       "csrutil_status" (list "enabled" "disabled")
       "defaults_autologin" (list "on" "off")
-      "sysadminctl_guest" (list "enabled" "disabled") -}}
+      "sysadminctl_guest" (list "enabled" "disabled")
+      "pgrep_oversight" (list "running" "stopped") -}}
 {{- range .macos.posture_controls -}}
 {{-   if not (hasKey . "id") -}}
 {{-     fail "macos_posture_controls.yaml: a record has no id; every control needs one, it is the identity in every error and every page" -}}

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -206,6 +206,49 @@ esac
 SHIM
   chmod +x "$POLLER_HOME/bin/defaults"
 
+  # pgrep: only the exact user-scoped process-name read of OverSight (the
+  # oversight running-state reader) is legitimate; every other argv is a
+  # recorded violation. POLLER_PGREP_MODE models three outcomes (pgrep exit
+  # statuses verified against the installed binary and its man page: 0
+  # matched, 1 no match with no output, 2 invalid options): running (a pid on
+  # stdout, exit 0, the default), stopped (no output at all, exit 1), and
+  # error (a pid on stdout AND exit 2, the untrustworthy-failure form: output
+  # that LOOKS running with a failed status must never be believed).
+  # POLLER_PGREP_OUTPUT/POLLER_PGREP_EXIT override output and status directly
+  # for the remaining forms (exit 1 that still printed something, exit 0 that
+  # printed nothing); ${VAR+x} so a deliberately empty output is programmable.
+  cat >"$POLLER_HOME/bin/pgrep" <<'SHIM'
+#!/usr/bin/env bash
+printf 'pgrep %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ "$*" != "-x -U $(id -u) OverSight" ]]; then
+  printf 'pgrep %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+if [[ -n ${POLLER_PGREP_SLEEP:-} ]]; then
+  exec sleep "$POLLER_PGREP_SLEEP"
+fi
+if [[ -n ${POLLER_PGREP_OUTPUT+x} || -n ${POLLER_PGREP_EXIT:-} ]]; then
+  if [[ -n ${POLLER_PGREP_OUTPUT:-} ]]; then
+    printf '%s\n' "$POLLER_PGREP_OUTPUT"
+  fi
+  exit "${POLLER_PGREP_EXIT:-0}"
+fi
+case "${POLLER_PGREP_MODE:-running}" in
+  stopped)
+    exit 1
+    ;;
+  error)
+    printf '3424\n'
+    exit 2
+    ;;
+  *)
+    printf '3424\n'
+    exit 0
+    ;;
+esac
+SHIM
+  chmod +x "$POLLER_HOME/bin/pgrep"
+
   # Tools the poller has NO business invoking at all, status or otherwise: any
   # call is a recorded violation. run_poller prepends this bin dir to PATH, so
   # a stray PATH-resolved invocation is caught even without an env override.
@@ -272,6 +315,7 @@ run_poller() {
     OSQUERY_POSTURE_CSRUTIL="$POLLER_HOME/bin/csrutil" \
     OSQUERY_POSTURE_SYSADMINCTL="$POLLER_HOME/bin/sysadminctl" \
     OSQUERY_POSTURE_DEFAULTS="$POLLER_HOME/bin/defaults" \
+    OSQUERY_POSTURE_PGREP="$POLLER_HOME/bin/pgrep" \
     bash "$POLLER_TOOL" "$@"
 }
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -124,7 +124,9 @@ GOLDEN_EOF
 # The Tier 2 runner's 5774ce0 render plus the firewall-baseline records
 # (global state first; stealth and both signed-software policies after it),
 # plus the SSH drop-in record the ssh-configuration slice declared (no sudo
-# prefix by design: the script escalates per operation itself).
+# prefix by design: the script escalates per operation itself), plus the
+# MANUAL pointer for OverSight's interactive permission grants (a runbook
+# echo and no command, the OverSight-posture slice).
 # No manual logging record: firewall logging on this macOS version is on by
 # default and cannot be enabled by hand, so nothing renders for it.
 tier2_golden="$work/tier2.golden"
@@ -152,6 +154,7 @@ echo "→ Firewall: auto-allow incoming connections for downloaded signed softwa
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
 echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
 "$HOME/.local/bin/ssh-hardening.sh"
+echo '→ MANUAL OverSight: grant the microphone and camera permissions its monitoring needs: see the runbook section OverSight microphone and camera permission grants'
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -125,8 +125,10 @@ GOLDEN_EOF
 # (global state first; stealth and both signed-software policies after it),
 # plus the SSH drop-in record the ssh-configuration slice declared (no sudo
 # prefix by design: the script escalates per operation itself), plus the
-# MANUAL pointer for OverSight's interactive permission grants (a runbook
-# echo and no command, the OverSight-posture slice).
+# MANUAL pointer for OverSight's Notification Center delivery, its only
+# output channel (a runbook echo and no command, the OverSight-posture
+# slice; deliberately NOT a microphone or camera grant, which macOS never
+# presents for OverSight: no usage-description keys, no entitlements).
 # No manual logging record: firewall logging on this macOS version is on by
 # default and cannot be enabled by hand, so nothing renders for it.
 tier2_golden="$work/tier2.golden"
@@ -154,7 +156,7 @@ echo "→ Firewall: auto-allow incoming connections for downloaded signed softwa
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
 echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
 "$HOME/.local/bin/ssh-hardening.sh"
-echo '→ MANUAL OverSight: grant the microphone and camera permissions its monitoring needs: see the runbook section OverSight microphone and camera permission grants'
+echo '→ MANUAL OverSight: allow its Notification Center alerts (its only output channel): see the runbook section OverSight notification delivery'
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 

--- a/test/integration/macos-firewall-globalstate-order.sh
+++ b/test/integration/macos-firewall-globalstate-order.sh
@@ -30,10 +30,14 @@
 #      re-runs the whole list on any data change, so a toggle would flip
 #      protection OFF on the second run. Asserted over EVERY declared firewall
 #      command, not a count.
-#   5. The data declares NO manual records. The only one ever declared here
+#   5. Every manual record's runbook field resolves to a real markdown
+#      heading in the runbook, so no manual pointer can dangle. No FIREWALL
+#      manual record may exist at all: the only one ever declared here
 #      (firewall logging) described an action that does not exist on this
 #      macOS version, and a manual record no reader can complete is worse
-#      than no record; this pins its removal.
+#      than no record. (Non-firewall manual records are legitimate; the
+#      OverSight permission-grant record's own pins live in
+#      oversight-posture.sh.)
 #
 # Real chezmoi against the REAL .chezmoidata; nothing is executed, only
 # rendered.
@@ -46,6 +50,7 @@ unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_F
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
 SETUP_YAML="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
+RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
 
 # The tool is not on PATH; every declared command carries the absolute path.
 SOCKETFILTERFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
@@ -107,19 +112,31 @@ while IFS= read -r firewall_command; do
     fail "firewall command is not an idempotent set-to-state form: $firewall_command"
 done <"$declared_firewall_commands"
 
-# Criterion 5: this data file declares NO manual records, asserted explicitly
-# so nothing here passes by iterating an empty set. The only manual record
-# ever declared (firewall logging) described an action that cannot be
-# performed: socketfilterfw on 26.2 has no logging flag, and firewall
-# activity flows to the unified log by default, so there is nothing to enable
-# by hand. If a legitimate manual record lands later, replace this assertion
-# with a check that its runbook field resolves to a real markdown heading in
-# the runbook (see git history for the loop this replaced).
-manual_record_descriptions="$(yq eval -r \
-  '[.macos.system_setup[] | select(.tier == "manual") | .description] | join(", ")' \
+# Criterion 5: every manual record's runbook field resolves to a real
+# markdown heading in the runbook, so no manual pointer can dangle; and no
+# FIREWALL manual record exists. The only firewall manual record ever
+# declared (firewall logging) described an action that cannot be performed:
+# socketfilterfw on 26.2 has no logging flag, and firewall activity flows to
+# the unified log by default, so there is nothing to enable by hand.
+# Legitimate non-firewall manual records (the OverSight permission grants)
+# are validated by the resolution loop, not refused.
+firewall_manual_descriptions="$(yq eval -r \
+  '[.macos.system_setup[] | select(.tier == "manual" and (.description | test("(?i)firewall"))) | .description] | join(", ")' \
   "$SETUP_YAML")"
-[[ -z $manual_record_descriptions ]] ||
-  fail "this data file must declare no manual records (nothing firewall-manual exists to perform on this macOS version); found: $manual_record_descriptions"
+[[ -z $firewall_manual_descriptions ]] ||
+  fail "no firewall manual record may exist (nothing firewall-manual is performable on this macOS version); found: $firewall_manual_descriptions"
+
+manual_runbook_sections="$work/manual-runbook-sections"
+yq eval -r \
+  '.macos.system_setup[] | select(.tier == "manual") | .runbook // ""' \
+  "$SETUP_YAML" >"$manual_runbook_sections" ||
+  fail "could not enumerate the manual records' runbook fields"
+while IFS= read -r manual_runbook_section; do
+  [[ -n $manual_runbook_section ]] ||
+    fail "a manual record has an empty runbook field (the render would refuse it; this names the gap first)"
+  grep -qxF "### $manual_runbook_section" "$RUNBOOK" ||
+    fail "manual runbook pointer dangles: no '### $manual_runbook_section' heading in $RUNBOOK"
+done <"$manual_runbook_sections"
 
 # ---- render properties (criteria 1, 2, 3; darwin render only) ---------------
 
@@ -183,4 +200,4 @@ EOF
 cmp -s "$expected_rendered_firewall_lines" "$rendered_firewall_lines" ||
   fail "the render must contain exactly the four declared socketfilterfw command lines (diff: $(diff "$expected_rendered_firewall_lines" "$rendered_firewall_lines" || true))"
 
-printf 'macos-firewall-globalstate-order: OK (global state renders first; both signed-software policies render sudo-prefixed; the render carries exactly the four declared commands; every declared firewall command is set-to-state; the data declares no manual records)\n'
+printf 'macos-firewall-globalstate-order: OK (global state renders first; both signed-software policies render sudo-prefixed; the render carries exactly the four declared commands; every declared firewall command is set-to-state; no firewall manual record exists and every manual runbook pointer resolves)\n'

--- a/test/integration/macos-posture-controls-agreement.sh
+++ b/test/integration/macos-posture-controls-agreement.sh
@@ -80,6 +80,13 @@ while IFS=$'\t' read -r reader expect; do
     sysadminctl_guest)
       export POLLER_SYSADMINCTL_GUEST_OUTPUT="stub sysadminctl Guest account ${expect}."
       ;;
+    pgrep_oversight)
+      if [[ $expect == "running" ]]; then
+        export POLLER_PGREP_MODE=running
+      else
+        export POLLER_PGREP_MODE=stopped
+      fi
+      ;;
     *)
       fail "record reader '$reader' has no mapping here: add the poller reader, the harness stub, and this mapping together"
       ;;

--- a/test/integration/oversight-posture.sh
+++ b/test/integration/oversight-posture.sh
@@ -312,8 +312,10 @@ fi
 # an un-scoped pgrep would count another user's OverSight, so an operator
 # following the runbook could read running while this user's monitor is
 # stopped and the poller pages.
-grep -qF 'pgrep -x -U "$(id -u)" OverSight' <<<"$manual_runbook_body" ||
-  fail 'B5: the runbook running check must be user-scoped exactly like the poller probe: pgrep -x -U "$(id -u)" OverSight'
+# shellcheck disable=SC2016  # the non-expanding $(id -u) literal is the point
+user_scoped_runbook_probe='pgrep -x -U "$(id -u)" OverSight'
+grep -qF "$user_scoped_runbook_probe" <<<"$manual_runbook_body" ||
+  fail "B5: the runbook running check must be user-scoped exactly like the poller probe: $user_scoped_runbook_probe"
 if grep -qE 'pgrep -x OverSight' <<<"$manual_runbook_body"; then
   fail "B5: the runbook section still carries the un-scoped running check (pgrep -x OverSight), which another user's OverSight can satisfy"
 fi

--- a/test/integration/oversight-posture.sh
+++ b/test/integration/oversight-posture.sh
@@ -30,10 +30,12 @@
 #   B2 lifecycle: stopped pages EXACTLY ONE CRIT naming the control and its
 #      remedy, stays quiet while stopped, silently re-arms on restore, and a
 #      LATER stop pages again.
-#   B3 indeterminate: a probe that exits nonzero is INDETERMINATE, never
-#      running (and never stopped): pid-looking output with a failed status,
-#      the no-match status that still printed, and a zero exit with no output
-#      all gap; the baseline is byte-for-byte untouched.
+#   B3 indeterminate: a status/output MISMATCH is INDETERMINATE, never
+#      running (and never stopped), in BOTH directions: pid-looking output
+#      with a failed status, the no-match status that still printed, a zero
+#      exit with no output, and a zero exit with non-pid output all gap; the
+#      baseline is byte-for-byte untouched. Exit 0 requires a well-formed pid
+#      list exactly as exit 1 requires empty output.
 #   B4 tier guard: the shipped record is tier: verify; flipped to enforce it
 #      is refused by the render template AND by the poller before any probe
 #      runs.
@@ -117,6 +119,22 @@ assert_probe_argv "$probe_argv" 1 ||
 assert_baseline_scalar oversight running ||
   fail "B1: the baseline must record the oversight control as running"
 assert_no_mutation_attempt || fail "B1: a posture read must never mutate"
+teardown_poller_harness
+trap - EXIT
+
+# A multi-pid match is still well-formed running output: pgrep prints one pid
+# per line, so the well-formedness gate must accept the multi-line form, not
+# just a single pid (over-tightening it would gap a healthy monitor).
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$oversight_records"
+export POLLER_PGREP_OUTPUT=$'3424\n3425' POLLER_PGREP_EXIT=0
+run_poller >/dev/null 2>&1 || fail "B1 multi-pid: expected exit 0"
+assert_no_page || fail "B1 multi-pid: a multi-pid zero-exit match is running, never a gap"
+assert_baseline_scalar oversight running ||
+  fail "B1 multi-pid: the baseline must record the oversight control as running"
+unset POLLER_PGREP_OUTPUT POLLER_PGREP_EXIT
 teardown_poller_harness
 trap - EXIT
 
@@ -204,6 +222,11 @@ run_indeterminate_case 'exit-1-with-output' POLLER_PGREP_OUTPUT=3424 POLLER_PGRE
 # A zero exit that printed nothing: pgrep always prints the matched pids on
 # success, so an empty success is unreadable, not running.
 run_indeterminate_case 'exit-0-without-output' POLLER_PGREP_OUTPUT= POLLER_PGREP_EXIT=0
+# A zero exit whose output is not a pid list: the mismatch in the other
+# direction. pgrep's success output is one pid per line and nothing else, so
+# a success that printed anything else is unreadable, never running; exit 0
+# requires well-formed pid output exactly as exit 1 requires empty output.
+run_indeterminate_case 'exit-0-with-malformed-output' POLLER_PGREP_OUTPUT='pgrep: not a pid list' POLLER_PGREP_EXIT=0
 
 # ---- B4: the tier guard refuses the record flipped to enforce ----------------
 

--- a/test/integration/oversight-posture.sh
+++ b/test/integration/oversight-posture.sh
@@ -285,5 +285,14 @@ grep -qF 'System Settings → Notifications' <<<"$manual_runbook_body" ||
 if grep -qE 'Privacy & Security → (Microphone|Camera)' <<<"$manual_runbook_body"; then
   fail "B5: the runbook section must not direct a Privacy & Security microphone or camera grant; macOS never presents that pane entry for OverSight, so the step cannot be completed"
 fi
+# The runbook's running check must be the poller's own probe, user-scoped:
+# an un-scoped pgrep would count another user's OverSight, so an operator
+# following the runbook could read running while this user's monitor is
+# stopped and the poller pages.
+grep -qF 'pgrep -x -U "$(id -u)" OverSight' <<<"$manual_runbook_body" ||
+  fail 'B5: the runbook running check must be user-scoped exactly like the poller probe: pgrep -x -U "$(id -u)" OverSight'
+if grep -qE 'pgrep -x OverSight' <<<"$manual_runbook_body"; then
+  fail "B5: the runbook section still carries the un-scoped running check (pgrep -x OverSight), which another user's OverSight can satisfy"
+fi
 
 printf 'ok: OverSight posture records (process probe, page-once lifecycle, indeterminate discipline, tier guard, manual notification delivery)\n'

--- a/test/integration/oversight-posture.sh
+++ b/test/integration/oversight-posture.sh
@@ -13,10 +13,13 @@
 #      is itself the proof that the state comes from the probe and not the
 #      disk, because on the development machine the bundle exists while the
 #      stub says stopped, and the poller pages anyway.
-#   2. A manual record for OverSight's microphone and camera permission
-#      grants (interactive-only; no supported command line writes them),
-#      declared in macos_system_setup.yaml with a runbook pointer whose
-#      section must exist.
+#   2. A manual record for OverSight's Notification Center delivery
+#      (interactive-only; no supported command line writes it), declared in
+#      macos_system_setup.yaml with a runbook pointer whose section must
+#      exist. Deliberately NOT a microphone or camera permission record: the
+#      installed bundle declares no usage-description keys and no
+#      entitlements, so macOS never offers those grants and OverSight never
+#      asks (it observes device activation events, not device content).
 #
 # The behaviours, each against the REAL repo record (extracted from
 # .chezmoidata/macos_posture_controls.yaml, so a fixture cannot drift from
@@ -34,9 +37,11 @@
 #   B4 tier guard: the shipped record is tier: verify; flipped to enforce it
 #      is refused by the render template AND by the poller before any probe
 #      runs.
-#   B5 manual record: the permission-grant record exists in
-#      macos_system_setup.yaml at tier: manual with no mutating payload, and
-#      the runbook section it names exists.
+#   B5 manual record: the notification-delivery record exists in
+#      macos_system_setup.yaml at tier: manual with no mutating payload, the
+#      runbook section it names exists, the section directs the operator at
+#      the Notifications pane, and neither the record nor the section directs
+#      the ungrantable microphone or camera privacy step.
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -237,20 +242,48 @@ assert_page_body_has 'oversight' || fail "B4: the refusal page must name the rec
 assert_no_probe_calls || fail "B4: a refused file must be rejected BEFORE any probe runs"
 teardown_poller_harness
 
-# ---- B5: the manual permission-grant record and its runbook section ----------
+# ---- B5: the manual notification-delivery record and its runbook section -----
+
+# The interactive dependency is Notification Center delivery, NOT a
+# microphone or camera privacy grant. Measured on the installed 2.4.0 bundle:
+# no NS*UsageDescription keys in Info.plist and an empty entitlements dict
+# under the hardened runtime, so macOS never presents a Microphone or Camera
+# grant for it (its TCC table is empty on a working install); it observes
+# device ACTIVATION EVENTS through CoreMediaIO property listeners, never
+# device content. Its only output is a notification: with delivery denied the
+# monitor observes correctly and tells nobody, a dead alert channel that
+# reads as healthy. So the record must direct the operator at notification
+# delivery, and the runbook section must name the pane an operator can
+# actually use, never the Privacy & Security step no reader can complete.
 
 manual_records="$(yq -o=json '[.macos.system_setup[] | select(.tier == "manual" and (.description | contains("OverSight")))]' "$SETUP_FILE")" ||
   fail "B5: could not read macos_system_setup.yaml"
 jq -e 'length == 1' <<<"$manual_records" >/dev/null ||
-  fail "B5: exactly one manual OverSight permission-grant record must be declared in macos_system_setup.yaml"
+  fail "B5: exactly one manual OverSight record must be declared in macos_system_setup.yaml"
 echo "$manual_records" | jq -e '.[0] | (has("command") or has("sudo")) | not' >/dev/null ||
-  fail "B5: the manual record must carry no mutating payload (the grants are interactive-only)"
+  fail "B5: the manual record must carry no mutating payload (the authorization is interactive-only)"
+manual_description="$(jq -r '.[0].description' <<<"$manual_records")"
+grep -qiE 'notification' <<<"$manual_description" ||
+  fail "B5: the manual record must direct the operator at notification delivery (the monitor's only output channel); got '$manual_description'"
+if grep -qiE 'microphone|camera' <<<"$manual_description"; then
+  fail "B5: the manual record must not describe a microphone or camera grant; macOS never presents one for OverSight (no usage-description keys, no entitlements) and it needs none; got '$manual_description'"
+fi
 manual_runbook="$(jq -r '.[0].runbook // empty' <<<"$manual_records")"
 [[ -n $manual_runbook ]] ||
   fail "B5: the manual record must name its runbook section"
 grep -qxF "### $manual_runbook" "$RUNBOOK" ||
   fail "B5: the runbook section '### $manual_runbook' must exist in $RUNBOOK"
-grep -qiE 'microphone' <<<"$(jq -r '.[0].description' <<<"$manual_records")" ||
-  fail "B5: the manual record's description must say what is being granted (microphone)"
+manual_runbook_body="$(awk -v heading="### $manual_runbook" '
+  $0 == heading { in_section = 1; next }
+  in_section && /^### / { exit }
+  in_section { print }
+' "$RUNBOOK")"
+[[ -n ${manual_runbook_body//[[:space:]]/} ]] ||
+  fail "B5: the runbook section '### $manual_runbook' has an empty body"
+grep -qF 'System Settings → Notifications' <<<"$manual_runbook_body" ||
+  fail "B5: the runbook section must name the concrete pane the operator uses (System Settings → Notifications)"
+if grep -qE 'Privacy & Security → (Microphone|Camera)' <<<"$manual_runbook_body"; then
+  fail "B5: the runbook section must not direct a Privacy & Security microphone or camera grant; macOS never presents that pane entry for OverSight, so the step cannot be completed"
+fi
 
-printf 'ok: OverSight posture records (process probe, page-once lifecycle, indeterminate discipline, tier guard, manual grants)\n'
+printf 'ok: OverSight posture records (process probe, page-once lifecycle, indeterminate discipline, tier guard, manual notification delivery)\n'

--- a/test/integration/oversight-posture.sh
+++ b/test/integration/oversight-posture.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# oversight-posture.sh -- slice 9: OverSight's two posture records.
+#
+#   1. A verify-tier control asserting the OverSight monitor PROCESS is
+#      actually running, read by the security-posture poller through the
+#      pgrep_oversight reader. The check is a live process-table probe,
+#      deliberately NOT the presence of /Applications/OverSight.app on disk:
+#      the bundle sits on disk whether or not the monitor is watching
+#      anything, so presence-on-disk would report healthy for a quit monitor.
+#      Every behaviour below drives the REAL poller against a STUBBED pgrep,
+#      so the suite passes regardless of whether OverSight is running (or even
+#      installed) on the machine running it; the stopped-lifecycle behaviour
+#      is itself the proof that the state comes from the probe and not the
+#      disk, because on the development machine the bundle exists while the
+#      stub says stopped, and the poller pages anyway.
+#   2. A manual record for OverSight's microphone and camera permission
+#      grants (interactive-only; no supported command line writes them),
+#      declared in macos_system_setup.yaml with a runbook pointer whose
+#      section must exist.
+#
+# The behaviours, each against the REAL repo record (extracted from
+# .chezmoidata/macos_posture_controls.yaml, so a fixture cannot drift from
+# what ships):
+#
+#   B1 healthy: monitor running -> silent tick, exactly one exact-argv pgrep
+#      probe, the baseline gains oversight/oversight:expect.
+#   B2 lifecycle: stopped pages EXACTLY ONE CRIT naming the control and its
+#      remedy, stays quiet while stopped, silently re-arms on restore, and a
+#      LATER stop pages again.
+#   B3 indeterminate: a probe that exits nonzero is INDETERMINATE, never
+#      running (and never stopped): pid-looking output with a failed status,
+#      the no-match status that still printed, and a zero exit with no output
+#      all gap; the baseline is byte-for-byte untouched.
+#   B4 tier guard: the shipped record is tier: verify; flipped to enforce it
+#      is refused by the render template AND by the poller before any probe
+#      runs.
+#   B5 manual record: the permission-grant record exists in
+#      macos_system_setup.yaml at tier: manual with no mutating payload, and
+#      the runbook section it names exists.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DATA_FILE="$REPO_ROOT/.chezmoidata/macos_posture_controls.yaml"
+SETUP_FILE="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
+TEMPLATE="$REPO_ROOT/dot_local/libexec/osquery/posture-controls.json.tmpl"
+RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
+
+# shellcheck source=../fixtures/osquery-poller-lib.bash
+source "$REPO_ROOT/test/fixtures/osquery-poller-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in yq jq chezmoi; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the OverSight posture records\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$DATA_FILE" "$SETUP_FILE" "$TEMPLATE" "$RUNBOOK"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+# ---- the shipped record, extracted so no fixture can drift from it ----------
+
+oversight_records="$(yq -o=json '[.macos.posture_controls[] | select(.id == "oversight")]' "$DATA_FILE")" ||
+  fail "could not read the oversight record from $DATA_FILE"
+jq -e 'length == 1' <<<"$oversight_records" >/dev/null ||
+  fail "exactly one oversight record must be declared in macos_posture_controls.yaml"
+oversight_tier="$(jq -r '.[0].tier' <<<"$oversight_records")"
+oversight_reader="$(jq -r '.[0].reader' <<<"$oversight_records")"
+oversight_expect="$(jq -r '.[0].expect' <<<"$oversight_records")"
+oversight_description="$(jq -r '.[0].description' <<<"$oversight_records")"
+oversight_remedy="$(jq -r '.[0].remedy // empty' <<<"$oversight_records")"
+
+[[ $oversight_tier == "verify" ]] ||
+  fail "the oversight record must be tier: verify (an apply-time runner must never restart an operator-quit login item); got '$oversight_tier'"
+[[ $oversight_reader == "pgrep_oversight" ]] ||
+  fail "the oversight record must be read by the pgrep_oversight process probe; got '$oversight_reader'"
+[[ $oversight_expect == "running" ]] ||
+  fail "the oversight record must expect 'running'; got '$oversight_expect'"
+[[ -n $oversight_remedy ]] ||
+  fail "the oversight record must carry a remedy (the page's fix-it line)"
+
+healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","oversight":"running","oversight:expect":"running"}'
+probe_argv="pgrep -x -U $(id -u) OverSight"
+
+# ---- B1: healthy tick -- a live process probe, silent, baselined -------------
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$oversight_records"
+export POLLER_PGREP_MODE=running
+
+poller_status=0
+poller_output="$(run_poller 2>&1)" || poller_status=$?
+[[ $poller_status -eq 0 ]] ||
+  fail "B1: a healthy tick must exit 0, got $poller_status: $poller_output"
+assert_no_page || fail "B1: a running monitor must page nothing"
+# The probe is the process table, by exact argv: the user-scoped exact-name
+# pgrep match on the pinned process identity, exactly once. A bundle-presence
+# check would never invoke pgrep at all.
+assert_probe_argv "$probe_argv" 1 ||
+  fail "B1: the poller must probe the process table exactly once, with the pinned identity"
+assert_baseline_scalar oversight running ||
+  fail "B1: the baseline must record the oversight control as running"
+assert_no_mutation_attempt || fail "B1: a posture read must never mutate"
+teardown_poller_harness
+trap - EXIT
+
+# ---- B2: lifecycle -- one page per stop, quiet while down, re-arm on restore --
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$oversight_records"
+seed_baseline "$healthy_seed"
+
+export POLLER_PGREP_MODE=stopped
+poller_status=0
+run_poller >/dev/null 2>&1 || poller_status=$?
+[[ $poller_status -eq 0 ]] || fail "B2 tick 1: expected exit 0, got $poller_status"
+assert_page_count 1 || fail "B2 tick 1: the stop must page exactly once"
+assert_page_severity_is CRIT || fail "B2 tick 1: the stop page must be CRIT"
+assert_page_body_has "\`$oversight_description\`: now stopped, declared running" ||
+  fail "B2 tick 1: the page must name the control and the stopped-vs-declared state"
+assert_page_body_has "$oversight_remedy" ||
+  fail "B2 tick 1: the page must carry the declared remedy"
+# Notify-before-persist: at page time the baseline still held the prior state.
+assert_page_saw_baseline "$healthy_seed" ||
+  fail "B2 tick 1: the baseline must not advance before the page is queued"
+assert_baseline_scalar oversight stopped ||
+  fail "B2 tick 1: after the queued page the baseline must advance to stopped"
+
+run_poller >/dev/null 2>&1 || fail "B2 tick 2: expected exit 0"
+assert_page_count 1 || fail "B2 tick 2: an ONGOING stop must stay quiet (page-once)"
+
+export POLLER_PGREP_MODE=running
+run_poller >/dev/null 2>&1 || fail "B2 tick 3: expected exit 0"
+assert_page_count 1 || fail "B2 tick 3: a restore is silent recovery, not a page"
+assert_baseline_scalar oversight running ||
+  fail "B2 tick 3: the restore must clear the marker (baseline back to running)"
+
+export POLLER_PGREP_MODE=stopped
+run_poller >/dev/null 2>&1 || fail "B2 tick 4: expected exit 0"
+assert_page_count 2 || fail "B2 tick 4: a LATER stop must page again"
+assert_no_mutation_attempt || fail "B2: the lifecycle must never mutate"
+teardown_poller_harness
+trap - EXIT
+
+# ---- B3: probe failures are indeterminate, never running, never stopped ------
+
+# <label> <env-assignments...>: run one tick under the given probe form and
+# require a monitoring-gap page naming the control, with the baseline
+# byte-for-byte untouched (nothing was believed, nothing advanced).
+run_indeterminate_case() {
+  local label="$1"
+  shift
+  local poller_status=0 env_assignment
+
+  setup_poller_harness
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  set_posture_controls "$oversight_records"
+  seed_baseline "$healthy_seed"
+  snapshot_baseline
+  for env_assignment in "$@"; do
+    export "${env_assignment?}"
+  done
+
+  run_poller >/dev/null 2>&1 || poller_status=$?
+  [[ $poller_status -eq 0 ]] ||
+    fail "B3 $label: expected exit 0 after paging the gap, got $poller_status"
+  assert_page_count 1 || fail "B3 $label: an unreadable probe must page a monitoring gap"
+  assert_page_severity_is CRIT || fail "B3 $label: the gap page must be CRIT"
+  assert_page_body_has 'monitoring gap' || fail "B3 $label: the page must name the gap"
+  assert_page_body_has 'oversight' || fail "B3 $label: the gap page must name the control"
+  assert_baseline_unchanged ||
+    fail "B3 $label: an indeterminate read must never advance the baseline"
+  assert_no_mutation_attempt || fail "B3 $label: the failure path must never mutate"
+
+  for env_assignment in "$@"; do
+    unset "${env_assignment%%=*}"
+  done
+  teardown_poller_harness
+}
+
+# A pid on stdout with a failed exit: running-looking output is never believed.
+run_indeterminate_case 'failure-with-pid-output' POLLER_PGREP_MODE=error
+# The no-match status that still printed something: not the documented silent
+# no-match, so never classified stopped.
+run_indeterminate_case 'exit-1-with-output' POLLER_PGREP_OUTPUT=3424 POLLER_PGREP_EXIT=1
+# A zero exit that printed nothing: pgrep always prints the matched pids on
+# success, so an empty success is unreadable, not running.
+run_indeterminate_case 'exit-0-without-output' POLLER_PGREP_OUTPUT= POLLER_PGREP_EXIT=0
+
+# ---- B4: the tier guard refuses the record flipped to enforce ----------------
+
+# (a) at render time: the template aborts, naming the record and the tier.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+render_home="$sandbox/render-home"
+mkdir -p "$render_home"
+flip_source="$sandbox/flip-src"
+mkdir -p "$flip_source/.chezmoidata"
+cp "$DATA_FILE" "$flip_source/.chezmoidata/macos_posture_controls.yaml"
+yq -i '(.macos.posture_controls[] | select(.id == "oversight")).tier = "enforce"' \
+  "$flip_source/.chezmoidata/macos_posture_controls.yaml" ||
+  fail "B4: could not flip the oversight tier in the fixture copy"
+render_status=0
+HOME="$render_home" chezmoi --source "$flip_source" execute-template --no-tty \
+  <"$TEMPLATE" >"$sandbox/render.out" 2>"$sandbox/render.err" || render_status=$?
+[[ $render_status -ne 0 ]] ||
+  fail "B4: the render must refuse the oversight record at tier enforce (rendered: $(cat "$sandbox/render.out"))"
+grep -qF 'oversight' "$sandbox/render.err" ||
+  fail "B4: the render refusal must name the record (stderr: $(cat "$sandbox/render.err"))"
+grep -qF 'tier "enforce"' "$sandbox/render.err" ||
+  fail "B4: the render refusal must name the offending tier (stderr: $(cat "$sandbox/render.err"))"
+
+# (b) at runtime: the poller refuses the deployed file BEFORE any probe runs.
+setup_poller_harness
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$(jq 'map(.tier = "enforce")' <<<"$oversight_records")"
+seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+poller_status=0
+run_poller >/dev/null 2>&1 || poller_status=$?
+[[ $poller_status -eq 0 ]] ||
+  fail "B4: expected exit 0 after paging the refused file, got $poller_status"
+assert_page_count 1 || fail "B4: a mis-tiered deployed file must page a monitoring gap"
+assert_page_body_has 'oversight' || fail "B4: the refusal page must name the record"
+assert_no_probe_calls || fail "B4: a refused file must be rejected BEFORE any probe runs"
+teardown_poller_harness
+
+# ---- B5: the manual permission-grant record and its runbook section ----------
+
+manual_records="$(yq -o=json '[.macos.system_setup[] | select(.tier == "manual" and (.description | contains("OverSight")))]' "$SETUP_FILE")" ||
+  fail "B5: could not read macos_system_setup.yaml"
+jq -e 'length == 1' <<<"$manual_records" >/dev/null ||
+  fail "B5: exactly one manual OverSight permission-grant record must be declared in macos_system_setup.yaml"
+echo "$manual_records" | jq -e '.[0] | (has("command") or has("sudo")) | not' >/dev/null ||
+  fail "B5: the manual record must carry no mutating payload (the grants are interactive-only)"
+manual_runbook="$(jq -r '.[0].runbook // empty' <<<"$manual_records")"
+[[ -n $manual_runbook ]] ||
+  fail "B5: the manual record must name its runbook section"
+grep -qxF "### $manual_runbook" "$RUNBOOK" ||
+  fail "B5: the runbook section '### $manual_runbook' must exist in $RUNBOOK"
+grep -qiE 'microphone' <<<"$(jq -r '.[0].description' <<<"$manual_records")" ||
+  fail "B5: the manual record's description must say what is being granted (microphone)"
+
+printf 'ok: OverSight posture records (process probe, page-once lifecycle, indeterminate discipline, tier guard, manual grants)\n'

--- a/test/unit/macos-posture-indeterminate.sh
+++ b/test/unit/macos-posture-indeterminate.sh
@@ -47,9 +47,10 @@ run_case() { # <control-id> <env-assignment VAR=VALUE>
     {"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on"},
     {"id":"sip","description":"System Integrity Protection","tier":"verify","reader":"csrutil_status","expect":"disabled"},
     {"id":"autologin","description":"Automatic login at the login window","tier":"verify","reader":"defaults_autologin","expect":"off"},
-    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"}
+    {"id":"guest","description":"The macOS Guest account","tier":"verify","reader":"sysadminctl_guest","expect":"disabled"},
+    {"id":"oversight","description":"The OverSight microphone and camera monitor process","tier":"verify","reader":"pgrep_oversight","expect":"running"}
   ]'
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on","sip":"disabled","sip:expect":"disabled","autologin":"off","autologin:expect":"off","guest":"disabled","guest:expect":"disabled","oversight":"running","oversight:expect":"running"}'
   snapshot_baseline
 
   export "${env_assignment?}" # the untrustworthy-failure form for this control
@@ -82,5 +83,8 @@ run_case filevault POLLER_FDESETUP_EXIT=1
 run_case sip POLLER_CSRUTIL_EXIT=1
 run_case autologin POLLER_DEFAULTS_AUTOLOGIN_MODE=unreadable
 run_case guest POLLER_SYSADMINCTL_GUEST_EXIT=1
+# pgrep's untrustworthy-failure form: a pid on stdout (running-looking) with a
+# failed exit status. Only exit 0 may ever read as running.
+run_case oversight POLLER_PGREP_MODE=error
 
 printf 'ok: untrustworthy probe failures are indeterminate for every declared control\n'


### PR DESCRIPTION
## Context

A background tool on this machine watches for the microphone or camera switching on and raises a
notification when it happens. Nothing was checking whether that tool was actually running, so it could be
quit weeks ago and the machine would look exactly as healthy as one being watched.

This adds two declarations: one the machine can check by itself every minute, and one that only a person
can do, with the steps written down. The tool is already installed and this changes nothing about it.

## Summary

- The machine now notices within a minute if the watcher stops running, and says so once.
- It notices again if the watcher is stopped a second time, rather than going quiet forever.
- A check that cannot be trusted is reported as unknown, never as healthy.
- The person-only step now describes something that can actually be done, replacing one that could not.
- The written instructions and the automatic check now ask the same question the same way.

## Checking the tool, not the icon

The easy check is whether the application exists on disk. It does, right now, and would keep saying yes
for months after someone quit it. So the check asks whether the monitoring process is genuinely running,
scoped to this login session, so that a copy running under another account cannot stand in for one that
has stopped here.

Three answers are possible, not two: running, stopped, and unknown. The middle one is the alarm, and the
last one exists because a check that failed to run has told you nothing. Both directions are pinned: a
failed check that happens to print something plausible is not believed, and a successful check that
prints something unreadable is not believed either.

## The instruction that could not be followed

The person-only step originally said to grant the watcher permission to use the microphone and camera.
Review found that this is impossible, and measuring the installed application confirmed it several ways:
it declares no such permission requests, holds no privacy grants at all in the system's own database
while working correctly, and never calls the function that would ask for one. It watches for devices
turning on, which is an observable event, rather than looking at what they capture, which is the part
that would need permission.

Following that instruction would have led to a settings pane where the tool never appears, leaving the
operator unable to tell whether they had done it wrong or been told wrong. That is worse than no
instruction, because it makes the surrounding steps untrustworthy at exactly the moment someone is
following them carefully.

What the tool genuinely depends on is permission to show notifications, which is its only output. Denied
that, it watches correctly and tells nobody, which reads as healthy from every direction. The binary
itself carries an error message for precisely this case, which is how the dependency was confirmed rather
than assumed. That is now what the record tracks, with the concrete steps written down, including an
explicit note that there is nothing to grant under privacy settings and why.

## What is not covered

Nothing here can prove the watcher is doing its job, only that it is running and can be heard from. Its
notification permission is checked by a person, not by the machine, because there is no supported way to
read that state without granting this repository's tooling broader access than it should have.

Two weaknesses in the surrounding machinery were found during review, confirmed to predate this change,
and filed separately rather than widened into it: a suppression marker that can stick after the condition
clears, and an empty settings file that is accepted as though it simply had nothing to say.

## Effect of merging

Advances `main` only. The live machine follows another branch, nothing is installed or configured, and no
permission is changed by applying this.
