### PR TITLE
fix(macos): carry tailnet pin data as arguments, not as root shell source

### DIFF
--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -125,10 +125,24 @@ echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook sec
      Guard-then-append keeps each idempotent across runner re-runs. The sh -c
      wrapper is load-bearing: this script inlines the command after `sudo`, so a
      bare >>/etc/hosts redirect would run in the outer USER shell and be denied;
-     `sudo sh -c '...'` puts the guard AND the append inside the root shell. */ -}}
+     `sudo sh -c '...'` puts the guard AND the append inside the root shell.
+
+     That wrapper means TWO shells see this line, and pin data must be inert in
+     both. Interpolating a field into the sh -c string placed it inside double
+     quotes in the INNER shell, which sudo runs as root, so a command
+     substitution in the data executed as root. Single-quoting alone does not
+     fix that: it only protects the outer shell, and the inner one re-parses
+     whatever the string contains.
+
+     So the sh -c script text is a FIXED constant with no interpolation at all,
+     and every field travels as a positional argument. `$1`/`$2`/`$3` are
+     parameters; no shell re-parses a parameter's value as source. The literal
+     `sh` before the fields is the conventional $0 for `sh -c`, without which
+     the first field would be swallowed as the program name. The printf format
+     is likewise constant, so a `%` in the data is no longer a directive. */ -}}
 {{ range $pins -}}
-echo "→ MagicDNS fallback pin: {{ .fqdn }} (per CLAUDE.md Tailscale DNS section)"
-sudo sh -c 'grep -qF "{{ .fqdn }}" /etc/hosts || printf "{{ .ip }}\t{{ .fqdn }}\t{{ .short }}\n" >>/etc/hosts'
+echo {{ template "shellSingleQuoted" (printf "→ MagicDNS fallback pin: %s (per CLAUDE.md Tailscale DNS section)" (toString .fqdn)) }}
+sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
 {{ end -}}
 {{ end -}}
 {{- end }}

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -196,8 +196,8 @@ echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf)
 echo '→ MANUAL OverSight: allow its Notification Center alerts (its only output channel): see the runbook section OverSight notification delivery'
 echo '→ MANUAL LuLu: approve its system extension (a one-time macOS security consent): see the runbook section LuLu system extension approval'
 echo '→ MANUAL LuLu: create the required outbound allow rules by answering its prompts: see the runbook section LuLu rule creation'
-echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
-sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
+echo '→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)'
+sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
 
 GOLDEN_EOF
 

--- a/test/integration/tailnet-pins.sh
+++ b/test/integration/tailnet-pins.sh
@@ -78,8 +78,16 @@ if [[ ! -s $rendered ]]; then
 fi
 
 # Independent expectation: the exact command the template must generate per pin.
-expected_1='sudo sh -c '\''grep -qF "pin.example.test" /etc/hosts || printf "192.0.2.7\tpin.example.test\tpin\n" >>/etc/hosts'\'''
-expected_2='sudo sh -c '\''grep -qF "pin2.example.test" /etc/hosts || printf "192.0.2.8\tpin2.example.test\tpin2\n" >>/etc/hosts'\'''
+# The sh -c script is a CONSTANT, identical for every pin; only the trailing
+# arguments differ. Single-quoted here so $1/$2/$3 stay literal, which is the
+# property under test: they must reach the inner shell as parameters, not as
+# text the template substituted.
+# shellcheck disable=SC2016  # the literal $1/$2/$3 ARE the property under test:
+# they must survive into the inner shell as parameters, so expanding them here
+# would assert the opposite of what this pins.
+pin_script='grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts'
+expected_1="sudo sh -c '$pin_script' sh 'pin.example.test' '192.0.2.7' 'pin'"
+expected_2="sudo sh -c '$pin_script' sh 'pin2.example.test' '192.0.2.8' 'pin2'"
 grep -qxF "$expected_1" "$rendered" ||
   fail "generated pin command 1 missing or wrong; expected exactly: $expected_1 (rendered: $(cat "$rendered"))"
 grep -qxF "$expected_2" "$rendered" ||
@@ -124,6 +132,64 @@ grep -qxF $'192.0.2.8\tpin2.example.test\tpin2' "$hosts" ||
 cmp -s "$hosts" "$work/hosts.after1" ||
   fail "NOT idempotent: round 2 changed the file ($(grep -cF example.test "$hosts") pin lines)"
 grep -qxF $'127.0.0.1\tlocalhost' "$hosts" || fail "pre-existing hosts content was clobbered"
