### PR TITLE
fix(macos): correct a MagicDNS pin whose address changed, instead of leaving it

### DIFF
--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -125,10 +125,24 @@ echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook sec
      Guard-then-append keeps each idempotent across runner re-runs. The sh -c
      wrapper is load-bearing: this script inlines the command after `sudo`, so a
      bare >>/etc/hosts redirect would run in the outer USER shell and be denied;
-     `sudo sh -c '...'` puts the guard AND the append inside the root shell. */ -}}
+     `sudo sh -c '...'` puts the guard AND the append inside the root shell.
+
+     That wrapper means TWO shells see this line, and pin data must be inert in
+     both. Interpolating a field into the sh -c string placed it inside double
+     quotes in the INNER shell, which sudo runs as root, so a command
+     substitution in the data executed as root. Single-quoting alone does not
+     fix that: it only protects the outer shell, and the inner one re-parses
+     whatever the string contains.
+
+     So the sh -c script text is a FIXED constant with no interpolation at all,
+     and every field travels as a positional argument. `$1`/`$2`/`$3` are
+     parameters; no shell re-parses a parameter's value as source. The literal
+     `sh` before the fields is the conventional $0 for `sh -c`, without which
+     the first field would be swallowed as the program name. The printf format
+     is likewise constant, so a `%` in the data is no longer a directive. */ -}}
 {{ range $pins -}}
-echo "→ MagicDNS fallback pin: {{ .fqdn }} (per CLAUDE.md Tailscale DNS section)"
-sudo sh -c 'grep -qF "{{ .fqdn }}" /etc/hosts || printf "{{ .ip }}\t{{ .fqdn }}\t{{ .short }}\n" >>/etc/hosts'
+echo {{ template "shellSingleQuoted" (printf "→ MagicDNS fallback pin: %s (per CLAUDE.md Tailscale DNS section)" (toString .fqdn)) }}
+sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
 {{ end -}}
 {{ end -}}
 {{- end }}

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -19,6 +19,23 @@ set -euo pipefail
      returns the empty value (falsy in `if`, a no-op under `range`), the
      repo's documented Tier-1 runner gotcha. */ -}}
 {{ $pins := index .macos "tailnet_pins" -}}
+{{- /* Tailnet-pin field validation: fqdn, ip and short must each be exactly
+one /etc/hosts column. Any whitespace would split one pin into extra columns
+or, for a newline, extra LINES in the file the generated command rewrites as
+root; a # starts a hosts comment and silently truncates the record; an empty
+or absent field renders a malformed line. Same contract as the system_setup
+validation below: any violation aborts the render, so chezmoi refuses the
+whole apply. */ -}}
+{{ range $pin := $pins -}}
+{{ range $field := list "fqdn" "ip" "short" -}}
+{{ if or (not (hasKey $pin $field)) (kindIs "invalid" (index $pin $field)) (eq (toString (index $pin $field)) "") -}}
+{{ fail (printf "macos_system_setup.yaml: a tailnet pin is missing %s (or has it empty); every pin declares fqdn, ip and short" $field) -}}
+{{ end -}}
+{{ if regexMatch "[\\s#]" (toString (index $pin $field)) -}}
+{{ fail (printf "macos_system_setup.yaml: tailnet pin %s %q is not a single hosts column (whitespace splits the record, # truncates it)" $field (toString (index $pin $field))) -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
 {{- /* Validation pass: every record must declare which control tier it
 belongs to, and its payload must MATCH the declared tier, before anything
 renders. The tier decides what the record IS; the payload never does. Any
@@ -123,40 +140,58 @@ echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook sec
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).
      The sh -c wrapper is load-bearing: this script inlines the command after
-     `sudo`, so a bare >>/etc/hosts redirect would run in the outer USER shell
+     `sudo`, so a bare >/etc/hosts redirect would run in the outer USER shell
      and be denied; `sudo sh -c '...'` puts the whole edit inside the root shell.
 
-     The guard tests for the EXACT desired line, not merely for the fqdn. Asking
-     only whether the name appears meant that once a line existed the pin was
-     never revisited, so a tailnet address that changed left the OLD one in place
-     forever. A stale pin is worse than no pin: the pin exists to be the fallback
-     when MagicDNS is down, and a stale fallback answers confidently with the
-     wrong host. When the exact line is absent, every line carrying that name as
-     a whole word is dropped and the current one appended, which corrects a
-     changed address and stays idempotent. `-w` is what keeps a different host
-     whose name merely contains this one (xmister vs mister) out of the filter.
+     Convergence is "exactly one line names this pin, and that line is exactly
+     ip<TAB>fqdn<TAB>short". Testing only that a correct line EXISTS let a
+     correct line plus a stale duplicate read as converged, leaving two lines
+     naming the pin. When not converged, the file is rebuilt: every line whose
+     NAME FIELDS (whitespace-split columns after the address, comment text
+     stripped) claim the fqdn OR the short name is dropped, every other line,
+     comments and blanks included, is kept byte-for-byte, and the one correct
+     line is appended. Field equality, not grep word boundaries: to grep, `.`
+     and `-` end a word, so a -w filter also deleted pin.example.test.evil and
+     other-pin.example.test, DIFFERENT hosts that merely contain the name. The
+     pin owns the short name too, by decision: the fallback exists to answer
+     for both names, so an unrelated line claiming the short name is dropped
+     rather than left to compete (macOS resolution order between two such
+     lines was not measured; ownership makes the ordering question moot).
 
-     Installing the result is gated on it still holding a loopback entry, and
-     refuses loudly otherwise. Rewriting /etc/hosts as root is the one step here
-     that can break the machine, so it fails closed rather than best-effort.
-     `cat >` rather than `mv` keeps the file's inode, mode and ownership.
+     Install: chmod/chown the temp file to the target's own mode and owner,
+     then mv (rename) it INTO the target path; mktemp creates it next to the
+     target so the rename never crosses filesystems and is atomic. The old
+     `cat "$tmp" > target` kept the inode but TRUNCATED first, so a failure or
+     interrupt mid-write left an EMPTY /etc/hosts and still exited 0. The
+     rename trades the inode away (a watcher pinning the vnode must re-open,
+     and a symlinked target would be replaced by a regular file) for never
+     exposing a partial or empty file. Every write and the install itself are
+     status-checked and every failure path exits nonzero via bail (which also
+     removes the temp file), so under this script's set -e a pin that cannot
+     converge fails the whole apply loudly instead of reporting success. The
+     loopback gate refuses (stderr + nonzero) to install a rebuild that lost
+     its anchored 127.0.0.1 line, 127.0.0.100 is not loopback; a missing
+     /etc/hosts is refused the same way rather than seeded pin-only. GNU stat
+     (-c) is tried before BSD stat (-f) because GNU's -f means "filesystem
+     status" and would SUCCEED with useless output, hiding the fallback.
 
-     That wrapper means TWO shells see this line, and pin data must be inert in
-     both. Interpolating a field into the sh -c string placed it inside double
-     quotes in the INNER shell, which sudo runs as root, so a command
-     substitution in the data executed as root. Single-quoting alone does not
-     fix that: it only protects the outer shell, and the inner one re-parses
-     whatever the string contains.
-
-     So the sh -c script text is a FIXED constant with no interpolation at all,
-     and every field travels as a positional argument. `$1`/`$2`/`$3` are
-     parameters; no shell re-parses a parameter's value as source. The literal
-     `sh` before the fields is the conventional $0 for `sh -c`, without which
-     the first field would be swallowed as the program name. The printf format
-     is likewise constant, so a `%` in the data is no longer a directive. */ -}}
+     The wrapper means TWO shells see this line, and pin data must be inert in
+     both, and in every parser downstream: inert in one interpreter is not
+     inert. Earlier versions made the fields safe in the shell and then let
+     them become grep PATTERNS, where a leading dash turned a field into a
+     grep OPTION and a newline turned a -xF pattern into a pattern LIST. Now
+     the sh -c script text is a FIXED constant with no interpolation at all,
+     every field travels as a positional argument ($1/$2/$3; the literal `sh`
+     is the conventional $0, without which the first field would be swallowed
+     as the program name), fields are only ever compared with [ = ] inside the
+     script, the one grep keeps a CONSTANT pattern, and the printf format is
+     constant, so a % in the data is not a directive. Render-time validation
+     above guarantees the fields are single hosts columns, so set -f plus the
+     unquoted $IFS split in `set -- ${l%%#*}` only ever splits FILE lines,
+     never pin data. */ -}}
 {{ range $pins -}}
 echo {{ template "shellSingleQuoted" (printf "→ MagicDNS fallback pin: %s (per CLAUDE.md Tailscale DNS section)" (toString .fqdn)) }}
