### PR TITLE
test(ssh): pin the off-loopback recovery sample and stop a spin hanging the suite

### DIFF
--- a/test/fixtures/ssh-hardening-lib.bash
+++ b/test/fixtures/ssh-hardening-lib.bash
@@ -115,16 +115,21 @@ ssh_sandbox_teardown() {
 
 # run_ssh_hardening <args...>: run the script under /bin/bash, capturing
 # stdout, stderr, and the exit status into SSH_RUN_OUT / SSH_RUN_ERR /
-# SSH_RUN_STATUS. Never lets a nonzero status kill the calling test.
-# shellcheck disable=SC2034  # the three run results are read by the sourcing test
+# SSH_RUN_STATUS. Never lets a nonzero status kill the calling test -- but a
+# script that HANGS does, loudly: every run goes through
+# run_ssh_hardening_bounded below with a wall clock of
+# SSH_HARDENING_TIME_LIMIT seconds (default 30), and exceeding it ABORTS the
+# suite naming the run that spun. A hang is strictly worse than a failure: it
+# blocks the pre-push gate with no diagnosis, and on CI it burns the job's
+# whole time budget before being killed. Observed, not hypothetical: under a
+# tokenizer mutation the --verify child spun and the whole suite hung here.
 run_ssh_hardening() {
-  local out_file="$SSH_SANDBOX/run.out" err_file="$SSH_SANDBOX/run.err"
-  SSH_RUN_STATUS=0
-  /bin/bash "$SSH_HARDENING_SCRIPT" "$@" >"$out_file" 2>"$err_file" ||
-    SSH_RUN_STATUS=$?
-  SSH_RUN_OUT="$(cat "$out_file")"
-  SSH_RUN_ERR="$(cat "$err_file")"
-  assert_no_escalation "run_ssh_hardening $*"
+  run_ssh_hardening_bounded "${SSH_HARDENING_TIME_LIMIT:-30}" "$@"
+  if [[ ${SSH_RUN_TIMED_OUT:-0} -eq 1 ]]; then
+    printf 'FAIL: run_ssh_hardening %s exceeded its %ss wall clock; a script that can spin must fail the suite, not hang it\n' \
+      "$*" "${SSH_HARDENING_TIME_LIMIT:-30}" >&2
+    exit 1
+  fi
 }
 
 # run_ssh_hardening_bounded <seconds> <args...>: run_ssh_hardening with a wall

--- a/test/fixtures/ssh-reload-lib.bash
+++ b/test/fixtures/ssh-reload-lib.bash
@@ -73,6 +73,16 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssh-hardening-lib.bash"
 #                                    still blocks passwords after the drop-in
 #                                    is gone, without verifying fully
 #                                    hardened)
+#   SSHD_STUB_BLOCKED_ADDRESSES      space-separated addr values: a `-G -T -C`
+#                                    resolution whose spec carries one of
+#                                    these addresses keeps BOTH interactive
+#                                    password channels closed even when the
+#                                    tree is otherwise open (models a Match
+#                                    block scoped to that address). This is
+#                                    what makes the stub's output VARY by
+#                                    connection spec, so a recovery gate that
+#                                    drops one of its two samples is caught
+#                                    by a test instead of staying green
 #   LAUNCHCTL_STUB_PRINT_STATUSES    space-separated exit statuses for
 #                                    successive `launchctl print` calls within
 #                                    one run; the last entry repeats
@@ -126,7 +136,10 @@ STUB
   # Controlled sshd: -t exits SSHD_STUB_SYNTAX_STATUS; -G (with or without
   # -T -C) prints a `port` line plus the seven protected directives, hardened
   # exactly when the sandbox drop-in exists (or SSHD_STUB_FORCE_HARDENED is
-  # set), unhardened defaults otherwise.
+  # set), unhardened defaults otherwise. A `-C` spec whose addr is listed in
+  # SSHD_STUB_BLOCKED_ADDRESSES resolves the two password channels closed
+  # even on an otherwise-open tree, so the output varies by connection spec
+  # the way the real resolver does under an address-scoped Match block.
   cat >"$SSH_STUB_DIR/sshd" <<'STUB'
 #!/bin/bash
 set -euo pipefail
@@ -155,6 +168,33 @@ if [[ ${statuses[$index]} -ne 0 ]]; then
   echo 'sshd stub: -G resolution failure injected' >&2
   exit "${statuses[$index]}"
 fi
+# The connection spec, when this call is a per-connection resolution
+# (`-G -T -C user=...,host=...,addr=...`). The addr field is what
+# SSHD_STUB_BLOCKED_ADDRESSES keys on.
+specification=''
+previous=''
+for argument in "$@"; do
+  if [[ $previous == '-C' ]]; then
+    specification="$argument"
+  fi
+  previous="$argument"
+done
+specification_address=''
+case $specification in
+  *addr=*)
+    specification_address="${specification##*addr=}"
+    specification_address="${specification_address%%,*}"
+    ;;
+esac
+blocked_for_specification=0
+if [[ -n ${SSHD_STUB_BLOCKED_ADDRESSES:-} && -n $specification_address ]]; then
+  for blocked_address in ${SSHD_STUB_BLOCKED_ADDRESSES}; do
+    if [[ $specification_address == "$blocked_address" ]]; then
+      blocked_for_specification=1
+      break
+    fi
+  done
+fi
 for stub_port in ${SSHD_STUB_PORT-2222}; do
   printf 'port %s\n' "$stub_port"
 done
