### PR TITLE
chore(brew): declare fluidvoice, minutes, ollama and silverstein/tap

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -12,6 +12,7 @@ packages:
         - openhue/cli
         - oven-sh/bun
         - owenthereal/upterm
+        - silverstein/tap
         - rjyo/moshi
         - steipete/tap
         - vjeantet/tap
@@ -35,6 +36,7 @@ packages:
         - openhue/cli
         - oven-sh/bun
         - owenthereal/upterm
+        - silverstein/tap
         - rjyo/moshi
         - steipete/tap
         - vjeantet/tap
@@ -112,6 +114,7 @@ packages:
         - nmap
         - node
         - obsidian-cli
+        - ollama
         - onefetch
         - openai-whisper
         - openhue/cli/openhue-cli
@@ -179,6 +182,7 @@ packages:
         - espanso
         - fantastical
         - firefox
+        - fluidvoice
         - font-fira-code
         - font-fira-code-nerd-font
         - font-symbols-only-nerd-font
@@ -192,6 +196,7 @@ packages:
         - mediosz/tap/swipeaerospace
         - microsoft-auto-update
         - microsoft-office
+        - minutes
         - mitmproxy
         - nikitabobko/tap/aerospace
         - obs


### PR DESCRIPTION
## Context

The package manifest is the list this machine's setup is rebuilt from, and the cleanup step removes
anything installed but not listed. Four things in daily use were missing from it, so the upcoming switch
to this branch would have uninstalled them.

## Summary

- Declares four installed items that the cleanup step would otherwise remove.
- Adds the tap one of them is published from, in both places taps have to be listed.
- Leaves the retired auto-update tap out on purpose, so cleanup removes it as intended.

## What was added

| Item | Kind | Why |
|---|---|---|
| fluidvoice | cask | In daily use |
| minutes | cask | Meeting manager |
| silverstein/tap | tap | Where `minutes` comes from |
| ollama | formula | Local model runtime |

Taps have to appear in two lists: the tap list itself, and the trust list that lets the bundle load
formulae from it. Both were updated together, and a check confirms the two lists still match.

## One deliberate omission

The automatic-update tap is installed on this machine but is **not** being re-declared. It was dropped
from the manifest when the weekly upgrade recipe replaced what it did, so cleanup removing it is the
intended outcome rather than an oversight.

## How the gap was found

By comparing what is installed against what is declared. An earlier version of that comparison produced
false positives, because the installed list prints short names while the manifest declares several items
with their tap prefix, so entries that were present looked missing. The window manager and its companion
were both flagged that way and are in fact declared. The list above is what survived comparing normalised
names, and only top-level installs were considered, so dependencies pulled in by other packages are not
counted as gaps.

## Effect of merging

Advances `main` only, and changes nothing on any machine until the settings are applied. Nothing here
installs, removes, or upgrades anything by itself.
