### PR TITLE
feat(macos): declare the LuLu firewall policy and posture as watched controls

### DIFF
--- a/.chezmoidata/macos_defaults.yaml
+++ b/.chezmoidata/macos_defaults.yaml
@@ -114,6 +114,92 @@ macos:
       type: bool
       value: false
       tier: enforce
+    # LuLu outbound-firewall policy (slice 10). Six records, one per policy
+    # preference, each declaring the value the live machine carried on
+    # 2026-07-27: the slice codifies todays posture so a later change is
+    # visible instead of silent; it changes nothing. The plist is LuLu's own
+    # absolute path (plain XML, world-readable, root-writable), not a
+    # /Library/Preferences domain, so each record rides slice 2's explicit
+    # plist_path form. The .plist extension in the declared path is
+    # load-bearing: `defaults write` on the extensionless form creates a NEW
+    # file beside the real one (verified on a copy, 2026-07-27).
+    #
+    # CAUTION, unsettled until the operator drill in the runbook section
+    # "LuLu preference write drill" runs: whether the RUNNING extension
+    # honours an external write to this file is unknown (LuLu rewrites both
+    # of its files at runtime, observed at wake 2026-07-27 13:25:06), and a
+    # `defaults write` to it converts the XML file to a binary plist, resets
+    # its mode 0644 -> 0600, and replaces the inode (all verified on a copy).
+    # Every declared value equals the live one, so the first apply is
+    # value-neutral, but the drill must settle the mechanics before these
+    # records are trusted as enforcement rather than drift declarations.
+    #
+    # allowLocalHost is the single most safety-critical preference on this
+    # machine, because
+    # alert-dispatch.sh POSTs every page to a Hermes gateway on 127.0.0.1:8644
+    # and the uptime watchdog route probe hits the same loopback URL.
+    # allowLocalHost is true, which is why that hop is unfiltered and why
+    # paging works at all.
+    # Flipping it to false would put LuLu in front of the alerting path itself:
+    # the mechanism that reports every other failure becomes the thing being
+    # filtered. Do not flip it, and do not drop this record as redundant.
+    - domain: com.objective-see.lulu
+      key: allowLocalHost
+      type: bool
+      value: true
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
+    # Apple-signed system processes stay allowed: blocking them breaks core
+    # OS services, and the accumulated rule set already allows them anyway.
+    - domain: com.objective-see.lulu
+      key: allowApple
+      type: bool
+      value: true
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
+    # DNS stays unprompted: every outbound connection needs resolution first,
+    # so filtering DNS would gate all egress behind interactive prompts.
+    - domain: com.objective-see.lulu
+      key: allowDNS
+      type: bool
+      value: true
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
+    # Applications already installed at LuLu install time keep their baseline
+    # allow rules; flipping this only affects future installs, but declaring
+    # it pins the posture the accumulated rule set was built under.
+    - domain: com.objective-see.lulu
+      key: allowInstalled
+      type: bool
+      value: true
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
+    # Prompt-and-decide, never block-all: blockMode true would sever every
+    # unruled outbound flow on an unattended machine, the alerting egress
+    # included.
+    - domain: com.objective-see.lulu
+      key: blockMode
+      type: bool
+      value: false
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
+    # Prompts stay on: passive mode would silently apply a default action to
+    # every new flow, removing the interactive gate that makes the accumulated
+    # rule set deliberate. (passiveModeAction and passiveModeRules are NOT
+    # declared: both are 0 and unconsulted while passiveMode is false, which
+    # is exactly what makes them the safe toggles for the write drill.)
+    - domain: com.objective-see.lulu
+      key: passiveMode
+      type: bool
+      value: false
+      scope: system
+      plist_path: /Library/Objective-See/LuLu/preferences.plist
+      tier: enforce
   killall:
     - Dock
     - Finder

--- a/.chezmoidata/macos_defaults.yaml
+++ b/.chezmoidata/macos_defaults.yaml
@@ -115,24 +115,28 @@ macos:
       value: false
       tier: enforce
     # LuLu outbound-firewall policy (slice 10). Six records, one per policy
-    # preference, each declaring the value the live machine carried on
-    # 2026-07-27: the slice codifies todays posture so a later change is
-    # visible instead of silent; it changes nothing. The plist is LuLu's own
-    # absolute path (plain XML, world-readable, root-writable), not a
+    # preference, each declaring the value the live base file carried on
+    # 2026-07-27; `just D` compares each against the live plist, so a later
+    # change is visible instead of silent. The plist is LuLu's own absolute
+    # path (plain XML, world-readable, root-writable), not a
     # /Library/Preferences domain, so each record rides slice 2's explicit
-    # plist_path form. The .plist extension in the declared path is
-    # load-bearing: `defaults write` on the extensionless form creates a NEW
-    # file beside the real one (verified on a copy, 2026-07-27).
+    # plist_path form. The .plist extension in the declared path is part of
+    # the real filename: `defaults` on the extensionless form addresses a
+    # DIFFERENT file beside it (verified on a copy, 2026-07-27).
     #
-    # CAUTION, unsettled until the operator drill in the runbook section
-    # "LuLu preference write drill" runs: whether the RUNNING extension
-    # honours an external write to this file is unknown (LuLu rewrites both
-    # of its files at runtime, observed at wake 2026-07-27 13:25:06), and a
-    # `defaults write` to it converts the XML file to a binary plist, resets
-    # its mode 0644 -> 0600, and replaces the inode (all verified on a copy).
-    # Every declared value equals the live one, so the first apply is
-    # value-neutral, but the drill must settle the mechanics before these
-    # records are trusted as enforcement rather than drift declarations.
+    # tier: verify, NOT enforce, from LuLu's own source (LuLu/Extension/
+    # Preferences.m, v4.3.2): the extension loads this file ONCE at start
+    # into an in-memory dictionary, never watches or re-reads it, and writes
+    # that whole dictionary back to disk on every preference change it
+    # processes. An external `defaults write` here is therefore both
+    # invisible to the running extension and clobbered by its next save; on a
+    # copy it also converted the XML file to a binary plist, reset mode 0644
+    # to 0600 (which blinds the unprivileged drift reader), and replaced the
+    # inode (verified 2026-07-27; LuLu also rewrote both of its files
+    # spontaneously at a display wake, 2026-07-27 13:25:06). The supported
+    # way to change these values is the LuLu app; see the runbook section
+    # "LuLu preference changes", which also states the promotion gate for
+    # ever returning these records to enforce.
     #
     # allowLocalHost is the single most safety-critical preference on this
     # machine, because
@@ -149,7 +153,7 @@ macos:
       value: true
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
     # Apple-signed system processes stay allowed: blocking them breaks core
     # OS services, and the accumulated rule set already allows them anyway.
     - domain: com.objective-see.lulu
@@ -158,7 +162,7 @@ macos:
       value: true
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
     # DNS stays unprompted: every outbound connection needs resolution first,
     # so filtering DNS would gate all egress behind interactive prompts.
     - domain: com.objective-see.lulu
@@ -167,7 +171,7 @@ macos:
       value: true
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
     # Applications already installed at LuLu install time keep their baseline
     # allow rules; flipping this only affects future installs, but declaring
     # it pins the posture the accumulated rule set was built under.
@@ -177,7 +181,7 @@ macos:
       value: true
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
     # Prompt-and-decide, never block-all: blockMode true would sever every
     # unruled outbound flow on an unattended machine, the alerting egress
     # included.
@@ -187,19 +191,19 @@ macos:
       value: false
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
     # Prompts stay on: passive mode would silently apply a default action to
     # every new flow, removing the interactive gate that makes the accumulated
     # rule set deliberate. (passiveModeAction and passiveModeRules are NOT
-    # declared: both are 0 and unconsulted while passiveMode is false, which
-    # is exactly what makes them the safe toggles for the write drill.)
+    # declared: both are 0 and unconsulted while passiveMode is false, so
+    # tracking them would verify values LuLu never reads.)
     - domain: com.objective-see.lulu
       key: passiveMode
       type: bool
       value: false
       scope: system
       plist_path: /Library/Objective-See/LuLu/preferences.plist
-      tier: enforce
+      tier: verify
   killall:
     - Dock
     - Finder

--- a/.chezmoidata/macos_defaults.yaml
+++ b/.chezmoidata/macos_defaults.yaml
@@ -138,6 +138,11 @@ macos:
     # "LuLu preference changes", which also states the promotion gate for
     # ever returning these records to enforce.
     #
+    # Residual, monitored elsewhere: when this file's currentProfile key
+    # names an active LuLu profile, LuLu consults the profile's own files
+    # and these records describe only the base file; the security-posture
+    # poller's active-profile guard pages the moment that key appears.
+    #
     # allowLocalHost is the single most safety-critical preference on this
     # machine, because
     # alert-dispatch.sh POSTs every page to a Hermes gateway on 127.0.0.1:8644

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -131,8 +131,11 @@ macos:
     #     poller needs no privilege). Same status/output symmetry as
     #     pgrep_oversight. Deliberately a PROCESS probe, not
     #     `systemextensionsctl list`: the list reports registration state,
-    #     which persists while a wedged extension filters nothing; the
-    #     process is the artifact that filters.
+    #     which persists even when the extension process is gone. The probe
+    #     proves only that the process EXISTS, not that it is filtering (a
+    #     wedged process can exist and filter nothing); it narrows the
+    #     registration-versus-running gap without closing the
+    #     running-versus-filtering one.
     #   - the lulu_rule readers are existence-only, stated here so nobody
     #     upgrades the claim: rules.plist is a keyed archive of LuLu's
     #     private Rule class, readable only as the path strings it mentions

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -25,13 +25,21 @@
 #     tier:        verify    # the only accepted value
 #     reader:      <name>    # HOW the poller reads it; one of the poller's
 #                            # reader functions and its value domain:
-#                            #   fdesetup_status     -> on|off
-#                            #   csrutil_status      -> enabled|disabled
-#                            #   defaults_autologin  -> on|off
-#                            #   sysadminctl_guest   -> enabled|disabled
-#                            #   pgrep_oversight     -> running|stopped
+#                            #   fdesetup_status            -> on|off
+#                            #   csrutil_status             -> enabled|disabled
+#                            #   defaults_autologin         -> on|off
+#                            #   sysadminctl_guest          -> enabled|disabled
+#                            #   pgrep_oversight            -> running|stopped
+#                            #   pgrep_lulu_extension       -> running|stopped
+#                            #   lulu_rule_present          -> present|absent
+#                            #   lulu_rule_resolved_present -> present|absent
 #     expect:      <value>   # the value the control must hold, inside the
 #                            # reader's domain; ANY in-domain deviation pages
+#     target:      <path>    # REQUIRED by the lulu_rule readers (the absolute
+#                            # binary path whose rule must exist), FORBIDDEN
+#                            # on every other reader. The baseline records the
+#                            # target each value was observed under, so
+#                            # repointing a control re-arms it.
 #     remedy:      <string>  # OPTIONAL: the page's fix-it line. Keep it
 #                            # apostrophe-free (the alerting stack's render jq
 #                            # is bash single-quoted).
@@ -114,3 +122,82 @@ macos:
       reader: pgrep_oversight
       expect: "running"
       remedy: "Relaunch it: open -a OverSight, and keep it in System Settings → General → Login Items so it returns at login"
+    # LuLu (slice 10). Three verify records: the outbound-filtering extension
+    # process, and the two safety-critical allow rules. Reader notes:
+    #   - pgrep_lulu_extension runs `pgrep -x -U 0
+    #     com.objective-see.lulu.extension`, root-scoped because the network
+    #     extension runs as root (verified 2026-07-27: pid 636, exact 32-char
+    #     name matches; the process table is world-readable so the user-agent
+    #     poller needs no privilege). Same status/output symmetry as
+    #     pgrep_oversight. Deliberately a PROCESS probe, not
+    #     `systemextensionsctl list`: the list reports registration state,
+    #     which persists while a wedged extension filters nothing; the
+    #     process is the artifact that filters.
+    #   - the lulu_rule readers are existence-only, stated here so nobody
+    #     upgrades the claim: rules.plist is a keyed archive of LuLu's
+    #     private Rule class, readable only as the path strings it mentions
+    #     (via a read-only `plutil -convert xml1 -o -`). The check proves a
+    #     rule MENTIONING the declared binary exists; it
+    #     does not prove the rule allows rather than blocks,
+    #     and it must not claim to. (Today
+    #     that gap is small: all 251 live rules were action=allow when
+    #     measured 2026-07-27, and LuLu offers no unattended way to flip
+    #     one.) Recovering the action would mean reimplementing
+    #     NSKeyedUnarchiver over a private, already-once-migrated format,
+    #     which the standing rule against depending on unofficial interfaces
+    #     forbids.
+    #   - lulu_rule_resolved_present resolves the declared launcher with
+    #     `readlink -f` at probe time and searches the archive for the
+    #     RESOLVED binary: LuLu keys rules on the executing Mach-O, and the
+    #     Hermes venv launcher is a symlink chain into a uv-managed CPython,
+    #     so a python upgrade that moves the interpreter pages here instead
+    #     of silently stranding the alerting egress behind a prompt.
+    - id: lulu_extension
+      description: "The LuLu outbound-firewall system extension process"
+      tier: verify
+      reader: pgrep_lulu_extension
+      expect: "running"
+      remedy: "Re-enable it: System Settings → General → Login Items & Extensions → Network Extensions, then open -a LuLu (runbook: LuLu system extension approval)"
+    - id: lulu_rule_tailscaled
+      description: "The LuLu allow rule for tailscaled (remote recovery path 2)"
+      tier: verify
+      reader: lulu_rule_present
+      expect: "present"
+      target: /usr/local/bin/tailscaled
+      remedy: "Recreate the allow rule for /usr/local/bin/tailscaled in the LuLu Rules window; see the runbook section LuLu rule creation"
+    - id: lulu_rule_hermes_gateway
+      description: "The LuLu allow rule for the Hermes gateway interpreter (the alerting egress hop)"
+      tier: verify
+      reader: lulu_rule_resolved_present
+      expect: "present"
+      target: /Users/stephen/.hermes/hermes-agent/venv/bin/python
+      remedy: "A python upgrade likely moved the interpreter; recreate its allow rule in the LuLu Rules window (runbook: LuLu rule creation)"
+
+  # The outbound talker set for the LuLu layer (slice 10), enumerated so a
+  # test can diff it against the declared lulu_rule controls: every talker
+  # carries EXACTLY ONE of `control` (a posture_controls id above) or
+  # `no_rule_reason` (why it deliberately has no rule-existence control).
+  # The alerting channel's real egress hop is the Hermes gateway; the
+  # osquery alerter itself never leaves loopback.
+  lulu_talkers:
+    - talker: "Hermes gateway"
+      needs: "Outbound; the alerting channel real egress hop (Discord delivery)"
+      control: lulu_rule_hermes_gateway
+    - talker: "the alerter curl"
+      needs: "Loopback only: alert-dispatch.sh POSTs to http://127.0.0.1:8644"
+      no_rule_reason: "The hop is loopback, kept unfiltered by the allowLocalHost PREFERENCE, so no rule is ever consulted; a rule on curl would allow every process on the machine to egress and would still not touch this path. Anyone writing a curl rule for the alerter has solved the wrong problem."
+    - talker: "tailscaled"
+      needs: "Outbound; slice 8 remote recovery path 2 (Screen Sharing over the tailnet)"
+      control: lulu_rule_tailscaled
+    - talker: "Homebrew"
+      needs: "Outbound, unattended (weekly upgrade LaunchAgent)"
+      no_rule_reason: "Its egress rides version-pinned Cellar paths plus Apple-signed system tools already covered by allowApple; every upgrade moves the Cellar path while the stale rule lingers in the archive, so a pinned-path existence check reads green forever and proves nothing about the live binary (the live archive carries three atuin and six codex versions). Failure mode is a visible one-time prompt, and Homebrew is neither the alerting nor the recovery path."
+    - talker: "npm"
+      needs: "Outbound, unattended (package installs ride node)"
+      no_rule_reason: "Same version-drift false green as Homebrew: node lives at a Cellar path that moves on every upgrade (the live archive already carries two node versions). A blanket rule on node would cover every node process on a machine running many unattended agents, which forfeits the layer."
+    - talker: "nix"
+      needs: "Outbound, unattended (flake evaluation and store fetches)"
+      no_rule_reason: "The nix binary lives at a hash-pinned /nix/store path that moves on every nix upgrade while the stale rule lingers (the live archive mentions nix-2.34.6), the same false green as Homebrew. Failure mode is a visible prompt; nix is neither the alerting nor the recovery path."
+    - talker: "gh"
+      needs: "Outbound, unattended (workflow polling and API reads)"
+      no_rule_reason: "Same version-pinned Cellar drift as Homebrew (the live archive mentions gh 2.96.0 only); an existence check on a pinned path cannot prove the live binary is ruled. Failure mode is a visible prompt; gh is neither the alerting nor the recovery path."

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -164,15 +164,20 @@ macos:
       reader: pgrep_lulu_extension
       expect: "running"
       remedy: "Re-enable it: System Settings → General → Login Items & Extensions → Network Extensions, then open -a LuLu (runbook: LuLu system extension approval)"
+    # The two rule-record descriptions are what a page prints, so they claim
+    # only what the reader proves: the archive MENTIONS the binary,
+    # existence-only. Never word them as "the allow rule": the reader cannot
+    # see the rule action or state, and a blocked, disabled, expired,
+    # endpoint-limited, or signing-mismatched rule all read present.
     - id: lulu_rule_tailscaled
-      description: "The LuLu allow rule for tailscaled (remote recovery path 2)"
+      description: "The LuLu rule-archive mention of /usr/local/bin/tailscaled, existence-only (remote recovery path 2)"
       tier: verify
       reader: lulu_rule_present
       expect: "present"
       target: /usr/local/bin/tailscaled
       remedy: "Recreate the allow rule for /usr/local/bin/tailscaled in the LuLu Rules window; see the runbook section LuLu rule creation"
     - id: lulu_rule_hermes_gateway
-      description: "The LuLu allow rule for the Hermes gateway interpreter (the alerting egress hop)"
+      description: "The LuLu rule-archive mention of the resolved Hermes gateway interpreter, existence-only (the alerting egress hop)"
       tier: verify
       reader: lulu_rule_resolved_present
       expect: "present"

--- a/.chezmoidata/macos_posture_controls.yaml
+++ b/.chezmoidata/macos_posture_controls.yaml
@@ -152,6 +152,12 @@ macos:
     #     Hermes venv launcher is a symlink chain into a uv-managed CPython,
     #     so a python upgrade that moves the interpreter pages here instead
     #     of silently stranding the alerting egress behind a prompt.
+    #   - both lulu_rule readers consult the BASE rules archive, behind the
+    #     poller's active-profile guard: when the base preferences carry a
+    #     currentProfile key, LuLu consults the named profile's own files
+    #     instead (Preferences.m, Rules.m), so the readers go indeterminate
+    #     and the poller pages the gap rather than trusting a file LuLu no
+    #     longer reads.
     - id: lulu_extension
       description: "The LuLu outbound-firewall system extension process"
       tier: verify

--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -110,6 +110,21 @@ macos:
     - description: "OverSight: allow its Notification Center alerts (its only output channel)"
       tier: manual
       runbook: "OverSight notification delivery"
+    # LuLu (the outbound firewall, slice 10): both of its interactive-only
+    # surfaces. The system-extension approval is a macOS security consent
+    # (System Settings, no supported command line writes it), and rule
+    # creation is interactive BY CONSTRUCTION: rules.plist is an
+    # NSKeyedArchiver archive of LuLu's private Rule class, so rules cannot
+    # be pre-seeded by any supported interface, only created by answering
+    # LuLu's prompts or through its Rules window. Whether the extension is
+    # RUNNING and whether the required rules EXIST are separate verify
+    # records in macos_posture_controls.yaml.
+    - description: "LuLu: approve its system extension (a one-time macOS security consent)"
+      tier: manual
+      runbook: "LuLu system extension approval"
+    - description: "LuLu: create the required outbound allow rules by answering its prompts"
+      tier: manual
+      runbook: "LuLu rule creation"
   tailnet_pins:
     - fqdn: mister.tail2f2430.ts.net
       ip: "100.109.58.54"

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -204,6 +204,29 @@ never writes, so it must never cost a credential prompt either. */ -}}
 # Sudo prelude: at least one record targets a root-owned system plist, so
 # validate sudo once, up front, before any write.
 sudo -v