-sudo sh -c 'want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
+sudo sh -c 'f=$1; s=$3; tmp=; bail(){ [ -n "$tmp" ] && rm -f "$tmp"; exit 1; }; w=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); [ -f /etc/hosts ] || { echo "refusing to edit /etc/hosts for $f: the file is missing" >&2; exit 1; }; tmp=$(mktemp /etc/hosts.XXXXXXXX) || exit 1; mc=0; ex=0; set -f; while IFS= read -r l || [ -n "$l" ]; do hit=0; set -- ${l%%#*}; if [ $# -gt 1 ]; then shift; for n in "$@"; do if [ "$n" = "$f" ] || [ "$n" = "$s" ]; then hit=1; fi; done; fi; if [ "$hit" = 1 ]; then mc=$((mc+1)); if [ "$l" = "$w" ]; then ex=1; fi; else printf "%s\n" "$l" || bail; fi; done </etc/hosts >"$tmp" || bail; if [ "$mc" = 1 ] && [ "$ex" = 1 ]; then rm -f "$tmp"; exit 0; fi; printf "%s\n" "$w" >>"$tmp" || bail; grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp" || { echo "refusing to rewrite /etc/hosts for $f: the filtered result lost its loopback entry" >&2; bail; }; m=$(stat -c "%a" /etc/hosts 2>/dev/null) || m=$(stat -f "%Lp" /etc/hosts) || bail; o=$(stat -c "%u:%g" /etc/hosts 2>/dev/null) || o=$(stat -f "%u:%g" /etc/hosts) || bail; chmod "$m" "$tmp" || bail; chown "$o" "$tmp" || bail; mv -f "$tmp" /etc/hosts || bail' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
 {{ end -}}
 {{ end -}}
 {{- end }}

--- a/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl
@@ -122,10 +122,24 @@ echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook sec
 {{ end -}}
 {{ end -}}
 {{/* Generated MagicDNS /etc/hosts fallback pins (structured tailnet_pins data).
-     Guard-then-append keeps each idempotent across runner re-runs. The sh -c
-     wrapper is load-bearing: this script inlines the command after `sudo`, so a
-     bare >>/etc/hosts redirect would run in the outer USER shell and be denied;
-     `sudo sh -c '...'` puts the guard AND the append inside the root shell.
+     The sh -c wrapper is load-bearing: this script inlines the command after
+     `sudo`, so a bare >>/etc/hosts redirect would run in the outer USER shell
+     and be denied; `sudo sh -c '...'` puts the whole edit inside the root shell.
+
+     The guard tests for the EXACT desired line, not merely for the fqdn. Asking
+     only whether the name appears meant that once a line existed the pin was
+     never revisited, so a tailnet address that changed left the OLD one in place
+     forever. A stale pin is worse than no pin: the pin exists to be the fallback
+     when MagicDNS is down, and a stale fallback answers confidently with the
+     wrong host. When the exact line is absent, every line carrying that name as
+     a whole word is dropped and the current one appended, which corrects a
+     changed address and stays idempotent. `-w` is what keeps a different host
+     whose name merely contains this one (xmister vs mister) out of the filter.
+
+     Installing the result is gated on it still holding a loopback entry, and
+     refuses loudly otherwise. Rewriting /etc/hosts as root is the one step here
+     that can break the machine, so it fails closed rather than best-effort.
+     `cat >` rather than `mv` keeps the file's inode, mode and ownership.
 
      That wrapper means TWO shells see this line, and pin data must be inert in
      both. Interpolating a field into the sh -c string placed it inside double
@@ -142,7 +156,7 @@ echo {{ template "shellSingleQuoted" (printf "→ MANUAL %s: see the runbook sec
      is likewise constant, so a `%` in the data is no longer a directive. */ -}}
 {{ range $pins -}}
 echo {{ template "shellSingleQuoted" (printf "→ MagicDNS fallback pin: %s (per CLAUDE.md Tailscale DNS section)" (toString .fqdn)) }}
-sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
+sudo sh -c 'want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"' sh {{ template "shellSingleQuoted" .fqdn }} {{ template "shellSingleQuoted" .ip }} {{ template "shellSingleQuoted" .short }}
 {{ end -}}
 {{ end -}}
 {{- end }}

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -168,6 +168,9 @@ GOLDEN_EOF
 # echo each and no command).
 # No manual logging record: firewall logging on this macOS version is on by
 # default and cannot be enabled by hand, so nothing renders for it.
+# The tailnet pin command line was re-derived by the pin-hardening fix
+# (exactly-one-line convergence, hosts field-structure filtering, loud
+# nonzero refusals, atomic mode-preserving install).
 tier2_golden="$work/tier2.golden"
 cat >"$tier2_golden" <<'GOLDEN_EOF'
 #!/bin/bash
@@ -197,7 +200,7 @@ echo '→ MANUAL OverSight: allow its Notification Center alerts (its only outpu
 echo '→ MANUAL LuLu: approve its system extension (a one-time macOS security consent): see the runbook section LuLu system extension approval'
 echo '→ MANUAL LuLu: create the required outbound allow rules by answering its prompts: see the runbook section LuLu rule creation'
 echo '→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)'
