### PR TITLE
fix(ssh): keep the GitHub connection alive while the pre-push gate runs

### DIFF
--- a/private_dot_ssh/config
+++ b/private_dot_ssh/config
@@ -1,6 +1,18 @@
-Host github
+# Both the alias and the real host name. Git remotes are written
+# git@github.com:..., which ssh matches against github.com, so a block naming
+# only the alias never applies to a push.
+#
+# The keepalive is load-bearing, not tuning. Git opens the connection to GitHub
+# BEFORE it runs the pre-push hook, and this repo's hook runs lint plus the whole
+# test suite, several minutes. GitHub closes the idle connection in the meantime,
+# so when the hook finally returns git writes into a dead socket and exits 141
+# with no error text and no branch pushed. Traffic every 20s keeps the connection
+# from going idle while the hook works.
+Host github github.com
   HostName github.com
   User git
+  ServerAliveInterval 20
+  ServerAliveCountMax 30
 
 Host unprovisioned_yoshimo
   HostName 192.168.1.70

--- a/test/integration/ssh-config-github-keepalive.sh
+++ b/test/integration/ssh-config-github-keepalive.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ssh-config-github-keepalive.sh, the managed ssh config must keep a GitHub
+# connection alive while a slow pre-push hook runs.
+#
+# Git opens the connection to GitHub BEFORE running the pre-push hook. This
+# repo's hook runs lint plus the whole test suite, several minutes, and GitHub
+# closes the connection it considers idle in the meantime. When the hook finally
+# returns, git writes into a dead socket and exits 141 with NO error text and no
+# branch pushed, while the hook's own "checks passed" line is the last thing on
+# screen. Traffic on an interval keeps the connection from going idle.
+#
+# Asserted through ssh's OWN parser (`ssh -G`), never by grepping the file: the
+# question is what ssh RESOLVES for the name git actually connects to, and a
+# block naming only the `github` alias resolves to nothing for `github.com`.
+# That was the original defect and a grep for the keyword would have missed it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="$REPO_ROOT/private_dot_ssh/config"
+# The interval this repo sets. Pinned exactly, not merely "nonzero": ssh also
+# reads the system-wide config, so a nonzero check could pass on someone else's
+# setting while this file said nothing.
+WANT_INTERVAL=20
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $CONFIG ]] || fail "missing managed ssh config: $CONFIG"
+# ssh is system-shipped on every platform this repo targets, so its absence is a
+# broken host rather than an optional tool to skip over.
+command -v ssh >/dev/null 2>&1 || fail "ssh is not on PATH; it is system-shipped, so this is a broken host, not a reason to skip"
+
+# resolved <host> <keyword> -> the value ssh computes, lowercased keyword match
+resolved() {
+  ssh -F "$CONFIG" -G "$1" 2>/dev/null | awk -v k="$2" 'tolower($1) == k { print $2; exit }'
+}
+
+# ---- 1: the name git actually connects to ----------------------------------
+# Remotes are written git@github.com:owner/repo, so ssh matches `github.com`.
+got="$(resolved github.com serveraliveinterval)"
+[[ $got == "$WANT_INTERVAL" ]] ||
+  fail "ssh resolves ServerAliveInterval=$got for github.com, want $WANT_INTERVAL; a push whose pre-push hook outlasts GitHub's idle timeout will die with exit 141 and no error"
+
+# The block must genuinely match github.com, not just happen to set a keyword.
+# User is the independent witness: it is git only if the Host pattern applied.
+got="$(resolved github.com user)"
+[[ $got == git ]] ||
+  fail "ssh resolves User=$got for github.com, so the Host pattern does not cover the name git connects to (this is exactly how the keepalive went missing)"
+
+# ---- 2: the alias keeps working --------------------------------------------
+# `ssh github` is an established shorthand here; extending the pattern must not
+# have cost it its settings.
+got="$(resolved github user)"
+[[ $got == git ]] || fail "the github alias no longer resolves User=git (got: $got)"
+got="$(resolved github serveraliveinterval)"
+[[ $got == "$WANT_INTERVAL" ]] ||
+  fail "the github alias resolves ServerAliveInterval=$got, want $WANT_INTERVAL"
+
+# ---- 3: the interval must survive long enough to cover the hook ------------
+# Interval times CountMax is how long ssh tolerates silence. It has to exceed the
+# hook's runtime or the client gives up mid-gate, trading one silent failure for
+# another.
+count_max="$(resolved github.com serveralivecountmax)"
+[[ $count_max =~ ^[0-9]+$ ]] || fail "ServerAliveCountMax is not numeric: $count_max"
+tolerated=$((WANT_INTERVAL * count_max))
+[[ $tolerated -ge 600 ]] ||
+  fail "keepalives tolerate only ${tolerated}s of silence (interval $WANT_INTERVAL x count $count_max); the pre-push gate runs longer than that, so the connection can still drop"
+
+printf 'ssh-config-github-keepalive: OK (github.com resolves User=git with ServerAliveInterval=%s, alias intact, %ss tolerated)\n' \
+  "$WANT_INTERVAL" "$tolerated"