+# system_defaults_write <plist_path> <key> <-type> <value>: one system-scope
+# write, then a root:wheel 0644 repair of the file `defaults` just replaced.
+# `defaults write` recreates its target as a root-owned 0600 binary plist
+# (verified on a copy, 2026-07-27), and an unreadable plist blinds the
+# unprivileged drift reader (`just D`) on every later run, so an unrepaired
+# write defeats the very drift check that verifies it. The repair is PER
+# WRITE, never a trailing chmod: under set -e a failed later write ends this
+# run before any trailing cleanup, leaving the writes that DID land
+# unreadable. The write's own failure is re-raised AFTER the repair; a failed
+# write that left no file behind skips the repair rather than failing on the
+# missing path. Mirrors system_defaults_write in macos-defaults-lib.sh, which
+# repairs the apply tool's writes the same way.
+system_defaults_write() {
+  local plist_path="$1" key="$2" type_option="$3" value="$4"
+  local write_status=0 written_file="$plist_path"
+  [[ $written_file == *.plist ]] || written_file="$written_file.plist"
+  sudo defaults write "$plist_path" "$key" "$type_option" "$value" || write_status=$?
+  if [[ $write_status -eq 0 || -e $written_file ]]; then
+    sudo chown root:wheel "$written_file"
+    sudo chmod 644 "$written_file"
+  fi
+  return "$write_status"
+}
 {{ end -}}
 # Main loop: one `defaults write` per record.
 {{- /* Per ENFORCE record, that is. The branch below decides by the DECLARED
@@ -232,7 +255,7 @@ declared path must be absolute, never resolved against a working directory. */ -
 {{ if not (hasPrefix "/" $plistPath) -}}
 {{ fail (printf "macos_defaults.yaml: relative plist_path %q on record %s %s; an absolute path is required" $plistPath .domain .key) -}}
 {{ end -}}
-sudo defaults write {{ template "shellSingleQuoted" $plistPath }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
+system_defaults_write {{ template "shellSingleQuoted" $plistPath }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
 {{ else -}}
 defaults {{ if index . "host" }}-currentHost {{ end }}write {{ template "shellSingleQuoted" .domain }} {{ template "shellSingleQuoted" .key }} -{{ .type }} {{ template "shellSingleQuoted" .value }}
 {{ end -}}

--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -24,6 +24,14 @@ set -euo pipefail
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
 {{ $hasSystemScopeRecord := false -}}
+{{- /* The directories an EXPLICIT plist_path may name, grown deliberately,
+one product at a time. An explicit path bypasses the domain construction that
+keeps default system records inside /Library/Preferences, so without this
+list a single record could aim the sudo write at any absolute path on the
+disk. Containment first (the .. checks below), then membership here.
+/Library/Preferences/ is permitted because an explicit path there names
+nothing the default construction could not already reach. */ -}}
+{{ $plistPathAllowedDirectories := list "/Library/Objective-See/LuLu/" "/Library/Preferences/" -}}
 {{- /* Validation pass: every record must declare which control tier it
 belongs to, and its payload must MATCH the declared tier, before anything
 renders. The tier decides what the record IS; the payload never does
@@ -163,6 +171,19 @@ rule is "does this resolve where I intend to write" and these do not. */ -}}
 {{ end -}}
 {{ if eq $declaredPath "/" -}}
 {{ fail (printf "macos_defaults.yaml: system-scope plist_path %q on record %s %s is the filesystem root; it names no plist" $declaredPath .domain .key) -}}
+{{ end -}}
+{{- /* Membership: an explicit path must sit under one of the permitted plist
+directories above. The .. checks keep the path from ESCAPING what it names;
+this keeps what it names inside the directories that were granted on
+purpose. */ -}}
+{{ if ne $declaredPath "" -}}
+{{ $plistPathPermitted := false -}}
+{{ range $allowedDirectory := $plistPathAllowedDirectories -}}
+{{ if hasPrefix $allowedDirectory $declaredPath }}{{ $plistPathPermitted = true }}{{ end -}}
+{{ end -}}
+{{ if not $plistPathPermitted -}}
+{{ fail (printf "macos_defaults.yaml: plist_path %q on record %s %s is outside every permitted plist directory (%s); grant the directory deliberately in the template or use the default /Library/Preferences form" $declaredPath .domain .key (join ", " $plistPathAllowedDirectories)) -}}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 {{ if eq $tier "enforce" -}}

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -141,6 +141,12 @@ a CONSULTED preference take effect). Until then an enforce tier would claim an e
 cannot deliver: the write would land, change nothing, and be silently reverted, the exact silent no-op
 the tier model exists to surface.
 
+Scope note: LuLu reads preferences and rules from an active profile directory when the base file's
+`currentProfile` key names one (`Preferences.m`, `Rules.m`). The tracked records and the rule-existence
+checks describe the BASE files, so the security-posture poller treats an active (or unconfirmable)
+profile as a monitoring gap and pages; deactivate the profile, or extend the monitor to the profile
+paths, before trusting those checks again.
+
 ### Firewall log diagnostics
 
 Nothing to enable here, this section is view-only. Firewall logging is on by default on macOS 26.2 and

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -63,6 +63,92 @@ interactive-only; no supported command line writes it:
    one here; the poller verifies this continuously (the `oversight` record in
    `.chezmoidata/macos_posture_controls.yaml`) and pages if the process stops.
 
+### LuLu system extension approval
+
+LuLu (the Objective-See outbound firewall, installed as a cask) filters through a network system
+extension that macOS only activates after an interactive security consent. No supported command line
+writes that approval:
+
+1. Launch LuLu once (`open -a LuLu`) and follow its prompts.
+1. Approve the extension: System Settings → General → Login Items & Extensions → Network Extensions →
+   enable LuLu. macOS may also raise a "System Extension Blocked" dialog with an Allow button; allow it.
+1. When prompted "LuLu would like to Filter Network Content", click Allow. This is the network-content
+   filter consent, separate from the extension approval.
+1. Confirm it took: `systemextensionsctl list` shows `com.objective-see.lulu.extension` with
+   `[activated enabled]`, and `pgrep -x -U 0 com.objective-see.lulu.extension` prints a PID. The
+   security-posture poller verifies the process continuously (the `lulu_extension` record in
+   `.chezmoidata/macos_posture_controls.yaml`) and pages if it stops.
+
+### LuLu rule creation
+
+Rules cannot be pre-seeded: `rules.plist` is an NSKeyedArchiver archive of LuLu's private `Rule` class,
+not hand-authorable by any supported tool, so every rule is created interactively, by answering LuLu's
+prompt when a binary first makes an outbound connection or ahead of time via the app's Rules window (LuLu
+menu bar icon → Rules → the plus button, which takes a binary path).
+
+The required rules, from the talker table in `.chezmoidata/macos_posture_controls.yaml`
+(`macos.lulu_talkers`):
+
+1. **tailscaled** (`/usr/local/bin/tailscaled`): allow. Slice 8's remote recovery path 2 rides the
+   tailnet; blocking this removes it.
+1. **The Hermes gateway interpreter**: allow. This is the alerting channel's real egress hop. The gateway
+   runs under the venv launcher `~/.hermes/hermes-agent/venv/bin/python`, a symlink into a uv-managed
+   CPython; LuLu keys the rule on the RESOLVED binary
+   (`readlink -f ~/.hermes/hermes-agent/venv/bin/python`), so create the rule for that resolved path.
+   After a python upgrade moves the interpreter, the `lulu_rule_hermes_gateway` control pages and this
+   step is repeated for the new path.
+
+Both rules are verified continuously by the security-posture poller as existence-only checks: the archive
+is readable enough to prove a rule mentioning the binary exists, but the rule action (allow vs block) is
+not recoverable by supported tooling, so the poller does not claim it. When either control pages,
+recreate the rule here and the poller re-arms on its own.
+
+Lean narrow, and accept the prompt cost. Do NOT create blanket allow rules for shared interpreters and
+clients (`/usr/bin/curl`, `/bin/bash`, `node`, `python3`, `/usr/bin/ssh`): LuLu keys rules on the
+executing binary and cannot see which script invoked a shared client, so allowing `curl` allows it for
+every process on the machine. Where a talker only reaches the network through a shared client, either
+leave it prompting or give that path its own dedicated client. Version-pinned paths (Homebrew Cellar,
+`/nix/store`) go stale on every upgrade; expect a one-time prompt after upgrades and answer it narrowly.
+
+The alerter's own `curl` needs NO rule: it POSTs to `http://127.0.0.1:8644` and loopback is kept
+unfiltered by the `allowLocalHost` preference (declared enforce-tier in
+`.chezmoidata/macos_defaults.yaml`). A curl rule would not protect that hop and would allow every process
+on the machine.
+
+### LuLu preference write drill
+
+OPERATOR-GATED, run once before trusting the enforce-tier LuLu policy records as enforcement. The open
+question it settles: does the RUNNING extension honour an external write to
+`/Library/Objective-See/LuLu/preferences.plist`, or does it cache old values and write them back (the
+System Settings / `cfprefsd` footgun this repo already documents)? Read-only evidence so far: LuLu
+rewrote both of its files at runtime on 2026-07-27 at 13:25:06, fifteen seconds after a display wake,
+with the extension up since 2026-07-25; and on a COPY, `defaults write` converted the XML file to a
+binary plist, reset mode 0644 to 0600, added a quarantine xattr, and replaced the inode. The toggles used
+here are `passiveModeAction` and `passiveModeRules`: both are 0 and are not consulted while `passiveMode`
+is false, so the drill never changes effective filtering behaviour.
+
+1. Baseline: `shasum -a 256 /Library/Objective-See/LuLu/preferences.plist`, `stat -f '%Sp %z %Sm'` on it,
+   and `plutil -p` output saved aside. Confirm a test CRIT page delivers end to end BEFORE touching
+   anything.
+1. Write the inert toggle exactly as the Tier 1 runner would:
+   `sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveModeAction -int 1`.
+1. Immediately re-read: `defaults read /Library/Objective-See/LuLu/preferences.plist passiveModeAction`
+   (expect 1) and note `file`, mode, and owner. If mode became 0600, restore readability now:
+   `sudo chmod 644 /Library/Objective-See/LuLu/preferences.plist` (the LuLu app runs as the user and the
+   drift checker reads unprivileged; both need the 0644 the file normally carries).
+1. Watch for a revert: re-read the value at one, five, and fifteen minutes. Then force LuLu's own write
+   path: open the LuLu app, change any preference in its UI, change it back, and quit; sleep and wake the
+   machine once (the observed self-rewrite trigger). After each, re-read `passiveModeAction`.
+1. Interpret: value still 1 everywhere means the extension tolerates external writes and the enforce
+   records take effect as written (also note whether LuLu's own rewrite restored the XML format). Value
+   back at 0 at any point means LuLu reverted the external write: flip the six policy records to
+   `tier: verify` (drift detection stays, the runner writes nothing) and record the finding here.
+1. Restore: `sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveModeAction -int 0`,
+   re-apply `sudo chmod 644` if needed, and if LuLu has not rewritten the file itself, restore the XML
+   format: `sudo plutil -convert xml1 /Library/Objective-See/LuLu/preferences.plist`. Confirm `plutil -p`
+   matches the saved baseline, `systemextensionsctl list` still shows `[activated enabled]`, and a final
+   test CRIT page delivers.
+
 ### Firewall log diagnostics
 
 Nothing to enable here, this section is view-only. Firewall logging is on by default on macOS 26.2 and

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -111,15 +111,15 @@ leave it prompting or give that path its own dedicated client. Version-pinned pa
 `/nix/store`) go stale on every upgrade; expect a one-time prompt after upgrades and answer it narrowly.
 
 The alerter's own `curl` needs NO rule: it POSTs to `http://127.0.0.1:8644` and loopback is kept
-unfiltered by the `allowLocalHost` preference (declared enforce-tier in
-`.chezmoidata/macos_defaults.yaml`). A curl rule would not protect that hop and would allow every process
-on the machine.
+unfiltered by the `allowLocalHost` preference (declared verify-tier in `.chezmoidata/macos_defaults.yaml`
+and drift-checked by `just D`; see the LuLu preference changes section below). A curl rule would not
+protect that hop and would allow every process on the machine.
 
 ### LuLu preference changes
 
 The six LuLu policy records in `.chezmoidata/macos_defaults.yaml` are `tier: verify`: `just D` compares
-them against the live base file, and nothing in this repo ever writes that file. That is a finding, not
-a gap, grounded in LuLu's source (`LuLu/Extension/Preferences.m`, v4.3.2): the extension loads
+them against the live base file, and nothing in this repo ever writes that file. That is a finding, not a
+gap, grounded in LuLu's source (`LuLu/Extension/Preferences.m`, v4.3.2): the extension loads
 `preferences.plist` ONCE at start into an in-memory dictionary, never watches or re-reads it, and writes
 that whole dictionary back to disk on every preference change it processes. An external `defaults write`
 is therefore invisible to the running extension AND clobbered by its next save. Supporting read-only
@@ -135,9 +135,9 @@ To change one of the six declared values:
 1. Update the record's `value` in `.chezmoidata/macos_defaults.yaml` to the new intent.
 1. Run `just D` and confirm the declaration and the live file agree again.
 
-Promotion gate: return these records to `tier: enforce` only when a LuLu version demonstrably re-reads
-an external write to the file (a reload mechanism in its source or release notes, verified by observing
-a CONSULTED preference take effect). Until then an enforce tier would claim an enforcement the machine
+Promotion gate: return these records to `tier: enforce` only when a LuLu version demonstrably re-reads an
+external write to the file (a reload mechanism in its source or release notes, verified by observing a
+CONSULTED preference take effect). Until then an enforce tier would claim an enforcement the machine
 cannot deliver: the write would land, change nothing, and be silently reverted, the exact silent no-op
 the tier model exists to surface.
 

--- a/docs/runbooks/macos-fresh-machine-quickstart.md
+++ b/docs/runbooks/macos-fresh-machine-quickstart.md
@@ -115,39 +115,31 @@ unfiltered by the `allowLocalHost` preference (declared enforce-tier in
 `.chezmoidata/macos_defaults.yaml`). A curl rule would not protect that hop and would allow every process
 on the machine.
 
-### LuLu preference write drill
+### LuLu preference changes
 
-OPERATOR-GATED, run once before trusting the enforce-tier LuLu policy records as enforcement. The open
-question it settles: does the RUNNING extension honour an external write to
-`/Library/Objective-See/LuLu/preferences.plist`, or does it cache old values and write them back (the
-System Settings / `cfprefsd` footgun this repo already documents)? Read-only evidence so far: LuLu
-rewrote both of its files at runtime on 2026-07-27 at 13:25:06, fifteen seconds after a display wake,
-with the extension up since 2026-07-25; and on a COPY, `defaults write` converted the XML file to a
-binary plist, reset mode 0644 to 0600, added a quarantine xattr, and replaced the inode. The toggles used
-here are `passiveModeAction` and `passiveModeRules`: both are 0 and are not consulted while `passiveMode`
-is false, so the drill never changes effective filtering behaviour.
+The six LuLu policy records in `.chezmoidata/macos_defaults.yaml` are `tier: verify`: `just D` compares
+them against the live base file, and nothing in this repo ever writes that file. That is a finding, not
+a gap, grounded in LuLu's source (`LuLu/Extension/Preferences.m`, v4.3.2): the extension loads
+`preferences.plist` ONCE at start into an in-memory dictionary, never watches or re-reads it, and writes
+that whole dictionary back to disk on every preference change it processes. An external `defaults write`
+is therefore invisible to the running extension AND clobbered by its next save. Supporting read-only
+evidence from this machine: LuLu rewrote both of its files spontaneously on 2026-07-27 at 13:25:06,
+fifteen seconds after a display wake; and on a COPY, `defaults write` converted the XML file to a binary
+plist, reset mode 0644 to 0600 (which blinds the unprivileged drift reader), added a quarantine xattr,
+and replaced the inode.
 
-1. Baseline: `shasum -a 256 /Library/Objective-See/LuLu/preferences.plist`, `stat -f '%Sp %z %Sm'` on it,
-   and `plutil -p` output saved aside. Confirm a test CRIT page delivers end to end BEFORE touching
-   anything.
-1. Write the inert toggle exactly as the Tier 1 runner would:
-   `sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveModeAction -int 1`.
-1. Immediately re-read: `defaults read /Library/Objective-See/LuLu/preferences.plist passiveModeAction`
-   (expect 1) and note `file`, mode, and owner. If mode became 0600, restore readability now:
-   `sudo chmod 644 /Library/Objective-See/LuLu/preferences.plist` (the LuLu app runs as the user and the
-   drift checker reads unprivileged; both need the 0644 the file normally carries).
-1. Watch for a revert: re-read the value at one, five, and fifteen minutes. Then force LuLu's own write
-   path: open the LuLu app, change any preference in its UI, change it back, and quit; sleep and wake the
-   machine once (the observed self-rewrite trigger). After each, re-read `passiveModeAction`.
-1. Interpret: value still 1 everywhere means the extension tolerates external writes and the enforce
-   records take effect as written (also note whether LuLu's own rewrite restored the XML format). Value
-   back at 0 at any point means LuLu reverted the external write: flip the six policy records to
-   `tier: verify` (drift detection stays, the runner writes nothing) and record the finding here.
-1. Restore: `sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveModeAction -int 0`,
-   re-apply `sudo chmod 644` if needed, and if LuLu has not rewritten the file itself, restore the XML
-   format: `sudo plutil -convert xml1 /Library/Objective-See/LuLu/preferences.plist`. Confirm `plutil -p`
-   matches the saved baseline, `systemextensionsctl list` still shows `[activated enabled]`, and a final
-   test CRIT page delivers.
+To change one of the six declared values:
+
+1. Change it in the LuLu app (menu bar icon → Preferences), which updates the running extension over its
+   own channel and persists the file itself.
+1. Update the record's `value` in `.chezmoidata/macos_defaults.yaml` to the new intent.
+1. Run `just D` and confirm the declaration and the live file agree again.
+
+Promotion gate: return these records to `tier: enforce` only when a LuLu version demonstrably re-reads
+an external write to the file (a reload mechanism in its source or release notes, verified by observing
+a CONSULTED preference take effect). Until then an enforce tier would claim an enforcement the machine
+cannot deliver: the write would land, change nothing, and be silently reverted, the exact silent no-op
+the tier model exists to surface.
 
 ### Firewall log diagnostics
 

--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -45,6 +45,10 @@ defaults_records_unit_separated "$DATA_FILE" |
     scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
     if [[ $scope == system ]]; then
       resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2
+      # The same write-directory allowlist the render enforces, at the tool
+      # that bypasses the render: apply reads the YAML directly, so this is
+      # the only gate between a hand-edited record and a root write.
+      require_system_plist_path_permitted "$resolved_plist_path" || exit 2
       system_defaults_write "$resolved_plist_path" "$key" "$type" "$value"
     elif [[ -n $host ]]; then
       defaults -currentHost write "$domain" "$key" "-$type" "$value"

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -10,9 +10,13 @@
 # Never writes.
 #
 # Exit codes:
-#   0: no drift (indeterminate rows, if any, are reported but not counted)
+#   0: every tracked record was read and matches
 #   1: drift detected
 #   2: data file missing or unreadable, or a record failed validation
+#   3: indeterminate row(s) and no confirmed drift. FAIL-CLOSED: an
+#      unreadable control is not a passing control, so a run that could not
+#      verify what it tracks must never exit 0. Distinct from 1 because the
+#      operator action differs: fix readability, not revert a value.
 
 set -euo pipefail
 shopt -s lastpipe
@@ -110,10 +114,13 @@ defaults_records_unit_separated "$DATA_FILE" |
   done
 
 if ((indeterminate_count > 0)); then
-  printf '\n%d indeterminate row(s): unreadable, not counted as drift.\n' "$indeterminate_count" >&2
+  printf '\n%d indeterminate row(s): unreadable, not counted as drift, and NOT passing; the gate fails closed.\n' "$indeterminate_count" >&2
 fi
 if ((drift_count > 0)); then
   printf '\n%d drift row(s) detected.\n' "$drift_count" >&2
   exit 1
+fi
+if ((indeterminate_count > 0)); then
+  exit 3
 fi
 exit 0

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -357,8 +357,32 @@ SYSTEM_READ_UNREADABLE=2
 # system_defaults_write <plist_path> <key> <type> <value>, one system-scope
 # write. /Library plists are root-owned, so the write goes through sudo;
 # keeping it here keeps apply and any future caller on one code path.
+#
+# After the write, the written file's ownership and mode are repaired to
+# root:wheel 0644 IN THE SAME CALL: `defaults write` recreates its target as
+# a root-owned 0600 binary plist (verified on a copy, 2026-07-27), and a 0600
+# plist reads back SYSTEM_READ_UNREADABLE for the unprivileged drift checker
+# on every later run, so an unrepaired write defeats the very drift gate that
+# verifies it. The repair is PER WRITE, never a trailing cleanup in a caller:
+# under set -e a failed later write ends the caller at that record, and a
+# trailing cleanup would never run for the writes that DID land. The write's
+# own failure is captured and re-raised AFTER the repair; a failed write that
+# left no file behind skips the repair rather than failing on the missing
+# path. The file repaired is the one `defaults` actually writes: the declared
+# path when it already ends in .plist, the .plist beside it otherwise (an
+# extensionless absolute path gets .plist appended by `defaults`, verified on
+# a copy, 2026-07-27). The rendered Tier 1 runner carries the same function
+# for the same reason; the render tests and the apply test pin both.
 system_defaults_write() { # <plist_path> <key> <type> <value>
-  sudo defaults write "$1" "$2" "-$3" "$4"
+  local plist_path="$1" key="$2" value_type="$3" value="$4"
+  local write_status=0 written_file="$plist_path"
+  [[ $written_file == *.plist ]] || written_file="$written_file.plist"
+  sudo defaults write "$plist_path" "$key" "-$value_type" "$value" || write_status=$?
+  if [[ $write_status -eq 0 || -e $written_file ]]; then
+    sudo chown root:wheel "$written_file"
+    sudo chmod 644 "$written_file"
+  fi
+  return "$write_status"
 }
 
 # system_defaults_read_actual <plist_path> <key>, the three-outcome system-scope

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -338,6 +338,36 @@ resolve_system_plist_path() { # <domain> <plist_path>
   printf '%s\n' "$plist_path"
 }
 
+# The directories an EXPLICIT plist_path may name at WRITE time, grown
+# deliberately, one product at a time. The render-time gate in
+# run_onchange_after_30-macos-defaults.sh.tmpl carries the same list
+# ($plistPathAllowedDirectories) and refuses the record before anything
+# renders; this list closes the path AROUND the render: `just defaults-apply`
+# reads the YAML directly, so without it a record the render would refuse was
+# still handed to `sudo defaults write` (verified against
+# /etc/example.evil.plist before the fix). The system-scope suite pins the
+# two lists identical. Plain assignment, not readonly, for the same
+# re-source reason as the read-status constants below.
+MACOS_DEFAULTS_PLIST_PATH_ALLOWED_DIRECTORIES=("/Library/Objective-See/LuLu/" "/Library/Preferences/")
+
+# require_system_plist_path_permitted <plist_path>, refuse (status 1, with a
+# message naming the path and the rule) any WRITE target outside the
+# permitted directories above. Called by apply for every system-scope record
+# before anything is written. Reads are deliberately NOT gated: drift
+# consulting an odd path mutates nothing, and refusing it would only hide
+# the row from the report.
+require_system_plist_path_permitted() { # <plist_path>
+  local plist_path="$1" allowed_directory
+  for allowed_directory in "${MACOS_DEFAULTS_PLIST_PATH_ALLOWED_DIRECTORIES[@]}"; do
+    if [[ $plist_path == "$allowed_directory"* ]]; then
+      return 0
+    fi
+  done
+  printf 'error: plist_path %q is outside every permitted plist directory (%s); grant the directory deliberately in BOTH the Tier 1 template and macos-defaults-lib.sh, or use the default /Library/Preferences form\n' \
+    "$plist_path" "${MACOS_DEFAULTS_PLIST_PATH_ALLOWED_DIRECTORIES[*]}" >&2
+  return 1
+}
+
 # The three outcomes of reading a system-scope setting, carried as an exit STATUS
 # rather than a marker string. A string sentinel is representable as a real value:
 # a tracked setting whose live value happened to be the marker would be reported

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -36,6 +36,12 @@ CSRUTIL="${OSQUERY_POSTURE_CSRUTIL:-/usr/bin/csrutil}"
 SYSADMINCTL="${OSQUERY_POSTURE_SYSADMINCTL:-/usr/sbin/sysadminctl}"
 DEFAULTS="${OSQUERY_POSTURE_DEFAULTS:-/usr/bin/defaults}"
 PGREP="${OSQUERY_POSTURE_PGREP:-/usr/bin/pgrep}"
+PLUTIL="${OSQUERY_POSTURE_PLUTIL:-/usr/bin/plutil}"
+READLINK="${OSQUERY_POSTURE_READLINK:-/usr/bin/readlink}"
+# LuLu's rules archive, world-readable (0644 root:wheel, verified 2026-07-27),
+# so this user-agent poller reads it unprivileged. READ-ONLY: the conversion
+# below goes to stdout; the archive file itself is never written.
+LULU_RULES_FILE="${OSQUERY_POSTURE_LULU_RULES:-/Library/Objective-See/LuLu/rules.plist}"
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -133,7 +139,19 @@ reader_domain() {
   case "$1" in
     fdesetup_status | defaults_autologin) printf 'on off' ;;
     csrutil_status | sysadminctl_guest) printf 'enabled disabled' ;;
-    pgrep_oversight) printf 'running stopped' ;;
+    pgrep_oversight | pgrep_lulu_extension) printf 'running stopped' ;;
+    lulu_rule_present | lulu_rule_resolved_present) printf 'present absent' ;;
+  esac
+}
+
+# reader_requires_target <reader> -- status 0 when the reader consumes a
+# per-record target (the absolute binary path whose LuLu rule must exist).
+# This table, the template's $readerTargets, and read_control below must
+# agree; the render test and the agreement test hold them together.
+reader_requires_target() {
+  case "$1" in
+    lulu_rule_present | lulu_rule_resolved_present) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -174,12 +192,64 @@ classify_probe() {
   fi
 }
 