-sudo sh -c 'want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
+sudo sh -c 'f=$1; s=$3; tmp=; bail(){ [ -n "$tmp" ] && rm -f "$tmp"; exit 1; }; w=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); [ -f /etc/hosts ] || { echo "refusing to edit /etc/hosts for $f: the file is missing" >&2; exit 1; }; tmp=$(mktemp /etc/hosts.XXXXXXXX) || exit 1; mc=0; ex=0; set -f; while IFS= read -r l || [ -n "$l" ]; do hit=0; set -- ${l%%#*}; if [ $# -gt 1 ]; then shift; for n in "$@"; do if [ "$n" = "$f" ] || [ "$n" = "$s" ]; then hit=1; fi; done; fi; if [ "$hit" = 1 ]; then mc=$((mc+1)); if [ "$l" = "$w" ]; then ex=1; fi; else printf "%s\n" "$l" || bail; fi; done </etc/hosts >"$tmp" || bail; if [ "$mc" = 1 ] && [ "$ex" = 1 ]; then rm -f "$tmp"; exit 0; fi; printf "%s\n" "$w" >>"$tmp" || bail; grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp" || { echo "refusing to rewrite /etc/hosts for $f: the filtered result lost its loopback entry" >&2; bail; }; m=$(stat -c "%a" /etc/hosts 2>/dev/null) || m=$(stat -f "%Lp" /etc/hosts) || bail; o=$(stat -c "%u:%g" /etc/hosts 2>/dev/null) || o=$(stat -f "%u:%g" /etc/hosts) || bail; chmod "$m" "$tmp" || bail; chown "$o" "$tmp" || bail; mv -f "$tmp" /etc/hosts || bail' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
 
 GOLDEN_EOF
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -197,7 +197,7 @@ echo '→ MANUAL OverSight: allow its Notification Center alerts (its only outpu
 echo '→ MANUAL LuLu: approve its system extension (a one-time macOS security consent): see the runbook section LuLu system extension approval'
 echo '→ MANUAL LuLu: create the required outbound allow rules by answering its prompts: see the runbook section LuLu rule creation'
 echo '→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)'
-sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
+sudo sh -c 'want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
 
 GOLDEN_EOF
 

--- a/test/integration/macos-control-tier-render-stability.sh
+++ b/test/integration/macos-control-tier-render-stability.sh
@@ -196,8 +196,8 @@ echo "→ SSH: install the public-key-only sshd drop-in (000-ssh-hardening.conf)
 echo '→ MANUAL OverSight: allow its Notification Center alerts (its only output channel): see the runbook section OverSight notification delivery'
 echo '→ MANUAL LuLu: approve its system extension (a one-time macOS security consent): see the runbook section LuLu system extension approval'
 echo '→ MANUAL LuLu: create the required outbound allow rules by answering its prompts: see the runbook section LuLu rule creation'
-echo "→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)"
-sudo sh -c 'grep -qF "mister.tail2f2430.ts.net" /etc/hosts || printf "100.109.58.54\tmister.tail2f2430.ts.net\tmister\n" >>/etc/hosts'
+echo '→ MagicDNS fallback pin: mister.tail2f2430.ts.net (per CLAUDE.md Tailscale DNS section)'
+sudo sh -c 'grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts' sh 'mister.tail2f2430.ts.net' '100.109.58.54' 'mister'
 
 GOLDEN_EOF
 

--- a/test/integration/tailnet-pins.sh
+++ b/test/integration/tailnet-pins.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # tailnet-pins.sh, MagicDNS /etc/hosts fallback pins are STRUCTURED DATA
 # (`macos.tailnet_pins` in .chezmoidata/macos_system_setup.yaml); the Tier-2 sudo
-# runner template (run_onchange_after_41) generates the guard-then-append command
-# for each pin. Two test layers:
+# runner template (run_onchange_after_41) generates the convergence command for
+# each pin. Test layers:
 #
 # LAYER 1, MACHINERY (fixture): copy the REAL template into a temp chezmoi
 # source dir with fixture chezmoidata carrying test-owned pins (TEST-NET-1
@@ -13,9 +13,23 @@
 #     (pins must still apply; the upfront timestamp covers them);
 #   - a fixture with NO tailnet_pins key still renders (the `index` absent-key
 #     gotcha) and keeps the `exit 0` early-return;
-#   - executing the generated command (sudo stripped, path substituted) against
-#     a temp hosts file twice: exact ip\tfqdn\tshort line present, byte-identical
-#     on run 2 (idempotent), pre-existing content preserved.
+#   - a pin field that is not a single hosts column (whitespace including
+#     newlines, a # that starts a hosts comment, empty, or missing) REFUSES to
+#     render, so one pin can never smuggle extra columns or extra LINES;
+#   - executing the generated commands against temp hosts files: idempotence,
+#     stale-IP correction, an exact line PLUS a stale duplicate collapses to
+#     exactly one line, the filter keys on hosts FIELD STRUCTURE (grep
+#     word-boundary victims like pin.example.test.evil survive), the pin owns
+#     its short name, comments and blank lines survive a rebuild, every
+#     refusal (lost loopback, loopback decoy, missing file) exits NONZERO and
+#     says why on stderr, a failed install never truncates the target, the
+#     installed file keeps the target's mode, and a missing trailing newline
+#     never produces a joined line.
+#
+# LAYER 1d, INERTNESS: hostile pin data (command substitution, backticks, a %s
+# printf directive, and single quotes, the one character shellSingleQuoted
+# exists to rewrite) must ride as positional arguments, never execute in either
+# shell, and arrive in the hosts file byte-exact.
 #
 # LAYER 2, SHAPE (real data): read the real YAML's pins via yq and validate form
 # only, fields non-empty, ip inside the proper Tailscale CGNAT range
@@ -59,6 +73,26 @@ render_fixture() {
     fail "$name: chezmoi failed to render the template (absent-key gotcha? see {{ index }})"
 }
 
+# render_fixture_must_fail <name> <error-substring> <fixture-yaml on stdin>:
+# the render itself must ABORT (malformed pin data is refused at render time,
+# before a root shell ever sees it), and the refusal must name the reason.
+render_fixture_must_fail() {
+  local name="$1" want_error="$2"
+  local src="$work/$name-src"
+  mkdir -p "$src/.chezmoiscripts" "$src/.chezmoidata"
+  cp "$TEMPLATE" "$src/.chezmoiscripts/"
+  cat >"$src/.chezmoidata/macos_system_setup.yaml"
+  local render_home="$work/$name-home"
+  mkdir -p "$render_home"
+  local render_error="$work/$name.render-err"
+  if HOME="$render_home" CI=1 chezmoi --source "$src" execute-template --no-tty \
+    <"$src/.chezmoiscripts/$(basename "$TEMPLATE")" >/dev/null 2>"$render_error"; then
+    fail "$name: the render SUCCEEDED but malformed pin data must refuse to render at all"
+  fi
+  grep -qF -- "$want_error" "$render_error" ||
+    fail "$name: render refused for the wrong reason; wanted '$want_error', got: $(cat "$render_error")"
+}
+
 # ---------- LAYER 1a: pins render with an EMPTY commands list ----------------
 render_fixture pins <<'EOF'
 macos:
@@ -85,7 +119,7 @@ fi
 # shellcheck disable=SC2016  # the literal $1/$2/$3 ARE the property under test:
 # they must survive into the inner shell as parameters, so expanding them here
 # would assert the opposite of what this pins.
