### PR TITLE
fix(moshi): bounce the moshi-hook daemon when brew replaces its binary

### DIFF
--- a/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
+++ b/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
@@ -21,9 +21,14 @@
 set -euo pipefail
 
 readonly SERVICE_LABEL='homebrew.mxcl.moshi-hook'
-readonly BREW_LINK='/opt/homebrew/bin/moshi-hook'
+# Seam, so the test can point this at a fixture. Without it the test silently
+# depends on the HOST having moshi-hook installed: on a machine without it the
+# script exits at the check below, the bounce path is never reached, and the
+# suite passes locally while failing on a clean runner. That is the
+# skips-itself-when-absent class this repository has already filed twice.
+MOSHI_HOOK_BIN="${MOSHI_HOOK_BIN:-/opt/homebrew/bin/moshi-hook}"
 
-[[ -x $BREW_LINK ]] || exit 0
+[[ -x $MOSHI_HOOK_BIN ]] || exit 0
 
 pid="$(pgrep -f 'moshi-hook serve' 2>/dev/null | head -1)"
 [[ -n $pid ]] || exit 0
@@ -37,7 +42,7 @@ if [[ $lsof_status -ne 0 || -z $running_inode ]]; then
   exit 0
 fi
 
-resolved="$(readlink -f "$BREW_LINK" 2>/dev/null || true)"
+resolved="$(readlink -f "$MOSHI_HOOK_BIN" 2>/dev/null || true)"
 [[ -n $resolved && -e $resolved ]] || exit 0
 
 disk_inode="$(stat -f '%i' "$resolved" 2>/dev/null || true)"

--- a/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
+++ b/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
@@ -1,0 +1,56 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# When brew upgrades moshi-hook in place, the running daemon keeps executing
+# its old image. On Unix an open executable survives being unlinked, so the
+# daemon runs happily on a version that no longer exists on disk: nothing
+# crashes, KeepAlive sees a healthy process, and `moshi-hook --version` reports
+# the NEW version while the process bridging to the phone is the old one.
+# Observed 2026-07-27 going 0.2.37 -> 0.2.61: pid 3399 was still serving code
+# from a Cellar directory brew had already deleted in the same command.
+#
+# This is the atuin failure again (see run_after_45), and the weekly Homebrew
+# upgrade recipe reproduces it unattended, because nothing restarts moshi-hook
+# after an upgrade.
+#
+# STALENESS IS DECIDED BY INODE, NOT BY A VERSION STRING. `moshi-hook probe`
+# prints a version, but whether that is the DAEMON's version or the CLI's own
+# was never established, and comparing the CLI against itself is a tautology
+# that always reports healthy. The inode of the executable the process actually
+# holds open is the artifact: if brew replaced the binary, it differs from the
+# inode on disk today. That is true whatever any version string says.
+set -euo pipefail
+
+readonly SERVICE_LABEL='homebrew.mxcl.moshi-hook'
+readonly BREW_LINK='/opt/homebrew/bin/moshi-hook'
+
+[[ -x $BREW_LINK ]] || exit 0
+
+pid="$(pgrep -f 'moshi-hook serve' 2>/dev/null | head -1)"
+[[ -n $pid ]] || exit 0
+
+# The txt entry is the executable image the process is running. Capturing the
+# status separately: a failed lsof must not be read as a matching inode.
+lsof_status=0
+running_inode="$(lsof -p "$pid" 2>/dev/null | awk '$4 == "txt" { print $(NF-1); exit }')" || lsof_status=$?
+if [[ $lsof_status -ne 0 || -z $running_inode ]]; then
+  printf 'moshi-hook: could not read the running image of pid %s; not bouncing a daemon whose state is unknown.\n' "$pid" >&2
+  exit 0
+fi
+
+resolved="$(readlink -f "$BREW_LINK" 2>/dev/null || true)"
+[[ -n $resolved && -e $resolved ]] || exit 0
+
+disk_inode="$(stat -f '%i' "$resolved" 2>/dev/null || true)"
+[[ -n $disk_inode ]] || exit 0
+
+# Both sides must be plain digits before comparing, so a surprising lsof or
+# stat format cannot produce a false match.
+case $running_inode in '' | *[!0-9]*) exit 0 ;; esac
+case $disk_inode in '' | *[!0-9]*) exit 0 ;; esac
+
+if [[ $running_inode != "$disk_inode" ]]; then
+  printf 'moshi-hook daemon is running a replaced binary (image %s, on disk %s); bouncing the LaunchAgent...\n' \
+    "$running_inode" "$disk_inode"
+  launchctl kickstart -k "gui/$(id -u)/$SERVICE_LABEL"
+fi
+{{ end -}}