-# read_control <reader> -> the normalized value, or "indeterminate". One
-# read-only status invocation of the authoritative tool per control, bounded
-# like the combined query, with stdout and stderr captured together
+# classify_pgrep <output> <rc> -- the shared classification for a pgrep
+# process probe (documented statuses: 0 matched, 1 no match, 2 invalid
+# options), with the status/output pairing symmetric: exit 0 with a
+# WELL-FORMED pid list on stdout (digits, one pid per line, pgrep's only
+# success output) is running; the no-match exit 1 with no output at all is
+# stopped; every other outcome (usage or internal error, a timeout kill, a
+# status/output mismatch in either direction) is indeterminate. A probe whose
+# status and output disagree is never believed, whatever it printed.
+classify_pgrep() {
+  local output="$1" rc="$2"
+  local pid_list_pattern=$'^[0-9]+(\n[0-9]+)*$'
+  if [[ $rc -eq 0 && $output =~ $pid_list_pattern ]]; then
+    printf 'running'
+  elif [[ $rc -eq 1 && -z $output ]]; then
+    printf 'stopped'
+  else
+    printf 'indeterminate'
+  fi
+}
+
+# lulu_rule_in_archive <absolute-binary-path> -- the EXISTENCE-ONLY LuLu rule
+# check: present when LuLu's rules archive mentions the path, absent when a
+# readable archive does not, indeterminate when the archive cannot be read.
+# The archive is an NSKeyedArchiver archive of LuLu's private Rule class, so
+# this deliberately claims no more than "a rule mentioning this binary
+# exists": the rule's action (allow vs block) is not recoverable without
+# reimplementing the private keyed-archive layout, and this check must not
+# pretend it did. The read is `plutil -convert xml1 -o -` (conversion to
+# stdout, the file is never written), and the match is the exact <string>
+# element in its XML-escaped form, so a longer path containing the target can
+# never satisfy it. A zero-exit conversion that printed nothing is a
+# status/output mismatch and stays indeterminate (plutil always prints the
+# converted document on success), never absent: absent is a claim about a
+# document that was actually read.
+lulu_rule_in_archive() {
+  local binary_path="$1" archive_xml="" rc=0 escaped_path
+  archive_xml=$(run_bounded "$PLUTIL" -convert xml1 -o - "$LULU_RULES_FILE" 2>/dev/null) || rc=$?
+  if [[ $rc -ne 0 || -z $archive_xml ]]; then
+    printf 'indeterminate'
+    return 0
+  fi
+  escaped_path=${binary_path//&/&amp;}
+  escaped_path=${escaped_path//</&lt;}
+  escaped_path=${escaped_path//>/&gt;}
+  if grep -qF "<string>$escaped_path</string>" <<<"$archive_xml"; then
+    printf 'present'
+  else
+    printf 'absent'
+  fi
+}
+
+# read_control <reader> <target> -> the normalized value, or "indeterminate".
+# One read-only status invocation of the authoritative tool per control,
+# bounded like the combined query, with stdout and stderr captured together
 # (sysadminctl and defaults report on stderr; verified on the target machine).
-# Raw probe text NEVER leaves this function: only the fixed normalized values
-# do.
+# The target argument is consumed only by the lulu_rule readers (load_controls
+# validates the pairing). Raw probe text NEVER leaves this function: only the
+# fixed normalized values do.
 #
 # Reader choices (each verified from the poller's gui/501 session context):
 #   - fdesetup, NOT osquery's disk_encryption table: FileVault lives on the
@@ -197,7 +267,7 @@ classify_probe() {
 #   - sysadminctl for the Guest account: it reports the state on stderr and
 #     exits 0 in both states.
 read_control() {
-  local reader="$1" output="" rc=0
+  local reader="$1" target="${2:-}" output="" rc=0
   case "$reader" in
     fdesetup_status)
       # Every zero-exit status form enumerated from the binary's strings
@@ -264,15 +334,37 @@ read_control() {
       # probe whose status and output disagree is never believed, whatever
       # it printed. The pairing is symmetric: exit 0 requires well-formed
       # pid output exactly as exit 1 requires empty output.
-      local pid_list_pattern=$'^[0-9]+(\n[0-9]+)*$'
       output=$(run_bounded "$PGREP" -x -U "$UID" OverSight 2>&1) || rc=$?
-      if [[ $rc -eq 0 && $output =~ $pid_list_pattern ]]; then
-        printf 'running'
-      elif [[ $rc -eq 1 && -z $output ]]; then
-        printf 'stopped'
-      else
+      classify_pgrep "$output" "$rc"
+      ;;
+    pgrep_lulu_extension)
+      # The LuLu network extension is a ROOT process (-U 0): the process
+      # table is world-readable, so the user-agent poller reads it
+      # unprivileged, and the root scope means no user process can
+      # impersonate the extension. The exact 32-character name match was
+      # verified live 2026-07-27 (pid 636). Deliberately a process probe,
+      # not `systemextensionsctl list`: the list reports REGISTRATION state,
+      # which persists while a wedged extension filters nothing; the process
+      # is the artifact that filters (verify the artifact, never a proxy).
+      output=$(run_bounded "$PGREP" -x -U 0 com.objective-see.lulu.extension 2>&1) || rc=$?
+      classify_pgrep "$output" "$rc"
+      ;;
+    lulu_rule_present)
+      lulu_rule_in_archive "$target"
+      ;;
+    lulu_rule_resolved_present)
+      # Resolve the declared launcher FIRST, then require the archive to
+      # mention the RESOLVED binary: LuLu keys rules on the executing
+      # Mach-O, so a rule on a launcher symlink's own path protects nothing.
+      # An unresolvable launcher is indeterminate (nothing was read), never
+      # absent (absent is a claim about a rule set actually searched).
+      local resolved_target="" resolve_rc=0
+      resolved_target=$(run_bounded "$READLINK" -f "$target" 2>/dev/null) || resolve_rc=$?
+      if [[ $resolve_rc -ne 0 || -z $resolved_target ]]; then
         printf 'indeterminate'
+        return 0
       fi
+      lulu_rule_in_archive "$resolved_target"
       ;;
     *)
       # Unreachable behind load_controls' reader validation; fail closed
@@ -293,10 +385,11 @@ control_ids=()
 control_descriptions=()
 control_readers=()
 control_expects=()
+control_targets=()
 control_remedies=()
 controls_problem=""
 load_controls() {
-  local count index record id tier reader expect description remedy domain
+  local count index record id tier reader expect target description remedy domain
   if [[ ! -f $CONTROLS_FILE ]]; then
     controls_problem="posture-controls file missing at $(sanitize_span "$CONTROLS_FILE")"
     return 0
@@ -321,6 +414,7 @@ load_controls() {
     tier=$(jq -r '.tier // empty' <<<"$record" 2>/dev/null || echo "")
     reader=$(jq -r '.reader // empty' <<<"$record" 2>/dev/null || echo "")
     expect=$(jq -r '.expect // empty' <<<"$record" 2>/dev/null || echo "")
+    target=$(jq -r '.target // empty' <<<"$record" 2>/dev/null || echo "")
     description=$(sanitize "$(jq -r '.description // empty' <<<"$record" 2>/dev/null || echo "")")
     remedy=$(sanitize "$(jq -r '.remedy // empty' <<<"$record" 2>/dev/null || echo "")")
     if ! [[ $id =~ ^[a-z0-9_]+$ ]]; then
@@ -351,6 +445,28 @@ load_controls() {
         return 0
         ;;
     esac
+    # The target pairing, both directions: a lulu_rule reader without an
+    # absolute target has nothing to check, and a target on any other reader
+    # is silently ignored data, which is how a mislabeled record hides. A
+    # multi-line target is refused because the archive match is line-based:
+    # a pattern spanning lines would match archive lines it never named.
+    if reader_requires_target "$reader"; then
+      if [[ -z $target ]]; then
+        controls_problem="posture-controls record [$id] names reader $reader, which requires a target (the absolute binary path whose rule must exist)"
+        return 0
+      fi
+      if [[ $target != /* ]]; then
+        controls_problem="posture-controls record [$id] target $(sanitize_span "$target") must be an absolute path"
+        return 0
+      fi
+      if [[ $target == *$'\n'* || $target == *$'\x1f'* ]]; then
+        controls_problem="posture-controls record [$id] target contains a newline or a unit separator"
+        return 0
+      fi
+    elif [[ -n $target ]]; then
+      controls_problem="posture-controls record [$id] declares a target its reader $reader does not consume"
+      return 0
+    fi
     if [[ -z $description ]]; then
       controls_problem="posture-controls record [$id] has no description"
       return 0
@@ -359,6 +475,7 @@ load_controls() {
     control_descriptions+=("$description")
     control_readers+=("$reader")
     control_expects+=("$expect")
+    control_targets+=("$target")
     control_remedies+=("$remedy")
   done
   return 0
@@ -372,6 +489,7 @@ if [[ -n $controls_problem ]]; then
   control_descriptions=()
   control_readers=()
   control_expects=()
+  control_targets=()
   control_remedies=()
 fi
 
@@ -381,7 +499,7 @@ fi
 control_values=()
 if [[ -z $controls_problem ]]; then
   for control_index in "${!control_ids[@]}"; do
-    control_values+=("$(read_control "${control_readers[$control_index]}")")
+    control_values+=("$(read_control "${control_readers[$control_index]}" "${control_targets[$control_index]}")")
   done
 fi
 
@@ -526,12 +644,21 @@ for control_index in "${!control_ids[@]}"; do
   if [[ $prev_valid -eq 1 ]]; then
     control_prev=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key] // empty' <<<"$prev_json" 2>/dev/null || echo "")
     control_prev_expect=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key + ":expect"] // empty' <<<"$prev_json" 2>/dev/null || echo "")
+    control_prev_target=$(jq -r --arg key "${control_ids[$control_index]}" '.[$key + ":target"] // empty' <<<"$prev_json" 2>/dev/null || echo "")
     domain=$(reader_domain "${control_readers[$control_index]}")
     case " $domain " in
       *" $control_prev "*) ;;
       *) control_prev="" ;;
     esac
     if [[ $control_prev_expect != "${control_expects[$control_index]}" ]]; then
+      control_prev=""
+    fi
+    # A prior recorded under a DIFFERENT target is never compared, for the
+    # same reason as a different expect: an operator repointing a rule
+    # control at a new binary declared a new intent, and the old baseline
+    # would read a steady-deviant new target as already-paged. Targetless
+    # readers store no :target key, so both sides are empty and match.
+    if [[ $control_prev_target != "${control_targets[$control_index]}" ]]; then
       control_prev=""
     fi
   fi
@@ -559,13 +686,20 @@ for control_index in "${!control_ids[@]}"; do
     control_field="${control_prevs[$control_index]}" # trusted prior, may be empty
   fi
   if [[ -n $control_field ]]; then
-    # The value AND the expect it was recorded under: the pair is what lets
-    # the next run detect a changed declaration and re-arm the control.
+    # The value AND the declaration it was recorded under (expect, and the
+    # target for the targeted readers): the pairing is what lets the next
+    # run detect a changed declaration and re-arm the control.
     baseline_json=$(jq -c \
       --arg key "${control_ids[$control_index]}" \
       --arg value "$control_field" \
       --arg expect "${control_expects[$control_index]}" \
       '. + {($key): $value, ($key + ":expect"): $expect}' <<<"$baseline_json")
+    if [[ -n ${control_targets[$control_index]} ]]; then
+      baseline_json=$(jq -c \
+        --arg key "${control_ids[$control_index]}" \
+        --arg target "${control_targets[$control_index]}" \
+        '. + {($key + ":target"): $target}' <<<"$baseline_json")
+    fi
   fi
 done
 

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -391,8 +391,10 @@ read_control() {
       # impersonate the extension. The exact 32-character name match was
       # verified live 2026-07-27 (pid 636). Deliberately a process probe,
       # not `systemextensionsctl list`: the list reports REGISTRATION state,
-      # which persists while a wedged extension filters nothing; the process
-      # is the artifact that filters (verify the artifact, never a proxy).
+      # which persists even when the extension process is gone. What pgrep
+      # proves is only that the process EXISTS: a wedged process can exist
+      # and filter nothing, so this probe narrows the registration-versus-
+      # running gap without closing the running-versus-filtering one.
       output=$(run_bounded "$PGREP" -x -U 0 com.objective-see.lulu.extension 2>&1) || rc=$?
       classify_pgrep "$output" "$rc"
       ;;

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -42,6 +42,11 @@ READLINK="${OSQUERY_POSTURE_READLINK:-/usr/bin/readlink}"
 # so this user-agent poller reads it unprivileged. READ-ONLY: the conversion
 # below goes to stdout; the archive file itself is never written.
 LULU_RULES_FILE="${OSQUERY_POSTURE_LULU_RULES:-/Library/Objective-See/LuLu/rules.plist}"
+# LuLu's BASE preferences file, read (read-only, the same conversion-to-stdout
+# discipline) by the active-profile guard below: when this file's
+# currentProfile key names a profile, LuLu consults the profile's own
+# preferences and rules instead of the base files.
+LULU_PREFERENCES_FILE="${OSQUERY_POSTURE_LULU_PREFERENCES:-/Library/Objective-See/LuLu/preferences.plist}"
 
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
@@ -155,6 +160,18 @@ reader_requires_target() {
   esac
 }
 
+# reader_reads_lulu_base_rules <reader> -- status 0 when the reader consults
+# LuLu's BASE rules archive and therefore depends on no LuLu profile being
+# active (see the profile guard below). Coincides with the target-requiring
+# set today, but the two predicates answer different questions and must be
+# free to diverge.
+reader_reads_lulu_base_rules() {
+  case "$1" in
+    lulu_rule_present | lulu_rule_resolved_present) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # classify_probe <output> <rc> <needle> <value> [<needle> <value>]...
 # The indeterminate-on-nonzero discipline (absorbed from the retired
 # apply-time posture reminder): a probe that exits NONZERO is INDETERMINATE
@@ -210,6 +227,36 @@ classify_pgrep() {
   else
     printf 'indeterminate'
   fi
+}
+
+# The active-profile guard. LuLu 4.x reads its preferences AND rules from an
+# ACTIVE PROFILE directory when the base preferences file names one
+# (Preferences.m getCurrentProfile reads the currentProfile key from the BASE
+# file; Rules.m getPath prefers <currentProfile>/rules.plist). The rule
+# readers below read the BASE archive, so while a profile is active they
+# would be reading a file LuLu no longer consults: a stale base mention must
+# never satisfy a control whose deciding rule set lives elsewhere. The guard
+# converts the base preferences to stdout ONCE per tick, lazily, and any
+# outcome other than a readable document with NO currentProfile key makes
+# every lulu_rule read indeterminate (which the gap gate pages, naming the
+# cause). Key PRESENCE is the trigger, fail-closed: nothing establishes what
+# an empty currentProfile would mean, so only its absence is trusted.
+lulu_profile_checked=0
+lulu_profile_state="no_profile"
+lulu_base_rules_authoritative() {
+  if [[ $lulu_profile_checked -eq 0 ]]; then
+    lulu_profile_checked=1
+    local preferences_xml="" rc=0
+    preferences_xml=$(run_bounded "$PLUTIL" -convert xml1 -o - "$LULU_PREFERENCES_FILE" 2>/dev/null) || rc=$?
+    if [[ $rc -ne 0 || -z $preferences_xml ]]; then
+      lulu_profile_state="indeterminate"
+    elif grep -qF '<key>currentProfile</key>' <<<"$preferences_xml"; then
+      lulu_profile_state="profile_active"
+    else
+      lulu_profile_state="no_profile"
+    fi
+  fi
+  [[ $lulu_profile_state == "no_profile" ]]
 }
 
 # lulu_rule_in_archive <absolute-binary-path> -- the EXISTENCE-ONLY LuLu rule
@@ -350,9 +397,20 @@ read_control() {
       classify_pgrep "$output" "$rc"
       ;;
     lulu_rule_present)
+      if ! lulu_base_rules_authoritative; then
+        printf 'indeterminate'
+        return 0
+      fi
       lulu_rule_in_archive "$target"
       ;;
     lulu_rule_resolved_present)
+      # The profile guard first: with an active (or unconfirmable) profile
+      # the base archive is not the deciding rule set, so neither the
+      # resolution nor the archive read should even run.
+      if ! lulu_base_rules_authoritative; then
+        printf 'indeterminate'
+        return 0
+      fi
       # Resolve the declared launcher FIRST, then require the archive to
       # mention the RESOLVED binary: LuLu keys rules on the executing
       # Mach-O, so a rule on a launcher symlink's own path protects nothing.
@@ -498,6 +556,18 @@ fi
 # a read nothing declared.
 control_values=()
 if [[ -z $controls_problem ]]; then
+  # The profile guard runs HERE, in the parent shell, before any read:
+  # read_control runs inside a command substitution, so state set there dies
+  # with the subshell; a guard first triggered inside one could neither
+  # memoize (one preferences read per tick) nor reach the gap report with
+  # its cause. Each read_control subshell inherits the settled state by
+  # fork, so its own guard call is a pure lookup.
+  for control_index in "${!control_ids[@]}"; do
+    if reader_reads_lulu_base_rules "${control_readers[$control_index]}"; then
+      lulu_base_rules_authoritative || true
+      break
+    fi
+  done
   for control_index in "${!control_ids[@]}"; do
     control_values+=("$(read_control "${control_readers[$control_index]}" "${control_targets[$control_index]}")")
   done
@@ -603,6 +673,15 @@ done
 if [[ -n $indeterminate_ids ]]; then
   gap_members+="${gap_members:+ }$indeterminate_ids"
   gap_detail+="${gap_detail:+; }indeterminate posture control read(s): [$indeterminate_ids]"
+fi
+# The profile guard's cause, spelled out beside the ids it blinded: an
+# indeterminate whose reason is "LuLu is consulting different files" needs a
+# different response (deactivate the profile, or teach the monitor the
+# profile paths) than a failed probe. Fixed script text, never probe output.
+if [[ $lulu_profile_checked -eq 1 && $lulu_profile_state == "profile_active" ]]; then
+  gap_detail+="${gap_detail:+; }a LuLu profile is ACTIVE (the base preferences carry a currentProfile key), so LuLu is consulting the profile's own files and the base rules archive these controls read is not the one deciding traffic"
+elif [[ $lulu_profile_checked -eq 1 && $lulu_profile_state == "indeterminate" ]]; then
+  gap_detail+="${gap_detail:+; }the LuLu base preferences could not be read to confirm no profile is active"
 fi
 if [[ -n $gap_detail ]]; then
   gap_body="**Security-posture monitoring gap**"$'\n'"- $gap_detail: the security posture there is currently UNKNOWN."$'\n'"- A blind monitor cannot see a protection turn off. Did osqueryi, a posture probe, or the LaunchAgent break? **Check now.**"$'\n'"- Diagnose: run the posture query and the control probes by hand, then re-check."

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -28,7 +28,17 @@ function; the poller-vs-data agreement test holds the two together. */ -}}
       "csrutil_status" (list "enabled" "disabled")
       "defaults_autologin" (list "on" "off")
       "sysadminctl_guest" (list "enabled" "disabled")
-      "pgrep_oversight" (list "running" "stopped") -}}
+      "pgrep_oversight" (list "running" "stopped")
+      "pgrep_lulu_extension" (list "running" "stopped")
+      "lulu_rule_present" (list "present" "absent")
+      "lulu_rule_resolved_present" (list "present" "absent") -}}
+{{- /* The readers that consume a per-record target (the absolute binary path
+whose LuLu rule must exist). Required there, forbidden everywhere else: a
+target on a targetless reader would be silently ignored data, which is how a
+mislabeled record hides. */ -}}
+{{- $readerTargets := dict
+      "lulu_rule_present" true
+      "lulu_rule_resolved_present" true -}}
 {{- range .macos.posture_controls -}}
 {{-   if not (hasKey . "id") -}}
 {{-     fail "macos_posture_controls.yaml: a record has no id; every control needs one, it is the identity in every error and every page" -}}
@@ -70,6 +80,20 @@ function; the poller-vs-data agreement test holds the two together. */ -}}
 {{-   $expect := toString (index . "expect") -}}
 {{-   if not (has $expect (get $readerDomains $reader)) -}}
 {{-     fail (printf "macos_posture_controls.yaml: record %q expects %q, outside the %s domain %v (a bare YAML boolean stringifies to true/false, which no reader returns)" $id $expect $reader (get $readerDomains $reader)) -}}
+{{-   end -}}
+{{-   if hasKey $readerTargets $reader -}}
+{{-     if or (not (hasKey . "target")) (kindIs "invalid" (index . "target")) -}}
+{{-       fail (printf "macos_posture_controls.yaml: record %q names reader %s, which requires a target (the absolute binary path whose rule must exist)" $id $reader) -}}
+{{-     end -}}
+{{-     $target := toString (index . "target") -}}
+{{-     if not (hasPrefix "/" $target) -}}
+{{-       fail (printf "macos_posture_controls.yaml: record %q target %q must be an absolute path" $id $target) -}}
+{{-     end -}}
+{{-     if or (contains "\n" $target) (contains "\x1f" $target) -}}
+{{-       fail (printf "macos_posture_controls.yaml: record %q target contains a newline or a unit separator; a multi-line pattern would match archive lines it never named" $id) -}}
+{{-     end -}}
+{{-   else if hasKey . "target" -}}
+{{-     fail (printf "macos_posture_controls.yaml: record %q declares a target its reader %s does not consume; drop the field or use a lulu_rule reader" $id $reader) -}}
 {{-   end -}}
 {{-   if or (not (hasKey . "description")) (kindIs "invalid" (index . "description")) (eq (toString (index . "description")) "") -}}
 {{-     fail (printf "macos_posture_controls.yaml: record %q has no description; a page must name the control" $id) -}}

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -44,6 +44,13 @@ set_posture_controls() {
 setup_poller_harness() {
   export POLLER_HOME
   POLLER_HOME="$(mktemp -d)"
+  # Refuse an empty or non-directory result BEFORE anything is built under it
+  # (or later torn down from it): a pathological mktemp that exits 0 with no
+  # output would otherwise send every path below to /.
+  [[ -n $POLLER_HOME && -d $POLLER_HOME ]] || {
+    printf 'setup_poller_harness: mktemp -d produced no usable directory (got %q)\n' "$POLLER_HOME" >&2
+    return 1
+  }
   # Ownership marker set only after our own mktemp, so teardown removes this
   # path and never a pre-set or inherited POLLER_HOME.
   _POLLER_HARNESS_OWNED_DIR="$POLLER_HOME"

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -206,48 +206,141 @@ esac
 SHIM
   chmod +x "$POLLER_HOME/bin/defaults"
 
-  # pgrep: only the exact user-scoped process-name read of OverSight (the
-  # oversight running-state reader) is legitimate; every other argv is a
-  # recorded violation. POLLER_PGREP_MODE models three outcomes (pgrep exit
-  # statuses verified against the installed binary and its man page: 0
-  # matched, 1 no match with no output, 2 invalid options): running (a pid on
-  # stdout, exit 0, the default), stopped (no output at all, exit 1), and
-  # error (a pid on stdout AND exit 2, the untrustworthy-failure form: output
-  # that LOOKS running with a failed status must never be believed).
-  # POLLER_PGREP_OUTPUT/POLLER_PGREP_EXIT override output and status directly
-  # for the remaining forms (exit 1 that still printed something, exit 0 that
-  # printed nothing); ${VAR+x} so a deliberately empty output is programmable.
+  # pgrep: exactly two read-only argvs are legitimate, the user-scoped
+  # OverSight probe and the root-scoped LuLu extension probe; every other
+  # argv is a recorded violation. Each probe has its own programming
+  # variables (POLLER_PGREP_* for OverSight, POLLER_PGREP_LULU_* for the
+  # extension) so one control's state never leaks into the other's.
+  # POLLER_PGREP_MODE models three outcomes (pgrep exit statuses verified
+  # against the installed binary and its man page: 0 matched, 1 no match
+  # with no output, 2 invalid options): running (a pid on stdout, exit 0,
+  # the default), stopped (no output at all, exit 1), and error (a pid on
+  # stdout AND exit 2, the untrustworthy-failure form: output that LOOKS
+  # running with a failed status must never be believed).
+  # POLLER_PGREP_OUTPUT/POLLER_PGREP_EXIT override output and status
+  # directly for the remaining forms (exit 1 that still printed something,
+  # exit 0 that printed nothing); ${VAR+x} so a deliberately empty output is
+  # programmable. The LuLu variables mirror all of it.
   cat >"$POLLER_HOME/bin/pgrep" <<'SHIM'
 #!/usr/bin/env bash
 printf 'pgrep %s\n' "$*" >>"$POLLER_PROBE_CALLS"
-if [[ "$*" != "-x -U $(id -u) OverSight" ]]; then
-  printf 'pgrep %s\n' "$*" >>"$POLLER_MUTATION_LOG"
-  exit 97
-fi
-if [[ -n ${POLLER_PGREP_SLEEP:-} ]]; then
-  exec sleep "$POLLER_PGREP_SLEEP"
-fi
-if [[ -n ${POLLER_PGREP_OUTPUT+x} || -n ${POLLER_PGREP_EXIT:-} ]]; then
-  if [[ -n ${POLLER_PGREP_OUTPUT:-} ]]; then
-    printf '%s\n' "$POLLER_PGREP_OUTPUT"
-  fi
-  exit "${POLLER_PGREP_EXIT:-0}"
-fi
-case "${POLLER_PGREP_MODE:-running}" in
-  stopped)
-    exit 1
+case "$*" in
+  "-x -U $(id -u) OverSight")
+    if [[ -n ${POLLER_PGREP_SLEEP:-} ]]; then
+      exec sleep "$POLLER_PGREP_SLEEP"
+    fi
+    if [[ -n ${POLLER_PGREP_OUTPUT+x} || -n ${POLLER_PGREP_EXIT:-} ]]; then
+      if [[ -n ${POLLER_PGREP_OUTPUT:-} ]]; then
+        printf '%s\n' "$POLLER_PGREP_OUTPUT"
+      fi
+      exit "${POLLER_PGREP_EXIT:-0}"
+    fi
+    case "${POLLER_PGREP_MODE:-running}" in
+      stopped)
+        exit 1
+        ;;
+      error)
+        printf '3424\n'
+        exit 2
+        ;;
+      *)
+        printf '3424\n'
+        exit 0
+        ;;
+    esac
     ;;