-pin_script='want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"'
+pin_script='f=$1; s=$3; tmp=; bail(){ [ -n "$tmp" ] && rm -f "$tmp"; exit 1; }; w=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); [ -f /etc/hosts ] || { echo "refusing to edit /etc/hosts for $f: the file is missing" >&2; exit 1; }; tmp=$(mktemp /etc/hosts.XXXXXXXX) || exit 1; mc=0; ex=0; set -f; while IFS= read -r l || [ -n "$l" ]; do hit=0; set -- ${l%%#*}; if [ $# -gt 1 ]; then shift; for n in "$@"; do if [ "$n" = "$f" ] || [ "$n" = "$s" ]; then hit=1; fi; done; fi; if [ "$hit" = 1 ]; then mc=$((mc+1)); if [ "$l" = "$w" ]; then ex=1; fi; else printf "%s\n" "$l" || bail; fi; done </etc/hosts >"$tmp" || bail; if [ "$mc" = 1 ] && [ "$ex" = 1 ]; then rm -f "$tmp"; exit 0; fi; printf "%s\n" "$w" >>"$tmp" || bail; grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp" || { echo "refusing to rewrite /etc/hosts for $f: the filtered result lost its loopback entry" >&2; bail; }; m=$(stat -c "%a" /etc/hosts 2>/dev/null) || m=$(stat -f "%Lp" /etc/hosts) || bail; o=$(stat -c "%u:%g" /etc/hosts 2>/dev/null) || o=$(stat -f "%u:%g" /etc/hosts) || bail; chmod "$m" "$tmp" || bail; chown "$o" "$tmp" || bail; mv -f "$tmp" /etc/hosts || bail'
 expected_1="sudo sh -c '$pin_script' sh 'pin.example.test' '192.0.2.7' 'pin'"
 expected_2="sudo sh -c '$pin_script' sh 'pin2.example.test' '192.0.2.8' 'pin2'"
 grep -qxF "$expected_1" "$rendered" ||
@@ -98,6 +132,9 @@ if grep -qxF 'exit 0' "$rendered"; then
   fail "early-return emitted despite pins being configured, pins would never apply"
 fi
 
+# The exact desired line for pin 1, reused by the execution tests below.
+want1=$'192.0.2.7\tpin.example.test\tpin'
+
 # ---------- LAYER 1b: no tailnet_pins key -> early-return survives ----------
 render_fixture nopins <<'EOF'
 macos:
@@ -109,15 +146,102 @@ if grep -qxF 'sudo -v' "$work/nopins.rendered"; then
   fail "spurious sudo -v emitted when there is nothing to run"
 fi
 
-# ---------- LAYER 1c: execute the generated commands (idempotence) ----------
-hosts="$work/hosts"
-printf '127.0.0.1\tlocalhost\n255.255.255.255\tbroadcasthost\n' >"$hosts"
+# ---------- LAYER 1b2: malformed pin fields REFUSE to render -----------------
+# One pin must be exactly one hosts record of three columns. A newline in a
+# field would write EXTRA LINES into /etc/hosts as root, any other whitespace
+# splits the record into extra columns, and # starts a hosts comment that
+# silently truncates it. Empty or missing fields render a malformed line.
+# All of these must abort the render, never reach the generated command.
+render_fixture_must_fail nl-ip "is not a single hosts column" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: nl.example.test
+      ip: "192.0.2.7\n203.0.113.9"
+      short: nl
+EOF
+render_fixture_must_fail cr-ip "is not a single hosts column" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: cr.example.test
+      ip: "192.0.2.7\r"
+      short: cr
+EOF
+render_fixture_must_fail sp-fqdn "is not a single hosts column" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: "pin space.example.test"
+      ip: "192.0.2.7"
+      short: pin
+EOF
+render_fixture_must_fail hash-short "is not a single hosts column" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: pin.example.test
+      ip: "192.0.2.7"
+      short: "pin#note"
+EOF
+render_fixture_must_fail empty-fqdn "missing fqdn" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: ""
+      ip: "192.0.2.7"
+      short: pin
+EOF
+render_fixture_must_fail no-short "missing short" <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: pin.example.test
+      ip: "192.0.2.7"
+EOF
 
+# ---------- execution helpers ------------------------------------------------
 run_pin_command() { # strip the sudo prefix, point at the temp hosts file, run
   local cmd="${1#sudo }"
   cmd="${cmd///etc\/hosts/$hosts}"
   bash -c "$cmd" || fail "generated pin command failed (rc=$?): $cmd"
 }
