### PR TITLE
fix(osquery): refuse a posture file that declares nothing, instead of watching nothing

### DIFF
--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -468,6 +468,16 @@ load_controls() {
     controls_problem="the posture-controls file is not a JSON array"
     return 0
   fi
+  # A zero-record array is refused, not accepted as nothing-to-monitor: the
+  # declaration is never empty (the repo data always carries records and the
+  # render refuses a blank set), so an empty deployed file means the pipeline
+  # that produces it broke. A blank control set is not an empty control set;
+  # silently watching nothing would be the fail-quiet path this gate exists
+  # to close.
+  if [[ $count -eq 0 ]]; then
+    controls_problem="the posture-controls file declares zero controls; the declaration is never empty, so a blank render is refused instead of silently watching nothing"
+    return 0
+  fi
   for ((index = 0; index < count; index++)); do
     record=$(jq -c ".[$index]" <"$CONTROLS_FILE" 2>/dev/null || echo "")
     id=$(jq -r '.id // empty' <<<"$record" 2>/dev/null || echo "")

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -22,6 +22,15 @@ function; the poller-vs-data agreement test holds the two together. */ -}}
 {{- if not (hasKey .macos "posture_controls") -}}
 {{-   fail "macos_posture_controls.yaml: macos.posture_controls is missing" -}}
 {{- end -}}
+{{- /* The top-level shape, fail-closed: a blank key (nil) and an empty list
+would both render cleanly (range over either is zero iterations) into a file
+that monitors nothing. A blank control set is not an empty control set. */ -}}
+{{- if kindIs "invalid" .macos.posture_controls -}}
+{{-   fail "macos_posture_controls.yaml: macos.posture_controls is blank; a blank control set is not an empty one, declare the verify-tier records" -}}
+{{- end -}}
+{{- if eq (len .macos.posture_controls) 0 -}}
+{{-   fail "macos_posture_controls.yaml: macos.posture_controls declares zero controls; the poller refuses a zero-control file, so an empty list must not render" -}}
+{{- end -}}
 {{- $seenIds := dict -}}
 {{- $readerDomains := dict
       "fdesetup_status" (list "on" "off")

--- a/test/fixtures/osquery-poller-lib.bash
+++ b/test/fixtures/osquery-poller-lib.bash
@@ -99,12 +99,15 @@ SHIM
   chmod +x "$POLLER_HOME/bin/osqueryi"
   export POLLER_OSQUERYI="$POLLER_HOME/bin/osqueryi"
 
-  # The declared-controls file. Default: an EMPTY declaration (no extra
-  # controls), so the legacy firewall/Gatekeeper/screen-lock tests exercise
-  # exactly the pre-controls surface; posture-controls tests install records
-  # via set_posture_controls.
+  # The declared-controls file. Default: ONE healthy-by-default record (the
+  # fdesetup stub reports FileVault on), NEVER an empty list: the poller
+  # refuses a zero-control file as a monitoring gap (a blank render must not
+  # read as a healthy tick), so an empty default would gap-page every legacy
+  # test. Posture-controls tests install their own records via
+  # set_posture_controls.
   export OSQUERY_POSTURE_CONTROLS="$POLLER_HOME/posture-controls.json"
-  printf '[]\n' >"$OSQUERY_POSTURE_CONTROLS"
+  printf '%s\n' '[{"id":"filevault","description":"FileVault disk encryption","tier":"verify","reader":"fdesetup_status","expect":"on"}]' \
+    >"$OSQUERY_POSTURE_CONTROLS"
 
   # Recording, programmable probe stubs for the declared-control readers, plus
   # always-refuse spies for tools the poller must never touch. EVERY invocation

--- a/test/integration/macos-posture-controls-render.sh
+++ b/test/integration/macos-posture-controls-render.sh
@@ -108,6 +108,21 @@ bad_tiers="$(jq -r '.[] | select(.tier != "verify") | .id' "$sandbox/rendered.js
 
 # ---- 2: refusal, fail-closed ------------------------------------------------
 
+# The top-level shape first: a present-but-blank key (nil) and a
+# present-but-empty list both used to render CLEANLY (hasKey passes, and range
+# over nil or an empty list is zero iterations), deploying a file that
+# monitors nothing. A blank control set is not an empty control set: both
+# shapes must abort the render.
+assert_rejects 'blank posture_controls key' 'is blank' <<EOF
+macos:
+  posture_controls:
+EOF
+
+assert_rejects 'empty posture_controls list' 'declares zero controls' <<EOF
+macos:
+  posture_controls: []
+EOF
+
 # A valid record comes FIRST in each fixture, so a template that warned and
 # skipped the offender instead of aborting would render cleanly, and the
 # required render failure is what catches it.

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -466,6 +466,31 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_baseline_unchanged
 }
 
+@test "T-PCTL-empty-controls-file-gaps: a controls file declaring zero controls pages a gap instead of silently watching nothing" {
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  snapshot_baseline
+  # The render of a blank declaration: a well-formed JSON array with no
+  # records. Every control the machine declares has silently vanished, which
+  # must read as a monitoring gap, never as a healthy zero-control tick (a
+  # blank control set is not an empty control set).
+  printf '[]\n' >"$OSQUERY_POSTURE_CONTROLS"
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'monitoring gap'
+  assert_page_body_has 'declares zero controls'
+  assert_gap_marker
+  assert_no_probe_calls # the refused file is refused whole, before any read
+  assert_baseline_unchanged
+}
+
 @test "T-PCTL-nonverify-tier-refused-before-reads: an enforce-tier record pages a gap naming it and no probe ever runs" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline
@@ -839,7 +864,7 @@ assert_bounded_hang_gaps() { # <control-id> <started-seconds>
 }
 
 @test "T-PCTL-legacy-gap-values-neutralized: hostile bytes in an osqueryi scalar never reach the gap page body raw" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   # An out-of-domain firewall value carrying shell metacharacters: the gap body
   # quotes the offending values, so they must arrive neutralized (no dollar, no
@@ -904,7 +929,7 @@ assert_bounded_hang_gaps() { # <control-id> <started-seconds>
 }
 
 @test "T-PCTL-gap-values-inline-code-span: a system-read value crosses into a gap page only inside an inline-code span (no structure forgery)" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   # Markdown that survives character-stripping unchanged: emphasis, a link, a
   # mention. It must arrive WRAPPED in an inline-code span so none of it can

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -700,6 +700,39 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_page_count 2
 }
 