-  error)
-    printf '3424\n'
-    exit 2
+  "-x -U 0 com.objective-see.lulu.extension")
+    if [[ -n ${POLLER_PGREP_LULU_SLEEP:-} ]]; then
+      exec sleep "$POLLER_PGREP_LULU_SLEEP"
+    fi
+    if [[ -n ${POLLER_PGREP_LULU_OUTPUT+x} || -n ${POLLER_PGREP_LULU_EXIT:-} ]]; then
+      if [[ -n ${POLLER_PGREP_LULU_OUTPUT:-} ]]; then
+        printf '%s\n' "$POLLER_PGREP_LULU_OUTPUT"
+      fi
+      exit "${POLLER_PGREP_LULU_EXIT:-0}"
+    fi
+    case "${POLLER_PGREP_LULU_MODE:-running}" in
+      stopped)
+        exit 1
+        ;;
+      error)
+        printf '636\n'
+        exit 2
+        ;;
+      *)
+        printf '636\n'
+        exit 0
+        ;;
+    esac
     ;;
   *)
-    printf '3424\n'
-    exit 0
+    printf 'pgrep %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+    exit 97
     ;;
 esac
 SHIM
   chmod +x "$POLLER_HOME/bin/pgrep"
+
+  # plutil: only the exact read-only conversion of the LuLu rules archive to
+  # stdout is legitimate (the archive file is never written); every other
+  # argv is a recorded violation. POLLER_PLUTIL_XML programs the converted
+  # document (default: an archive mentioning nothing); ${VAR-default} so a
+  # deliberately empty output (the status/output-mismatch form) is
+  # programmable. POLLER_PLUTIL_EXIT models a failed conversion (missing or
+  # corrupt archive).
+  cat >"$POLLER_HOME/bin/plutil" <<'SHIM'
+#!/usr/bin/env bash
+printf 'plutil %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ "$*" != "-convert xml1 -o - ${OSQUERY_POSTURE_LULU_RULES:-}" ]]; then
+  printf 'plutil %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+if [[ -n ${POLLER_PLUTIL_SLEEP:-} ]]; then
+  exec sleep "$POLLER_PLUTIL_SLEEP"
+fi
+exit_code="${POLLER_PLUTIL_EXIT:-0}"
+if [[ $exit_code -ne 0 ]]; then
+  exit "$exit_code"
+fi
+default_archive='<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>$objects</key>
+	<array>
+	</array>
+</dict>
+</plist>'
+printf '%s\n' "${POLLER_PLUTIL_XML-$default_archive}"
+SHIM
+  chmod +x "$POLLER_HOME/bin/plutil"
+
+  # readlink: only the -f resolution the lulu_rule_resolved_present reader
+  # performs is legitimate. Identity resolution by default (the path resolves
+  # to itself); POLLER_READLINK_OUTPUT programs a distinct resolution and
+  # POLLER_READLINK_EXIT a resolution failure (a dangling or missing
+  # launcher).
+  cat >"$POLLER_HOME/bin/readlink" <<'SHIM'
+#!/usr/bin/env bash
+printf 'readlink %s\n' "$*" >>"$POLLER_PROBE_CALLS"
+if [[ $1 != "-f" || $# -ne 2 ]]; then
+  printf 'readlink %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+  exit 97
+fi
+if [[ -n ${POLLER_READLINK_SLEEP:-} ]]; then
+  exec sleep "$POLLER_READLINK_SLEEP"
+fi
+exit_code="${POLLER_READLINK_EXIT:-0}"
+if [[ $exit_code -ne 0 ]]; then
+  exit "$exit_code"
+fi
+printf '%s\n' "${POLLER_READLINK_OUTPUT-$2}"
+SHIM
+  chmod +x "$POLLER_HOME/bin/readlink"
+
+  # The LuLu rules-archive path handed to the poller (and embedded in the
+  # plutil stub's accepted argv): a sandbox path, so no test ever depends on
+  # the real /Library/Objective-See archive.
+  export OSQUERY_POSTURE_LULU_RULES="$POLLER_HOME/lulu-rules.plist"
 
   # Tools the poller has NO business invoking at all, status or otherwise: any
   # call is a recorded violation. run_poller prepends this bin dir to PATH, so
@@ -316,6 +409,9 @@ run_poller() {
     OSQUERY_POSTURE_SYSADMINCTL="$POLLER_HOME/bin/sysadminctl" \
     OSQUERY_POSTURE_DEFAULTS="$POLLER_HOME/bin/defaults" \
     OSQUERY_POSTURE_PGREP="$POLLER_HOME/bin/pgrep" \
+    OSQUERY_POSTURE_PLUTIL="$POLLER_HOME/bin/plutil" \
+    OSQUERY_POSTURE_READLINK="$POLLER_HOME/bin/readlink" \
+    OSQUERY_POSTURE_LULU_RULES="$OSQUERY_POSTURE_LULU_RULES" \
     bash "$POLLER_TOOL" "$@"
 }
 

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -288,28 +288,28 @@ esac
 SHIM
   chmod +x "$POLLER_HOME/bin/pgrep"
 
-  # plutil: only the exact read-only conversion of the LuLu rules archive to
-  # stdout is legitimate (the archive file is never written); every other
-  # argv is a recorded violation. POLLER_PLUTIL_XML programs the converted
-  # document (default: an archive mentioning nothing); ${VAR-default} so a
-  # deliberately empty output (the status/output-mismatch form) is
-  # programmable. POLLER_PLUTIL_EXIT models a failed conversion (missing or
-  # corrupt archive).
+  # plutil: exactly two read-only conversions to stdout are legitimate, the
+  # LuLu rules archive and the LuLu base preferences (the active-profile
+  # guard's read); neither file is ever written, and every other argv is a
+  # recorded violation. POLLER_PLUTIL_XML / POLLER_PLUTIL_EXIT program the
+  # rules conversion (default: an archive mentioning nothing);
+  # POLLER_PLUTIL_PREFS_XML / POLLER_PLUTIL_PREFS_EXIT program the
+  # preferences conversion (default: a document WITHOUT a currentProfile
+  # key, the no-profile healthy state). ${VAR-default} so a deliberately
+  # empty output (the status/output-mismatch form) is programmable on both.
   cat >"$POLLER_HOME/bin/plutil" <<'SHIM'
 #!/usr/bin/env bash
 printf 'plutil %s\n' "$*" >>"$POLLER_PROBE_CALLS"
-if [[ "$*" != "-convert xml1 -o - ${OSQUERY_POSTURE_LULU_RULES:-}" ]]; then
-  printf 'plutil %s\n' "$*" >>"$POLLER_MUTATION_LOG"
-  exit 97
-fi
-if [[ -n ${POLLER_PLUTIL_SLEEP:-} ]]; then
-  exec sleep "$POLLER_PLUTIL_SLEEP"
-fi
-exit_code="${POLLER_PLUTIL_EXIT:-0}"
-if [[ $exit_code -ne 0 ]]; then
-  exit "$exit_code"
-fi
-default_archive='<?xml version="1.0" encoding="UTF-8"?>
+case "$*" in
+  "-convert xml1 -o - ${OSQUERY_POSTURE_LULU_RULES:-}")
+    if [[ -n ${POLLER_PLUTIL_SLEEP:-} ]]; then
+      exec sleep "$POLLER_PLUTIL_SLEEP"
+    fi
+    exit_code="${POLLER_PLUTIL_EXIT:-0}"
+    if [[ $exit_code -ne 0 ]]; then
+      exit "$exit_code"
+    fi
+    default_archive='<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
 	<key>$objects</key>
@@ -317,7 +317,30 @@ default_archive='<?xml version="1.0" encoding="UTF-8"?>
 	</array>
 </dict>
 </plist>'
-printf '%s\n' "${POLLER_PLUTIL_XML-$default_archive}"
+    printf '%s\n' "${POLLER_PLUTIL_XML-$default_archive}"
+    ;;
+  "-convert xml1 -o - ${OSQUERY_POSTURE_LULU_PREFERENCES:-}")
+    if [[ -n ${POLLER_PLUTIL_PREFS_SLEEP:-} ]]; then
+      exec sleep "$POLLER_PLUTIL_PREFS_SLEEP"
+    fi
+    exit_code="${POLLER_PLUTIL_PREFS_EXIT:-0}"
+    if [[ $exit_code -ne 0 ]]; then
+      exit "$exit_code"
+    fi
+    default_preferences='<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>allowLocalHost</key>
+	<true/>
+</dict>
+</plist>'
+    printf '%s\n' "${POLLER_PLUTIL_PREFS_XML-$default_preferences}"
+    ;;
+  *)
+    printf 'plutil %s\n' "$*" >>"$POLLER_MUTATION_LOG"
+    exit 97
+    ;;
+esac
 SHIM
   chmod +x "$POLLER_HOME/bin/plutil"
 
@@ -344,10 +367,11 @@ printf '%s\n' "${POLLER_READLINK_OUTPUT-$2}"
 SHIM
   chmod +x "$POLLER_HOME/bin/readlink"
 
-  # The LuLu rules-archive path handed to the poller (and embedded in the
-  # plutil stub's accepted argv): a sandbox path, so no test ever depends on
-  # the real /Library/Objective-See archive.
+  # The LuLu rules-archive and base-preferences paths handed to the poller
+  # (and embedded in the plutil stub's accepted argvs): sandbox paths, so no
+  # test ever depends on the real /Library/Objective-See files.
   export OSQUERY_POSTURE_LULU_RULES="$POLLER_HOME/lulu-rules.plist"
+  export OSQUERY_POSTURE_LULU_PREFERENCES="$POLLER_HOME/lulu-preferences.plist"
 
   # Tools the poller has NO business invoking at all, status or otherwise: any
   # call is a recorded violation. run_poller prepends this bin dir to PATH, so
@@ -419,6 +443,7 @@ run_poller() {
     OSQUERY_POSTURE_PLUTIL="$POLLER_HOME/bin/plutil" \
     OSQUERY_POSTURE_READLINK="$POLLER_HOME/bin/readlink" \
     OSQUERY_POSTURE_LULU_RULES="$OSQUERY_POSTURE_LULU_RULES" \
+    OSQUERY_POSTURE_LULU_PREFERENCES="$OSQUERY_POSTURE_LULU_PREFERENCES" \
     bash "$POLLER_TOOL" "$@"
 }
 

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -394,8 +394,13 @@ jq -e '[.[] | select(.id == "lulu_extension")] | .[0].reader == "pgrep_lulu_exte
   fail "D: lulu_extension must be verify tier, read by pgrep_lulu_extension, expecting running"
 jq -e '[.[] | select(.id == "lulu_rule_tailscaled")] | .[0].reader == "lulu_rule_present" and .[0].expect == "present" and .[0].target == "/usr/local/bin/tailscaled"' <<<"$controls_json" >/dev/null ||
   fail "D: lulu_rule_tailscaled must check the stable tailscaled path via lulu_rule_present"
-jq -e '[.[] | select(.id == "lulu_rule_hermes_gateway")] | .[0].reader == "lulu_rule_resolved_present" and .[0].expect == "present" and (.[0].target | startswith("/"))' <<<"$controls_json" >/dev/null ||
-  fail "D: lulu_rule_hermes_gateway must resolve the venv launcher via lulu_rule_resolved_present"
+# The target is pinned EXACTLY, not merely absolute: the agreement test
+# generates its archive fixture from this same declaration, so any absolute
+# path would satisfy both tests while the control watched the wrong binary.
+# This is the venv launcher the Hermes gateway actually runs under (the
+# runbook's rule-creation section names the same path).
+jq -e '[.[] | select(.id == "lulu_rule_hermes_gateway")] | .[0].reader == "lulu_rule_resolved_present" and .[0].expect == "present" and .[0].target == "/Users/stephen/.hermes/hermes-agent/venv/bin/python"' <<<"$controls_json" >/dev/null ||
+  fail "D: lulu_rule_hermes_gateway must watch the real venv launcher /Users/stephen/.hermes/hermes-agent/venv/bin/python via lulu_rule_resolved_present (got target: $(jq -r '.[] | select(.id == "lulu_rule_hermes_gateway") | .target' <<<"$controls_json"))"
 
 # ---- E: extension lifecycle against a stubbed probe --------------------------
 

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -94,8 +94,25 @@ for required_file in "$DEFAULTS_YAML" "$SETUP_YAML" "$CONTROLS_YAML" "$TIER1_TEM
   [[ -f $required_file ]] || fail "missing file: $required_file"
 done
 
-sandbox="$(cd "$(mktemp -d)" && pwd -P)"
-trap 'rm -rf "$sandbox"' EXIT
+# The sandbox is validated BEFORE any trap is armed and before any cd: on
+# bash 3.2 `cd ""` succeeds without moving, so an unguarded
+# `cd "$(mktemp -d)"` after a failed mktemp would leave the suite standing in
+# the worktree with an `rm -rf` trap aimed at it.
+sandbox="$(mktemp -d)"
+[[ -n $sandbox && -d $sandbox ]] ||
+  fail "mktemp -d produced no usable sandbox directory (got '$sandbox')"
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$sandbox" && pwd -P)"
+# The ONE exit trap for the whole suite. Per-section `trap ... EXIT` installs
+# would REPLACE it (and a final `trap - EXIT` would clear it), leaking the
+# sandbox on every successful run, so sections below call
+# teardown_poller_harness explicitly instead of touching the trap; the
+# teardown is a no-op when no harness is live.
+cleanup() {
+  teardown_poller_harness
+  rm -rf "$sandbox"
+}
+trap cleanup EXIT
 render_home="$sandbox/render-home"
 mkdir -p "$render_home"
 render_error="$sandbox/render.err"
@@ -273,7 +290,6 @@ EOF
 # The poller re-validates the deployed file itself: a target its reader does
 # not consume is refused BEFORE any probe runs, as a monitoring gap.
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 set_posture_controls '[{"id":"demo_guest","description":"A guest control carrying a target","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","target":"/usr/local/bin/tailscaled"}]'
 seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
@@ -282,7 +298,6 @@ assert_page_count 1 || fail "B2 poller: a mis-paired deployed file must page a m
 assert_page_body_has 'demo_guest' || fail "B2 poller: the refusal page must name the record"
 assert_no_probe_calls || fail "B2 poller: a refused file must be rejected BEFORE any probe runs"
 teardown_poller_harness
-trap - EXIT
 
 # ---- C: the manual records and their runbook sections ------------------------
 
@@ -390,7 +405,6 @@ extension_probe_argv="pgrep -x -U 0 com.objective-see.lulu.extension"
 extension_healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","lulu_extension":"running","lulu_extension:expect":"running"}'
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 set_posture_controls "$extension_record"
 export POLLER_PGREP_LULU_MODE=running
@@ -405,10 +419,8 @@ assert_baseline_scalar lulu_extension running ||
   fail "E healthy: the baseline must record the extension as running"
 assert_no_mutation_attempt || fail "E healthy: a posture read must never mutate"
 teardown_poller_harness
-trap - EXIT
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 set_posture_controls "$extension_record"
 seed_baseline "$extension_healthy_seed"
@@ -433,7 +445,6 @@ assert_page_count 2 || fail "E re-stop: a LATER stop must page again"
 assert_no_mutation_attempt || fail "E: the lifecycle must never mutate"
 unset POLLER_PGREP_LULU_MODE
 teardown_poller_harness
-trap - EXIT
 
 # ---- F: a missing required rule pages once, names the rule, stays quiet ------
 
@@ -454,7 +465,6 @@ archive_xml_mentioning() {
 }
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 set_posture_controls "$tailscaled_record"
 seed_baseline "$rule_healthy_seed"
@@ -476,12 +486,10 @@ assert_baseline_scalar lulu_rule_tailscaled present ||
 assert_no_mutation_attempt || fail "F: the rule check must never mutate"
 unset POLLER_PLUTIL_XML
 teardown_poller_harness
-trap - EXIT
 
 # ---- G: a changed declared target re-arms the control ------------------------
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
 set_posture_controls "$tailscaled_record"
 POLLER_PLUTIL_XML="$(archive_xml_mentioning "$tailscaled_target")"
@@ -500,7 +508,6 @@ assert_page_body_has 'first observation' ||
   fail "G repoint: the page must be a first observation under the new target, not a transition from the old one"
 unset POLLER_PLUTIL_XML
 teardown_poller_harness