+
+run_against() { # <command> <hosts-file>
+  local cmd="${1#sudo }"
+  cmd="${cmd///etc\/hosts/$2}"
+  bash -c "$cmd" || fail "pin command failed (rc=$?) against $2"
+}
+
+# A refusal must be LOUD: nonzero exit (the rendered runner runs under set -e,
+# so chezmoi apply fails instead of reporting success over a pin that did not
+# apply) and a stderr line saying why.
+run_expect_refusal() { # <command> <hosts-file> <stderr-substring> <label>
+  local cmd="${1#sudo }" refusal_err="$work/refuse-$4.err"
+  cmd="${cmd///etc\/hosts/$2}"
+  if bash -c "$cmd" >/dev/null 2>"$refusal_err"; then
+    fail "$4: expected a nonzero refusal, but the pin command exited 0 against $2"
+  fi
+  grep -qF -- "$3" "$refusal_err" ||
+    fail "$4: refusal ran silent or with the wrong message; wanted stderr to contain '$3', got: $(cat "$refusal_err")"
+}
+
+run_with_shims() { # <command> <hosts-file> <shim-dir>: force tool failures
+  local cmd="${1#sudo }"
+  cmd="${cmd///etc\/hosts/$2}"
+  PATH="$3:$PATH" bash -c "$cmd"
+}
+
+# GNU stat first, BSD fallback: GNU's -f means "filesystem status" and would
+# SUCCEED with useless output, so the GNU form must be the one tried first.
+file_mode() { # <file>
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+# ---------- LAYER 1c: execute the generated commands (idempotence) ----------
+hosts="$work/hosts"
+printf '127.0.0.1\tlocalhost\n255.255.255.255\tbroadcasthost\n' >"$hosts"
+
 for round in 1 2; do
   run_pin_command "$expected_1"
   run_pin_command "$expected_2"
@@ -125,7 +249,7 @@ for round in 1 2; do
     cp "$hosts" "$work/hosts.after1"
   fi
 done
-grep -qxF $'192.0.2.7\tpin.example.test\tpin' "$hosts" ||
+grep -qxF "$want1" "$hosts" ||
   fail "pin 1 line missing or malformed after execution: $(grep -F pin.example.test "$hosts" || echo '<absent>')"
 grep -qxF $'192.0.2.8\tpin2.example.test\tpin2' "$hosts" ||
   fail "pin 2 line missing or malformed after execution"
@@ -139,35 +263,165 @@ grep -qxF $'127.0.0.1\tlocalhost' "$hosts" || fail "pre-existing hosts content w
 # the OLD one in place forever. That is worse than having no pin: the pin exists
 # to be the fallback when MagicDNS is down, and a stale fallback resolves
 # confidently to the wrong host.
+#
+# The filter must key on the FIELD STRUCTURE of /etc/hosts, not on grep word
+# boundaries: to grep, `.` and `-` end a word, so a -w filter kept the prefix
+# case (xpin) but deleted pin.example.test.evil and other-pin.example.test,
+# both DIFFERENT hosts that merely contain the pinned name.
 stale="$work/stale-hosts"
-printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n10.0.0.1\txpin.example.test\tunrelated\n' >"$stale"
-run_against() { # <command> <hosts-file>
-  local cmd="${1#sudo }"
-  cmd="${cmd///etc\/hosts/$2}"
-  bash -c "$cmd" || fail "pin command failed (rc=$?) against $2"
-}
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n10.0.0.1\txpin.example.test\tunrelated\n203.0.113.5\tpin.example.test.evil\tevil\n203.0.113.6\tother-pin.example.test\totherpin\n' >"$stale"
 run_against "$expected_1" "$stale"
-grep -qxF $'192.0.2.7\tpin.example.test\tpin' "$stale" ||
+grep -qxF "$want1" "$stale" ||
   fail "a changed pin IP was not corrected; hosts still reads: $(grep -F pin.example.test "$stale")"
 if grep -qF '198.51.100.1' "$stale"; then
   fail "the stale pin line survived alongside the new one, so resolution is now ambiguous"
 fi
 grep -qxF $'127.0.0.1\tlocalhost' "$stale" || fail "correcting a pin clobbered unrelated hosts content"
 grep -qxF $'10.0.0.1\txpin.example.test\tunrelated' "$stale" ||
-  fail "correcting a pin removed a DIFFERENT host whose name merely contains the pinned one"
+  fail "correcting a pin removed a DIFFERENT host whose name merely contains the pinned one (prefix case)"
+grep -qxF $'203.0.113.5\tpin.example.test.evil\tevil' "$stale" ||
+  fail "correcting a pin removed pin.example.test.evil, a DIFFERENT host; the filter must match whole hosts fields, not grep words"
+grep -qxF $'203.0.113.6\tother-pin.example.test\totherpin' "$stale" ||
+  fail "correcting a pin removed other-pin.example.test, a DIFFERENT host; the filter must match whole hosts fields, not grep words"
 cp "$stale" "$work/stale.after1"
 run_against "$expected_1" "$stale"
 cmp -s "$stale" "$work/stale.after1" || fail "correcting a pin is not idempotent on a second run"
 
-# Correcting a pin rewrites /etc/hosts as root, the one step here that can break
-# the machine. It is gated on the result still carrying a loopback entry and must
-# refuse rather than install a file that lost it.
+# ---------- LAYER 1c3: an exact line PLUS a stale duplicate is NOT converged -
+# "At least one correct line exists" is the wrong property: it reads a correct
+# line plus a stale duplicate as converged and leaves two lines naming the pin.
+# Convergence is "exactly one line names this pin, and it is exactly right".
+dup="$work/dup-hosts"
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n%s\n' "$want1" >"$dup"
+run_against "$expected_1" "$dup"
+dup_expected="$work/dup-expected"
+printf '127.0.0.1\tlocalhost\n%s\n' "$want1" >"$dup_expected"
+cmp -s "$dup" "$dup_expected" ||
+  fail "an exact line plus a stale duplicate must collapse to exactly one pin line; got: $(diff "$dup_expected" "$dup" | head -5)"
+
+# ---------- LAYER 1c4: comments and blank lines survive; a commented-out copy
+# of the exact pin line must not count as convergence (an ACTIVE stale line
+# would then be left uncorrected, reopening the exact bug this command fixes).
+commented="$work/commented-hosts"
+printf '127.0.0.1\tlocalhost\n\n# plain comment\n#%s\n198.51.100.1\tpin.example.test\tpin\n' "$want1" >"$commented"
+run_against "$expected_1" "$commented"
+commented_expected="$work/commented-expected"
+printf '127.0.0.1\tlocalhost\n\n# plain comment\n#%s\n%s\n' "$want1" "$want1" >"$commented_expected"
+cmp -s "$commented" "$commented_expected" ||
+  fail "a commented-out copy of the pin line must be preserved AND never satisfy convergence; got: $(diff "$commented_expected" "$commented" | head -5)"
+
+# ---------- LAYER 1c5: the pin owns its short name ---------------------------
+# The pin exists so BOTH names answer with the tailnet address when MagicDNS is
+# down. An unrelated line claiming only the short name would compete with the
+# pin for that name, so it is dropped, by decision, not by accident.
+shortclaim="$work/shortclaim-hosts"
+printf '127.0.0.1\tlocalhost\n192.168.1.5\tpin\n' >"$shortclaim"
+run_against "$expected_1" "$shortclaim"
+shortclaim_expected="$work/shortclaim-expected"
+printf '127.0.0.1\tlocalhost\n%s\n' "$want1" >"$shortclaim_expected"
+cmp -s "$shortclaim" "$shortclaim_expected" ||
+  fail "a line claiming the pin's short name must be replaced by the pin; got: $(diff "$shortclaim_expected" "$shortclaim" | head -5)"
+
+# ---------- LAYER 1c6: refusals are LOUD and change nothing ------------------
+# Rewriting /etc/hosts as root is the one step here that can break the machine.
+# A rebuild that lost its loopback entry must be refused: file untouched, exit
+# NONZERO (so chezmoi apply fails instead of reporting success), reason on
+# stderr.
 noloop="$work/noloop-hosts"
 printf '198.51.100.1\tpin.example.test\tpin\n' >"$noloop"
 cp "$noloop" "$work/noloop.before"
-run_against "$expected_1" "$noloop"
+run_expect_refusal "$expected_1" "$noloop" "lost its loopback entry" noloop
 cmp -s "$noloop" "$work/noloop.before" ||
   fail "a rewrite that would drop the loopback entry was installed instead of refused: $(cat "$noloop")"
+
+# The gate must match a REAL loopback line, anchored: 127.0.0.100 is a decoy
+# that an unanchored 127.0.0.1 match would accept, installing a hosts file with
+# no working localhost when the actual loopback line was filtered away (here it
+# also names the pin, so the rebuild drops it).
+decoy="$work/decoy-hosts"
+printf '127.0.0.1\tlocalhost pin.example.test\n127.0.0.100\tdev.local\n' >"$decoy"
+cp "$decoy" "$work/decoy.before"
+run_expect_refusal "$expected_1" "$decoy" "lost its loopback entry" decoy
+cmp -s "$decoy" "$work/decoy.before" ||
+  fail "a rebuild whose only 127.0.0.1 match is the decoy 127.0.0.100 was installed instead of refused: $(cat "$decoy")"
+
+# A missing hosts file is refused the same way: nothing safe exists to rewrite,
+# and seeding a pin-only /etc/hosts with no loopback would break the machine.
+absent="$work/absent-hosts"
+run_expect_refusal "$expected_1" "$absent" "the file is missing" absent
+[[ ! -e $absent ]] ||
+  fail "a missing hosts file was seeded with pin content instead of refused: $(cat "$absent")"
+
+# ---------- LAYER 1c7: a failed install must never destroy the target --------
+# The old install (`cat "$tmp" > target`) truncated the target BEFORE writing,
+# so a failure or interrupt during it left an EMPTY /etc/hosts and still exited
+# 0. Force the install tools to fail: the target must be byte-identical after,
+# the command must exit nonzero, and no temp droppings may remain.
+shimdir="$work/shims"
+mkdir -p "$shimdir"
+printf '#!/bin/sh\nexit 75\n' >"$shimdir/mv"
+printf '#!/bin/sh\nexit 75\n' >"$shimdir/cat"
+chmod +x "$shimdir/mv" "$shimdir/cat"
+atomic_dir="$work/atomic"
+mkdir -p "$atomic_dir"
+atomic_hosts="$atomic_dir/hosts"
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n' >"$atomic_hosts"
+cp "$atomic_hosts" "$work/atomic.before"
+if run_with_shims "$expected_1" "$atomic_hosts" "$shimdir" >/dev/null 2>&1; then
+  fail "the install step failed but the pin command still exited 0; install status must be checked"
+fi
+cmp -s "$atomic_hosts" "$work/atomic.before" ||
+  fail "a failed install altered or truncated the target hosts file: $(cat "$atomic_hosts")"
+[[ $(find "$atomic_dir" -type f | wc -l) -eq 1 ]] ||
+  fail "a failed install left temp droppings next to the target: $(ls "$atomic_dir")"
+
+# ---------- LAYER 1c8: the installed file keeps the target's mode ------------
+# The template comment claims the install preserves the file's mode. Pin it:
+# mktemp creates 0600, /etc/hosts is 0644, and an install that ships the temp
+# file's mode would leave a hosts file other daemons cannot read.
+modehosts="$work/mode-hosts"
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n' >"$modehosts"
+chmod 644 "$modehosts"
+run_against "$expected_1" "$modehosts"
+grep -qxF "$want1" "$modehosts" || fail "mode-preservation run did not converge the pin"
+mode_after="$(file_mode "$modehosts")" || fail "could not stat the installed hosts file"
+[[ $mode_after == 644 ]] ||
+  fail "the install changed the hosts file mode from 644 to $mode_after (mktemp's private mode leaking through?)"
+
+# ---------- LAYER 1c9: a missing trailing newline never joins lines ----------
+# Appending to a file whose last line is unterminated used to produce one
+# joined line (localhost192.0.2.7...). The rebuild must terminate every line.
+nonl="$work/nonl-hosts"
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n10.0.0.9\tkeeper.example.test' >"$nonl"
+run_against "$expected_1" "$nonl"
+nonl_expected="$work/nonl-expected"
+printf '127.0.0.1\tlocalhost\n10.0.0.9\tkeeper.example.test\n%s\n' "$want1" >"$nonl_expected"
+cmp -s "$nonl" "$nonl_expected" ||
+  fail "a hosts file without a trailing newline was corrupted by the rebuild; got: $(diff "$nonl_expected" "$nonl" | head -5)"
+
+# ---------- LAYER 1c10: a leading-dash field stays DATA in every parser ------
+# Shell-inert is not enough: a field that reaches grep unbound became an OPTION
+# (-eunrelated.ts.net turned into `-e unrelated.ts.net` and deleted the REAL
+# unrelated.ts.net line). No parser downstream of the shell may read pin data
+# as anything but bytes.
+render_fixture dashpin <<'EOF'
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: "-eunrelated.ts.net"
+      ip: "192.0.2.11"
+      short: dashpin
+EOF
+expected_dash="sudo sh -c '$pin_script' sh '-eunrelated.ts.net' '192.0.2.11' 'dashpin'"
+grep -qxF "$expected_dash" "$work/dashpin.rendered" ||
+  fail "generated leading-dash pin command missing or wrong; expected exactly: $expected_dash"
+dashhosts="$work/dash-hosts"
+printf '127.0.0.1\tlocalhost\n9.9.9.9\tunrelated.ts.net\tunrelated\n' >"$dashhosts"
+run_against "$expected_dash" "$dashhosts"
+dash_expected="$work/dash-expected"
+printf '127.0.0.1\tlocalhost\n9.9.9.9\tunrelated.ts.net\tunrelated\n192.0.2.11\t-eunrelated.ts.net\tdashpin\n' >"$dash_expected"
+cmp -s "$dashhosts" "$dash_expected" ||
+  fail "a leading-dash fqdn steered a downstream parser; the REAL unrelated.ts.net line must survive; got: $(diff "$dash_expected" "$dashhosts" | head -5)"
 
 # ---------- LAYER 1d: pin data is DATA, never source, in either shell --------
 # The generated command runs `sudo sh -c`, so there are TWO shells: the outer one
@@ -175,20 +429,26 @@ cmp -s "$noloop" "$work/noloop.before" ||
 # pin field into the sh -c string put it inside double quotes in that inner root
 # shell, so a command substitution in the data executed AS ROOT. The fix carries
 # each field as a positional argument, which no shell re-parses as source.
-refute_contains() { # <file> <literal> <message>
-  if grep -qF -- "$2" "$1"; then
-    fail "$3 (found the literal: $2)"
-  fi
-}
-
-# Three hostile shapes, one per field, so a fix that closes only one is caught:
-# command substitution, backtick substitution, and a printf format directive.
-# The last one matters because the old command put pin data in printf's FORMAT
-# position, where a % is a directive rather than a character.
+#
+# Four hostile shapes across the three fields, so a fix that closes only one is
+# caught: command substitution, backtick substitution, a printf format
+# directive, and SINGLE QUOTES. The quotes are load-bearing: shellSingleQuoted's
+# entire job is the ' -> '\'' rewrite, so without a quote in a fixture field a
+# naive literal-quote regression would render byte-identical commands for clean
+# data and this suite would never notice. TWO adjacent quotes, so the naive
+# render still balances its quotes and PARSES (one quote would unbalance the
+# line into a syntax error and nothing would run at all): the outer shell then
+# EATS the data quotes as its own syntax and delivers a corrupted line, which
+# the byte-exact assertion below catches; the marker assertion stands guard
+# for arrangements where a substitution lands unquoted and executes. The
+# payload is `:>file` (the : builtin plus a redirect) because it creates the
+# marker WITHOUT any whitespace: the render-time column validation rightly
+# refuses whitespace-bearing fields, and an injection needs no spaces to do
+# damage.
 marker="$work/PIN_INJECTION_EXECUTED"
-hostile_fqdn="a\$(touch $marker).example.test"
+hostile_fqdn="a''\$(:>$marker).example.test"
 hostile_ip='192.0.2.9%s'
-hostile_short="s\`touch $marker\`"
+hostile_short="s\`:>$marker\`"
 render_fixture hostile <<EOF
 macos:
   system_setup: []
@@ -199,9 +459,10 @@ macos:
 EOF
 hostile_rendered="$work/hostile.rendered"
 if [[ -s $hostile_rendered ]]; then
-  # The rendered SOURCE must not place the substitution where a shell expands it.
-  refute_contains "$hostile_rendered" "sh -c 'grep -qF \"a\$(touch" \
-    "pin fqdn is interpolated into the sudo sh -c string, so the ROOT shell expands it"
+  # The sh -c script text must stay the FIXED constant even for hostile data:
+  # fields ride as arguments AFTER it, never inside it.
+  grep -qF "sudo sh -c '$pin_script' sh '" "$hostile_rendered" ||
+    fail "the sh -c script text is no longer the fixed constant when hostile pin data renders; fields must ride as arguments only"
 
   # Executing it must move bytes, not run them. sudo stripped, hosts redirected.
   rm -f "$marker"
@@ -246,4 +507,4 @@ while IFS=$'\t' read -r fqdn ip short; do
     fail "pin short name '$short' is not the first label of '$fqdn'"
 done < <(yq eval '.macos.tailnet_pins[] | [.fqdn, .ip, .short] | @tsv' "$YAML")
 
-echo "tailnet-pins: OK (template generates exact idempotent commands from fixture data; $pin_count real pin(s) well-formed)"
+echo "tailnet-pins: OK (exact idempotent convergence commands from fixture data; malformed pin fields refuse to render; refusals are loud and nonzero; hostile fields stay inert; $pin_count real pin(s) well-formed)"

--- a/test/integration/tailnet-pins.sh
+++ b/test/integration/tailnet-pins.sh
@@ -78,8 +78,16 @@ if [[ ! -s $rendered ]]; then
 fi
 
 # Independent expectation: the exact command the template must generate per pin.
-expected_1='sudo sh -c '\''grep -qF "pin.example.test" /etc/hosts || printf "192.0.2.7\tpin.example.test\tpin\n" >>/etc/hosts'\'''
-expected_2='sudo sh -c '\''grep -qF "pin2.example.test" /etc/hosts || printf "192.0.2.8\tpin2.example.test\tpin2\n" >>/etc/hosts'\'''
+# The sh -c script is a CONSTANT, identical for every pin; only the trailing
+# arguments differ. Single-quoted here so $1/$2/$3 stay literal, which is the
+# property under test: they must reach the inner shell as parameters, not as
+# text the template substituted.
+# shellcheck disable=SC2016  # the literal $1/$2/$3 ARE the property under test:
+# they must survive into the inner shell as parameters, so expanding them here
+# would assert the opposite of what this pins.
+pin_script='grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts'
+expected_1="sudo sh -c '$pin_script' sh 'pin.example.test' '192.0.2.7' 'pin'"
+expected_2="sudo sh -c '$pin_script' sh 'pin2.example.test' '192.0.2.8' 'pin2'"
 grep -qxF "$expected_1" "$rendered" ||
   fail "generated pin command 1 missing or wrong; expected exactly: $expected_1 (rendered: $(cat "$rendered"))"
 grep -qxF "$expected_2" "$rendered" ||
@@ -124,6 +132,64 @@ grep -qxF $'192.0.2.8\tpin2.example.test\tpin2' "$hosts" ||
 cmp -s "$hosts" "$work/hosts.after1" ||
   fail "NOT idempotent: round 2 changed the file ($(grep -cF example.test "$hosts") pin lines)"
 grep -qxF $'127.0.0.1\tlocalhost' "$hosts" || fail "pre-existing hosts content was clobbered"
+
+# ---------- LAYER 1d: pin data is DATA, never source, in either shell --------
+# The generated command runs `sudo sh -c`, so there are TWO shells: the outer one
+# this runner is written in, and the inner ROOT one sudo starts. Interpolating a
+# pin field into the sh -c string put it inside double quotes in that inner root
+# shell, so a command substitution in the data executed AS ROOT. The fix carries
+# each field as a positional argument, which no shell re-parses as source.
+refute_contains() { # <file> <literal> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3 (found the literal: $2)"
+  fi
+}
+
+# Three hostile shapes, one per field, so a fix that closes only one is caught:
+# command substitution, backtick substitution, and a printf format directive.
+# The last one matters because the old command put pin data in printf's FORMAT
+# position, where a % is a directive rather than a character.
+marker="$work/PIN_INJECTION_EXECUTED"
+hostile_fqdn="a\$(touch $marker).example.test"
+hostile_ip='192.0.2.9%s'
+hostile_short="s\`touch $marker\`"
+render_fixture hostile <<EOF
+macos:
+  system_setup: []
+  tailnet_pins:
+    - fqdn: "$hostile_fqdn"
+      ip: "$hostile_ip"
+      short: "$hostile_short"
+EOF
+hostile_rendered="$work/hostile.rendered"
+if [[ -s $hostile_rendered ]]; then
+  # The rendered SOURCE must not place the substitution where a shell expands it.
+  refute_contains "$hostile_rendered" "sh -c 'grep -qF \"a\$(touch" \
+    "pin fqdn is interpolated into the sudo sh -c string, so the ROOT shell expands it"
+
+  # Executing it must move bytes, not run them. sudo stripped, hosts redirected.
+  rm -f "$marker"
+  hostile_hosts="$work/hostile-hosts"
+  : >"$hostile_hosts"
+  # Both emitted lines, not just the sudo one. The trace `echo` runs in the OUTER
+  # user shell, so an unquoted field there is its own injection, at user rather
+  # than root privilege. Running only the sh -c line would leave that uncovered.
+  while IFS= read -r line; do
+    cmd="${line#sudo }"
+    cmd="${cmd///etc\/hosts/$hostile_hosts}"
+    bash -c "$cmd" >/dev/null 2>&1 || true
+  done < <(grep -E '^(echo |sudo sh -c )' "$hostile_rendered")
+  [[ -e $marker ]] &&
+    fail "pin data EXECUTED: the generated command ran a substitution from the data (this is root under sudo)"
+
+  # Every field must arrive byte-for-byte, which is what proves each was carried
+  # as data rather than as text some shell re-read. The whole-line comparison is
+  # also what pins the printf FORMAT: move data back into the format position and
+  # the %s in the ip is consumed as a directive, so the line comes out truncated.
+  expected_line="$(printf '%s\t%s\t%s' "$hostile_ip" "$hostile_fqdn" "$hostile_short")"
+  grep -qxF -- "$expected_line" "$hostile_hosts" ||
+    fail "hostile pin line wrong; expected exactly $(printf '%q' "$expected_line"), got $(printf '%q' "$(cat "$hostile_hosts")")"
+fi
 
 # ---------- LAYER 2: shape of the REAL pins data -----------------------------
 pin_count="$(yq eval '.macos.tailnet_pins | length' "$YAML")"

--- a/test/integration/tailnet-pins.sh
+++ b/test/integration/tailnet-pins.sh
@@ -85,7 +85,7 @@ fi
 # shellcheck disable=SC2016  # the literal $1/$2/$3 ARE the property under test:
 # they must survive into the inner shell as parameters, so expanding them here
 # would assert the opposite of what this pins.
-pin_script='grep -qF "$1" /etc/hosts || printf "%s\t%s\t%s\n" "$2" "$1" "$3" >>/etc/hosts'
+pin_script='want=$(printf "%s\t%s\t%s" "$2" "$1" "$3"); grep -qxF "$want" /etc/hosts && exit 0; tmp=$(mktemp) || exit 1; grep -vwF "$1" /etc/hosts >"$tmp"; printf "%s\n" "$want" >>"$tmp"; if grep -qE "^127\.0\.0\.1[[:space:]]" "$tmp"; then cat "$tmp" >/etc/hosts; else echo "refusing to rewrite /etc/hosts for $1: the filtered result lost its loopback entry" >&2; fi; rm -f "$tmp"'
 expected_1="sudo sh -c '$pin_script' sh 'pin.example.test' '192.0.2.7' 'pin'"
 expected_2="sudo sh -c '$pin_script' sh 'pin2.example.test' '192.0.2.8' 'pin2'"
 grep -qxF "$expected_1" "$rendered" ||
@@ -133,6 +133,42 @@ cmp -s "$hosts" "$work/hosts.after1" ||
   fail "NOT idempotent: round 2 changed the file ($(grep -cF example.test "$hosts") pin lines)"
 grep -qxF $'127.0.0.1\tlocalhost' "$hosts" || fail "pre-existing hosts content was clobbered"
 
+# ---------- LAYER 1c2: a pin whose IP changed must be CORRECTED --------------
+# The guard used to ask only "does this fqdn appear anywhere", so once a line
+# existed the pin was never touched again. A tailnet address that changed left
+# the OLD one in place forever. That is worse than having no pin: the pin exists
+# to be the fallback when MagicDNS is down, and a stale fallback resolves
+# confidently to the wrong host.
+stale="$work/stale-hosts"
+printf '127.0.0.1\tlocalhost\n198.51.100.1\tpin.example.test\tpin\n10.0.0.1\txpin.example.test\tunrelated\n' >"$stale"
+run_against() { # <command> <hosts-file>
+  local cmd="${1#sudo }"
+  cmd="${cmd///etc\/hosts/$2}"
+  bash -c "$cmd" || fail "pin command failed (rc=$?) against $2"
+}
+run_against "$expected_1" "$stale"
+grep -qxF $'192.0.2.7\tpin.example.test\tpin' "$stale" ||
+  fail "a changed pin IP was not corrected; hosts still reads: $(grep -F pin.example.test "$stale")"
+if grep -qF '198.51.100.1' "$stale"; then
+  fail "the stale pin line survived alongside the new one, so resolution is now ambiguous"
+fi
+grep -qxF $'127.0.0.1\tlocalhost' "$stale" || fail "correcting a pin clobbered unrelated hosts content"
+grep -qxF $'10.0.0.1\txpin.example.test\tunrelated' "$stale" ||
+  fail "correcting a pin removed a DIFFERENT host whose name merely contains the pinned one"
+cp "$stale" "$work/stale.after1"
+run_against "$expected_1" "$stale"
+cmp -s "$stale" "$work/stale.after1" || fail "correcting a pin is not idempotent on a second run"
+
+# Correcting a pin rewrites /etc/hosts as root, the one step here that can break
+# the machine. It is gated on the result still carrying a loopback entry and must
+# refuse rather than install a file that lost it.
+noloop="$work/noloop-hosts"
+printf '198.51.100.1\tpin.example.test\tpin\n' >"$noloop"
+cp "$noloop" "$work/noloop.before"
+run_against "$expected_1" "$noloop"
+cmp -s "$noloop" "$work/noloop.before" ||
+  fail "a rewrite that would drop the loopback entry was installed instead of refused: $(cat "$noloop")"
+
 # ---------- LAYER 1d: pin data is DATA, never source, in either shell --------
 # The generated command runs `sudo sh -c`, so there are TWO shells: the outer one
 # this runner is written in, and the inner ROOT one sudo starts. Interpolating a
@@ -170,7 +206,9 @@ if [[ -s $hostile_rendered ]]; then
   # Executing it must move bytes, not run them. sudo stripped, hosts redirected.
   rm -f "$marker"
   hostile_hosts="$work/hostile-hosts"
-  : >"$hostile_hosts"
+  # Seeded with loopback because installing the result is gated on it: an edit
+  # that would leave /etc/hosts without 127.0.0.1 is refused by design.
+  printf '127.0.0.1\tlocalhost\n' >"$hostile_hosts"
   # Both emitted lines, not just the sudo one. The trace `echo` runs in the OUTER
   # user shell, so an unquoted field there is its own injection, at user rather
   # than root privilege. Running only the sh -c line would leave that uncovered.


### PR DESCRIPTION
## Context

MagicDNS fallback pins are lines this repo adds to `/etc/hosts` so tailnet names still resolve when
MagicDNS is unavailable. Each is declared as data (fqdn, ip, short name) and the Tier 2 runner
generates one guard-then-write command per pin at apply time.

The guard was written to make the runner idempotent, which it did. What it also did was make the pin
permanent: once a line existed, the pin was never revisited again.

Stacked on #104, which rewrote the same generated command to stop pasting data into a root shell.

## Summary

- A pin whose tailnet address changed is now corrected instead of left stale.
- The guard tests the exact desired line, not merely whether the name appears.
- A different host whose name contains the pinned one is no longer swept away.
- Rewriting `/etc/hosts` refuses if the result would lose its loopback entry.
- Still idempotent: a second run changes nothing.

Key files: `.chezmoiscripts/run_onchange_after_41-macos-system-setup.sh.tmpl`,
`test/integration/tailnet-pins.sh`

## Why a stale pin is worse than no pin

The old guard asked "does this fqdn appear anywhere in `/etc/hosts`". Once the line existed the answer
was always yes, so a changed tailnet address left the original entry in place indefinitely.

A pin exists to be the fallback when MagicDNS is down. A stale one does not fail and fall through to
something else. It answers, confidently, with an address that no longer belongs to that host. That is
the failure mode the pin was meant to prevent, arriving through the mechanism meant to prevent it.

## What replaced it

The guard now compares against the exact line the data implies. When that line is absent, every line
carrying the name as a whole word is dropped and the current line appended.

The `-w` is load-bearing rather than decorative. Without it the filter is a substring match, so pinning
`mister.tail…` would also delete a legitimate `xmister.tail…` entry. Verified against real `grep`
before building on it: `-w` treats the dotted name as one word, removes the exact host, and leaves the
longer one alone.

## The guard on the guard

Correcting a pin means rewriting `/etc/hosts` as root, which is the one step here that can make the
machine unusable. Installing the new file is therefore conditional on it still containing a loopback
entry, and refuses loudly otherwise rather than proceeding best-effort.

`cat` into the existing file rather than `mv` over it, so the inode, mode and ownership survive.

## How it was verified

The failing case was reproduced first: a hosts file carrying the pinned name at a wrong address came
back unchanged.

| Mutation | Result |
| --- | --- |
| guard on the name again instead of the exact line | caught |
| drop `-w`, so a longer host name is swept up | caught |
| install unconditionally, with no loopback guard | caught |
| append without filtering the stale line | caught |
| unmutated control | passes |

The template was confirmed byte-identical to pristine afterward. Gates: `just T`, `just lint-check`,
`just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

The generated command changes, so the render-stability golden moves with it. On a machine whose pin
data has not changed, behavior is identical and nothing is rewritten, because the exact line is
already present.