+
+# ---------- LAYER 1d: pin data is DATA, never source, in either shell --------
+# The generated command runs `sudo sh -c`, so there are TWO shells: the outer one
+# this runner is written in, and the inner ROOT one sudo starts. Interpolating a
+# pin field into the sh -c string put it inside double quotes in that inner root
+# shell, so a command substitution in the data executed AS ROOT. The fix carries
+# each field as a positional argument, which no shell re-parses as source.
+refute_contains() { # <file> <literal> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3 (found the literal: $2)"
+  fi
+}
+
+# Three hostile shapes, one per field, so a fix that closes only one is caught:
+# command substitution, backtick substitution, and a printf format directive.
+# The last one matters because the old command put pin data in printf's FORMAT
+# position, where a % is a directive rather than a character.
+marker="$work/PIN_INJECTION_EXECUTED"
+hostile_fqdn="a\$(touch $marker).example.test"
+hostile_ip='192.0.2.9%s'
+hostile_short="s\`touch $marker\`"
+render_fixture hostile <<EOF
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: "$hostile_fqdn"
+      ip: "$hostile_ip"
+      short: "$hostile_short"
+EOF
+hostile_rendered="$work/hostile.rendered"
+if [[ -s $hostile_rendered ]]; then
+  # The rendered SOURCE must not place the substitution where a shell expands it.
+  refute_contains "$hostile_rendered" "sh -c 'grep -qF \"a\$(touch" \
+    "pin fqdn is interpolated into the sudo sh -c string, so the ROOT shell expands it"
+
+  # Executing it must move bytes, not run them. sudo stripped, hosts redirected.
+  rm -f "$marker"
+  hostile_hosts="$work/hostile-hosts"
+  : >"$hostile_hosts"
+  # Both emitted lines, not just the sudo one. The trace `echo` runs in the OUTER
+  # user shell, so an unquoted field there is its own injection, at user rather
+  # than root privilege. Running only the sh -c line would leave that uncovered.
+  while IFS= read -r line; do
+    cmd="${line#sudo }"
+    cmd="${cmd///etc\/hosts/$hostile_hosts}"
+    bash -c "$cmd" >/dev/null 2>&1 || true
+  done < <(grep -E '^(echo |sudo sh -c )' "$hostile_rendered")
+  [[ -e $marker ]] &&
+    fail "pin data EXECUTED: the generated command ran a substitution from the data (this is root under sudo)"
+
+  # Every field must arrive byte-for-byte, which is what proves each was carried
+  # as data rather than as text some shell re-read. The whole-line comparison is
+  # also what pins the printf FORMAT: move data back into the format position and
+  # the %s in the ip is consumed as a directive, so the line comes out truncated.
+  expected_line="$(printf '%s\t%s\t%s' "$hostile_ip" "$hostile_fqdn" "$hostile_short")"
+  grep -qxF -- "$expected_line" "$hostile_hosts" ||
+    fail "hostile pin line wrong; expected exactly $(printf '%q' "$expected_line"), got $(printf '%q' "$(cat "$hostile_hosts")")"
+fi
 
 # ---------- LAYER 2: shape of the REAL pins data -----------------------------
 pin_count="$(yq eval '.macos.tailnet_pins | length' "$YAML")"


### PR DESCRIPTION
## Context

The Tier 2 runner is the chezmoi script that applies macOS settings needing root. Part of what it
emits is a set of MagicDNS fallback pins: lines added to `/etc/hosts` so tailnet names still resolve
when MagicDNS is unavailable. Each pin is declared as data (fqdn, ip, short name) and the runner
generates a `sudo sh -c` command per pin.

Generating a root command by pasting data into it is the shape this repo already treats as a defect
elsewhere, and the pins were doing exactly that.

## Summary

- Pin data now travels as arguments, so no shell ever reads it as source.
- Closes a path where a hostile fqdn executed as root.
- The trace line is quoted too, closing the same hole at user privilege.
- A `%` in pin data is no longer a printf directive.
- Adds a hostile-data test layer covering all three fields.

Key files: `.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl`,
`test/integration/tailnet-pins.sh`

## The defect

The generated line was:

```
sudo sh -c 'grep -qF "<fqdn>" /etc/hosts || printf "<ip>\t<fqdn>\t<short>\n" >>/etc/hosts'
```

Two shells read that line. The outer one this runner is written in, and the inner one `sudo` starts
as root. Each field landed inside double quotes in the inner shell, so a command substitution in the
data ran with root privilege.

Confirmed before fixing rather than argued: a pin whose fqdn contained a substitution rendered it
straight into the generated command, and running that command executed it.

## Why quoting alone was not the fix

Single-quoting each field protects only the outer shell. The inner shell receives whatever the string
contains and parses it again, so the substitution would still run.

The fix instead makes the `sh -c` script a constant with no interpolation at all, and passes each
field as a positional argument. A parameter's value is never re-read as source by any shell. The
literal `sh` before the fields is the conventional `$0`, without which the first field would be
swallowed as the program name.

The printf format is now constant as well, which closes a smaller variant: the ip previously sat in
the format position, where a `%` is a directive rather than a character.

## How it was verified

Four mutations, each reverted afterward, with the template confirmed byte-identical to pristine at
the end:

| Mutation | Result |
| --- | --- |
| put the fqdn back inside the `sh -c` string | caught |
| drop the `sh` placeholder so the fields shift | caught |
| move data back into the printf format string | caught |
| restore the unquoted trace echo | caught |
| unmutated control | passes |

Worth recording: the first two mutation attempts were written with a pattern that matched nothing.
They reported the test as catching them when it had caught nothing at all. The mutation helper now
refuses to report a result for a replacement that changes no bytes.

Gates: `just T`, `just lint-check`, `just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

The generated command changes shape, so the render-stability golden moves with it. Behavior on a real
machine is unchanged for well-formed pin data: the same line is written to `/etc/hosts`, and it stays
idempotent across runs.