-trap - EXIT
 
 # ---- H: the existence-only limitation is stated, in data and runbook ---------
 

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+# lulu-policy-records.sh -- slice 10: LuLu policy and posture.
+#
+# LuLu is the outbound firewall on this machine. Its policy surface
+# (/Library/Objective-See/LuLu/preferences.plist, plain XML at an absolute
+# path) is declaratively manageable; its rules surface (rules.plist, an
+# NSKeyedArchiver archive of LuLu's private Rule class) is interactive-only.
+# The slice therefore declares:
+#
+#   - the six policy preferences as enforce records in macos_defaults.yaml,
+#     scope system with an explicit plist_path, each carrying the value the
+#     machine holds today (the slice codifies posture, it never changes it);
+#   - the system-extension approval and rule creation as manual records in
+#     macos_system_setup.yaml with runbook sections that exist;
+#   - the extension running and the required allow rules existing as verify
+#     records in macos_posture_controls.yaml, read by the security-posture
+#     poller.
+#
+# The behaviours, each against the REAL repo data (so a fixture cannot drift
+# from what ships), with the poller driven against STUBS (a stubbed rule-file
+# reader, a stubbed extension probe), so the suite passes on any machine
+# regardless of LuLu's state:
+#
+#   A  the six policy records: enforce, scope system, the LuLu plist_path,
+#      todays live values, and the allowLocalHost record carries the
+#      alerting-path reason inline so it cannot be quietly flipped or dropped.
+#      The rendered Tier 1 runner writes each record to the absolute plist
+#      path under sudo.
+#   B  containment: a system record naming a plist_path outside the permitted
+#      plist directories (LuLu's install directory) aborts the render.
+#   C  manual records: the system-extension approval and rule creation are
+#      declared manual with no mutating payload, their runbook sections
+#      exist and are non-empty, and the rendered Tier 2 runner emits a
+#      pointer and no command for either.
+#   D  the talker table: every enumerated outbound talker carries exactly one
+#      of a declared verify control or a written no-rule reason, and the set
+#      of named controls equals the set of declared lulu_rule records; the
+#      table and the control set are diffed, so adding a talker without a
+#      control fails here.
+#   E  extension lifecycle: the poller probes the extension with one exact
+#      user-scoped pgrep, pages exactly one CRIT when it stops (naming the
+#      control and its remedy), stays quiet while stopped, re-arms silently
+#      on restore, and pages again on a later stop.
+#   F  missing rule: with the stubbed rule reader reporting a required rule
+#      missing, the poller pages once, names the missing rule, and stays
+#      quiet while it remains missing; a restored rule re-arms silently.
+#   G  a changed declared target re-arms the control: the baseline records
+#      the target each value was observed under, so repointing a rule
+#      control at a new binary pages a fresh first observation instead of
+#      riding the old baseline.
+#   H  honesty: the rule-existence records and the runbook state the
+#      existence-only limitation (the archive proves a rule mentioning the
+#      binary exists; the check does not prove the rule allows).
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULTS_YAML="$REPO_ROOT/.chezmoidata/macos_defaults.yaml"
+SETUP_YAML="$REPO_ROOT/.chezmoidata/macos_system_setup.yaml"
+CONTROLS_YAML="$REPO_ROOT/.chezmoidata/macos_posture_controls.yaml"
+TIER1_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+TIER2_TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl"
+POSTURE_TEMPLATE="$REPO_ROOT/dot_local/libexec/osquery/posture-controls.json.tmpl"
+RUNBOOK="$REPO_ROOT/docs/runbooks/macos-fresh-machine-quickstart.md"
+LULU_PLIST_PATH="/Library/Objective-See/LuLu/preferences.plist"
+
+# shellcheck source=../fixtures/osquery-poller-lib.bash
+source "$REPO_ROOT/test/fixtures/osquery-poller-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# refute_file_contains <file> <fixed-string> <message> -- an explicit refute
+# helper (never a bare negated grep in a test body).
+refute_file_contains() {
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+for tool in yq jq chezmoi; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'SKIP: %s not on PATH; cannot exercise the LuLu policy records\n' "$tool"
+    exit 0
+  }
+done
+for required_file in "$DEFAULTS_YAML" "$SETUP_YAML" "$CONTROLS_YAML" "$TIER1_TEMPLATE" \
+  "$TIER2_TEMPLATE" "$POSTURE_TEMPLATE" "$RUNBOOK"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+render_home="$sandbox/render-home"
+mkdir -p "$render_home"
+render_error="$sandbox/render.err"
+
+# ---- A: the six policy records, todays values, the inline reason -------------
+
+# The declared values ARE the values the live machine carries today (measured
+# 2026-07-27, plutil -p on the live plist). A record whose declared value
+# silently differed from the live one would turn a codification into a change.
+declare -a policy_expectations=(
+  "allowLocalHost|true"
+  "allowApple|true"
+  "allowDNS|true"
+  "allowInstalled|true"
+  "blockMode|false"
+  "passiveMode|false"
+)
+
+lulu_records="$(yq -o=json '[.macos.defaults[] | select(.domain == "com.objective-see.lulu")]' "$DEFAULTS_YAML")" ||
+  fail "A: could not read the LuLu records from $DEFAULTS_YAML"
+jq -e 'length == 6' <<<"$lulu_records" >/dev/null ||
+  fail "A: exactly six LuLu policy records must be declared; got $(jq 'length' <<<"$lulu_records")"
+
+for expectation in "${policy_expectations[@]}"; do
+  policy_key="${expectation%%|*}"
+  policy_value="${expectation##*|}"
+  record="$(jq --arg key "$policy_key" '[.[] | select(.key == $key)]' <<<"$lulu_records")"
+  jq -e 'length == 1' <<<"$record" >/dev/null ||
+    fail "A: exactly one record for $policy_key must be declared"
+  jq -e '.[0].tier == "enforce"' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must be tier: enforce (got $(jq -r '.[0].tier' <<<"$record"))"
+  jq -e '.[0].scope == "system"' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must be scope: system"
+  jq -e --arg path "$LULU_PLIST_PATH" '.[0].plist_path == $path' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must declare plist_path: $LULU_PLIST_PATH"
+  jq -e '.[0].type == "bool"' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must be type: bool"
+  jq -e --arg value "$policy_value" '(.[0].value | tostring) == $value' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must declare todays live value $policy_value (got $(jq -r '.[0].value' <<<"$record"))"
+done
+
+# The allowLocalHost reason, inline where anyone tempted to tidy it will read
+# it: the alerting path itself rides loopback, so this preference is the most
+# safety-critical one on the machine. Both fragments must survive.
+grep -qF 'alert-dispatch.sh POSTs every page to a Hermes gateway on 127.0.0.1:8644' "$DEFAULTS_YAML" ||
+  fail "A: the allowLocalHost record must carry the alerting-path reason (the loopback POST target)"
+grep -qF 'Flipping it to false would put LuLu in front of the alerting path itself' "$DEFAULTS_YAML" ||
+  fail "A: the allowLocalHost record must carry the alerting-path consequence inline"
+
+# The rendered Tier 1 runner writes each record to the absolute plist path,
+# under sudo (the slice 2 system-scope form, confirmed for this exact path).
+if [[ "$(uname)" == Darwin ]]; then
+  tier1_rendered="$sandbox/tier1.rendered"
+  HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+    <"$TIER1_TEMPLATE" >"$tier1_rendered" 2>"$render_error" ||
+    fail "A: the Tier 1 runner must render against the real data (stderr: $(cat "$render_error"))"
+  for expectation in "${policy_expectations[@]}"; do
+    policy_key="${expectation%%|*}"
+    policy_value="${expectation##*|}"
+    write_line="sudo defaults write '$LULU_PLIST_PATH' '$policy_key' -bool '$policy_value'"
+    grep -qxF -- "$write_line" "$tier1_rendered" ||
+      fail "A: the rendered runner must write $policy_key to the absolute plist path under sudo: [$write_line]"
+  done
+fi
+
+# ---- B: a plist_path outside the permitted directories aborts the render ----
+
+make_defaults_source() { # fixture YAML on stdin; prints the source dir
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/defaults-src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_defaults.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+escape_source="$(
+  make_defaults_source <<'EOF'
+macos:
+  defaults:
+    - domain: com.evil.example
+      key: EvilKey
+      type: bool
+      value: true
+      tier: enforce
+      scope: system
+      plist_path: /etc/evil.plist
+  killall: []
+EOF
+)"
+escape_status=0
+HOME="$render_home" chezmoi --source "$escape_source" execute-template --no-tty \
+  <"$TIER1_TEMPLATE" >"$sandbox/escape.rendered" 2>"$render_error" || escape_status=$?
+[[ $escape_status -ne 0 ]] ||
+  fail "B: a plist_path outside the permitted plist directories must abort the render (rendered: $(grep -F EvilKey "$sandbox/escape.rendered" || true))"
+grep -qF '/etc/evil.plist' "$render_error" ||
+  fail "B: the refusal must name the offending path (stderr: $(cat "$render_error"))"
+grep -qF 'permitted plist director' "$render_error" ||
+  fail "B: the refusal must name the containment rule (stderr: $(cat "$render_error"))"
+
+# Positive control: the same fixture shape with the LuLu path renders.
+inside_source="$(
+  make_defaults_source <<EOF
+macos:
+  defaults:
+    - domain: com.objective-see.lulu
+      key: allowApple
+      type: bool
+      value: true
+      tier: enforce
+      scope: system
+      plist_path: $LULU_PLIST_PATH
+  killall: []
+EOF
+)"
+HOME="$render_home" chezmoi --source "$inside_source" execute-template --no-tty \
+  <"$TIER1_TEMPLATE" >"$sandbox/inside.rendered" 2>"$render_error" ||
+  fail "B: the LuLu plist_path must render cleanly (stderr: $(cat "$render_error"))"
+
+# ---- B2: the target pairing is refused in both directions, at both layers ----
+
+make_posture_source() { # fixture YAML on stdin; prints the source dir
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/posture-src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_posture_controls.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+assert_posture_render_rejects() { # <label> <stderr-fragment>...
+  local label="$1" source_dir status=0 fragment
+  shift
+  source_dir="$(make_posture_source)"
+  HOME="$render_home" chezmoi --source "$source_dir" execute-template --no-tty \
+    <"$POSTURE_TEMPLATE" >"$sandbox/posture.rendered" 2>"$render_error" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "B2 $label: the posture render must refuse (rendered: $(cat "$sandbox/posture.rendered"))"
+  for fragment in "$@"; do
+    grep -qF -- "$fragment" "$render_error" ||
+      fail "B2 $label: the refusal must name '$fragment' (stderr: $(cat "$render_error"))"
+  done
+}
+
+assert_posture_render_rejects 'rule reader without a target' 'requires a target' <<'EOF'
+macos:
+  posture_controls:
+    - id: demo_rule
+      description: "A rule control with no target"
+      tier: verify
+      reader: lulu_rule_present
+      expect: "present"
+EOF
+
+assert_posture_render_rejects 'target on a targetless reader' 'does not consume' <<'EOF'
+macos:
+  posture_controls:
+    - id: demo_guest
+      description: "A guest control carrying a target"
+      tier: verify
+      reader: sysadminctl_guest
+      expect: "disabled"
+      target: /usr/local/bin/tailscaled
+EOF
+
+assert_posture_render_rejects 'relative target' 'must be an absolute path' <<'EOF'
+macos:
+  posture_controls:
+    - id: demo_rule
+      description: "A rule control with a relative target"
+      tier: verify
+      reader: lulu_rule_present
+      expect: "present"
+      target: usr/local/bin/tailscaled
+EOF
+
+# The poller re-validates the deployed file itself: a target its reader does
+# not consume is refused BEFORE any probe runs, as a monitoring gap.
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls '[{"id":"demo_guest","description":"A guest control carrying a target","tier":"verify","reader":"sysadminctl_guest","expect":"disabled","target":"/usr/local/bin/tailscaled"}]'
+seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+run_poller >/dev/null 2>&1 || fail "B2 poller: expected exit 0 after paging the refused file"
+assert_page_count 1 || fail "B2 poller: a mis-paired deployed file must page a monitoring gap"
+assert_page_body_has 'demo_guest' || fail "B2 poller: the refusal page must name the record"
+assert_no_probe_calls || fail "B2 poller: a refused file must be rejected BEFORE any probe runs"
+teardown_poller_harness
+trap - EXIT
+
+# ---- C: the manual records and their runbook sections ------------------------
+
+assert_manual_record() { # <description-fragment> <expected-runbook-section>
+  local fragment="$1" expected_runbook="$2" records
+  records="$(yq -o=json "[.macos.system_setup[] | select(.tier == \"manual\" and (.description | contains(\"$fragment\")))]" "$SETUP_YAML")" ||
+    fail "C: could not read $SETUP_YAML"
+  jq -e 'length == 1' <<<"$records" >/dev/null ||
+    fail "C: exactly one manual record matching '$fragment' must be declared; got $(jq 'length' <<<"$records")"
+  jq -e '.[0] | (has("command") or has("sudo")) | not' <<<"$records" >/dev/null ||
+    fail "C: the '$fragment' manual record must carry no mutating payload"
+  [[ "$(jq -r '.[0].runbook' <<<"$records")" == "$expected_runbook" ]] ||
+    fail "C: the '$fragment' manual record must name the runbook section '$expected_runbook'"
+  grep -qxF "### $expected_runbook" "$RUNBOOK" ||
+    fail "C: the runbook section '### $expected_runbook' must exist in $RUNBOOK"
+  local section_body
+  section_body="$(awk -v heading="### $expected_runbook" '
+    $0 == heading { in_section = 1; next }
+    in_section && /^### / { exit }
+    in_section { print }
+  ' "$RUNBOOK")"
+  [[ -n ${section_body//[[:space:]]/} ]] ||
+    fail "C: the runbook section '### $expected_runbook' has an empty body"
+  printf '%s\n' "$section_body"
+}
+
+approval_body="$(assert_manual_record 'approve its system extension' 'LuLu system extension approval')"
+grep -qF 'Login Items & Extensions' <<<"$approval_body" ||
+  fail "C: the approval section must name the System Settings pane the operator uses"
+
+rules_body="$(assert_manual_record 'outbound allow rules' 'LuLu rule creation')"
+grep -qF 'Do NOT create blanket allow rules for shared interpreters' <<<"$rules_body" ||
+  fail "C: the rule-creation section must carry the lean-narrow shared-client warning"
+grep -qiF 'rules cannot be pre-seeded' <<<"$rules_body" ||
+  fail "C: the rule-creation section must state why creation is interactive-only"
+
+# The rendered Tier 2 runner emits a pointer and no command for either record.
+if [[ "$(uname)" == Darwin ]]; then
+  tier2_rendered="$sandbox/tier2.rendered"
+  HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+    <"$TIER2_TEMPLATE" >"$tier2_rendered" 2>"$render_error" ||
+    fail "C: the Tier 2 runner must render against the real data (stderr: $(cat "$render_error"))"
+  grep -qF 'see the runbook section LuLu system extension approval' "$tier2_rendered" ||
+    fail "C: the rendered runner must point at the approval runbook section"
+  grep -qF 'see the runbook section LuLu rule creation' "$tier2_rendered" ||
+    fail "C: the rendered runner must point at the rule-creation runbook section"
+  refute_file_contains "$tier2_rendered" 'systemextensionsctl' \
+    "C: the runner must emit no command for the manual extension approval"
+fi
+
+# ---- D: the talker table and the declared control set are diffed -------------
+
+talkers_json="$(yq -o=json '.macos.lulu_talkers' "$CONTROLS_YAML")" ||
+  fail "D: could not read the talker table from $CONTROLS_YAML"
+jq -e 'type == "array" and length > 0' <<<"$talkers_json" >/dev/null ||
+  fail "D: macos.lulu_talkers must enumerate the outbound talker set"
+
+# The enumerated set from the spec, by name: each must appear exactly once.
+for talker_name in "Hermes gateway" "the alerter curl" "tailscaled" "Homebrew" "npm" "nix" "gh"; do
+  jq -e --arg name "$talker_name" '[.[] | select(.talker == $name)] | length == 1' <<<"$talkers_json" >/dev/null ||
+    fail "D: the talker table must enumerate '$talker_name' exactly once"
+done
+
+# Exactly one of control / no_rule_reason per talker, never both, never neither.
+bad_talkers="$(jq -r '[.[] | select((has("control")) == (has("no_rule_reason"))) | .talker] | join(", ")' <<<"$talkers_json")"
+[[ -z $bad_talkers ]] ||
+  fail "D: every talker needs exactly one of control or no_rule_reason; violated by: $bad_talkers"
+
+# THE DIFF: the set of controls the table names == the set of declared
+# lulu_rule records. A talker added without a control fails here, and so does
+# a rule control no talker claims.
+controls_json="$(yq -o=json '.macos.posture_controls' "$CONTROLS_YAML")" ||
+  fail "D: could not read the posture controls"
+jq -r '[.[] | select(has("control")) | .control] | sort | .[]' <<<"$talkers_json" >"$sandbox/talker-controls"
+jq -r '[.[] | select(.reader | startswith("lulu_rule")) | .id] | sort | .[]' <<<"$controls_json" >"$sandbox/declared-rule-controls"
+diff -u "$sandbox/talker-controls" "$sandbox/declared-rule-controls" >&2 ||
+  fail "D: the talker tables named controls and the declared lulu_rule records have drifted apart"
+
+# The alerter curl needs no rule BECAUSE its hop is loopback under the
+# allowLocalHost preference; anyone writing a curl rule has solved the wrong
+# problem, and the reason must say so.
+curl_reason="$(jq -r '.[] | select(.talker == "the alerter curl") | .no_rule_reason' <<<"$talkers_json")"
+grep -qF 'allowLocalHost' <<<"$curl_reason" ||
+  fail "D: the alerter-curl no-rule reason must rest on the allowLocalHost preference, not on a rule"
+
+# The extension record and the two rule records exist with their exact shape.
+jq -e '[.[] | select(.id == "lulu_extension")] | length == 1' <<<"$controls_json" >/dev/null ||
+  fail "D: the lulu_extension verify record must be declared"
+jq -e '[.[] | select(.id == "lulu_extension")] | .[0].reader == "pgrep_lulu_extension" and .[0].expect == "running" and .[0].tier == "verify"' <<<"$controls_json" >/dev/null ||
+  fail "D: lulu_extension must be verify tier, read by pgrep_lulu_extension, expecting running"
+jq -e '[.[] | select(.id == "lulu_rule_tailscaled")] | .[0].reader == "lulu_rule_present" and .[0].expect == "present" and .[0].target == "/usr/local/bin/tailscaled"' <<<"$controls_json" >/dev/null ||
+  fail "D: lulu_rule_tailscaled must check the stable tailscaled path via lulu_rule_present"
+jq -e '[.[] | select(.id == "lulu_rule_hermes_gateway")] | .[0].reader == "lulu_rule_resolved_present" and .[0].expect == "present" and (.[0].target | startswith("/"))' <<<"$controls_json" >/dev/null ||
+  fail "D: lulu_rule_hermes_gateway must resolve the venv launcher via lulu_rule_resolved_present"
+
+# ---- E: extension lifecycle against a stubbed probe --------------------------
+
+extension_record="$(jq -c '[.[] | select(.id == "lulu_extension")]' <<<"$controls_json")"
+extension_description="$(jq -r '.[0].description' <<<"$extension_record")"
+extension_remedy="$(jq -r '.[0].remedy // empty' <<<"$extension_record")"
+[[ -n $extension_remedy ]] ||
+  fail "E: the lulu_extension record must carry a remedy"
+
+extension_probe_argv="pgrep -x -U 0 com.objective-see.lulu.extension"
+extension_healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","lulu_extension":"running","lulu_extension:expect":"running"}'
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$extension_record"
+export POLLER_PGREP_LULU_MODE=running
+poller_status=0
+poller_output="$(run_poller 2>&1)" || poller_status=$?
+[[ $poller_status -eq 0 ]] ||
+  fail "E healthy: expected exit 0, got $poller_status: $poller_output"
+assert_no_page || fail "E healthy: a running extension must page nothing"
+assert_probe_argv "$extension_probe_argv" 1 ||
+  fail "E healthy: the poller must probe the extension process exactly once, root-scoped by exact name"
+assert_baseline_scalar lulu_extension running ||
+  fail "E healthy: the baseline must record the extension as running"
+assert_no_mutation_attempt || fail "E healthy: a posture read must never mutate"
+teardown_poller_harness
+trap - EXIT
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$extension_record"
+seed_baseline "$extension_healthy_seed"
+export POLLER_PGREP_LULU_MODE=stopped
+run_poller >/dev/null 2>&1 || fail "E stop: expected exit 0"
+assert_page_count 1 || fail "E stop: the stop must page exactly once"
+assert_page_severity_is CRIT || fail "E stop: the stop page must be CRIT"
+assert_page_body_has "\`$extension_description\`: now stopped, declared running" ||
+  fail "E stop: the page must name the control and the stopped-vs-declared state"
+assert_page_body_has "$extension_remedy" ||
+  fail "E stop: the page must carry the declared remedy"
+run_poller >/dev/null 2>&1 || fail "E quiet: expected exit 0"
+assert_page_count 1 || fail "E quiet: an ONGOING stop must stay quiet (page-once)"
+export POLLER_PGREP_LULU_MODE=running
+run_poller >/dev/null 2>&1 || fail "E restore: expected exit 0"
+assert_page_count 1 || fail "E restore: a restore is silent recovery, not a page"
+assert_baseline_scalar lulu_extension running ||
+  fail "E restore: the baseline must return to running"
+export POLLER_PGREP_LULU_MODE=stopped
+run_poller >/dev/null 2>&1 || fail "E re-stop: expected exit 0"
+assert_page_count 2 || fail "E re-stop: a LATER stop must page again"
+assert_no_mutation_attempt || fail "E: the lifecycle must never mutate"
+unset POLLER_PGREP_LULU_MODE
+teardown_poller_harness
+trap - EXIT
+
+# ---- F: a missing required rule pages once, names the rule, stays quiet ------
+
+tailscaled_record="$(jq -c '[.[] | select(.id == "lulu_rule_tailscaled")]' <<<"$controls_json")"
+tailscaled_description="$(jq -r '.[0].description' <<<"$tailscaled_record")"
+tailscaled_target="$(jq -r '.[0].target' <<<"$tailscaled_record")"
+rule_healthy_seed="{\"firewall\":\"1\",\"gatekeeper\":\"1\",\"screenlock\":\"1\",\"lulu_rule_tailscaled\":\"present\",\"lulu_rule_tailscaled:expect\":\"present\",\"lulu_rule_tailscaled:target\":\"$tailscaled_target\"}"
+
+# archive_xml_mentioning <path>... -- a minimal plutil-shaped XML body whose
+# $objects array mentions each path, the way LuLu's keyed archive does.
+archive_xml_mentioning() {
+  local body="" mentioned_path
+  for mentioned_path in "$@"; do
+    body+="		<string>$mentioned_path</string>"$'\n'
+  done
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>\$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
+}
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$tailscaled_record"
+seed_baseline "$rule_healthy_seed"
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/unrelated/binary)"
+export POLLER_PLUTIL_XML
+run_poller >/dev/null 2>&1 || fail "F missing: expected exit 0"
+assert_page_count 1 || fail "F missing: a missing required rule must page exactly once"
+assert_page_severity_is CRIT || fail "F missing: the missing-rule page must be CRIT"
+assert_page_body_has "\`$tailscaled_description\`: now absent, declared present" ||
+  fail "F missing: the page must name the missing rule control"
+run_poller >/dev/null 2>&1 || fail "F quiet: expected exit 0"
+assert_page_count 1 || fail "F quiet: the rule STAYING missing must not re-page"
+POLLER_PLUTIL_XML="$(archive_xml_mentioning "$tailscaled_target")"
+export POLLER_PLUTIL_XML
+run_poller >/dev/null 2>&1 || fail "F restore: expected exit 0"
+assert_page_count 1 || fail "F restore: a restored rule is silent recovery"
+assert_baseline_scalar lulu_rule_tailscaled present ||
+  fail "F restore: the baseline must return to present"
+assert_no_mutation_attempt || fail "F: the rule check must never mutate"
+unset POLLER_PLUTIL_XML
+teardown_poller_harness
+trap - EXIT
+
+# ---- G: a changed declared target re-arms the control ------------------------
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$tailscaled_record"
+POLLER_PLUTIL_XML="$(archive_xml_mentioning "$tailscaled_target")"
+export POLLER_PLUTIL_XML
+run_poller >/dev/null 2>&1 || fail "G seed: expected exit 0"
+assert_no_page || fail "G seed: a present rule must page nothing"
+assert_baseline_scalar "lulu_rule_tailscaled:target" "$tailscaled_target" ||
+  fail "G seed: the baseline must record the target the value was observed under"
+# Repoint the control at a binary the archive does NOT mention: the prior was
+# recorded under the old target, so it must not be trusted, and the deviation
+# pages as a fresh first observation rather than riding the stale baseline.
+set_posture_controls "$(jq -c '.[0].target = "/usr/local/bin/relocated-tailscaled" | [.[0]]' <<<"$tailscaled_record")"
+run_poller >/dev/null 2>&1 || fail "G repoint: expected exit 0"
+assert_page_count 1 || fail "G repoint: a repointed control whose rule is absent must page"
+assert_page_body_has 'first observation' ||
+  fail "G repoint: the page must be a first observation under the new target, not a transition from the old one"
+unset POLLER_PLUTIL_XML
+teardown_poller_harness
+trap - EXIT
+
+# ---- H: the existence-only limitation is stated, in data and runbook ---------
+
+grep -qF 'existence-only' "$CONTROLS_YAML" ||
+  fail "H: the rule records must state the existence-only limitation in the data file"
+grep -qF 'does not prove the rule allows' "$CONTROLS_YAML" ||
+  fail "H: the data file must state the check cannot see the rule action"
+grep -qF 'existence-only' "$RUNBOOK" ||
+  fail "H: the runbook must state the existence-only limitation"
+
+printf 'ok: LuLu policy and posture (six enforce policy records with the inline alerting-path reason, plist_path containment, manual approval and rule-creation records, talker-vs-control diff, extension lifecycle, missing-rule paging, target re-arm, existence-only honesty)\n'

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -449,7 +449,8 @@ archive_xml_mentioning() {
   for mentioned_path in "$@"; do
     body+="		<string>$mentioned_path</string>"$'\n'
   done
-  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>\$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
+  # shellcheck disable=SC2016 # the literal $objects key is the archive format
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
 }
 
 setup_poller_harness

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -513,10 +513,38 @@ assert_page_body_has 'first observation' ||
 unset POLLER_PLUTIL_XML
 teardown_poller_harness
 
-# ---- H: the existence-only limitation is stated, in data and runbook ---------
+# ---- H: the existence-only limitation is stated where it binds ---------------
 
-grep -qF 'existence-only' "$CONTROLS_YAML" ||
-  fail "H: the rule records must state the existence-only limitation in the data file"
+# The record DESCRIPTIONS are what a page prints, so the honesty must live in
+# them, not only in adjacent comments: each rule record states the
+# existence-only limit itself, and claims no rule ACTION the reader cannot
+# see (a blocked, disabled, expired, endpoint-limited, or signing-mismatched
+# rule all read present in the archive).
+for rule_control_id in lulu_rule_tailscaled lulu_rule_hermes_gateway; do
+  rule_description="$(jq -r --arg id "$rule_control_id" '.[] | select(.id == $id) | .description' <<<"$controls_json")"
+  grep -qF 'existence-only' <<<"$rule_description" ||
+    fail "H: the $rule_control_id description must state the existence-only limit (got: $rule_description)"
+  if grep -qiF 'allow' <<<"$rule_description"; then
+    fail "H: the $rule_control_id description must not claim a rule action the reader cannot see (got: $rule_description)"
+  fi
+done
+
+# And the page a missing mention produces carries that limited claim, because
+# the description IS the page's header: one first-observation tick against an
+# archive that does not mention the target.
+setup_poller_harness
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$tailscaled_record"
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/unrelated/binary)"
+export POLLER_PLUTIL_XML
+run_poller >/dev/null 2>&1 || fail "H page: expected exit 0"
+assert_page_count 1 || fail "H page: an unmentioned target must page (first observation)"
+assert_page_body_has 'existence-only' ||
+  fail "H page: the page must carry the existence-only limitation through the description"
+unset POLLER_PLUTIL_XML
+teardown_poller_harness
+
+# The comment-level statements hold too, beside the per-record pins above.
 grep -qF 'does not prove the rule allows' "$CONTROLS_YAML" ||
   fail "H: the data file must state the check cannot see the rule action"
 grep -qF 'existence-only' "$RUNBOOK" ||

--- a/test/integration/lulu-policy-records.sh
+++ b/test/integration/lulu-policy-records.sh
@@ -7,9 +7,13 @@
 # NSKeyedArchiver archive of LuLu's private Rule class) is interactive-only.
 # The slice therefore declares:
 #
-#   - the six policy preferences as enforce records in macos_defaults.yaml,
+#   - the six policy preferences as verify records in macos_defaults.yaml,
 #     scope system with an explicit plist_path, each carrying the value the
-#     machine holds today (the slice codifies posture, it never changes it);
+#     live base file holds today. Verify, not enforce, from LuLu's own source
+#     (Extension/Preferences.m): the extension loads this file once at start
+#     and writes its in-memory dictionary back on every change, so an
+#     external write is both unobserved and clobbered. The records buy drift
+#     detection (`just D`); the runner renders no write for them.
 #   - the system-extension approval and rule creation as manual records in
 #     macos_system_setup.yaml with runbook sections that exist;
 #   - the extension running and the required allow rules existing as verify
@@ -21,11 +25,12 @@
 # reader, a stubbed extension probe), so the suite passes on any machine
 # regardless of LuLu's state:
 #
-#   A  the six policy records: enforce, scope system, the LuLu plist_path,
+#   A  the six policy records: verify, scope system, the LuLu plist_path,
 #      todays live values, and the allowLocalHost record carries the
 #      alerting-path reason inline so it cannot be quietly flipped or dropped.
-#      The rendered Tier 1 runner writes each record to the absolute plist
-#      path under sudo.
+#      The rendered Tier 1 runner touches the LuLu plist with NO command at
+#      all: a rendered write would claim an enforcement LuLu silently
+#      reverts.
 #   B  containment: a system record naming a plist_path outside the permitted
 #      plist directories (LuLu's install directory) aborts the render.
 #   C  manual records: the system-extension approval and rule creation are
@@ -142,8 +147,8 @@ for expectation in "${policy_expectations[@]}"; do
   record="$(jq --arg key "$policy_key" '[.[] | select(.key == $key)]' <<<"$lulu_records")"
   jq -e 'length == 1' <<<"$record" >/dev/null ||
     fail "A: exactly one record for $policy_key must be declared"
-  jq -e '.[0].tier == "enforce"' <<<"$record" >/dev/null ||
-    fail "A: the $policy_key record must be tier: enforce (got $(jq -r '.[0].tier' <<<"$record"))"
+  jq -e '.[0].tier == "verify"' <<<"$record" >/dev/null ||
+    fail "A: the $policy_key record must be tier: verify (got $(jq -r '.[0].tier' <<<"$record"))"
   jq -e '.[0].scope == "system"' <<<"$record" >/dev/null ||
     fail "A: the $policy_key record must be scope: system"
   jq -e --arg path "$LULU_PLIST_PATH" '.[0].plist_path == $path' <<<"$record" >/dev/null ||
@@ -162,20 +167,19 @@ grep -qF 'alert-dispatch.sh POSTs every page to a Hermes gateway on 127.0.0.1:86
 grep -qF 'Flipping it to false would put LuLu in front of the alerting path itself' "$DEFAULTS_YAML" ||
   fail "A: the allowLocalHost record must carry the alerting-path consequence inline"
 
-# The rendered Tier 1 runner writes each record to the absolute plist path,
-# under sudo (the slice 2 system-scope form, confirmed for this exact path).
+# The six records are tier: verify, so the rendered Tier 1 runner must not
+# touch the LuLu plist with any command at all. LuLu's extension loads its
+# preferences ONCE at start and writes its in-memory dictionary back on every
+# change it processes (Extension/Preferences.m), so a rendered write would be
+# both unobserved by the running extension and clobbered by its next save: an
+# enforcement claim the machine cannot deliver.
 if [[ "$(uname)" == Darwin ]]; then
   tier1_rendered="$sandbox/tier1.rendered"
   HOME="$render_home" chezmoi --source "$REPO_ROOT" execute-template --no-tty \
     <"$TIER1_TEMPLATE" >"$tier1_rendered" 2>"$render_error" ||
     fail "A: the Tier 1 runner must render against the real data (stderr: $(cat "$render_error"))"
-  for expectation in "${policy_expectations[@]}"; do
-    policy_key="${expectation%%|*}"
-    policy_value="${expectation##*|}"
-    write_line="sudo defaults write '$LULU_PLIST_PATH' '$policy_key' -bool '$policy_value'"
-    grep -qxF -- "$write_line" "$tier1_rendered" ||
-      fail "A: the rendered runner must write $policy_key to the absolute plist path under sudo: [$write_line]"
-  done
+  refute_file_contains "$tier1_rendered" "$LULU_PLIST_PATH" \
+    "A: the rendered runner must render NO command naming the LuLu plist (the records are verify tier)"
 fi
 
 # ---- B: a plist_path outside the permitted directories aborts the render ----
@@ -518,4 +522,4 @@ grep -qF 'does not prove the rule allows' "$CONTROLS_YAML" ||
 grep -qF 'existence-only' "$RUNBOOK" ||
   fail "H: the runbook must state the existence-only limitation"
 
-printf 'ok: LuLu policy and posture (six enforce policy records with the inline alerting-path reason, plist_path containment, manual approval and rule-creation records, talker-vs-control diff, extension lifecycle, missing-rule paging, target re-arm, existence-only honesty)\n'
+printf 'ok: LuLu policy and posture (six verify policy records with the inline alerting-path reason and no rendered write, plist_path containment, manual approval and rule-creation records, talker-vs-control diff, extension lifecycle, missing-rule paging, target re-arm, existence-only honesty)\n'

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -83,9 +83,11 @@ invalid_setup_tiers="$(yq eval -r \
 
 # ---- 2: both runners render byte-identically to their goldens ----------------
 
-# The Tier 1 runner's 5774ce0 render plus the security-defaults records: the
+# The Tier 1 runner's 5774ce0 render plus the security-defaults records (the
 # sudo -v prelude, the sudo-routed system-scope SoftwareUpdate write, and the
-# user-scope Safari write.
+# user-scope Safari write), plus the six LuLu policy writes the LuLu-posture
+# slice declared (system scope with an explicit plist_path, each value the
+# live machine carried when declared).
 tier1_golden="$work/tier1.golden"
 cat >"$tier1_golden" <<'GOLDEN_EOF'
 #!/bin/bash
@@ -112,6 +114,12 @@ defaults write 'com.apple.WindowManager' 'EnableTilingOptionAccelerator' -bool '
 defaults write 'com.apple.WindowManager' 'EnableTopTilingByEdgeDrag' -bool 'false'
 sudo defaults write '/Library/Preferences/com.apple.SoftwareUpdate' 'AutomaticCheckEnabled' -bool 'true'
 defaults write 'com.apple.Safari' 'AutoOpenSafeDownloads' -bool 'false'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowLocalHost' -bool 'true'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowApple' -bool 'true'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowDNS' -bool 'true'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowInstalled' -bool 'true'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'blockMode' -bool 'false'
+sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'passiveMode' -bool 'false'
 # Post-loop: restart user-facing processes so changes take effect immediately.
 # cfprefsd kill is non-negotiable (caches plist values in memory).
 killall 'Dock' 2>/dev/null || true
@@ -128,7 +136,10 @@ GOLDEN_EOF
 # MANUAL pointer for OverSight's Notification Center delivery, its only
 # output channel (a runbook echo and no command, the OverSight-posture
 # slice; deliberately NOT a microphone or camera grant, which macOS never
-# presents for OverSight: no usage-description keys, no entitlements).
+# presents for OverSight: no usage-description keys, no entitlements), plus
+# the two MANUAL LuLu pointers the LuLu-posture slice declared (the
+# system-extension approval and interactive-only rule creation; a runbook
+# echo each and no command).
 # No manual logging record: firewall logging on this macOS version is on by
 # default and cannot be enabled by hand, so nothing renders for it.
 tier2_golden="$work/tier2.golden"
@@ -157,6 +168,8 @@ sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
 echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf) and verify the effective configuration"
 "$HOME/.local/bin/ssh-hardening.sh"
 echo '→ MANUAL OverSight: allow its Notification Center alerts (its only output channel): see the runbook section OverSight notification delivery'
+echo '→ MANUAL LuLu: approve its system extension (a one-time macOS security consent): see the runbook section LuLu system extension approval'
+echo '→ MANUAL LuLu: create the required outbound allow rules by answering its prompts: see the runbook section LuLu rule creation'
 echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
 sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -52,7 +52,15 @@ for required_file in "$TIER1_TEMPLATE" "$TIER2_TEMPLATE" "$DEFAULTS_YAML" "$SETU
   [[ -f $required_file ]] || fail "missing file: $required_file"
 done
 
-work="$(cd "$(mktemp -d)" && pwd -P)"
+# Validated BEFORE any trap is armed and before any cd: on bash 3.2 `cd ""`
+# succeeds without moving, so an unguarded `cd "$(mktemp -d)"` after a failed
+# mktemp would leave the suite in the worktree with an `rm -rf` trap aimed at
+# it. The second assignment canonicalizes away macOS's /var -> /private/var
+# symlink.
+work="$(mktemp -d)"
+[[ -n $work && -d $work ]] ||
+  fail "mktemp -d produced no usable work directory (got '$work')"
+work="$(cd "$work" && pwd -P)"
 trap 'rm -rf "$work"' EXIT
 
 # ---- 1: every real record declares a recognized tier -------------------------

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -93,9 +93,10 @@ invalid_setup_tiers="$(yq eval -r \
 
 # The Tier 1 runner's 5774ce0 render plus the security-defaults records (the
 # sudo -v prelude, the sudo-routed system-scope SoftwareUpdate write, and the
-# user-scope Safari write), plus the six LuLu policy writes the LuLu-posture
-# slice declared (system scope with an explicit plist_path, each value the
-# live machine carried when declared).
+# user-scope Safari write). The six LuLu policy records the LuLu-posture
+# slice declared are tier: verify (LuLu's extension loads its preferences
+# once at start and writes them back from memory, so an external write is
+# unobserved and clobbered) and render NO line here at all.
 tier1_golden="$work/tier1.golden"
 cat >"$tier1_golden" <<'GOLDEN_EOF'
 #!/bin/bash
@@ -122,12 +123,6 @@ defaults write 'com.apple.WindowManager' 'EnableTilingOptionAccelerator' -bool '
 defaults write 'com.apple.WindowManager' 'EnableTopTilingByEdgeDrag' -bool 'false'
 sudo defaults write '/Library/Preferences/com.apple.SoftwareUpdate' 'AutomaticCheckEnabled' -bool 'true'
 defaults write 'com.apple.Safari' 'AutoOpenSafeDownloads' -bool 'false'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowLocalHost' -bool 'true'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowApple' -bool 'true'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowDNS' -bool 'true'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'allowInstalled' -bool 'true'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'blockMode' -bool 'false'
-sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'passiveMode' -bool 'false'
 # Post-loop: restart user-facing processes so changes take effect immediately.
 # cfprefsd kill is non-negotiable (caches plist values in memory).
 killall 'Dock' 2>/dev/null || true

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -113,6 +113,29 @@ osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 # Sudo prelude: at least one record targets a root-owned system plist, so
 # validate sudo once, up front, before any write.
 sudo -v
+# system_defaults_write <plist_path> <key> <-type> <value>: one system-scope
+# write, then a root:wheel 0644 repair of the file `defaults` just replaced.
+# `defaults write` recreates its target as a root-owned 0600 binary plist
+# (verified on a copy, 2026-07-27), and an unreadable plist blinds the
+# unprivileged drift reader (`just D`) on every later run, so an unrepaired
+# write defeats the very drift check that verifies it. The repair is PER
+# WRITE, never a trailing chmod: under set -e a failed later write ends this
+# run before any trailing cleanup, leaving the writes that DID land
+# unreadable. The write's own failure is re-raised AFTER the repair; a failed
+# write that left no file behind skips the repair rather than failing on the
+# missing path. Mirrors system_defaults_write in macos-defaults-lib.sh, which
+# repairs the apply tool's writes the same way.
+system_defaults_write() {
+  local plist_path="$1" key="$2" type_option="$3" value="$4"
+  local write_status=0 written_file="$plist_path"
+  [[ $written_file == *.plist ]] || written_file="$written_file.plist"
+  sudo defaults write "$plist_path" "$key" "$type_option" "$value" || write_status=$?
+  if [[ $write_status -eq 0 || -e $written_file ]]; then
+    sudo chown root:wheel "$written_file"
+    sudo chmod 644 "$written_file"
+  fi
+  return "$write_status"
+}
 # Main loop: one `defaults write` per record.
 defaults write 'com.apple.dock' 'mru-spaces' -bool 'false'
 defaults write 'com.apple.dock' 'expose-group-apps' -bool 'false'
@@ -121,7 +144,7 @@ defaults write 'com.apple.WindowManager' 'EnableStandardClickToShowDesktop' -boo
 defaults write 'com.apple.WindowManager' 'EnableTilingByEdgeDrag' -bool 'false'
 defaults write 'com.apple.WindowManager' 'EnableTilingOptionAccelerator' -bool 'false'
 defaults write 'com.apple.WindowManager' 'EnableTopTilingByEdgeDrag' -bool 'false'
-sudo defaults write '/Library/Preferences/com.apple.SoftwareUpdate' 'AutomaticCheckEnabled' -bool 'true'
+system_defaults_write '/Library/Preferences/com.apple.SoftwareUpdate' 'AutomaticCheckEnabled' -bool 'true'
 defaults write 'com.apple.Safari' 'AutoOpenSafeDownloads' -bool 'false'
 # Post-loop: restart user-facing processes so changes take effect immediately.
 # cfprefsd kill is non-negotiable (caches plist values in memory).

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -665,6 +665,54 @@ refute_file_contains "$defaults_log" 'rel.plist' \
 refute_file_contains "$sudo_log" 'rel.plist' \
   'apply must not sudo-write a relative plist_path record at all'
 
+# apply refuses a plist_path outside the permitted write directories and
+# never writes it: the render-time allowlist alone did not cover this path
+# (`just defaults-apply` reads the YAML directly, and the resolver accepted
+# /etc/example.evil.plist before the fix).
+for evil_plist_path in /etc/example.evil.plist /Library/LaunchDaemons/com.example.evil.plist; do
+  apply_escape_src="$(
+    make_source_dir <<EOF
+macos:
+  defaults:
+    - domain: com.example.evil
+      key: EvilKey
+      type: bool
+      value: true
+      scope: system
+      plist_path: $evil_plist_path
+      tier: enforce
+  killall: []
+EOF
+  )"
+  : >"$defaults_log"
+  : >"$sudo_log"
+  apply_escape_status=0
+  run_tool "$apply_escape_src" "$APPLY" 2>"$sandbox/apply-escape.err" || apply_escape_status=$?
+  [[ $apply_escape_status -eq 2 ]] ||
+    fail "apply must refuse the out-of-allowlist path $evil_plist_path with the validation status 2 (got $apply_escape_status)"
+  assert_file_contains "$sandbox/apply-escape.err" 'permitted plist director' \
+    "the refusal must name the containment rule (stderr: $(cat "$sandbox/apply-escape.err"))"
+  assert_file_contains "$sandbox/apply-escape.err" "$evil_plist_path" \
+    "the refusal must name the offending path (stderr: $(cat "$sandbox/apply-escape.err"))"
+  refute_file_contains "$defaults_log" 'example.evil' \
+    "apply must not write $evil_plist_path at all"
+  refute_file_contains "$sudo_log" 'example.evil' \
+    "apply must not sudo-anything for $evil_plist_path"
+done
+
+# The render-time allowlist in the template and the write-time allowlist in
+# the library must be the SAME list: two lists that can drift apart is
+# exactly how apply accepted a path the render refused. Source-form pin,
+# beside the behavioral pins above and in the render sections.
+template_allowlist="$(grep -F 'plistPathAllowedDirectories := list' "$TEMPLATE" | grep -o '"[^"]*"' | tr -d '"' | LC_ALL=C sort)"
+lib_allowlist="$(bash -c 'source "$1"; printf "%s\n" "${MACOS_DEFAULTS_PLIST_PATH_ALLOWED_DIRECTORIES[@]}"' _ "$LIB" 2>/dev/null | LC_ALL=C sort)"
+[[ -n $template_allowlist ]] ||
+  fail 'could not extract the render-time allowlist from the template'
+[[ -n $lib_allowlist ]] ||
+  fail 'could not extract the write-time allowlist from the library'
+[[ $template_allowlist == "$lib_allowlist" ]] ||
+  fail "the render-time and write-time plist_path allowlists have drifted apart (template: $template_allowlist; lib: $lib_allowlist)"
+
 # apply refuses an unknown scope rather than guessing a write target.
 apply_bogus_src="$(
   make_source_dir <<'EOF'

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -22,7 +22,9 @@
 #   4. A RELATIVE plist_path is rejected (render fails; apply refuses), never
 #      resolved against the ambient working directory.
 #   5. drift reports an unreadable system-scope record as indeterminate, with a
-#      marker distinct from <unset>, and does NOT count it as drift.
+#      marker distinct from <unset>, never counted as drift, and FAILS CLOSED:
+#      an unreadable control is not a passing control, so indeterminate rows
+#      exit 3 (their own status, distinct from drift's 1 and the data-error 2).
 #   6. drift on a set-and-matching system-scope record reports no drift.
 #   7. capture --scope system appends a record carrying `scope: system`.
 #   8. capture rejects --scope system combined with --host current.
@@ -712,12 +714,14 @@ assert_file_contains "$defaults_log" 'read /Library/Preferences/com.example.sys 
   "drift must read the system record from its resolved plist path (defaults log: $(cat "$defaults_log"))"
 
 # criterion 5, defaults-failure route: an unknown read failure is indeterminate,
-# marked distinctly from <unset>, and NOT counted as drift.
+# marked distinctly from <unset>, never counted as drift, and FAILS the gate
+# with its own status 3: an unreadable control is not a passing control, and a
+# drift run that cannot verify what it tracks must not exit 0.
 write_defaults_stub read-denied
 drift_status=0
 run_tool "$drift_system_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
-[[ $drift_status -eq 0 ]] ||
-  fail "an unreadable system record must not count as drift (got exit $drift_status, stderr: $(cat "$drift_err"))"
+[[ $drift_status -eq 3 ]] ||
+  fail "an unreadable system record must fail the gate with the indeterminate status 3, never 0 and never drift's 1 (got exit $drift_status, stderr: $(cat "$drift_err"))"
 indeterminate_row="$(grep -F 'com.example.sys' "$drift_out" || true)"
 [[ -n $indeterminate_row ]] ||
   fail "an unreadable system record must be reported as its own row, not silently skipped (stdout: $(cat "$drift_out"))"
@@ -757,8 +761,8 @@ write_defaults_stub read-value
 drift_status=0
 run_tool "$drift_locked_src" "$DRIFT" >"$drift_out" 2>"$drift_err" || drift_status=$?
 chmod u+rw "$locked_plist"
-[[ $drift_status -eq 0 ]] ||
-  fail "an unreadable plist file must not count as drift (got exit $drift_status, stderr: $(cat "$drift_err"))"
+[[ $drift_status -eq 3 ]] ||
+  fail "an unreadable plist file must fail the gate with the indeterminate status 3, never 0 and never drift's 1 (got exit $drift_status, stderr: $(cat "$drift_err"))"
 assert_file_contains "$drift_out" '<unreadable>' \
   "an existing-but-unreadable plist must be reported indeterminate even when a read would have answered (stdout: $(cat "$drift_out"))"
 

--- a/test/integration/macos-defaults-system-scope.sh
+++ b/test/integration/macos-defaults-system-scope.sh
@@ -281,12 +281,12 @@ sudo_validate_count="$(grep -cxF 'sudo -v' "$rendered_system" || true)"
 [[ $sudo_validate_count -eq 1 ]] ||
   fail "system-record render must contain exactly one 'sudo -v' (got $sudo_validate_count)"
 sudo_validate_line="$(grep -nxF 'sudo -v' "$rendered_system" | cut -d: -f1)"
-first_write_line="$(grep -nE '^(sudo )?defaults ' "$rendered_system" | head -1 | cut -d: -f1)"
+first_write_line="$(grep -nE '^(sudo )?defaults |^system_defaults_write ' "$rendered_system" | head -1 | cut -d: -f1)"
 [[ -n $first_write_line ]] || fail 'system-record render must contain defaults writes'
 [[ $sudo_validate_line -lt $first_write_line ]] ||
   fail "the sudo -v prelude must come before any write (sudo -v at line $sudo_validate_line, first write at line $first_write_line)"
-grep -qxF "sudo defaults write '/Library/Preferences/com.example.sys' 'SysKey' -bool 'false'" "$rendered_system" ||
-  fail "the system record's write must be sudo-prefixed and target /Library/Preferences/<domain> (got: $(grep -F 'com.example.sys' "$rendered_system"))"
+grep -qxF "system_defaults_write '/Library/Preferences/com.example.sys' 'SysKey' -bool 'false'" "$rendered_system" ||
+  fail "the system record's write must ride the repairing write helper and target /Library/Preferences/<domain> (got: $(grep -F 'com.example.sys' "$rendered_system"))"
 grep -qxF "defaults write 'com.example.alpha' 'AlphaKey' -bool 'true'" "$rendered_system" ||
   fail 'the user record must keep its plain, un-sudoed write'
 refute_file_contains "$rendered_system" "sudo defaults write 'com.example.alpha'" \
@@ -312,7 +312,7 @@ EOF
 rendered_explicit="$sandbox/rendered-explicit"
 render_template "$explicit_path_src" "$rendered_explicit" "$render_error" ||
   fail "explicit-path render must succeed (stderr: $(cat "$render_error"))"
-grep -qxF "sudo defaults write '/Library/Objective-See/LuLu/preferences.plist' 'LuLuKey' -string 'block'" "$rendered_explicit" ||
+grep -qxF "system_defaults_write '/Library/Objective-See/LuLu/preferences.plist' 'LuLuKey' -string 'block'" "$rendered_explicit" ||
   fail "an explicit absolute plist_path must be the write target (got: $(grep -F LuLuKey "$rendered_explicit"))"
 refute_file_contains "$rendered_explicit" '/Library/Preferences/com.example.lulu' \
   'an explicit plist_path must replace the /Library/Preferences default, not coexist with it'
@@ -457,7 +457,9 @@ sudo_log="$sandbox/sudo.log"
 
 # sudo stub: records the space-joined invocation, then runs it (so the
 # defaults stub behind it still answers). Fixture values contain no spaces, so
-# the space-joined log parses back per field unambiguously.
+# the space-joined log parses back per field unambiguously. chown and chmod
+# are stubbed no-ops so the per-write root:wheel 0644 repair is observable in
+# the sudo log without touching anything real.
 cat >"$stub_bin/sudo" <<EOF
 #!/bin/bash
 printf '%s\n' "\$*" >>"$sudo_log"
@@ -465,7 +467,10 @@ exec "\$@"
 EOF
 printf '#!/bin/bash\nexit 0\n' >"$stub_bin/osascript"
 printf '#!/bin/bash\nexit 0\n' >"$stub_bin/killall"
-chmod +x "$stub_bin/sudo" "$stub_bin/osascript" "$stub_bin/killall"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/chown"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/chmod"
+chmod +x "$stub_bin/sudo" "$stub_bin/osascript" "$stub_bin/killall" \
+  "$stub_bin/chown" "$stub_bin/chmod"
 
 # write_defaults_stub <write-only|read-value|read-unset|read-denied|capture-bool>
 # -- the per-section behavior of the `defaults` stub. Every variant logs its
@@ -568,6 +573,67 @@ assert_file_contains "$defaults_log" 'write com.example.alpha AlphaKey -bool tru
   "apply must still write the user record (defaults log: $(cat "$defaults_log"))"
 refute_file_contains "$sudo_log" 'com.example.alpha' \
   'apply must not route a user-scope write through sudo'
+
+# Each system write is followed IMMEDIATELY by its own root:wheel 0644 repair:
+# `defaults write` recreates the target as a root-owned 0600 binary plist, and
+# an unrepaired one reads back <unreadable> for the unprivileged drift checker
+# forever after. The extensionless record is repaired on the .plist file
+# `defaults` actually writes; the explicit .plist record is repaired as itself.
+sys_write_line="$(grep -nxF 'defaults write /Library/Preferences/com.example.sys SysKey -bool false' "$sudo_log" | cut -d: -f1)"
+sys_chown_line="$(grep -nxF 'chown root:wheel /Library/Preferences/com.example.sys.plist' "$sudo_log" | cut -d: -f1)"
+sys_chmod_line="$(grep -nxF 'chmod 644 /Library/Preferences/com.example.sys.plist' "$sudo_log" | cut -d: -f1)"
+[[ -n $sys_write_line && -n $sys_chown_line && -n $sys_chmod_line ]] ||
+  fail "apply must repair root:wheel 0644 on the extensionless system record's .plist (sudo log: $(cat "$sudo_log"))"
+[[ $sys_chown_line -eq $((sys_write_line + 1)) && $sys_chmod_line -eq $((sys_write_line + 2)) ]] ||
+  fail "the repair must follow its own write immediately, per write (write at $sys_write_line, chown at $sys_chown_line, chmod at $sys_chmod_line)"
+assert_file_contains "$sudo_log" 'chmod 644 /Library/Objective-See/LuLu/preferences.plist' \
+  "apply must repair the explicit .plist record as itself (sudo log: $(cat "$sudo_log"))"
+refute_file_contains "$sudo_log" 'preferences.plist.plist' \
+  'the repair must never append a second .plist to an explicit .plist path'
+
+# A write that FAILS midway must not cost the EARLIER write its repair: under
+# set -e apply ends at the failing record, so a trailing cleanup would never
+# run; only per-write repair survives. The failing record's own repair is
+# skipped because no file exists at its path.
+apply_midfail_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.first
+      key: FirstKey
+      type: bool
+      value: true
+      scope: system
+      tier: enforce
+    - domain: com.example.fail
+      key: FailKey
+      type: bool
+      value: true
+      scope: system
+      tier: enforce
+  killall: []
+EOF
+)"
+# defaults stub that fails only the FailKey write, after both records validated.
+cat >"$stub_bin/defaults" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$defaults_log"
+if [[ \$* == *FailKey* ]]; then exit 9; fi
+exit 0
+EOF
+chmod +x "$stub_bin/defaults"
+: >"$defaults_log"
+: >"$sudo_log"
+apply_midfail_status=0
+run_tool "$apply_midfail_src" "$APPLY" 2>"$sandbox/apply-midfail.err" || apply_midfail_status=$?
+[[ $apply_midfail_status -ne 0 ]] ||
+  fail 'apply must fail when a write fails'
+assert_file_contains "$sudo_log" 'chmod 644 /Library/Preferences/com.example.first.plist' \
+  "the EARLIER write must keep its repair when a later write fails (sudo log: $(cat "$sudo_log"))"
+assert_file_contains "$sudo_log" 'defaults write /Library/Preferences/com.example.fail FailKey -bool true' \
+  "the failing write must have been attempted (sudo log: $(cat "$sudo_log"))"
+refute_file_contains "$sudo_log" 'chmod 644 /Library/Preferences/com.example.fail.plist' \
+  'a failed write that left no file behind must not be repaired'
 
 # apply refuses a relative plist_path and never writes it.
 apply_relative_src="$(

--- a/test/integration/macos-posture-controls-agreement.sh
+++ b/test/integration/macos-posture-controls-agreement.sh
@@ -58,7 +58,11 @@ set_posture_controls "$records_json"
 
 # Program every stub HEALTHY from the record's own reader and expect, so the
 # run is silent and the baseline seeds. An unmapped reader fails the gate.
-while IFS=$'\t' read -r reader expect; do
+# The lulu_rule readers accumulate their targets into one stubbed archive
+# document (the harness readlink stub resolves identically by default, so a
+# resolved reader's target is its own resolution here).
+lulu_archive_mentions=""
+while IFS=$'\t' read -r reader expect target; do
   case "$reader" in
     fdesetup_status)
       if [[ $expect == "on" ]]; then
