### PR TITLE
fix(ssh): follow the include paths sshd follows, unescaping them the way it does

### DIFF
--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -689,6 +689,120 @@ parse_config_line() {
   return 0
 }
 
+# --- Include path resolution --------------------------------------------------
+# An Include path is unescaped TWICE before sshd opens anything.
+#
+#   Stage 1, argv_split, tokenizes the line (see read_argument_token): it
+#   consumes `\"`, `\'`, `\\` and, OUTSIDE a quoted segment, `\<space>`, and
+#   keeps every other backslash literally.
+#   Stage 2, glob(3), is handed that token: it consumes EVERY remaining `\X`
+#   and yields a literal X, metacharacter or not.
+#
+# Both stages were measured on OpenSSH 10.0p2 against temporary trees, one
+# marker file per candidate name, asking `sshd -G` which file it ended up
+# reading. `<dir>/pay\load.conf`, `<dir>/pay\\load.conf` and
+# `"<dir>/with\ space/payload.conf"` all reach a file with no backslash in its
+# name; `<dir>/pay\\\load.conf` reaches one whose name really does contain a
+# backslash, which is what pins the count at exactly two.
+#
+# Bash pathname expansion is NOT a substitute for stage 2. It performs that
+# unescaping only when it expands at all, and it does not expand a word whose
+# metacharacters are all escaped (or which has none): such a word is left
+# exactly as it was found, backslash and all. Handing the token straight to
+# bash therefore tested a path no file has, the -f test failed, and the scan
+# walked past a file sshd reads -- a Match block inside it re-enabled password
+# authentication with --verify still reporting the tree clean.
+#
+# So the token is analysed here instead, and bash is used only where it is
+# faithful: for a token carrying a LIVE metacharacter, where it does expand and
+# does unescape exactly as glob(3) does (measured on `pa\y[ab]load.conf`,
+# `pa\y?load.conf`, `z\*load?.conf` and `z[ab\]c]load.conf`, which resolve
+# identically both ways).
+#
+# Two known glob-semantics divergences are deliberately NOT addressed here,
+# because neither belongs to this class and both are filed as their own work:
+# bash reads a leading `^` in a bracket as negation while glob(3) reads it as
+# an ordinary member, and a bash pattern matching nothing is left in place as a
+# literal word (glob(3) returns no match). Both are reachable only through a
+# bracket, and both leave the token stream untouched, so nothing below changes
+# their behaviour either way.
+
+# include_bracket_opens_a_set <text following an unescaped '['>: does that '['
+# open a bracket, or is it literal text? glob(3) wants a closing ']' that is
+# UNESCAPED and sits at least one character past the '['. Measured: `z[]load`
+# is the literal text `z[]load`, `z[]]load` is a bracket whose one member is
+# ']', `z[ab\]load` is literal, and `z[ab\]c]load` is a bracket whose members
+# include ']'. One leading '!' is glob(3)'s negation marker and is skipped
+# before that count.
+include_bracket_opens_a_set() {
+  local rest="$1" character
+  case $rest in
+    '!'*) rest="${rest:1}" ;;
+  esac
+  # The first body character is a member whatever it is, ']' included, so the
+  # search for the closing bracket starts after it.
+  if [[ ${rest:0:1} == "$CONFIG_BACKSLASH" ]]; then
+    rest="${rest:2}"
+  else
+    rest="${rest:1}"
+  fi
+  while [[ -n $rest ]]; do
+    character="${rest:0:1}"
+    if [[ $character == "$CONFIG_BACKSLASH" ]]; then
+      rest="${rest:2}"
+      continue
+    fi
+    if [[ $character == ']' ]]; then
+      return 0
+    fi
+    rest="${rest:1}"
+  done
+  return 1
+}
+
+# unescape_include_pattern <argv_split token>: apply stage 2 to the token.
+# INCLUDE_UNESCAPED_PATH is the path with every `\X` reduced to X, which is
+# what glob(3) stats when nothing in the pattern is live.
+# INCLUDE_HAS_METACHARACTER says whether anything IS live, so the caller knows
+# whether it is holding a path or a pattern.
+#
+# The case patterns below are QUOTED on purpose: unquoted, `*` and `?` in a
+# case pattern match any character and every byte of every path would look
+# live.
+INCLUDE_UNESCAPED_PATH=''
+INCLUDE_HAS_METACHARACTER=0
+unescape_include_pattern() {
+  local rest="$1" character
+  INCLUDE_UNESCAPED_PATH=''
+  INCLUDE_HAS_METACHARACTER=0
+  while [[ -n $rest ]]; do
+    character="${rest:0:1}"
+    if [[ $character == "$CONFIG_BACKSLASH" ]]; then
+      if [[ ${#rest} -eq 1 ]]; then
+        # A TRAILING backslash escapes nothing: glob(3) keeps it as a protected
+        # literal backslash, and the pattern names a file whose own name ends
+        # in one (measured). Dropping it here would send the scan to a
+        # different file entirely.
+        INCLUDE_UNESCAPED_PATH="$INCLUDE_UNESCAPED_PATH$CONFIG_BACKSLASH"
+        break
+      fi
+      INCLUDE_UNESCAPED_PATH="$INCLUDE_UNESCAPED_PATH${rest:1:1}"
+      rest="${rest:2}"
+      continue
+    fi
+    case $character in
+      '*' | '?') INCLUDE_HAS_METACHARACTER=1 ;;
+      '[')
+        if include_bracket_opens_a_set "${rest:1}"; then
+          INCLUDE_HAS_METACHARACTER=1
+        fi
+        ;;
+    esac
+    INCLUDE_UNESCAPED_PATH="$INCLUDE_UNESCAPED_PATH$character"
+    rest="${rest:1}"
+  done
+}
+
 # scan_included_files <including file> <in-match> <depth> <chain>: follow the
 # Include whose arguments are sitting in PARSED_ARGS.
 #
@@ -723,19 +837,34 @@ scan_included_files() {
     return 0
   fi
   for pattern in "${patterns[@]}"; do
+    # The relative test is on the RAW token, before any unescaping, because
+    # that is where sshd makes it: `Include \/etc/ssh/x.conf` is RELATIVE to
+    # the daemon (its first byte is a backslash, not a slash) and resolves
+    # under the configuration directory, not at the root (measured).
     case $pattern in
       /*) ;;
       *) pattern="$SSHD_CONFIG_DIR/$pattern" ;;
     esac
-    # IFS=newline so a path containing spaces survives the split while the
-    # glob still expands: pathname expansion produces its own fields whatever
-    # IFS holds. A pattern matching nothing stays literal and is dropped by
-    # the -f test below, which is what sshd does with it.
-    old_ifs="$IFS"
-    IFS=$'\n'
-    # shellcheck disable=SC2206  # deliberate glob expansion of the Include pattern
-    matches=($pattern)
-    IFS="$old_ifs"
+    unescape_include_pattern "$pattern"
+    matches=()
+    if [[ $INCLUDE_HAS_METACHARACTER -eq 0 ]]; then
+      # Nothing live in the pattern, so glob(3) matches nothing: it stats the
+      # unescaped path and returns that one file if it is there. Testing that
+      # path directly is what reaches the file the daemon opens; bash would
+      # have left the backslashes standing in the path it tested.
+      matches=("$INCLUDE_UNESCAPED_PATH")
+    else
+      # A real pattern, and bash expands it exactly as glob(3) does. IFS=newline
+      # so a path containing spaces survives the split while the glob still
+      # expands: pathname expansion produces its own fields whatever IFS holds.
+      # A pattern matching nothing stays literal and is dropped by the -f test
+      # below, which is what sshd does with it.
+      old_ifs="$IFS"
+      IFS=$'\n'
+      # shellcheck disable=SC2206  # deliberate glob expansion of the Include pattern
+      matches=($pattern)
+      IFS="$old_ifs"
+    fi
     if [[ ${#matches[@]} -eq 0 ]]; then
       continue
     fi

--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -33,7 +33,20 @@
 # bashism from a newer bash must fail here, not on the machine.
 
 # Path to the script under test, resolved from this library's location.
-SSH_HARDENING_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dot_local/bin/executable_ssh-hardening.sh"
+#
+# Overridable ONLY so a suite can be pointed at a DIFFERENT checkout of the same
+# script and the two outcomes compared form by form. That comparison is not a
+# nicety: the previous fix in the tokenizer family closed 27 bypasses and opened
+# a regression at the same time, because it was judged against its own targets
+# and never against the version it replaced. With this seam the check is one
+# command:
+#
+#   SSH_HARDENING_SCRIPT=<other checkout>/dot_local/bin/executable_ssh-hardening.sh \
+#     ./test/integration/ssh-hardening-tokenizer-differential.sh
+#
+# and the per-form outcome lines of the two runs diff directly. Nothing in the
+# repo sets it, so `just T` and CI always exercise the script beside this file.
+SSH_HARDENING_SCRIPT="${SSH_HARDENING_SCRIPT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/dot_local/bin/executable_ssh-hardening.sh}"
 
 # The managed drop-in's file name, in ONE place (exported: the reload lib's
 # sshd stub reads it at run time). Must match DROPIN_NAME in the script.

--- a/test/integration/ssh-hardening-tokenizer-differential.sh
+++ b/test/integration/ssh-hardening-tokenizer-differential.sh
@@ -81,6 +81,10 @@ CARRIAGE_RETURN="$SSH_CARRIAGE_RETURN"
 HORIZONTAL_TAB=$'\t'
 VERTICAL_TAB=$'\v'
 FORM_FEED=$'\f'
+# ANSI-C quoted, not a plain quoted backslash: shellcheck reads '\' as a botched
+# escape of a single quote (SC1003), and shfmt -s rewrites "\\" into exactly
+# that. This spelling is the one both tools accept.
+BACKSLASH=$'\\'
 
 # Pulled in by an Include from inside a Match block. It lives OUTSIDE the
 # drop-in directory so the main config's own Include glob does not read it: the
@@ -111,6 +115,49 @@ printf 'PasswordAuthentication yes\n' >"$carriage_return_include"
 # QUOTED segment carries a tab into an Include path.
 tab_include="$SSH_SANDBOX/pay${HORIZONTAL_TAB}load.conf"
 printf 'PasswordAuthentication yes\n' >"$tab_include"
+
+# The double-unescape family. sshd hands the argv_split token to glob(3), which
+# unescapes it a SECOND time, so a backslash the tokenizer preserved is gone
+# before the daemon opens the file. Each name below is what one Include form
+# resolves to after BOTH stages, measured against OpenSSH 10.0p2.
+#
+# The backslash-named copy sits in a subdirectory of its own. Beside
+# payload.conf it would mask the single-backslash bypass: a scan that models
+# only stage 1 tests the un-unescaped word, and a same-named neighbour lets it
+# open SOME file, so the case would stop separating "reached the right file"
+# from "reached any file at all".
+backslash_named_include="$SSH_SANDBOX/nested/pay${BACKSLASH}load.conf"
+mkdir -p "$SSH_SANDBOX/nested"
+printf 'PasswordAuthentication yes\n' >"$backslash_named_include"
+
+# Names carrying a real glob metacharacter. glob(3) reads `\*`, `\?` and `\[`
+# as the literal character, so each of these forms names exactly one file --
+# while bash performs no pathname expansion at all on a word whose only
+# metacharacter is escaped, and leaves the backslash sitting in the path.
+star_named_include="$SSH_SANDBOX/pay*load.conf"
+question_named_include="$SSH_SANDBOX/pay?load.conf"
+bracket_named_include="$SSH_SANDBOX/pay[ab]load.conf"
+open_bracket_named_include="$SSH_SANDBOX/pay[load.conf"
+# A trailing backslash is NOT dropped: glob(3) keeps it as a protected literal
+# and the pattern names a file whose own name ends in a backslash (measured). It
+# lives in the nested directory, beside no payload.conf of its own, so that a
+# scan which DID drop the backslash resolves to nothing instead of landing on a
+# same-named neighbour and passing the case by accident.
+trailing_backslash_include="$SSH_SANDBOX/nested/payload.conf${BACKSLASH}"
+# An unescaped '[' opens a bracket only when an UNESCAPED ']' sits at least one
+# character further on. With the only ']' escaped the whole run is literal text;
+# with a live ']' after it the escaped one is a MEMBER of the set; and a ']'
+# sitting immediately after the '[' is a member too, not a closing bracket, so
+# `z[]load.conf` is literal text as well.
+escaped_close_include="$SSH_SANDBOX/z[ab]load.conf"
+close_member_include="$SSH_SANDBOX/z]load.conf"
+empty_bracket_include="$SSH_SANDBOX/z[]load.conf"
+for glob_named_include in "$star_named_include" "$question_named_include" \
+  "$bracket_named_include" "$open_bracket_named_include" \
+  "$trailing_backslash_include" "$escaped_close_include" \
+  "$close_member_include" "$empty_bracket_include"; do
+  printf 'PasswordAuthentication yes\n' >"$glob_named_include"
+done
 
 # An inert file whose name begins with '#', for the mirror-image rule: a '#'
 # opening an argument is a COMMENT to sshd, so a scan that reads it as another
@@ -334,17 +381,77 @@ differential_case 'argument: a # comment naming a file that exists' \
 differential_case 'argument: Match criteria with a quoted segment' \
   'Match Addr"ess" *,!127.0.0.1' 'PasswordAuthentication yes'
 
-# --- the backslash-and-glob class, filed separately ---------------------------
-# Recorded, not asserted: sshd unescapes `\\` to `\` and the following space
-# then SEPARATES, so this Include resolves nothing on this binary and the tree
-# stays hardened -- the case lands in the 'safe' bin and exercises no walk.
-# The scanner's real divergence in this family (sshd unescapes an Include path
-# TWICE, argv_split then glob(3), while the scan unescapes once) predates this
-# branch, is live on main, and is filed as its own task. This entry only pins
-# that the form is inert today, so an OpenSSH that starts following it flips
-# the case to unsafe and the assertion fires on its own.
-differential_case 'inert today (backslash-glob class, filed separately): with\\ space' \
-  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/with\\\\ space/payload.conf"
+# --- the double-unescape class ------------------------------------------------
+# sshd unescapes an Include path TWICE. argv_split consumes `\"`, `\'`, `\\`
+# and (outside a quoted segment) `\<space>`, keeping every other backslash
+# literally; sshd then hands that token to glob(3), which consumes EVERY
+# remaining `\X` and yields a literal X. bash pathname expansion performs the
+# second unescape only when the word still carries a LIVE metacharacter -- a
+# word without one is left exactly as it was found, backslash and all -- so a
+# scan that models argv_split and then globs in bash tests a path that no file
+# has and walks past the file the daemon opens.
+#
+# The rules, each measured on OpenSSH 10.0p2 and each carried by an entry here:
+#   `\X`                 X survives, the backslash does not, whatever X is
+#   `\\`                 one backslash survives BOTH stages, so the pair reads
+#                        as an ordinary escape and three read as a real one
+#   `\<space>` in quotes argv_split declines it, glob(3) takes it
+#   `\*` `\?` `\[`       the metacharacter goes literal and names one file
+#   trailing `\`         kept, as a protected literal backslash
+#   `[` ... `]`          a bracket only when the closing ']' is UNESCAPED and
+#                        at least one character past the opening '['
+differential_case 'include escape: single backslash before an ordinary character' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}load.conf"
+differential_case 'include escape: single backslash inside a quoted path' \
+  "$MATCH_OFF_LOOPBACK" "Include \"${SSH_SANDBOX}/pay${BACKSLASH}load.conf\""
+differential_case 'include escape: doubled backslash, unquoted' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}${BACKSLASH}load.conf"
+differential_case 'include escape: doubled backslash, quoted' \
+  "$MATCH_OFF_LOOPBACK" "Include \"${SSH_SANDBOX}/pay${BACKSLASH}${BACKSLASH}load.conf\""
+differential_case 'include escape: tripled backslash reaches the backslash-named file' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/nested/pay${BACKSLASH}${BACKSLASH}${BACKSLASH}load.conf"
+differential_case 'include escape: quoted backslash-space' \
+  "$MATCH_OFF_LOOPBACK" "Include \"${SSH_SANDBOX}/with${BACKSLASH} space/payload.conf\""
+differential_case 'include escape: quoted backslash-tab' \
+  "$MATCH_OFF_LOOPBACK" "Include \"${SSH_SANDBOX}/pay${BACKSLASH}${HORIZONTAL_TAB}load.conf\""
+differential_case 'include escape: escaped asterisk names the literal file' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}*load.conf"
+differential_case 'include escape: escaped question mark names the literal file' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}?load.conf"
+differential_case 'include escape: escaped bracket pair names the literal file' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}[ab${BACKSLASH}]load.conf"
+differential_case 'include escape: escaped unmatched bracket names the literal file' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pay${BACKSLASH}[load.conf"
+differential_case 'include escape: bracket closed only by an escaped ] is literal' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/z[ab${BACKSLASH}]load.conf"
+differential_case 'include escape: ] immediately after [ is a member, so the run is literal' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/z[]load.conf"
+
+# The three forms bash and glob(3) already agree on, kept as regression cover:
+# a fix that discarded backslashes wholesale, or that answered every form with
+# a literal path test instead of a pattern expansion, breaks these instead of
+# passing quietly.
+differential_case 'include escape: trailing backslash stays a literal backslash' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/nested/payload.conf${BACKSLASH}"
+differential_case 'include escape: escape beside a live metacharacter still expands' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pa${BACKSLASH}yload*.conf"
+differential_case 'include escape: escaped ] is a MEMBER when a live ] closes the bracket' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/z[ab${BACKSLASH}]c]load.conf"
+
+# The mirror image, and the reason the fix is not "unescape and stop globbing":
+# a live bracket really is a pattern. Nothing named payaload.conf or
+# paybload.conf exists, so sshd opens no file at all -- even though a file whose
+# NAME is the pattern text is sitting right beside it.
+differential_case 'include escape: live bracket matching nothing opens nothing' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/pa${BACKSLASH}y[ab]load.conf"
+
+# Still inert, and still worth an entry. argv_split turns `\\` into one
+# backslash and the following space then SEPARATES, leaving `<dir>/with\` (a
+# protected literal backslash to glob(3), matching nothing) and a relative
+# `space/payload.conf` that resolves nowhere. The day an OpenSSH starts
+# following it, the case flips to unsafe and the assertion fires on its own.
+differential_case 'inert: with\\ space splits at the space and resolves nothing' \
+  "$MATCH_OFF_LOOPBACK" "Include ${SSH_SANDBOX}/with${BACKSLASH}${BACKSLASH} space/payload.conf"
 
 # --- line-trailing whitespace -------------------------------------------------
 # sshd trims trailing space, tab, carriage return and FORM FEED off the whole
@@ -436,8 +543,8 @@ printf '\ncorpus outcomes: %d accepted-and-unsafe, %d accepted-and-inert, %d rej
 # corpus would have passed. Adding forms raises the count and should raise the
 # floor with it; a count BELOW the floor means forms stopped being exercised
 # (or this OpenSSH stopped resolving one unsafe), and either way a human looks.
-[[ $unsafe_count -ge 52 ]] ||
-  fail "only $unsafe_count corpus forms resolved unsafe, below the pinned floor of 52; forms have dropped out of the corpus or the parser changed, and neither may pass silently"
+[[ $unsafe_count -ge 68 ]] ||
+  fail "only $unsafe_count corpus forms resolved unsafe, below the pinned floor of 68; forms have dropped out of the corpus or the parser changed, and neither may pass silently"
 
 status=0
 if [[ ${#bypass_forms[@]} -gt 0 ]]; then

--- a/test/unit/ssh-hardening-include-glob-unescape.sh
+++ b/test/unit/ssh-hardening-include-glob-unescape.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# ssh-hardening-include-glob-unescape.sh -- sshd unescapes an Include path
+# TWICE, and the scan must reach the same file the daemon reaches.
+#
+# Stage 1 is argv_split, which tokenizes the line: it consumes `\"`, `\'`,
+# `\\`, and (outside a quoted segment) `\<space>`, and keeps every other
+# backslash literally. Stage 2 is glob(3), which sshd hands that token to: it
+# consumes EVERY remaining `\X` and yields a literal X, so a backslash the
+# tokenizer preserved disappears before the daemon opens the file.
+#
+# The scan used to model stage 1 only and then hand the token to bash pathname
+# expansion, which does NOT unescape a word containing no glob metacharacter --
+# bash leaves such a word exactly as it found it. So `Include <dir>/pay\load.conf`
+# left the scan testing a path with a backslash in it, the `-f` test failed, the
+# file was never opened, and a Match block inside it re-enabled password access
+# with --verify still reporting the tree clean.
+#
+# Why this suite is a UNIT test and stubs the daemon: the scan is pure bash and
+# a clean runner may have no sshd at all. SSHD_BIN points at a stub that answers
+# every resolution HARDENED, so check_global and check_connection_specs pass
+# unconditionally and the ONLY thing that can fail --verify here is the include
+# walk. Nothing in this file needs a tool the base system does not ship, and the
+# absent-daemon case is pinned rather than skipped: the stub log is asserted, so
+# a run that quietly fell back to a real /usr/sbin/sshd fails.
+#
+# The expectations below come from measurements against OpenSSH 10.0p2; the
+# differential corpus in test/integration re-derives them from the real binary
+# on every run, so a wrong expectation here cannot stay wrong quietly.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-commit and pre-push hooks.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+BACKSLASH=$'\\'
+HORIZONTAL_TAB=$'\t'
+MATCH_OFF_LOOPBACK='Match Address *,!127.0.0.1'
+
+# --- the stubbed daemon -------------------------------------------------------
+# Its resolution is generated from the shared SSH_HARDENED_PAIRS, so adding a
+# directive to policy cannot leave this stub answering the old, shorter set and
+# turning a real failure into a pass.
+SSHD_STUB="$SSH_SANDBOX/bin/sshd-stub"
+SSHD_STUB_LOG="$SSH_SANDBOX/sshd-stub.log"
+: >"$SSHD_STUB_LOG"
+{
+  printf '#!/bin/bash\n'
+  # shellcheck disable=SC2016  # deliberate: this line is the stub's SOURCE, and
+  # "$*" and ${SSHD_STUB_LOG} must reach it unexpanded to be evaluated when the
+  # stub runs, not while it is being written.
+  printf 'printf "%%s\\n" "$*" >>"${SSHD_STUB_LOG:?}"\n'
+  printf "cat <<'RESOLUTION'\n"
+  printf '%s\n' "${SSH_HARDENED_PAIRS[@]}"
+  printf 'RESOLUTION\n'
+} >"$SSHD_STUB"
+chmod +x "$SSHD_STUB"
+SSHD_BIN="$SSHD_STUB"
+export SSHD_BIN SSHD_STUB_LOG
+
+# The absent-daemon pin: this suite must never reach a real sshd. If SSHD_BIN
+# ever escaped the sandbox, every case below would be measuring the host's
+# installed daemon instead of the scan.
+case $SSHD_BIN in
+  "$SSH_SANDBOX"/*) ;;
+  *) fail "SSHD_BIN must point inside the sandbox, got '$SSHD_BIN'" ;;
+esac
+
+hostile_file="$SSHD_CONFIG_D/500-hostile.conf"
+
+# --- the include targets ------------------------------------------------------
+# One hostile file per shape the derivation turned up. Each name is the file
+# sshd ends up opening for exactly one Include form below, so an assertion can
+# name the resolved path instead of settling for "something failed".
+hostile_target() { # <path>
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' 'PasswordAuthentication yes' >"$1" ||
+    fail "could not create the include target '$1'; this filesystem cannot hold the name the case needs"
+}
+
+plain_target="$SSH_SANDBOX/payload.conf"
+spaced_target="$SSH_SANDBOX/with space/payload.conf"
+tab_target="$SSH_SANDBOX/pay${HORIZONTAL_TAB}load.conf"
+# The one file whose NAME contains a backslash lives in a directory of its own.
+# Beside payload.conf it would mask the single-backslash bypass: the unfixed
+# scan tests the un-unescaped word, so a same-named neighbour lets it open SOME
+# file and the case stops distinguishing "reached the right file" from "reached
+# any file at all".
+backslash_target="$SSH_SANDBOX/nested/pay${BACKSLASH}load.conf"
+star_target="$SSH_SANDBOX/pay*load.conf"
+question_target="$SSH_SANDBOX/pay?load.conf"
+bracket_target="$SSH_SANDBOX/pay[ab]load.conf"
+open_bracket_target="$SSH_SANDBOX/pay[load.conf"
+# Beside no payload.conf of its own, for the same reason: a scan that DROPPED
+# the trailing backslash would otherwise land on a same-named neighbour and the
+# case would pass without proving anything.
+trailing_backslash_target="$SSH_SANDBOX/nested/payload.conf${BACKSLASH}"
+escaped_close_target="$SSH_SANDBOX/z[ab]load.conf"
+close_member_target="$SSH_SANDBOX/z]load.conf"
+empty_bracket_target="$SSH_SANDBOX/z[]load.conf"
+
+for target in "$plain_target" "$spaced_target" "$tab_target" \
+  "$backslash_target" "$star_target" "$question_target" "$bracket_target" \
+  "$open_bracket_target" "$trailing_backslash_target" \
+  "$escaped_close_target" "$close_member_target" "$empty_bracket_target"; do
+  hostile_target "$target"
+done
+
+write_hardened_dropin
+
+# --- case runners -------------------------------------------------------------
+
+# Every case RECORDS rather than aborts, and the run fails at the end with the
+# whole list. Aborting on the first miss hides how wide a divergence is, and the
+# width is the thing worth knowing: the last fix in this class was judged by its
+# targets alone and shipped a regression nobody measured.
+missed_forms=()
+false_alarm_forms=()
+
+run_include_case() { # <include argument, verbatim>
+  printf '%s\nInclude %s\n' "$MATCH_OFF_LOOPBACK" "$1" >"$hostile_file"
+  run_ssh_hardening --verify
+  rm -f "$hostile_file"
+}
+
+# assert_scan_reaches <label> <include argument> <path sshd opens>: the scan
+# must open that exact file and report the Match-scoped re-enable inside it.
+assert_scan_reaches() {
+  local label="$1" argument="$2" expected="$3"
+  run_include_case "$argument"
+  if [[ $SSH_RUN_STATUS -eq 0 ]]; then
+    printf '  [MISSED  ] %s -> --verify PASSED\n' "$label"
+    missed_forms+=("$label: sshd opens '$expected', which re-enables password authentication inside a Match block, yet --verify exited 0")
+    return 0
+  fi
+  if ! grep -qF -- "$expected" <<<"$SSH_RUN_ERR"; then
+    printf '  [WRONG   ] %s -> refused, but not for that file\n' "$label"
+    missed_forms+=("$label: --verify refused the tree but never names '$expected', the file sshd opens (stderr: $SSH_RUN_ERR)")
+    return 0
+  fi
+  printf '  [reaches ] %s\n' "$label"
+}
+
+# assert_scan_reaches_nothing <label> <include argument>: sshd resolves this
+# form to no file at all, so the scan must not invent one. Over-strictness here
+# is a false alarm that would make install roll its own hardening back.
+assert_scan_reaches_nothing() {
+  local label="$1" argument="$2"
+  run_include_case "$argument"
+  if [[ $SSH_RUN_STATUS -ne 0 ]]; then
+    printf '  [ALARM   ] %s -> --verify refused a tree sshd opens nothing for\n' "$label"
+    false_alarm_forms+=("$label: sshd resolves this Include to no file at all, yet --verify exited $SSH_RUN_STATUS (stderr: $SSH_RUN_ERR)")
+    return 0
+  fi
+  printf '  [inert   ] %s\n' "$label"
+}
+
+# The vacuity control. If a plain Include of the plain payload stops failing
+# --verify, every "reaches" assertion below is measuring nothing.
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "positive control: --verify must PASS on the clean hardened tree (stderr: $SSH_RUN_ERR)"
+[[ -s $SSHD_STUB_LOG ]] ||
+  fail 'the stubbed daemon was never invoked; this suite is not exercising what it claims'
+grep -qF -- '-G' "$SSHD_STUB_LOG" ||
+  fail "the stub must have answered a 'sshd -G' resolution (log: $(cat "$SSHD_STUB_LOG"))"
+
+printf 'include-path unescaping (expectations measured on OpenSSH 10.0p2):\n'
+
+assert_scan_reaches 'control: plain absolute path' \
+  "$plain_target" "$plain_target"
+
+# --- stage 2 alone: a backslash the tokenizer kept, glob(3) removes -----------
+assert_scan_reaches 'single backslash before an ordinary character' \
+  "$SSH_SANDBOX/pay${BACKSLASH}load.conf" "$plain_target"
+assert_scan_reaches 'single backslash inside a quoted path' \
+  "\"$SSH_SANDBOX/pay${BACKSLASH}load.conf\"" "$plain_target"
+
+# --- both stages: argv_split eats one backslash, glob(3) eats the next --------
+assert_scan_reaches 'doubled backslash, unquoted' \
+  "$SSH_SANDBOX/pay${BACKSLASH}${BACKSLASH}load.conf" "$plain_target"
+assert_scan_reaches 'doubled backslash, quoted' \
+  "\"$SSH_SANDBOX/pay${BACKSLASH}${BACKSLASH}load.conf\"" "$plain_target"
+# Three backslashes leave one standing after BOTH stages, so this one reaches a
+# file whose name really does contain a backslash. It is the case that pins the
+# unescape COUNT at exactly two: a scan that unescaped once would look for the
+# two-backslash name, one that unescaped three times would look for payload.conf.
+assert_scan_reaches 'tripled backslash reaches the backslash-named file' \
+  "$SSH_SANDBOX/nested/pay${BACKSLASH}${BACKSLASH}${BACKSLASH}load.conf" "$backslash_target"
+
+# --- the quoted escape argv_split declines to consume -------------------------
+# Outside quotes `\<space>` is argv_split's own escape; INSIDE quotes it is not,
+# and the backslash survives to glob(3), which removes it there. Measured with a
+# directory named `q\ s` beside one named `q s`: the three-backslash quoted form
+# reaches `q\ s`, which is only possible if stage 1 left the escape alone.
+assert_scan_reaches 'quoted backslash-space' \
+  "\"$SSH_SANDBOX/with${BACKSLASH} space/payload.conf\"" "$spaced_target"
+# `\<TAB>` is an escape to NEITHER stage 1 (the tab separates instead) nor to a
+# reader that only models stage 1 -- but glob(3) removes the backslash all the
+# same once a quoted segment has carried the tab into the token.
+assert_scan_reaches 'quoted backslash-tab' \
+  "\"$SSH_SANDBOX/pay${BACKSLASH}${HORIZONTAL_TAB}load.conf\"" "$tab_target"
+
+# --- a backslash before a glob metacharacter ---------------------------------
+# glob(3) strips the backslash AND the metacharacter loses its magic, so the
+# form names one literal file. bash agrees only when the word carries a SECOND,
+# live metacharacter; with the escaped one alone bash performs no pathname
+# expansion at all and the backslash survives into the -f test.
+assert_scan_reaches 'escaped asterisk names the literal file' \
+  "$SSH_SANDBOX/pay${BACKSLASH}*load.conf" "$star_target"
+assert_scan_reaches 'escaped question mark names the literal file' \
+  "$SSH_SANDBOX/pay${BACKSLASH}?load.conf" "$question_target"
+assert_scan_reaches 'escaped bracket pair names the literal file' \
+  "$SSH_SANDBOX/pay${BACKSLASH}[ab${BACKSLASH}]load.conf" "$bracket_target"
+assert_scan_reaches 'escaped unmatched bracket names the literal file' \
+  "$SSH_SANDBOX/pay${BACKSLASH}[load.conf" "$open_bracket_target"
+# An unescaped '[' whose only ']' is ESCAPED opens no bracket at all: glob(3)
+# needs an UNESCAPED ']' at least one character further on, so the whole run is
+# literal text (measured).
+assert_scan_reaches 'unescaped bracket closed only by an escaped ] is literal' \
+  "$SSH_SANDBOX/z[ab${BACKSLASH}]load.conf" "$escaped_close_target"
+# A ']' sitting immediately after the '[' is a MEMBER, not the closing bracket,
+# so with no further ']' the whole run is literal text (measured).
+assert_scan_reaches 'a ] immediately after [ leaves the run literal' \
+  "$SSH_SANDBOX/z[]load.conf" "$empty_bracket_target"
+
+# --- forms where bash and glob(3) already agree, kept as regression cover -----
+# These pass on the unfixed scan too. They are here so a fix that reaches the
+# forms above by discarding backslashes wholesale, or by replacing pattern
+# expansion with a literal path test, fails instead of passing quietly.
+assert_scan_reaches 'trailing backslash stays a literal backslash' \
+  "$SSH_SANDBOX/nested/payload.conf${BACKSLASH}" "$trailing_backslash_target"
+assert_scan_reaches 'escape beside a live metacharacter still expands' \
+  "$SSH_SANDBOX/pa${BACKSLASH}yload*.conf" "$plain_target"
+assert_scan_reaches 'escaped ] is a MEMBER when a live ] closes the bracket' \
+  "$SSH_SANDBOX/z[ab${BACKSLASH}]c]load.conf" "$close_member_target"
+
+# --- forms sshd resolves to nothing: the scan must not invent a file ----------
+# `\<TAB>` outside quotes is not an escape at all: argv_split ends the argument
+# at the tab, so the first path ends in a bare backslash (which glob(3) keeps as
+# a literal backslash, matching no file here) and `load.conf` becomes a further,
+# relative argument that resolves nowhere.
+assert_scan_reaches_nothing 'unquoted backslash-tab resolves to nothing' \
+  "$SSH_SANDBOX/pay${BACKSLASH}${HORIZONTAL_TAB}load.conf"
+# argv_split turns `\\` into one backslash and the following space then
+# SEPARATES, so this leaves `<dir>/with\` and a relative `space/payload.conf`,
+# neither of which exists.
+assert_scan_reaches_nothing 'unquoted doubled-backslash-space resolves to nothing' \
+  "$SSH_SANDBOX/with${BACKSLASH}${BACKSLASH} space/payload.conf"
+# A live bracket really is a pattern: nothing named payaload.conf or
+# paybload.conf exists, so sshd opens no file even though a file whose NAME is
+# the pattern text is sitting right there. A fix that answered every form with
+# the literal unescape would open it and raise a false alarm.
+assert_scan_reaches_nothing 'live bracket matching nothing opens nothing' \
+  "$SSH_SANDBOX/pa${BACKSLASH}y[ab]load.conf"
+
+# The hostile file is removed by every case, so one final check proves no case
+# leaked state into the tree.
+run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "--verify must PASS again on the clean tree once every case is done; state leaked (stderr: $SSH_RUN_ERR)"
+
+status=0
+if [[ ${#missed_forms[@]} -gt 0 ]]; then
+  printf '\nFAIL: %d Include form(s) sshd follows into a Match-scoped re-enable that the scan does not reach:\n' \
+    "${#missed_forms[@]}" >&2
+  printf '  - %s\n' "${missed_forms[@]}" >&2
+  status=1
+fi
+# Reported separately and after the misses, because a false alarm is a different
+# defect: it blocks an install rather than certifying a hole.
+if [[ ${#false_alarm_forms[@]} -gt 0 ]]; then
+  printf '\nFAIL: %d Include form(s) sshd opens no file for that the scan refused anyway:\n' \
+    "${#false_alarm_forms[@]}" >&2
+  printf '  - %s\n' "${false_alarm_forms[@]}" >&2
+  status=1
+fi
+if [[ $status -ne 0 ]]; then
+  exit "$status"
+fi
+
+printf 'ssh-hardening-include-glob-unescape: OK (every Include form resolves to the file sshd opens, and no form invents one)\n'


### PR DESCRIPTION
## Context

The tool that checks this machine's remote-login policy has to follow the same chain of configuration
files the login daemon follows. Where it fails to follow one, that file goes unexamined, and a rule
inside it can re-open password access for outside visitors while the check reports everything is fine.

This closes the last known family of files it was failing to follow. The family turned out to be four
times larger than the report that prompted this work described.

## Summary

- Twelve configuration forms that the daemon follows and the checker did not are now followed.
- Each one is proven against the real daemon by which file it actually opens, not by an exit code.
- The corpus of forms the checker is measured against grows from seventy-six to ninety-three.
- The checker is confirmed at least as strict as the current version on every one of them.
- A pattern that legitimately matches nothing still opens nothing, so the fix does not overreach.

## What was wrong

A filename in an include line is unescaped **twice** by the daemon: once when the line is split into
words, and again when the name is matched against the filesystem. The checker unescaped once and handed
the rest to the shell, which does not unescape a name containing nothing for it to match against. So the
checker looked for a filename that does not exist, found nothing, and moved on, while the daemon opened
the file and applied it.

Both stages were measured rather than assumed, using a trick worth recording: each candidate filename got
its own marker file setting a different port number, so asking the daemon for its effective port names
exactly which file it opened. A form with three consecutive escape characters is what pins the count at
exactly two, since one would look for a different name and three would look for another.

## The report was wrong about the size of it, and measuring said so

The work was briefed on three known forms, with a prediction that escaping one of the shell's special
characters would be a case where both sides already agree.

Measuring showed the opposite. The shell only unescapes when it has some reason to search at all; a name
whose special characters are all escaped is left exactly as written, backslashes and all. So those forms
are failures too, and the family is twelve rather than three.

That is the reason the brief asked for the rules to be derived from the daemon rather than taken from the
description, and it is why the number in the original report should not have been trusted.

## The check that was missing last time

An earlier fix in this area closed twenty-seven of these and simultaneously opened a new one, because it
tested its fix against the cases it aimed at and never compared against the version it replaced. So this
one is required to be at least as strict as the current version on every form in the corpus, and it is.

## What is deliberately kept

Names that genuinely contain a wildcard still go through matching rather than being treated as literal
text. Without that, a pattern intended to match several files, or none, would be mistaken for a file with
a strange name. A test pins that case specifically, so the fix cannot overreach in the other direction.

One deliberate mutation of the new code was not caught by any test. It is reported rather than hidden: it
changes behaviour only for a shape the daemon itself treats as ordinary text, so both readings reach the
same file.

## Effect of merging

Advances `main` only. It changes what the checker reads, never what the daemon is configured to do.