+@test "T-PCTL-partial-recovery-rearms-member: a member recovering during another members ongoing gap re-pages when it re-gaps" {
+  seed_baseline "$healthy_seed"
+  declare_posture_controls
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  export POLLER_FDESETUP_EXIT=1 POLLER_CSRUTIL_EXIT=1
+  run run_poller # tick 1: filevault AND sip gap together, one page covering both
+  [[ $status -eq 0 ]] || {
+    echo "tick 1 status $status: $output"
+    false
+  }
+  assert_page_count 1
+
+  unset POLLER_FDESETUP_EXIT
+  run run_poller # tick 2: filevault recovers while sip stays gapped: covered, no
+  # page, but the marker must SHRINK to the still-gapped member
+  [[ $status -eq 0 ]] || {
+    echo "tick 2 status $status: $output"
+    false
+  }
+  assert_page_count 1
+
+  export POLLER_FDESETUP_EXIT=1
+  run run_poller # tick 3: filevault gaps AGAIN during the same sip outage: a
+  # marker still covering the recovered member would silence this real failure
+  [[ $status -eq 0 ]] || {
+    echo "tick 3 status $status: $output"
+    false
+  }
+  assert_page_count 2
+  assert_page_body_has 'filevault'
+}
+
 @test "T-PCTL-controls-file-gap-never-blinds-builtins: a refused controls file never suppresses a firewall-off page (the trio still compares)" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   rm "$OSQUERY_POSTURE_CONTROLS"

--- a/test/integration/osquery-poller.bats
+++ b/test/integration/osquery-poller.bats
@@ -81,7 +81,10 @@ teardown() { teardown_poller_harness; }
 }
 
 @test "T-POLL-read-failure-preserves-baseline: a hard osqueryi failure pages the monitoring gap and leaves the good baseline intact at 0600" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  # The seed carries the harness default control's fields: a clean member is
+  # persisted even while the trio gaps (per-member gaps), so byte-for-byte
+  # preservation needs the control present in the prior too.
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   export POLLER_OSQUERYI_EXIT=1 # osqueryi hard-fails: no output, non-zero exit
 