@@ -87,11 +91,28 @@ while IFS=$'\t' read -r reader expect; do
         export POLLER_PGREP_MODE=stopped
       fi
       ;;
+    pgrep_lulu_extension)
+      if [[ $expect == "running" ]]; then
+        export POLLER_PGREP_LULU_MODE=running
+      else
+        export POLLER_PGREP_LULU_MODE=stopped
+      fi
+      ;;
+    lulu_rule_present | lulu_rule_resolved_present)
+      if [[ $expect == "present" ]]; then
+        lulu_archive_mentions+="		<string>$target</string>"$'\n'
+      fi
+      ;;
     *)
       fail "record reader '$reader' has no mapping here: add the poller reader, the harness stub, and this mapping together"
       ;;
   esac
-done < <(jq -r '.[] | [.reader, .expect] | @tsv' <<<"$records_json")
+done < <(jq -r '.[] | [.reader, .expect, .target // ""] | @tsv' <<<"$records_json")
+if [[ -n $lulu_archive_mentions ]]; then
+  # shellcheck disable=SC2016 # the literal $objects key is the archive format
+  POLLER_PLUTIL_XML="$(printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$lulu_archive_mentions")"
+  export POLLER_PLUTIL_XML
+fi
 
 poller_status=0
 poller_output="$(run_poller 2>&1)" || poller_status=$?