@@ -162,7 +202,7 @@ if [[ -f "${SSHD_CONFIG_D:?}/${SSH_DROPIN_NAME:?}" || -n ${SSHD_STUB_FORCE_HARDE
   printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
     'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin no' \
     'gssapiauthentication no' 'hostbasedauthentication no'
-elif [[ -n ${SSHD_STUB_PARTIAL_HARDENED:-} ]]; then
+elif [[ -n ${SSHD_STUB_PARTIAL_HARDENED:-} || $blocked_for_specification -eq 1 ]]; then
   printf '%s\n' 'passwordauthentication no' 'kbdinteractiveauthentication no' \
     'usepam yes' 'pubkeyauthentication yes' 'permitrootlogin prohibit-password' \
     'gssapiauthentication no' 'hostbasedauthentication no'
@@ -363,6 +403,7 @@ STUB
   SSHD_STUB_PORT=2222
   SSHD_STUB_FORCE_HARDENED=""
   SSHD_STUB_PARTIAL_HARDENED=""
+  SSHD_STUB_BLOCKED_ADDRESSES=""
   LAUNCHCTL_STUB_PRINT_STATUSES='0'
   LAUNCHCTL_STUB_KICKSTART_STATUS=0
   KEYSCAN_STUB_MODE=banner
@@ -375,6 +416,7 @@ STUB
     SSHD_BIN LAUNCHCTL_BIN KEYSCAN_BIN SLEEP_BIN SSH_HARDENING_SUDO \
     SSHD_STUB_SYNTAX_STATUS SSHD_STUB_RESOLVE_STATUSES SSHD_STUB_PORT \
     SSHD_STUB_FORCE_HARDENED SSHD_STUB_PARTIAL_HARDENED \
+    SSHD_STUB_BLOCKED_ADDRESSES \
     LAUNCHCTL_STUB_PRINT_STATUSES LAUNCHCTL_STUB_KICKSTART_STATUS \
     KEYSCAN_STUB_MODE KEYSCAN_STUB_ANSWER_PORT
 }

--- a/test/integration/ssh-hardening-rollback.sh
+++ b/test/integration/ssh-hardening-rollback.sh
@@ -26,6 +26,13 @@
 #   8. a verifier that runs but ERRORS is the error outcome, distinct from
 #      "still blocked" and never a success
 #   9. the already-absent path with the policy still in force fails loudly
+#   10. the OFF-LOOPBACK recovery sample is load-bearing: a tree that blocks
+#       passwords only for the off-loopback sample fails the gate, so a
+#       rollback verified over loopback alone can never claim success (the
+#       locked-out operator this gate exists for connects from OFF the
+#       machine, where loopback proves nothing)
+#   11. the LOOPBACK sample is load-bearing the same way, so neither sample
+#       can be deleted with the suite still green
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -212,4 +219,42 @@ refute_contains "$SSH_RUN_OUT" 'rollback complete' \
 assert_no_reload_side_effects '9'
 rm -f "$dropin"
 
-printf 'ssh-hardening-rollback: OK (success means a PROVEN password channel, on both the removal and the already-absent path; blocked, errored, and unverifiable are three distinct loud failures)\n'
+# --- 10: the off-loopback sample is load-bearing ------------------------------
+# The stub resolves the two password channels CLOSED for the off-loopback
+# recovery sample (SSHD_STUB_BLOCKED_ADDRESSES) while loopback resolves them
+# open -- the shape of a Match block scoped away from loopback still enforcing
+# the password block for the address the locked-out operator actually
+# connects from. The gate must report BLOCKED. A gate sampling only loopback
+# claims success here, so deleting the off-loopback sample fails this case.
+# The address is pinned to the script's documented RFC 5737 recovery sample.
+
+write_hardened_dropin
+SSHD_STUB_BLOCKED_ADDRESSES='198.51.100.23' run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '10: with passwords still blocked for the OFF-LOOPBACK sample, rollback must fail even though loopback resolves open'
+[[ ! -e $dropin ]] ||
+  fail '10: the removal itself must still happen'
+grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
+  fail "10: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '10: a loopback-only proof must not produce a completion claim'
+assert_no_reload_side_effects '10'
+
+# --- 11: the loopback sample is load-bearing the same way ---------------------
+# The mirror image: loopback still blocks passwords while the off-loopback
+# sample resolves open. Together with case 10 this pins BOTH samples: neither
+# can be deleted from the gate with the suite still green.
+
+write_hardened_dropin
+SSHD_STUB_BLOCKED_ADDRESSES='127.0.0.1' run_ssh_reload --rollback
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '11: with passwords still blocked for the LOOPBACK sample, rollback must fail even though off-loopback resolves open'
+[[ ! -e $dropin ]] ||
+  fail '11: the removal itself must still happen'
+grep -qi 'NOT restored' <<<"$SSH_RUN_ERR" ||
+  fail "11: the failure must say password access is NOT restored (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '11: an off-loopback-only proof must not produce a completion claim'
+assert_no_reload_side_effects '11'
+
+printf 'ssh-hardening-rollback: OK (success means a PROVEN password channel, on both the removal and the already-absent path; blocked, errored, and unverifiable are three distinct loud failures; both recovery samples are load-bearing)\n'

--- a/test/unit/ssh-hardening-harness-wallclock.sh
+++ b/test/unit/ssh-hardening-harness-wallclock.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ssh-hardening-harness-wallclock.sh -- run_ssh_hardening (the runner every
+# ssh-hardening suite drives the script through) must FAIL the suite when the
+# script under test spins, never hang it. A hang is strictly worse than a
+# failure: it blocks the pre-push gate with no diagnosis, and on CI it burns
+# the job's whole time budget before being killed. run_ssh_reload already
+# carries a wall clock; this suite pins the same property onto the base
+# runner, because every tokenizer and verify test reaches the script through
+# run_ssh_hardening and a spinning --verify child was observed to hang the
+# whole suite under mutation.
+#
+# Properties pinned:
+#   1. a script that spins forever makes run_ssh_hardening ABORT nonzero
+#      within its wall clock (seconds), naming the wall clock in the failure
+#   2. a well-behaved script still runs to completion through the SAME bound,
+#      with SSH_RUN_STATUS / SSH_RUN_OUT captured as before
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite runs from the pre-push hook.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-hardening-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-hardening-lib.bash"
+
+ssh_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+# --- 1: a spinning script fails the runner in seconds, not never --------------
+# The runner aborts with `exit 1` on timeout, so it runs inside a subshell
+# here and the abort is read out of the subshell's status. The elapsed-time
+# cap is deliberately loose (the limit is 2s, the cap 15s): it separates
+# "failed within the wall clock" from "hung until something external killed
+# it", not one second from two.
+
+spin_script="$SSH_SANDBOX/spin.sh"
+printf '#!/bin/bash\nwhile :; do :; done\n' >"$spin_script"
+chmod +x "$spin_script"
+
+started_at=$SECONDS
+spin_status=0
+spin_output="$(
+  SSH_HARDENING_SCRIPT="$spin_script" SSH_HARDENING_TIME_LIMIT=2 \
+    run_ssh_hardening --verify 2>&1
+)" || spin_status=$?
+elapsed=$((SECONDS - started_at))
+
+[[ $spin_status -ne 0 ]] ||
+  fail "1: a spinning script under test must abort run_ssh_hardening nonzero (output: $spin_output)"
+[[ $elapsed -le 15 ]] ||
+  fail "1: the abort took ${elapsed}s; the wall clock was 2s, so this is a hang, not a bound"
+grep -qi 'wall clock' <<<"$spin_output" ||
+  fail "1: the failure must name the wall clock so the hang is diagnosable (output: $spin_output)"
+
+# The spinning child must not outlive the runner: a leaked spinner burns CPU
+# for the rest of the suite and on CI for the rest of the job.
+if pgrep -f "$spin_script" >/dev/null 2>&1; then
+  pkill -9 -f "$spin_script" 2>/dev/null || true
+  fail '1: the spinning child survived the abort; the runner must kill what it timed out'
+fi
+
+# --- 2: a well-behaved script still completes through the same bound ----------
+
+well_behaved_script="$SSH_SANDBOX/well-behaved.sh"
+printf '#!/bin/bash\nprintf "ran to completion\\n"\nexit 0\n' >"$well_behaved_script"
+chmod +x "$well_behaved_script"
+
+SSH_HARDENING_SCRIPT="$well_behaved_script" run_ssh_hardening --verify
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "2: a well-behaved script must still succeed through the bounded runner (status $SSH_RUN_STATUS, stderr: $SSH_RUN_ERR)"
+grep -qF 'ran to completion' <<<"$SSH_RUN_OUT" ||
+  fail "2: SSH_RUN_OUT must still capture the script's stdout (got: $SSH_RUN_OUT)"
+
+printf 'ssh-hardening-harness-wallclock: OK (a spinning script fails the runner inside its wall clock; a healthy one still completes)\n'


### PR DESCRIPTION
## Context

Two guards in the remote-login checker could be deleted with every test still passing, and the test
harness could hang instead of failing when the thing under test spun. Both came out of the review of the
restart-and-rollback work.

Two further items from that review turned out to be already fixed by later work on the same file, so this
carries the two that were real.

## Summary

- The rollback check now proves it consulted the connection an outside visitor actually makes.
- A script that spins now fails the suite in seconds instead of hanging it indefinitely.
- Both fixes are pinned by breaking them deliberately and confirming the suite catches it.

## The rollback sample that proved nothing

Rollback is the way back in for someone locked out, so it has to prove password access is genuinely
restored. It asks the daemon what two sample connections would resolve to: one from this machine, one
from outside.

The outside sample could be deleted with the whole suite still green, because the stand-in daemon used in
tests ignored which connection it was asked about. Connections from this machine always resolve
permissively here, so a rollback verified only that way proves nothing about the connection the operator
is actually trying to make, which is by definition from somewhere else.

The stand-in now answers differently depending on which connection it is asked about, so removing either
sample fails.

## A hang is worse than a failure

Under one deliberate breakage during review, the checker spun forever and the whole suite hung, because
only one of the two ways tests invoke it had a time limit.

A hang in the pre-commit gate is worse than a failure: it blocks with no explanation, and on the build
server it burns the entire time budget before anything kills it. A failure names the problem in seconds.

Both invocation paths now share one time limit, and the message says plainly that a script which can spin
must fail rather than hang. Removing the limit is caught by its own test.

## Two items that no longer applied

The review also flagged an unpinned quoting form and a loop that could spin while its comment denied it.
Checking against the current file first, both were already fixed by later work: the quoting form is now a
corpus entry, and both readers share one guard whose comment states honestly that it protects against a
future edit rather than a live condition.

They are called out here rather than silently dropped, because a finding filed weeks ago is a hypothesis
about the code, not a fact about it, and this is the second time today that checking first avoided fixing
something already fixed.

## Effect of merging

Advances `main` only. Nothing here changes what the checker concludes about a real configuration; it
changes what the tests are able to notice.