### PR DESCRIPTION
## Context

Pushes from this repository stopped working. `git push` ran the pre-push gate, printed
`✅ All pre-push checks passed!`, then exited 141 with no error text at all. The branch never reached
GitHub, and because the last visible line was the gate reporting success, every symptom pointed at the
gate.

It was not the gate. It was the clock.

## Summary

- Pushes no longer die with exit 141 after the pre-push gate.
- Adds a keepalive so GitHub does not close the connection while the gate runs.
- Fixes a GitHub host block that never applied to pushes in the first place.
- The test asserts through ssh's own parser, not by grepping for a keyword.

Key files: `private_dot_ssh/config`, `test/integration/ssh-config-github-keepalive.sh`

## What was actually happening

`GIT_TRACE=1` gave the order in one run:

```
01:01:28.921   ssh git@github.com 'git-receive-pack webdavis/dotfiles.git'
01:01:30.051   ~/.config/git/hooks/pre-push          <- 1.1s later
01:07:58       (hook finishes, 6.5 minutes in)
               Connection to github.com closed by remote host.
```

Git opens the connection first and runs the hook second. This repo's hook runs lint plus the entire
test suite. GitHub closes a connection that has sat silent for minutes, so by the time the hook says
go, git is writing into a socket that died several minutes earlier.

This is a problem that grew rather than broke. The gate was fine when the suite was short, and every
test added since moved it closer to GitHub's limit. Nothing announced the crossing.

## Ruled out first

Each of these was reproduced in a throwaway repository rather than reasoned about, and none of them
caused a 141:

- the hook never reading the ref list git writes to its stdin
- the hook producing a large volume of output
- the hook simply taking a long time

Authentication was never involved: `ssh -T git@github.com` answers *"Hi webdavis!"*. Neither was the
transport: `git-receive-pack` opens instantly on port 22 and on port 443.

## Two defects in the config, not one

There was no keepalive anywhere. That is the one that caused the failure.

The second is the more interesting one. The GitHub block named only the `github` alias, but remotes
are written `git@github.com:owner/repo`, which ssh matches against `github.com`. That block never
applied to a push at all:

```
$ ssh -G github.com | grep -E '^(user|serveraliveinterval) '
user stephen                 <- not git
serveraliveinterval 0
```

So adding a keepalive to the existing block would have changed nothing, and the change would have
looked correct in review. The Host pattern now covers both names.

Interval 20 with a count of 30 tolerates ten minutes of silence, comfortably longer than the gate
takes today.

## How the test avoids the trap that hid this

It asks ssh what it RESOLVES for `github.com`, rather than grepping the file for `ServerAliveInterval`.
The original defect was a block that did not match; a grep would have found the keyword sitting in the
file and reported everything fine.

`User=git` is asserted as an independent witness. It is only `git` if the Host pattern actually
applied, so it catches a regression to an alias-only block even if the keepalive line is still present.

| Mutation | Result |
| --- | --- |
| alias-only Host pattern (the original defect) | caught |
| drop `ServerAliveInterval` | caught |
| `ServerAliveCountMax 3`, too short to cover the gate | caught |
| unmutated control | passes |

Gates: `just T`, `just lint-check`, `just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

Merging alone changes nothing on a running machine. This is a chezmoi source file, so it reaches
`~/.ssh/config` only on the next apply, and the live machine still applies from
`integration/modernization` rather than `main` until the cutover. Until then, pushes need
`GIT_SSH_COMMAND='ssh -o ServerAliveInterval=20 -o ServerAliveCountMax=30'` in the environment, which
is what landed this branch.

## What this does not address

The keepalive treats the symptom. A pre-push gate that takes six and a half minutes is worth
questioning on its own, and moving the heavy suite into an explicit ship command would leave pre-push
fast and remove the dependency on connection tuning entirely. That is a larger change and is tracked
separately.