@@ -110,8 +131,11 @@ actual_keys="$POLLER_HOME/actual-keys"
   jq -r '.[].id' <<<"$records_json"
   # One recorded-declaration field per control: the poller persists the expect
   # each value was recorded under, so a changed declaration re-arms the control
-  # instead of reading as a silent steady-deviant.
+  # instead of reading as a silent steady-deviant. Targeted (lulu_rule)
+  # controls additionally persist the target the value was observed under,
+  # for the same re-arm reason.
   jq -r '.[].id + ":expect"' <<<"$records_json"
+  jq -r '.[] | select(has("target")) | .id + ":target"' <<<"$records_json"
 } | LC_ALL=C sort >"$expected_keys"
 jq -r 'keys_unsorted[]' "$OSQUERY_POSTURE_STATE" | LC_ALL=C sort >"$actual_keys"
 diff -u "$expected_keys" "$actual_keys" >&2 ||

--- a/test/integration/macos-security-defaults-render.sh
+++ b/test/integration/macos-security-defaults-render.sh
@@ -43,6 +43,7 @@ DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
 DEFAULTS_YAML="$REPO_ROOT/.chezmoidata/macos_defaults.yaml"
 
 SOFTWAREUPDATE_PLIST_PATH='/Library/Preferences/com.apple.SoftwareUpdate'
+LULU_PLIST_PATH='/Library/Objective-See/LuLu/preferences.plist'
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -143,11 +144,27 @@ sudo_prelude_count="$(grep -cxF "$sudo_prelude_pattern" "$combined_log" || true)
 [[ $sudo_prelude_count -eq 1 ]] ||
   fail "the runner must validate sudo exactly once up front (got $sudo_prelude_count 'sudo -v' invocations)"
 
+# The sudo-routed set is exactly the system-scope records: the SoftwareUpdate
+# record plus the six LuLu policy records the LuLu-posture slice declared
+# (each asserted per argv below). Nothing else may escalate.
 sudo_write_lines="$(grep -F "$(printf 'sudo\x1fdefaults')" "$combined_log" || true)"
 sudo_write_count=0
 [[ -n $sudo_write_lines ]] && sudo_write_count="$(printf '%s\n' "$sudo_write_lines" | wc -l | tr -d ' ')"
-[[ $sudo_write_count -eq 1 ]] ||
-  fail "exactly one write must be routed through sudo, the SoftwareUpdate record (got $sudo_write_count: $sudo_write_lines)"
+[[ $sudo_write_count -eq 7 ]] ||
+  fail "exactly seven writes must be routed through sudo, SoftwareUpdate plus the six LuLu policy records (got $sudo_write_count: $sudo_write_lines)"
+for lulu_expectation in 'allowLocalHost|true' 'allowApple|true' 'allowDNS|true' \
+  'allowInstalled|true' 'blockMode|false' 'passiveMode|false'; do
+  lulu_key="${lulu_expectation%%|*}"
+  lulu_value="${lulu_expectation##*|}"
+  lulu_argv_line="$(printf 'sudo\x1fdefaults\x1fwrite\x1f%s\x1f%s\x1f-bool\x1f%s' \
+    "$LULU_PLIST_PATH" "$lulu_key" "$lulu_value")"
+  lulu_line_count="$(grep -cxF "$lulu_argv_line" "$combined_log" || true)"
+  [[ $lulu_line_count -eq 1 ]] ||
+    fail "the LuLu $lulu_key record must execute exactly once as [sudo defaults write $LULU_PLIST_PATH $lulu_key -bool $lulu_value] (got $lulu_line_count)"
+done
+sudo_write_lines="$(grep -F "$(printf 'sudo\x1fdefaults')" "$combined_log" | grep -F 'AutomaticCheckEnabled' || true)"
+[[ -n $sudo_write_lines ]] ||
+  fail 'the SoftwareUpdate record must execute under sudo'
 IFS=$'\x1f' read -r -a sudo_write_fields <<<"$sudo_write_lines"
 [[ ${#sudo_write_fields[@]} -eq 7 ]] ||
   fail "the sudo write must carry exactly 7 fields, command plus 6 arguments (got ${#sudo_write_fields[@]})"
@@ -252,6 +269,12 @@ expected_execution_log="$sandbox/execution.expected"
   log_line defaults write com.apple.WindowManager EnableTopTilingByEdgeDrag -bool false
   log_line sudo defaults write "$SOFTWAREUPDATE_PLIST_PATH" AutomaticCheckEnabled -bool true
   log_line defaults write com.apple.Safari AutoOpenSafeDownloads -bool false
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowLocalHost -bool true
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowApple -bool true
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowDNS -bool true
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowInstalled -bool true
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist blockMode -bool false
+  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveMode -bool false
   log_line killall Dock
   log_line killall Finder
   log_line killall SystemUIServer
@@ -279,7 +302,7 @@ new_record_tiers="$(yq eval -r \
 # stubbed read, so the real path must be absent or readable (on macOS it is a
 # root-owned 0644 plist). An unreadable one is an environment this test
 # cannot run in, and saying so beats a silent wrong answer.
-for plist_candidate in "$SOFTWAREUPDATE_PLIST_PATH" "$SOFTWAREUPDATE_PLIST_PATH.plist"; do
+for plist_candidate in "$SOFTWAREUPDATE_PLIST_PATH" "$SOFTWAREUPDATE_PLIST_PATH.plist" "$LULU_PLIST_PATH"; do
   if [[ -e $plist_candidate && ! -r $plist_candidate ]]; then
     fail "environment: $plist_candidate exists but is unreadable; the drift scenarios would be classified indeterminate for reasons outside the code under test"
   fi
@@ -287,8 +310,10 @@ done
 
 # write_drift_defaults_stub <softwareupdate-answer> <safari-answer> -- replace
 # the defaults stub with a read-answering one: every `read` is logged, the two
-# security records answer as told, every other record answers its declared
-# value (the seven Aerospace records are all bool false, normalized 0).
+# security records answer as told, the four true-valued LuLu policy records
+# answer their declared 1, and every other record answers its declared value
+# (the seven Aerospace records and the two false-valued LuLu records are all
+# bool false, normalized 0).
 write_drift_defaults_stub() { # <softwareupdate-answer> <safari-answer>
   local softwareupdate_answer="$1" safari_answer="$2"
   cat >"$stub_bin/defaults" <<EOF
@@ -302,6 +327,10 @@ if [[ \$1 == read ]]; then
   case "\$2 \$3" in
     '$SOFTWAREUPDATE_PLIST_PATH AutomaticCheckEnabled') printf '%s\\n' '$softwareupdate_answer' ;;
     'com.apple.Safari AutoOpenSafeDownloads') printf '%s\\n' '$safari_answer' ;;
+    '$LULU_PLIST_PATH allowLocalHost') printf '1\\n' ;;
+    '$LULU_PLIST_PATH allowApple') printf '1\\n' ;;
+    '$LULU_PLIST_PATH allowDNS') printf '1\\n' ;;
+    '$LULU_PLIST_PATH allowInstalled') printf '1\\n' ;;
     *) printf '0\\n' ;;
   esac
 fi
@@ -346,6 +375,12 @@ expected_drift_reads="$sandbox/drift-reads.expected"
   log_line defaults read com.apple.WindowManager EnableTopTilingByEdgeDrag
   log_line defaults read "$SOFTWAREUPDATE_PLIST_PATH" AutomaticCheckEnabled
   log_line defaults read com.apple.Safari AutoOpenSafeDownloads
+  log_line defaults read "$LULU_PLIST_PATH" allowLocalHost
+  log_line defaults read "$LULU_PLIST_PATH" allowApple
+  log_line defaults read "$LULU_PLIST_PATH" allowDNS
+  log_line defaults read "$LULU_PLIST_PATH" allowInstalled
+  log_line defaults read "$LULU_PLIST_PATH" blockMode
+  log_line defaults read "$LULU_PLIST_PATH" passiveMode
 } >"$expected_drift_reads"
 cmp -s "$expected_drift_reads" "$combined_log" ||
   fail "drift must read every tracked record, the two security records included, from its declared place (diff: $(diff <(cat -v "$expected_drift_reads") <(cat -v "$combined_log") | head -20))"

--- a/test/integration/macos-security-defaults-render.sh
+++ b/test/integration/macos-security-defaults-render.sh
@@ -270,6 +270,8 @@ expected_execution_log="$sandbox/execution.expected"
   log_line defaults write com.apple.WindowManager EnableTilingOptionAccelerator -bool false
   log_line defaults write com.apple.WindowManager EnableTopTilingByEdgeDrag -bool false
   log_line sudo defaults write "$SOFTWAREUPDATE_PLIST_PATH" AutomaticCheckEnabled -bool true
+  log_line sudo chown root:wheel "$SOFTWAREUPDATE_PLIST_PATH.plist"
+  log_line sudo chmod 644 "$SOFTWAREUPDATE_PLIST_PATH.plist"
   log_line defaults write com.apple.Safari AutoOpenSafeDownloads -bool false
   log_line killall Dock
   log_line killall Finder

--- a/test/integration/macos-security-defaults-render.sh
+++ b/test/integration/macos-security-defaults-render.sh
@@ -66,8 +66,15 @@ for required_file in "$TEMPLATE" "$DRIFT" "$DEFAULTS_YAML"; do
   [[ -f $required_file ]] || fail "missing file: $required_file"
 done
 
-# Canonicalize away macOS's /var -> /private/var symlink.
-sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+# Validated BEFORE any trap is armed and before any cd: on bash 3.2 `cd ""`
+# succeeds without moving, so an unguarded `cd "$(mktemp -d)"` after a failed
+# mktemp would leave the suite in the worktree with an `rm -rf` trap aimed at
+# it. The second assignment canonicalizes away macOS's /var -> /private/var
+# symlink.
+sandbox="$(mktemp -d)"
+[[ -n $sandbox && -d $sandbox ]] ||
+  fail "mktemp -d produced no usable sandbox directory (got '$sandbox')"
+sandbox="$(cd "$sandbox" && pwd -P)"
 trap 'rm -rf "$sandbox"' EXIT
 render_home="$sandbox/render-home"
 mkdir -p "$render_home"

--- a/test/integration/macos-security-defaults-render.sh
+++ b/test/integration/macos-security-defaults-render.sh
@@ -151,24 +151,19 @@ sudo_prelude_count="$(grep -cxF "$sudo_prelude_pattern" "$combined_log" || true)
 [[ $sudo_prelude_count -eq 1 ]] ||
   fail "the runner must validate sudo exactly once up front (got $sudo_prelude_count 'sudo -v' invocations)"
 
-# The sudo-routed set is exactly the system-scope records: the SoftwareUpdate
-# record plus the six LuLu policy records the LuLu-posture slice declared
-# (each asserted per argv below). Nothing else may escalate.
+# The sudo-routed defaults-write set is exactly the enforced system-scope
+# records: the SoftwareUpdate record alone. The six LuLu policy records are
+# tier: verify (LuLu's extension loads its preferences once at start and
+# writes them back from memory, so an external write is unobserved and
+# clobbered) and must execute NOTHING, so nothing else may escalate.
 sudo_write_lines="$(grep -F "$(printf 'sudo\x1fdefaults')" "$combined_log" || true)"
 sudo_write_count=0
 [[ -n $sudo_write_lines ]] && sudo_write_count="$(printf '%s\n' "$sudo_write_lines" | wc -l | tr -d ' ')"
-[[ $sudo_write_count -eq 7 ]] ||
-  fail "exactly seven writes must be routed through sudo, SoftwareUpdate plus the six LuLu policy records (got $sudo_write_count: $sudo_write_lines)"
-for lulu_expectation in 'allowLocalHost|true' 'allowApple|true' 'allowDNS|true' \
-  'allowInstalled|true' 'blockMode|false' 'passiveMode|false'; do
-  lulu_key="${lulu_expectation%%|*}"
-  lulu_value="${lulu_expectation##*|}"
-  lulu_argv_line="$(printf 'sudo\x1fdefaults\x1fwrite\x1f%s\x1f%s\x1f-bool\x1f%s' \
-    "$LULU_PLIST_PATH" "$lulu_key" "$lulu_value")"
-  lulu_line_count="$(grep -cxF "$lulu_argv_line" "$combined_log" || true)"
-  [[ $lulu_line_count -eq 1 ]] ||
-    fail "the LuLu $lulu_key record must execute exactly once as [sudo defaults write $LULU_PLIST_PATH $lulu_key -bool $lulu_value] (got $lulu_line_count)"
-done
+[[ $sudo_write_count -eq 1 ]] ||
+  fail "exactly one write must be routed through sudo, the SoftwareUpdate record (got $sudo_write_count: $sudo_write_lines)"
+lulu_executed_lines="$(grep -F "$LULU_PLIST_PATH" "$combined_log" || true)"
+[[ -z $lulu_executed_lines ]] ||
+  fail "the six verify-tier LuLu policy records must execute NO command (got: $lulu_executed_lines)"
 sudo_write_lines="$(grep -F "$(printf 'sudo\x1fdefaults')" "$combined_log" | grep -F 'AutomaticCheckEnabled' || true)"
 [[ -n $sudo_write_lines ]] ||
   fail 'the SoftwareUpdate record must execute under sudo'
@@ -276,12 +271,6 @@ expected_execution_log="$sandbox/execution.expected"
   log_line defaults write com.apple.WindowManager EnableTopTilingByEdgeDrag -bool false
   log_line sudo defaults write "$SOFTWAREUPDATE_PLIST_PATH" AutomaticCheckEnabled -bool true
   log_line defaults write com.apple.Safari AutoOpenSafeDownloads -bool false
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowLocalHost -bool true
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowApple -bool true
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowDNS -bool true
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist allowInstalled -bool true
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist blockMode -bool false
-  log_line sudo defaults write /Library/Objective-See/LuLu/preferences.plist passiveMode -bool false
   log_line killall Dock
   log_line killall Finder
   log_line killall SystemUIServer

--- a/test/unit/lulu-rule-existence-reader.sh
+++ b/test/unit/lulu-rule-existence-reader.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# lulu-rule-existence-reader.sh -- the poller's LuLu rule-existence readers,
+# unit-tested through the real poller against stubs (no LuLu, no live archive).
+#
+# LuLu's rules.plist is an NSKeyedArchiver archive of a private class: not
+# hand-authorable, and not safely interpretable beyond the path strings it
+# mentions. The readers therefore make an EXISTENCE-ONLY claim: the archive
+# mentions the declared binary path. They read via `plutil -convert xml1 -o -`
+# (a read-only conversion to stdout; the archive file is never written) and
+# match the exact <string> element.
+#
+#   R1 lulu_rule_present: the archive mentioning the target reads present; an
+#      archive not mentioning it reads absent; the plutil invocation is the
+#      exact read-only argv, once per tick.
+#   R2 substring honesty: a longer path that CONTAINS the target does not
+#      count as the target (the closing </string> pins the element boundary).
+#   R3 XML escaping: a target containing & is matched against its XML-escaped
+#      form, so an escaped archive entry still reads present.
+#   R4 failure discipline: a failed plutil is INDETERMINATE (a monitoring
+#      gap), never absent (absent would page a deviation on a read nobody
+#      completed); a zero-exit plutil that printed nothing is indeterminate
+#      too (plutil always prints the converted document on success).
+#   R5 lulu_rule_resolved_present: the target is resolved (readlink -f) at
+#      probe time and the RESOLVED path is matched, so the control follows
+#      the live binary behind a launcher symlink; an unresolvable target is
+#      indeterminate, never absent.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=../fixtures/osquery-poller-lib.bash
+source "$REPO_ROOT/test/fixtures/osquery-poller-lib.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || {
+  printf 'SKIP: jq not on PATH; cannot exercise the rule-existence readers\n'
+  exit 0
+}
+
+# archive_xml_mentioning <path>... -- a minimal plutil-shaped XML body whose
+# $objects array mentions each (already-escaped) path string.
+archive_xml_mentioning() {
+  local body="" mentioned_path
+  for mentioned_path in "$@"; do
+    body+="		<string>$mentioned_path</string>"$'\n'
+  done
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>\$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
+}
+
+rule_control() { # <id> <reader> <target> -- one verify record as a JSON array
+  jq -cn --arg id "$1" --arg reader "$2" --arg target "$3" \
+    '[{id: $id, description: ("The LuLu allow rule for " + $id), tier: "verify", reader: $reader, expect: "present", target: $target}]'
+}
+
+# run_reader_case <controls-json> -> runs one first-observation tick; the
+# caller programs the stubs first and asserts pages/baseline after.
+run_reader_case() {
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  set_posture_controls "$1"
+  run_poller >/dev/null 2>&1
+}
+
+# ---- R1: present / absent, via the exact read-only plutil argv ---------------
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled)"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
+  fail "R1 present: expected exit 0"
+assert_no_page || fail "R1 present: a mentioned target must read present (silent, healthy)"
+assert_baseline_scalar demo_rule present || fail "R1 present: baseline must record present"
+assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_RULES" 1 ||
+  fail "R1 present: the reader must run exactly one read-only plutil conversion"
+assert_no_mutation_attempt || fail "R1 present: the reader must never mutate"
+teardown_poller_harness
+trap - EXIT
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/unrelated/binary)"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
+  fail "R1 absent: expected exit 0"
+assert_page_count 1 || fail "R1 absent: an unmentioned target is a deviation (first observation)"
+assert_baseline_scalar demo_rule absent || fail "R1 absent: baseline must record absent"
+teardown_poller_harness
+trap - EXIT
+
+# ---- R2: a longer path containing the target is NOT the target ---------------
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled-helper)"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
+  fail "R2: expected exit 0"
+assert_page_count 1 || fail "R2: a superstring path must not satisfy the target (absent must page)"
+assert_baseline_scalar demo_rule absent || fail "R2: baseline must record absent"
+teardown_poller_harness
+trap - EXIT
+
+# ---- R3: the target is matched in its XML-escaped form -----------------------
+
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+POLLER_PLUTIL_XML="$(archive_xml_mentioning '/opt/tools/fetch &amp; sync')"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_rule lulu_rule_present '/opt/tools/fetch & sync')" ||
+  fail "R3: expected exit 0"
+assert_no_page || fail "R3: an ampersand target must match its XML-escaped archive form"
+assert_baseline_scalar demo_rule present || fail "R3: baseline must record present"
+teardown_poller_harness
+trap - EXIT
+
+# ---- R4: plutil failures are indeterminate, never absent ---------------------
+
+run_plutil_failure_case() { # <label> <env-assignment>...
+  local label="$1" poller_status=0 env_assignment
+  shift
+  setup_poller_harness
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  set_posture_controls "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)"
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","demo_rule":"present","demo_rule:expect":"present","demo_rule:target":"/usr/local/bin/tailscaled"}'
+  snapshot_baseline
+  for env_assignment in "$@"; do
+    export "${env_assignment?}"
+  done
+  run_poller >/dev/null 2>&1 || poller_status=$?
+  [[ $poller_status -eq 0 ]] ||
+    fail "R4 $label: expected exit 0 after paging the gap, got $poller_status"
+  assert_page_count 1 || fail "R4 $label: a failed archive read must page a monitoring gap"
+  assert_page_body_has 'monitoring gap' || fail "R4 $label: the page must name the gap"
+  assert_page_body_has 'demo_rule' || fail "R4 $label: the gap page must name the control"
+  assert_baseline_unchanged ||
+    fail "R4 $label: an indeterminate read must never advance the baseline"
+  for env_assignment in "$@"; do
+    unset "${env_assignment%%=*}"
+  done
+  teardown_poller_harness
+}
+
+# A nonzero plutil (missing or unreadable archive, a corrupt document).
+run_plutil_failure_case 'nonzero-exit' POLLER_PLUTIL_EXIT=1
+# A zero exit that printed nothing: plutil prints the converted document on
+# success, so an empty success is a status/output mismatch, never absent.
+run_plutil_failure_case 'exit-0-without-output' POLLER_PLUTIL_XML= POLLER_PLUTIL_EXIT=0
+
+# ---- R5: the resolved reader follows the launcher symlink --------------------
+
+# The readlink stub resolves identically by default; program a distinct
+# resolution and require the RESOLVED path, not the declared launcher, to be
+# what the archive is searched for.
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+export POLLER_READLINK_OUTPUT='/real/interpreters/cpython-3.11/python3.11'
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /real/interpreters/cpython-3.11/python3.11)"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_resolved lulu_rule_resolved_present /opt/venv/bin/python)" ||
+  fail "R5 resolved-present: expected exit 0"
+assert_no_page || fail "R5 resolved-present: the archive mentioning the RESOLVED path must read present"
+assert_baseline_scalar demo_resolved present ||
+  fail "R5 resolved-present: baseline must record present"
+assert_probe_argv 'readlink -f /opt/venv/bin/python' 1 ||
+  fail "R5 resolved-present: the reader must resolve the declared launcher exactly once"
+teardown_poller_harness
+trap - EXIT
+
+# The archive mentioning only the LAUNCHER path while the resolution points
+# elsewhere reads absent: the rule must cover the binary that executes.
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+export POLLER_READLINK_OUTPUT='/real/interpreters/cpython-3.11/python3.11'
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/venv/bin/python)"
+export POLLER_PLUTIL_XML
+run_reader_case "$(rule_control demo_resolved lulu_rule_resolved_present /opt/venv/bin/python)" ||
+  fail "R5 launcher-only: expected exit 0"
+assert_page_count 1 ||
+  fail "R5 launcher-only: a rule on the launcher path alone must read absent (the resolved binary is unruled)"
+assert_baseline_scalar demo_resolved absent ||
+  fail "R5 launcher-only: baseline must record absent"
+teardown_poller_harness
+trap - EXIT
+
+# An unresolvable target (the launcher is gone) is indeterminate, never absent.
+setup_poller_harness
+trap 'teardown_poller_harness' EXIT
+export POLLER_READLINK_EXIT=1
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /real/interpreters/cpython-3.11/python3.11)"
+export POLLER_PLUTIL_XML
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$(rule_control demo_resolved lulu_rule_resolved_present /opt/venv/bin/python)"
+seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","demo_resolved":"present","demo_resolved:expect":"present","demo_resolved:target":"/opt/venv/bin/python"}'
+snapshot_baseline
+run_poller >/dev/null 2>&1 || fail "R5 unresolvable: expected exit 0 after paging the gap"
+assert_page_count 1 || fail "R5 unresolvable: an unresolvable launcher must page a monitoring gap"
+assert_page_body_has 'monitoring gap' || fail "R5 unresolvable: the page must name the gap"
+assert_baseline_unchanged ||
+  fail "R5 unresolvable: an unresolvable target must never advance the baseline"
+unset POLLER_READLINK_EXIT POLLER_READLINK_OUTPUT POLLER_PLUTIL_XML
+teardown_poller_harness
+trap - EXIT
+
+printf 'ok: LuLu rule-existence readers (exact-element existence claim, XML escaping, indeterminate-on-failure, resolved-target following)\n'