@@ -102,7 +105,7 @@ teardown() { teardown_poller_harness; }
 }
 
 @test "T-POLL-failed-read-healthy-output-gaps: a nonzero osqueryi exit with healthy-looking JSON is a monitoring gap, never a trusted read" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   # The printed posture is healthy AND in-domain but DIFFERS from the baseline
   # (firewall 2, block-all): a poller that trusted the output of a failed query
@@ -126,7 +129,7 @@ teardown() { teardown_poller_harness; }
 }
 
 @test "T-POLL-empty-read-preserves-baseline: an empty osqueryi result pages the monitoring gap and leaves the good baseline intact at 0600" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   set_posture '[]' # osqueryi succeeds but returns no row
 
@@ -303,7 +306,7 @@ teardown() { teardown_poller_harness; }
 # the prior-baseline trust check (do not fabricate a transition).
 
 @test "T-POLL-partial-read-preserves-baseline: a partial posture preserves the baseline (a gap page, not a poisoned baseline), and recovery still detects a real transition" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
 
   # Tick 1: the screenlock field is absent, a monitoring gap. It pages the gap but
@@ -352,7 +355,7 @@ teardown() { teardown_poller_harness; }
 # the marker only on success. Recovery (a valid read) clears the marker.
 
 @test "T-POLL-gap-pages-once: a gap read with no marker pages exactly one CRIT naming the gap, writes the marker, and preserves the baseline" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   set_posture '[{"firewall":"9","gatekeeper":"1","screenlock":"1"}]' # firewall out of domain
 
@@ -573,7 +576,7 @@ teardown() { teardown_poller_harness; }
 # --- bounded posture query: a wedged osqueryi becomes a gap, not silent blindness -
 
 @test "T-POLL-osqueryi-hang-pages-gap: a posture query that outlasts the bound is killed and pages a monitoring gap" {
-  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
+  seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on","filevault:expect":"on"}'
   snapshot_baseline
   export OSQUERY_POSTURE_TIMEOUT=1 # bound the query at 1s
   export POLLER_OSQUERYI_SLEEP=30  # osqueryi wedges far past the bound


### PR DESCRIPTION
## Context

The background check that watches this machine's security protections had two ways of reporting
everything is fine while watching nothing at all. Both are the surviving half of a problem already fixed
once in a neighbouring form.

## Summary

- A settings file that declares no protections is now refused loudly instead of accepted silently.
- The refusal happens both when the file is built and when the checker reads it.
- A protection that recovers while another is still broken now raises an alarm if it breaks again.
- The test harness no longer defaults to the empty shape that was hiding the problem.

## Declaring nothing is now an error, not a quiet success

A settings file whose list of protections is present but empty rendered cleanly and produced no
protections to watch. Everything stopped being monitored and nothing said so.

There were two empty shapes and only one of them was caught. A key with nothing after it produced output
the checker already rejected loudly. An explicitly empty list was accepted end to end: no complaint, no
alarm, nothing watched. Both are now refused when the file is built, and the empty list is refused again
at read time, so neither route can go quiet.

## A recovery that was working but unprotected

The other item turned out to be already fixed. When one protection cannot be read, the checker notes the
gap and remembers it so it does not repeat itself every minute. An earlier round rebuilt that memory so
it tracks each protection separately, and a recovery correctly forgets only the one that recovered.

But deleting that behaviour left the entire existing suite passing, while the failure reappeared exactly
as described: a protection that recovered during another one's ongoing outage would never raise an alarm
again if it broke a second time. Correct behaviour, no test holding it in place.

So this adds the missing test rather than changing working code, and confirms it by deleting the
behaviour and watching the test fail.

## The harness was part of the problem

The test harness itself defaulted to the empty list, which is the very shape that was failing quietly. So
tests could pass on a configuration that watches nothing. The default is now a real protection, and the
tests that relied on the old default were updated to match.

That is the same pattern already tracked separately: a test that passes because the thing under test
produced nothing is not a passing test.

## One correction to the instructions this was built from

The brief described both empty shapes as failing quietly. Only one of them did; the other was already
being refused at read time. Both are fixed regardless, but the description was wrong and is corrected
here rather than repeated.

## Effect of merging

Advances `main` only. No protection changes, nothing is installed or restarted, and the checker's
conclusions about a correctly declared file are unchanged.
