### PR TITLE
fix(shell): stop the himalaya completion syntax error in every new shell

### DIFF
--- a/.chezmoiscripts/run_onchange_after_20-himalaya-completion.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-himalaya-completion.sh.tmpl
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Generate a WORKING bash completion for himalaya into the XDG completions
+# directory.
+#
+# Why this exists: himalaya 2.0.0's `completion bash` does not print the script
+# to stdout. It WRITES `himalaya.bash` into the current working directory and
+# prints a status line ("1 completion script(s) successfully generated in ...")
+# to stdout. The Homebrew formula redirects stdout into
+# etc/bash_completion.d/himalaya, so the installed file is that prose, and bash
+# reports a syntax error on its `(` in every new shell. bash-completion sources
+# that directory eagerly, which is why dot_bashrc.tmpl also sets
+# BASH_COMPLETION_COMPAT_IGNORE=himalaya to skip the broken file.
+#
+# This script takes the file the subcommand actually writes. It is a
+# run_onchange keyed on the installed version, so a himalaya upgrade
+# regenerates the completion, and a future release that fixes the subcommand
+# does not silently leave a stale copy behind.
+#
+# himalaya version: {{ output "sh" "-c" "himalaya --version 2>/dev/null | head -1 || echo none" | trim }}
+#
+# `head -1` is load-bearing: `himalaya --version` prints THREE lines (version,
+# build platform, git revision). Interpolating all of them here left lines two
+# and three OUTSIDE the comment, where the shell tried to execute them.
+set -euo pipefail
+
+readonly COMPLETION_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+readonly TARGET="$COMPLETION_DIR/himalaya"
+
+if ! command -v himalaya >/dev/null 2>&1; then
+  printf 'himalaya-completion: himalaya is not installed; nothing to generate.\n'
+  exit 0
+fi
+
+work_dir="$(mktemp -d)"
+if [[ -z $work_dir || ! -d $work_dir ]]; then
+  printf 'himalaya-completion: could not create a working directory; refusing to continue.\n' >&2
+  exit 1
+fi
+trap 'rm -rf "$work_dir"' EXIT
+
+# The subcommand writes into the working directory, so run it from there.
+if ! (cd "$work_dir" && himalaya completion bash >/dev/null 2>&1); then
+  printf 'himalaya-completion: the completion subcommand failed; leaving any existing completion alone.\n' >&2
+  exit 1
+fi
+
+generated="$work_dir/himalaya.bash"
+if [[ ! -s $generated ]]; then
+  printf 'himalaya-completion: the subcommand produced no completion file; leaving any existing completion alone.\n' >&2
+  exit 1
+fi
+
+# Reject the prose the formula captured, in case a future release starts
+# printing to stdout AND writing the file: a completion script defines the
+# function, a status line does not.
+if ! grep -q '^_himalaya()' "$generated"; then
+  printf 'himalaya-completion: the generated file does not define _himalaya; refusing to install it.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$COMPLETION_DIR"
+# Publish with one rename so a partially written file is never sourced.
+staging="$COMPLETION_DIR/.himalaya.staging"
+cp -- "$generated" "$staging"
+chmod 0644 "$staging"
+mv -f -- "$staging" "$TARGET"
+
+printf 'himalaya-completion: installed %s\n' "$TARGET"

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -60,6 +60,20 @@ path_prepend "${HOMEBREW_PREFIX}/sbin"
 export SHELL="${HOMEBREW_PREFIX}/bin/bash"
 
 # General Homebrew-Bash completions.
+#
+# BASH_COMPLETION_COMPAT_IGNORE skips a compat file by basename. himalaya 2.0.0
+# ships a broken one: its `completion bash` subcommand WRITES the script to a
+# file in the working directory and prints a status line to stdout, so the
+# formula's `himalaya completion bash > .../himalaya` captured the status line
+# instead. The installed file is two lines of prose, and bash reports a syntax
+# error on the `(` in "1 completion script(s) successfully generated" in every
+# new shell. bash-completion sources that directory eagerly, so shadowing the
+# file from the XDG completions directory is not enough on its own.
+#
+# The working completion is generated into the XDG directory by
+# run_onchange_after_20-himalaya-completion.sh.tmpl, which takes the file the
+# subcommand actually writes rather than its stdout.
+export BASH_COMPLETION_COMPAT_IGNORE='himalaya'
 bash_completion="${HOMEBREW_PREFIX}/opt/bash-completion@2/etc/profile.d/bash_completion.sh"
 [[ -r $bash_completion ]] && . "$bash_completion"
 


### PR DESCRIPTION
## Context

Every new terminal pane has been printing a syntax error from a mail client's tab-completion file. The
file is installed by the package manager and is not a script at all: it contains two lines of status
text, and the shell chokes on a bracket in the phrase.

The cause is a change in the tool rather than a mistake in the packaging. Its completion command used to
print the script; it now writes the script to a file and prints a progress message instead. The package
recipe still captures what is printed, so it captures the progress message.

## Summary

- New panes stop printing a syntax error.
- Tab completion for that tool starts working again, from a correctly generated file.
- The generated file is refreshed whenever the tool is upgraded.
- Nothing installed by the package manager is edited or patched.

## How it is fixed

Two separate problems, because fixing one alone would leave the other.

The broken file has to be skipped. Completion files in that directory are read eagerly at shell start, so
simply providing a better one elsewhere does not stop the bad one being read. There is a supported
setting that skips a file there by name, and it is now set before completions load.

A working file has to exist. A small script asks the tool to generate its completion, takes the file the
tool actually writes rather than what it prints, and installs that into the per-user completions
directory. It runs whenever the installed version changes, so an upgrade refreshes it.

The generator refuses to install anything that does not define the expected completion function. So if a
future release goes back to printing the script, the progress message cannot quietly reappear as a
completion file.

## Two bugs caught before this shipped

Both were found by running the generator rather than reading it, and both are shapes this repository has
been bitten by before.

Asking the tool for its version returns **three** lines, not one. Putting that into a single-line comment
left the second and third lines outside the comment, where the shell tried to run them. One of them
looked enough like a command to produce a confusing error. The fix keeps only the first line, and says
why in place so it does not get tidied away later.

A message quoting the failing command used backticks inside single quotes, which the shell linter
rejects. It was reworded rather than escaped.

The second one is worth noting because the same lint failure is currently blocking another branch, and it
would have blocked this one too had it not been caught locally.

## What this does not do

Nothing here changes the mail client, its configuration, or anything the package manager installed. It
also does not fix the packaging upstream; that is worth reporting separately, and until it is fixed this
handles it locally without touching their files.

## Effect of merging

Advances `main` only. The live machine follows another branch, so panes keep printing the error until the
settings are applied there.