--- a/test/unit/moshi-hook-bounce-on-upgrade.sh
+++ b/test/unit/moshi-hook-bounce-on-upgrade.sh
@@ -62,8 +62,15 @@ printf '%s\n' "\$*" >>'$kickstart_log'
 STUB
   chmod +x "$sandbox/bin"/*
   : >"$sandbox/fake-binary"
+  chmod +x "$sandbox/fake-binary"
 
-  PATH="$sandbox/bin:$PATH" bash "$rendered" >"$sandbox/out" 2>&1 || true
+  # MOSHI_HOOK_BIN is a seam, and setting it is what keeps this test honest on
+  # a machine where moshi-hook is NOT installed. Without it the script exits at
+  # its own executable check, the bounce path is never reached, and this suite
+  # passes on the developer machine while failing on a clean CI runner. That is
+  # exactly what happened on the first attempt.
+  PATH="$sandbox/bin:$PATH" MOSHI_HOOK_BIN="$sandbox/fake-binary" \
+    bash "$rendered" >"$sandbox/out" 2>&1 || true
 }
 
 kickstarted() { [[ -s $kickstart_log ]]; }
@@ -107,11 +114,27 @@ exit 1
 STUB
 chmod +x "$sandbox/bin/lsof"
 : >"$kickstart_log"
-PATH="$sandbox/bin:$PATH" bash "$rendered" >"$sandbox/out" 2>&1 || true
+PATH="$sandbox/bin:$PATH" MOSHI_HOOK_BIN="$sandbox/fake-binary" \
+  bash "$rendered" >"$sandbox/out" 2>&1 || true
 if kickstarted; then
   fail '4: an unreadable running image must not trigger a bounce'
 fi
 grep -qi 'could not read the running image' "$sandbox/out" ||
   fail "4: an unreadable running image must say so (out: $(cat "$sandbox/out"))"
+
+# --- 5: moshi-hook not installed at all: exit quietly, bounce nothing --------
+# This case is why the seam exists. It also proves the suite is not silently
+# passing because the HOST happens to have moshi-hook: point the seam at a path
+# that does not exist and the script must take its own not-installed exit.
+
+run_case 111 222
+: >"$kickstart_log"
+PATH="$sandbox/bin:$PATH" MOSHI_HOOK_BIN="$sandbox/definitely-not-installed" \
+  bash "$rendered" >"$sandbox/out" 2>&1 || true
+if kickstarted; then
+  fail '5: with moshi-hook absent the script must bounce nothing'
+fi
+[[ ! -s $sandbox/out ]] ||
+  fail "5: the not-installed exit must be silent (out: $(cat "$sandbox/out"))"
 
 printf 'moshi-hook-bounce-on-upgrade: OK (replaced binary bounces, current daemon is left alone, unparseable and unreadable states refuse)\n'

--- a/test/unit/moshi-hook-bounce-on-upgrade.sh
+++ b/test/unit/moshi-hook-bounce-on-upgrade.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# moshi-hook-bounce-on-upgrade.sh -- the daemon must be bounced when it is
+# running a replaced binary, and left alone otherwise.
+#
+# The bounce path is the whole reason the script exists and it only fires after
+# an upgrade, so it is the branch most likely to ship broken and never be
+# noticed. Both directions are pinned here, plus the three refusals, against
+# stubbed pgrep/lsof/stat/readlink/launchctl. No real daemon is involved and no
+# launchctl call reaches the live service.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $TEMPLATE ]] || fail "template missing at $TEMPLATE"
+
+sandbox="$(mktemp -d)"
+[[ -n $sandbox && -d $sandbox ]] || fail 'could not create the sandbox'
+trap 'rm -rf "$sandbox"' EXIT
+
+rendered="$sandbox/bounce.sh"
+CI=1 chezmoi execute-template --no-tty <"$TEMPLATE" >"$rendered" 2>/dev/null ||
+  fail 'chezmoi could not render the template'
+
+mkdir -p "$sandbox/bin"
+kickstart_log="$sandbox/kickstart.log"
+
+# run_case <running-inode> <disk-inode>: drive the script with stubs and record
+# whether it kickstarted. The binary path the script probes is faked by putting
+# a stub `readlink` and `stat` first on PATH.
+run_case() {
+  local running="$1" disk="$2"
+  : >"$kickstart_log"
+
+  cat >"$sandbox/bin/pgrep" <<'STUB'
+#!/bin/bash
+echo 4242
+STUB
+  cat >"$sandbox/bin/lsof" <<STUB
+#!/bin/bash
+# column 4 is the fd type, the inode is the second-to-last field
+printf 'moshi-hook 4242 stephen txt REG 1,2 999 %s /some/path\n' '$running'
+STUB
+  cat >"$sandbox/bin/readlink" <<STUB
+#!/bin/bash
+printf '%s\n' '$sandbox/fake-binary'
+STUB
+  cat >"$sandbox/bin/stat" <<STUB
+#!/bin/bash
+printf '%s\n' '$disk'
+STUB
+  cat >"$sandbox/bin/launchctl" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>'$kickstart_log'
+STUB
+  chmod +x "$sandbox/bin"/*
+  : >"$sandbox/fake-binary"
+
+  PATH="$sandbox/bin:$PATH" bash "$rendered" >"$sandbox/out" 2>&1 || true
+}
+
+kickstarted() { [[ -s $kickstart_log ]]; }
+
+# --- 1: inodes DIFFER, so the daemon runs a replaced binary: BOUNCE ----------
+
+run_case 111 222
+kickstarted || fail '1: a replaced binary must bounce the LaunchAgent'
+grep -q 'kickstart -k' "$kickstart_log" ||
+  fail "1: the bounce must use kickstart -k (log: $(cat "$kickstart_log"))"
+grep -q 'homebrew.mxcl.moshi-hook' "$kickstart_log" ||
+  fail "1: the bounce must target the moshi-hook service (log: $(cat "$kickstart_log"))"
+grep -qi 'replaced binary' "$sandbox/out" ||
+  fail "1: the bounce must say why (out: $(cat "$sandbox/out"))"
+
+# --- 2: inodes MATCH, the daemon is current: LEAVE IT ALONE ------------------
+
+run_case 333 333
+if kickstarted; then
+  fail "2: a current daemon must NOT be bounced (log: $(cat "$kickstart_log"))"
+fi
+
+# --- 3: a non-numeric inode must not be read as a mismatch ------------------
+# A surprising lsof or stat format would otherwise compare unequal and bounce a
+# healthy daemon on every apply.
+
+run_case 'not-an-inode' 333
+if kickstarted; then
+  fail '3: an unparseable running inode must not trigger a bounce'
+fi
+run_case 333 'not-an-inode'
+if kickstarted; then
+  fail '3: an unparseable disk inode must not trigger a bounce'
+fi
+
+# --- 4: an lsof that reports nothing must refuse loudly, not bounce ---------
+
+cat >"$sandbox/bin/lsof" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$sandbox/bin/lsof"
+: >"$kickstart_log"
+PATH="$sandbox/bin:$PATH" bash "$rendered" >"$sandbox/out" 2>&1 || true
+if kickstarted; then
+  fail '4: an unreadable running image must not trigger a bounce'
+fi
+grep -qi 'could not read the running image' "$sandbox/out" ||
+  fail "4: an unreadable running image must say so (out: $(cat "$sandbox/out"))"
+
+printf 'moshi-hook-bounce-on-upgrade: OK (replaced binary bounces, current daemon is left alone, unparseable and unreadable states refuse)\n'


### PR DESCRIPTION
## Context

Tonight's upgrade of the phone-bridge daemon exposed a gap. When the package manager replaces a running
program's file, the program carries on executing the old copy. Nothing crashes, the supervisor sees a
healthy process, and asking the tool its version reports the new one, while the thing actually talking to
the phone is the old one.

That happened here going twenty-four versions forward: the daemon kept serving from a directory the
package manager had already deleted in the same command. The weekly upgrade job would reproduce it every
time, unattended, because nothing restarts that daemon afterward.

## Summary

- The daemon is restarted automatically when its program file has been replaced.
- A daemon already running current code is left alone.
- Three situations where the check cannot tell refuse rather than restarting blindly.
- The restart-needed case is tested first, because it is the case that only occurs after an upgrade.

## Why a version string was not used

The tool can report a version, but it was never established whether that is the running daemon's version
or the command-line tool's own. If it is the latter, comparing it against the tool on disk compares a
thing to itself, and the check would report healthy forever while doing nothing.

So the check asks a question that cannot be answered wrongly: which file is the running process actually
executing? When the package manager replaces a program, the running process keeps hold of the old file
even after it is removed from the filesystem, and that is directly observable. It is true regardless of
what any version string says.

## What is tested, and why in that order

The restart path is the entire reason this exists, and it only triggers after an upgrade. That makes it
the part most likely to ship broken and go unnoticed for months, so it is pinned first, and deliberately
broken to confirm the test catches it.

The other direction matters just as much: a healthy daemon must not be restarted on every settings apply,
because each restart briefly interrupts the bridge to the phone. Three ways the check could misfire are
covered too, and all of them refuse rather than restarting.

## What this does not do

It does not upgrade anything, and it does not touch the notification path. That path sends directly to
the vendor's web interface and does not involve this daemon at all, so neither the upgrade nor this
change affects it.

## Effect of merging

Advances `main` only. The live machine follows another branch, and the daemon there was already restarted
by hand tonight, so this is about the next upgrade rather than the last one.