--- a/test/unit/lulu-rule-existence-reader.sh
+++ b/test/unit/lulu-rule-existence-reader.sh
@@ -52,7 +52,8 @@ archive_xml_mentioning() {
   for mentioned_path in "$@"; do
     body+="		<string>$mentioned_path</string>"$'\n'
   done
-  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>\$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
+  # shellcheck disable=SC2016 # the literal $objects key is the archive format
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>$objects</key>\n	<array>\n%s	</array>\n</dict>\n</plist>\n' "$body"
 }
 
 rule_control() { # <id> <reader> <target> -- one verify record as a JSON array

--- a/test/unit/lulu-rule-existence-reader.sh
+++ b/test/unit/lulu-rule-existence-reader.sh
@@ -45,6 +45,16 @@ command -v jq >/dev/null 2>&1 || {
   exit 0
 }
 
+# The ONE exit trap for the whole suite: per-section `trap ... EXIT` installs
+# would replace each other (and a `trap - EXIT` would clear the last one), so
+# a failure inside a section without its own trap would leak that section's
+# harness. Sections call teardown_poller_harness explicitly; the teardown is a
+# no-op when no harness is live.
+cleanup() {
+  teardown_poller_harness
+}
+trap cleanup EXIT
+
 # archive_xml_mentioning <path>... -- a minimal plutil-shaped XML body whose
 # $objects array mentions each (already-escaped) path string.
 archive_xml_mentioning() {
@@ -72,7 +82,6 @@ run_reader_case() {
 # ---- R1: present / absent, via the exact read-only plutil argv ---------------
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled)"
 export POLLER_PLUTIL_XML
 run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
@@ -83,10 +92,8 @@ assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_RULES" 1 ||
   fail "R1 present: the reader must run exactly one read-only plutil conversion"
 assert_no_mutation_attempt || fail "R1 present: the reader must never mutate"
 teardown_poller_harness
-trap - EXIT
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/unrelated/binary)"
 export POLLER_PLUTIL_XML
 run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
@@ -94,12 +101,10 @@ run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tails
 assert_page_count 1 || fail "R1 absent: an unmentioned target is a deviation (first observation)"
 assert_baseline_scalar demo_rule absent || fail "R1 absent: baseline must record absent"
 teardown_poller_harness
-trap - EXIT
 
 # ---- R2: a longer path containing the target is NOT the target ---------------
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled-helper)"
 export POLLER_PLUTIL_XML
 run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)" ||
@@ -107,12 +112,10 @@ run_reader_case "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tails
 assert_page_count 1 || fail "R2: a superstring path must not satisfy the target (absent must page)"
 assert_baseline_scalar demo_rule absent || fail "R2: baseline must record absent"
 teardown_poller_harness
-trap - EXIT
 
 # ---- R3: the target is matched in its XML-escaped form -----------------------
 
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 POLLER_PLUTIL_XML="$(archive_xml_mentioning '/opt/tools/fetch &amp; sync')"
 export POLLER_PLUTIL_XML
 run_reader_case "$(rule_control demo_rule lulu_rule_present '/opt/tools/fetch & sync')" ||
@@ -120,7 +123,6 @@ run_reader_case "$(rule_control demo_rule lulu_rule_present '/opt/tools/fetch & 
 assert_no_page || fail "R3: an ampersand target must match its XML-escaped archive form"
 assert_baseline_scalar demo_rule present || fail "R3: baseline must record present"
 teardown_poller_harness
-trap - EXIT
 
 # ---- R4: plutil failures are indeterminate, never absent ---------------------
 
@@ -161,7 +163,6 @@ run_plutil_failure_case 'exit-0-without-output' POLLER_PLUTIL_XML= POLLER_PLUTIL
 # resolution and require the RESOLVED path, not the declared launcher, to be
 # what the archive is searched for.
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 export POLLER_READLINK_OUTPUT='/real/interpreters/cpython-3.11/python3.11'
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /real/interpreters/cpython-3.11/python3.11)"
 export POLLER_PLUTIL_XML
@@ -173,12 +174,10 @@ assert_baseline_scalar demo_resolved present ||
 assert_probe_argv 'readlink -f /opt/venv/bin/python' 1 ||
   fail "R5 resolved-present: the reader must resolve the declared launcher exactly once"
 teardown_poller_harness
-trap - EXIT
 
 # The archive mentioning only the LAUNCHER path while the resolution points
 # elsewhere reads absent: the rule must cover the binary that executes.
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 export POLLER_READLINK_OUTPUT='/real/interpreters/cpython-3.11/python3.11'
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /opt/venv/bin/python)"
 export POLLER_PLUTIL_XML
@@ -189,11 +188,9 @@ assert_page_count 1 ||
 assert_baseline_scalar demo_resolved absent ||
   fail "R5 launcher-only: baseline must record absent"
 teardown_poller_harness
-trap - EXIT
 
 # An unresolvable target (the launcher is gone) is indeterminate, never absent.
 setup_poller_harness
-trap 'teardown_poller_harness' EXIT
 export POLLER_READLINK_EXIT=1
 POLLER_PLUTIL_XML="$(archive_xml_mentioning /real/interpreters/cpython-3.11/python3.11)"
 export POLLER_PLUTIL_XML
@@ -208,6 +205,5 @@ assert_baseline_unchanged ||
   fail "R5 unresolvable: an unresolvable target must never advance the baseline"
 unset POLLER_READLINK_EXIT POLLER_READLINK_OUTPUT POLLER_PLUTIL_XML
 teardown_poller_harness
-trap - EXIT
 
 printf 'ok: LuLu rule-existence readers (exact-element existence claim, XML escaping, indeterminate-on-failure, resolved-target following)\n'

--- a/test/unit/lulu-rule-existence-reader.sh
+++ b/test/unit/lulu-rule-existence-reader.sh
@@ -24,6 +24,15 @@
 #      probe time and the RESOLVED path is matched, so the control follows
 #      the live binary behind a launcher symlink; an unresolvable target is
 #      indeterminate, never absent.
+#   R6 profile guard: LuLu reads preferences AND rules from an ACTIVE
+#      PROFILE directory when the base preferences name one (currentProfile;
+#      Preferences.m getCurrentProfile, Rules.m getPath), so with a profile
+#      active the base archive these readers consult is not the one deciding
+#      traffic. Both rule readers go indeterminate, the gap page names the
+#      profile as the cause, the base archive is not even read, and an
+#      UNREADABLE base preferences file is the same fail-closed
+#      indeterminate. One preferences read per tick, however many rule
+#      controls are declared.
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -206,4 +215,80 @@ assert_baseline_unchanged ||
 unset POLLER_READLINK_EXIT POLLER_READLINK_OUTPUT POLLER_PLUTIL_XML
 teardown_poller_harness
 
-printf 'ok: LuLu rule-existence readers (exact-element existence claim, XML escaping, indeterminate-on-failure, resolved-target following)\n'
+# ---- R6: an active LuLu profile makes the base archive non-authoritative -----
+
+# preferences_xml_with_profile -- a base preferences document whose
+# currentProfile key names an active profile directory, the way LuLu stores
+# the selection (full path under Profiles/).
+preferences_xml_with_profile() {
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n	<key>currentProfile</key>\n	<string>/Library/Objective-See/LuLu/Profiles/travel</string>\n</dict>\n</plist>\n'
+}
+
+# A STALE base mention must not read present while a profile is active: the
+# profile's own rules.plist is the one deciding traffic. Indeterminate, one
+# gap page naming the profile, baseline untouched, and the base archive is
+# never even read.
+setup_poller_harness
+POLLER_PLUTIL_PREFS_XML="$(preferences_xml_with_profile)"
+export POLLER_PLUTIL_PREFS_XML
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled)"
+export POLLER_PLUTIL_XML
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)"
+seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","demo_rule":"present","demo_rule:expect":"present","demo_rule:target":"/usr/local/bin/tailscaled"}'
+snapshot_baseline
+run_poller >/dev/null 2>&1 || fail "R6 active: expected exit 0 after paging the gap"
+assert_page_count 1 || fail "R6 active: an active profile must page a monitoring gap"
+assert_page_body_has 'monitoring gap' || fail "R6 active: the page must name the gap"
+assert_page_body_has 'LuLu profile is ACTIVE' ||
+  fail "R6 active: the page must name the active profile as the cause"
+assert_page_body_has 'demo_rule' || fail "R6 active: the page must name the blinded control"
+assert_baseline_unchanged ||
+  fail "R6 active: a non-authoritative read must never advance the baseline"
+assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_RULES" 0 ||
+  fail "R6 active: the base archive must not be read while a profile is active"
+assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_PREFERENCES" 1 ||
+  fail "R6 active: the profile check must read the base preferences exactly once"
+unset POLLER_PLUTIL_PREFS_XML POLLER_PLUTIL_XML
+teardown_poller_harness
+
+# An UNREADABLE base preferences file cannot confirm no profile is active:
+# same fail-closed indeterminate, page names the unconfirmed check.
+setup_poller_harness
+export POLLER_PLUTIL_PREFS_EXIT=1
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled)"
+export POLLER_PLUTIL_XML
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$(rule_control demo_rule lulu_rule_present /usr/local/bin/tailscaled)"
+seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","demo_rule":"present","demo_rule:expect":"present","demo_rule:target":"/usr/local/bin/tailscaled"}'
+snapshot_baseline
+run_poller >/dev/null 2>&1 || fail "R6 unreadable: expected exit 0 after paging the gap"
+assert_page_count 1 || fail "R6 unreadable: an unconfirmable profile state must page a gap"
+assert_page_body_has 'confirm no profile is active' ||
+  fail "R6 unreadable: the page must say the profile state could not be confirmed"
+assert_baseline_unchanged ||
+  fail "R6 unreadable: an unconfirmable read must never advance the baseline"
+unset POLLER_PLUTIL_PREFS_EXIT POLLER_PLUTIL_XML
+teardown_poller_harness
+
+# Healthy control: NO profile (the harness default preferences carry no
+# currentProfile key), two rule controls, one tick: the preferences are read
+# exactly ONCE (memoized per tick), both rule reads proceed, silence.
+setup_poller_harness
+POLLER_PLUTIL_XML="$(archive_xml_mentioning /usr/local/bin/tailscaled /usr/local/bin/other)"
+export POLLER_PLUTIL_XML
+set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+set_posture_controls "$(jq -cn '[
+  {id: "demo_rule", description: "rule one", tier: "verify", reader: "lulu_rule_present", expect: "present", target: "/usr/local/bin/tailscaled"},
+  {id: "demo_rule_two", description: "rule two", tier: "verify", reader: "lulu_rule_present", expect: "present", target: "/usr/local/bin/other"}]')"
+run_poller >/dev/null 2>&1 || fail "R6 healthy: expected exit 0"
+assert_no_page || fail "R6 healthy: no profile and both rules mentioned must stay silent"
+assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_PREFERENCES" 1 ||
+  fail "R6 healthy: the profile check must run exactly once per tick, however many rule controls exist"
+assert_probe_argv "plutil -convert xml1 -o - $OSQUERY_POSTURE_LULU_RULES" 2 ||
+  fail "R6 healthy: both rule controls must still read the base archive"
+assert_no_mutation_attempt || fail "R6 healthy: the profile check must never mutate"
+unset POLLER_PLUTIL_XML
+teardown_poller_harness
+
+printf 'ok: LuLu rule-existence readers (exact-element existence claim, XML escaping, indeterminate-on-failure, resolved-target following, active-profile fail-closed guard)\n'

--- a/test/unit/lulu-rule-existence-reader.sh
+++ b/test/unit/lulu-rule-existence-reader.sh
@@ -77,7 +77,7 @@ archive_xml_mentioning() {
 
 rule_control() { # <id> <reader> <target> -- one verify record as a JSON array
   jq -cn --arg id "$1" --arg reader "$2" --arg target "$3" \
-    '[{id: $id, description: ("The LuLu allow rule for " + $id), tier: "verify", reader: $reader, expect: "present", target: $target}]'
+    '[{id: $id, description: ("The LuLu rule-archive mention for " + $id + ", existence-only"), tier: "verify", reader: $reader, expect: "present", target: $target}]'
 }
 
 # run_reader_case <controls-json> -> runs one first-observation tick; the

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -321,12 +321,17 @@ constants_output="$(SYSTEM_READ_OK=9 SYSTEM_READ_UNSET=9 SYSTEM_READ_UNREADABLE=
 # ---- system_defaults_write -----------------------------------------------------
 
 # case 16: the write goes through sudo with the exact argument shape
-# `defaults write <plist-path> <key> -<type> <value>`, asserted PER FIELD. The
-# sudo stub records each argument on its own line and does not execute anything.
+# `defaults write <plist-path> <key> -<type> <value>`, then repairs the
+# written file to root:wheel 0644 IN THE SAME CALL. `defaults write` recreates
+# the target as a root-owned 0600 binary plist (verified on a copy,
+# 2026-07-27), and a 0600 plist reads back SYSTEM_READ_UNREADABLE for the
+# unprivileged drift checker forever after, so an unrepaired write defeats the
+# very drift gate that verifies it. The sudo stub records one line per CALL
+# and does not execute anything.
 sudo_log="$work/sudo.log"
 cat >"$stub_bin/sudo" <<EOF
 #!/bin/bash
-printf '%s\n' "\$@" >>"$sudo_log"
+printf '%s\n' "\$*" >>"$sudo_log"
 exit 0
 EOF
 chmod +x "$stub_bin/sudo"
@@ -335,15 +340,61 @@ status=0
 call_function system_defaults_write /Library/Preferences/com.example.sys SysKey bool false >/dev/null || status=$?
 [[ $status -eq 0 ]] ||
   fail "write: system_defaults_write must succeed when sudo succeeds (got $status, stderr: $(cat "$work/err"))"
-mapfile -t sudo_arguments <"$sudo_log"
-[[ ${#sudo_arguments[@]} -eq 6 ]] ||
-  fail "write: sudo must receive exactly 6 arguments (got ${#sudo_arguments[@]}: $(cat "$sudo_log"))"
-[[ ${sudo_arguments[0]} == defaults ]] || fail "write: argument 1 must be 'defaults' (got '${sudo_arguments[0]}')"
-[[ ${sudo_arguments[1]} == write ]] || fail "write: argument 2 must be 'write' (got '${sudo_arguments[1]}')"
-[[ ${sudo_arguments[2]} == /Library/Preferences/com.example.sys ]] ||
-  fail "write: argument 3 must be the plist path (got '${sudo_arguments[2]}')"
-[[ ${sudo_arguments[3]} == SysKey ]] || fail "write: argument 4 must be the key (got '${sudo_arguments[3]}')"
-[[ ${sudo_arguments[4]} == -bool ]] || fail "write: argument 5 must be the dashed type (got '${sudo_arguments[4]}')"
-[[ ${sudo_arguments[5]} == false ]] || fail "write: argument 6 must be the value (got '${sudo_arguments[5]}')"
+mapfile -t sudo_calls <"$sudo_log"
+[[ ${#sudo_calls[@]} -eq 3 ]] ||
+  fail "write: one write must make exactly 3 sudo calls, the write plus its two-step repair (got ${#sudo_calls[@]}: $(cat "$sudo_log"))"
+[[ ${sudo_calls[0]} == 'defaults write /Library/Preferences/com.example.sys SysKey -bool false' ]] ||
+  fail "write: call 1 must be the exact defaults write (got '${sudo_calls[0]}')"
+[[ ${sudo_calls[1]} == 'chown root:wheel /Library/Preferences/com.example.sys.plist' ]] ||
+  fail "write: call 2 must repair ownership on the file defaults actually writes, the .plist beside the extensionless path (got '${sudo_calls[1]}')"
+[[ ${sudo_calls[2]} == 'chmod 644 /Library/Preferences/com.example.sys.plist' ]] ||
+  fail "write: call 3 must repair the mode to 0644 so the unprivileged drift reader can read the value back (got '${sudo_calls[2]}')"
 
-printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative, traversal and degenerate targets on BOTH branches while the tracked Objective-See path still resolves; re-sourcing under set -euo pipefail is a no-op that still fixes the constants; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape)\n'
+# case 16b: a declared path already ending in .plist is repaired AS ITSELF,
+# never with a second .plist appended.
+: >"$sudo_log"
+status=0
+call_function system_defaults_write /Library/Objective-See/LuLu/preferences.plist LuLuKey bool true >/dev/null || status=$?
+[[ $status -eq 0 ]] ||
+  fail "write .plist: system_defaults_write must succeed (got $status, stderr: $(cat "$work/err"))"
+grep -qxF 'chmod 644 /Library/Objective-See/LuLu/preferences.plist' "$sudo_log" ||
+  fail "write .plist: the repair must target the declared .plist file itself (log: $(cat "$sudo_log"))"
+if grep -qF 'preferences.plist.plist' "$sudo_log"; then
+  fail "write .plist: the repair must not append a second .plist (log: $(cat "$sudo_log"))"
+fi
+
+# case 16c: a FAILED write that left no file behind re-raises the write's
+# status and skips the repair rather than failing on the missing path.
+cat >"$stub_bin/sudo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$sudo_log"
+if [[ \$1 == defaults ]]; then exit 7; fi
+exit 0
+EOF
+chmod +x "$stub_bin/sudo"
+: >"$sudo_log"
+status=0
+call_function system_defaults_write /Library/Preferences/com.example.absent AbsentKey bool true >/dev/null || status=$?
+[[ $status -eq 7 ]] ||
+  fail "write failure: the write's own exit status must be re-raised (got $status)"
+if grep -qE '^(chown|chmod) ' "$sudo_log"; then
+  fail "write failure: no file was left behind, so no repair call may run (log: $(cat "$sudo_log"))"
+fi
+
+# case 16d: a FAILED write whose target file EXISTS still repairs it before
+# re-raising the failure: a write can die after replacing the file, and under
+# set -e the caller ends at this record, so a trailing cleanup would never
+# run. Per-write repair is the property that survives that.
+existing_target="$work/failed-write.plist"
+: >"$existing_target"
+: >"$sudo_log"
+status=0
+call_function system_defaults_write "$existing_target" FailKey bool true >/dev/null || status=$?
+[[ $status -eq 7 ]] ||
+  fail "write failure with file: the write's exit status must be re-raised (got $status)"
+grep -qxF "chown root:wheel $existing_target" "$sudo_log" ||
+  fail "write failure with file: ownership must still be repaired on the failure path (log: $(cat "$sudo_log"))"
+grep -qxF "chmod 644 $existing_target" "$sudo_log" ||
+  fail "write failure with file: the mode must still be repaired on the failure path (log: $(cat "$sudo_log"))"
+
+printf 'macos-defaults-scope-read: OK (plist path defaults, passes absolute, rejects relative, traversal and degenerate targets on BOTH branches while the tracked Objective-See path still resolves; re-sourcing under set -euo pipefail is a no-op that still fixes the constants; scope enum and pairings validated fail-closed; the system read distinguishes value/unset/unreadable by STATUS, so no live value can impersonate an outcome and never collapses unknown failures; the system write goes through sudo with the exact argument shape and repairs root:wheel 0644 per write, success and failure alike)\n'

--- a/test/unit/macos-defaults-scope-read.sh
+++ b/test/unit/macos-defaults-scope-read.sh
@@ -318,6 +318,34 @@ constants_output="$(SYSTEM_READ_OK=9 SYSTEM_READ_UNSET=9 SYSTEM_READ_UNREADABLE=
 [[ $status -eq 0 && $constants_output == '0 1 2' ]] ||
   fail "double source: the read-outcome constants must be 0 1 2 even when the environment presets them (got status $status, output '$constants_output')"
 
+# ---- require_system_plist_path_permitted ------------------------------------
+
+# case 18: the WRITE-path allowlist. Rendering already refuses an
+# out-of-allowlist plist_path, but `just defaults-apply` reads the YAML
+# directly, so without this gate a record the render would refuse was still
+# handed to `sudo defaults write` (verified against /etc/example.evil.plist
+# before the fix). Absolute and parent-free is not enough: membership in the
+# deliberately granted directories is its own rule.
+for evil_path in /etc/example.evil.plist /Library/LaunchDaemons/com.example.evil.plist; do
+  status=0
+  output="$(call_function require_system_plist_path_permitted "$evil_path")" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "allowlist: $evil_path must be refused as a write target (got 0)"
+  grep -qF 'permitted plist director' "$work/err" ||
+    fail "allowlist: the refusal must name the containment rule (stderr: $(cat "$work/err"))"
+  grep -qF "$evil_path" "$work/err" ||
+    fail "allowlist: the refusal must name the offending path (stderr: $(cat "$work/err"))"
+done
+
+# Positive controls: the default construction and the tracked Objective-See
+# path both pass, so the refusals above were not bought with a blanket deny.
+for permitted_path in /Library/Preferences/com.example.sys /Library/Objective-See/LuLu/preferences.plist; do
+  status=0
+  call_function require_system_plist_path_permitted "$permitted_path" >/dev/null || status=$?
+  [[ $status -eq 0 ]] ||
+    fail "allowlist: $permitted_path must be permitted (got $status, stderr: $(cat "$work/err"))"
+done
+
 # ---- system_defaults_write -----------------------------------------------------
 
 # case 16: the write goes through sudo with the exact argument shape


### PR DESCRIPTION
## Context

An outbound firewall runs on this machine, deciding which programs may reach the network. It is
installed, approved, and carrying a large set of accumulated allow decisions, and none of that is written
down anywhere. Its settings could change and nothing would notice.

This declares them, so a later change becomes visible. It changes no setting, creates no rule, and
installs nothing. It ships last of this group because it is the only part that could interfere with the
alerting channel itself: the machine sends every alert through a local service that this firewall is
capable of blocking.

## Summary

- Six firewall settings are now declared and compared against the machine every minute.
- Three more checks watch that the filter is running and that two required allow decisions still exist.
- The interactive steps that only a person can do are written down with a runbook pointer.
- A settings write no longer leaves the file unreadable to the check that reads it back.
- A check that cannot be trusted now fails the drift command instead of passing quietly.
- Two paths that write settings now share one containment rule, rather than only the automatic one.

## The claim that turned out to be false

The settings were originally declared as something this repository would apply and keep applied. Review
asked for proof that the firewall notices such a change, and the proof does not exist. Reading the
product's own source: the filter loads its settings **once** when it starts, never watches the file, and
saves its whole in-memory copy back on any change of its own.

So a write from outside is invisible to the running filter, and gets overwritten the next time the filter
saves. That is not an unproven claim, it is a disproven one.

The records are therefore declared as *watched* rather than *applied*. They still detect any change and
still raise it, which is the real value here; they no longer claim an authority the product does not
grant. Promotion later is a small data change if a future release adds a reload mechanism, and the
runbook records the supported way to change these settings in the meantime.

The alternative was a live experiment, and it was rejected on its own terms: proving the filter honours
an outside write requires changing a setting the filter actually consults, and the only such settings
change what the firewall blocks, on the machine that carries the alerting. There is no safe version of
that experiment.

## What review found in the machinery underneath

Writing one of these settings turned the file from readable to owner-only, and the check that reads it
back runs without privilege. So the very first write would have blinded all six checks, and the drift
command would have reported success while verifying nothing. Both halves are fixed: the write restores
the file's readability, on failure as well as success, and a check that cannot be read now fails the
command rather than passing.

Two further gaps: one of the two ways to write settings skipped the containment rule the other enforced,
and the rule checks described themselves as proving more than they do. A rule that is present but
disabled, expired, or signature-mismatched is not an active permission, so the descriptions now claim
only what is actually observed.

The firewall also supports profiles, and reads its settings and rules from the active one. Nothing here
looked at that, so an activated profile could have made every check report healthy about files the
firewall was no longer using. The checks now refuse to answer at all when a profile is active, and say
why.

## A test that could have deleted the working copy

One new test built a scratch directory and removed it afterwards. If creating that directory failed, the
variable holding its path was empty, and on this shell moving into an empty path silently succeeds and
stays put. The cleanup was therefore aimed at whatever directory the test happened to be in, which was
the checked-out repository. It never fired, because the filesystem refused. Every affected test now
refuses to continue unless the scratch directory really exists.

## What is not proven here

Nothing observes whether the filter is working, only whether its process exists and what its files say. A
process that is running but no longer filtering reads as healthy, and that limit is now stated where the
check lives rather than implied away.

No setting was changed, no rule was created, the extension was never restarted, and the two files it owns
are byte-identical to how this work found them.

## Effect of merging

Advances `main` only. The live machine follows another branch, and nothing here changes the firewall even
once applied, because every record is now a comparison rather than a write.
