### PR TITLE
test(osquery): pin the timeout bound on every unbounded posture probe

### DIFF
--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -905,6 +905,89 @@ process_healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","oversig
   assert_bounded_hang_gaps lulu_extension "$started"
 }
 
+# The two rule-archive controls. Both need a `target`, the absolute binary path
+# whose rule must exist, which is REQUIRED by these readers and forbidden on
+# every other one.
+#
+# Reaching the archive read at all depends on the preferences read first:
+# lulu_base_rules_authoritative returns true only for "no_profile", and the
+# fixture's default preferences plist carries no currentProfile key, so the
+# default path is authoritative and the archive IS read. That is what makes the
+# archive and readlink wedges reachable without any extra fixture.
+lulu_rule_target='/usr/bin/curl'
+declare_rule_controls() {
+  set_posture_controls '[
+    {"id":"lulu_rule","description":"A LuLu rule mentioning the tracked binary","tier":"verify","reader":"lulu_rule_present","expect":"present","target":"/usr/bin/curl","remedy":"Recreate the rule in LuLu"},
+    {"id":"lulu_rule_resolved","description":"A LuLu rule mentioning the resolved launcher","tier":"verify","reader":"lulu_rule_resolved_present","expect":"present","target":"/usr/bin/curl","remedy":"Recreate the rule in LuLu"}
+  ]'
+}
+
+rule_healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","lulu_rule":"present","lulu_rule:expect":"present","lulu_rule:target":"/usr/bin/curl","lulu_rule_resolved":"present","lulu_rule_resolved:expect":"present","lulu_rule_resolved:target":"/usr/bin/curl"}'
+
+@test "T-PCTL-plutil-prefs-hang-pages-gap: a wedged preferences read is killed at the bound and gaps the rule controls" {
+  seed_baseline "$rule_healthy_seed"
+  declare_rule_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_PLUTIL_PREFS_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps lulu_rule "$started"
+}
+
+@test "T-PCTL-plutil-archive-hang-pages-gap: a wedged rules-archive read is killed at the bound and gaps the rule control" {
+  seed_baseline "$rule_healthy_seed"
+  declare_rule_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_PLUTIL_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps lulu_rule "$started"
+}
+
+# Only the resolved control, because readlink is the one probe the OTHER rule
+# reader never touches. With both declared, the plain lulu_rule control still
+# completes its archive read, correctly finds no rule for the target, and pages
+# that as a real divergence, so the tick emits two pages and the count assertion
+# fails on a second page that is not a defect.
+declare_resolved_rule_control_only() {
+  set_posture_controls '[
+    {"id":"lulu_rule_resolved","description":"A LuLu rule mentioning the resolved launcher","tier":"verify","reader":"lulu_rule_resolved_present","expect":"present","target":"/usr/bin/curl","remedy":"Recreate the rule in LuLu"}
+  ]'
+}
+
+resolved_only_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","lulu_rule_resolved":"present","lulu_rule_resolved:expect":"present","lulu_rule_resolved:target":"/usr/bin/curl"}'
+
+@test "T-PCTL-readlink-hang-pages-gap: a wedged readlink is killed at the bound and gaps the resolved-rule control" {
+  seed_baseline "$resolved_only_seed"
+  declare_resolved_rule_control_only
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_READLINK_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps lulu_rule_resolved "$started"
+}
+
 @test "T-PCTL-defaults-hang-pages-gap: a wedged defaults read is killed at the bound and gaps the autologin control" {
   seed_baseline "$healthy_seed"
   declare_posture_controls

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -854,6 +854,57 @@ assert_bounded_hang_gaps() { # <control-id> <started-seconds>
   assert_bounded_hang_gaps guest "$started"
 }
 
+# The two process-table controls, declared SEPARATELY from
+# declare_posture_controls on purpose: adding them there would change the
+# control set every other test's $healthy_seed was written against, so a
+# coverage addition would have rewritten unrelated expectations.
+#
+# These exist because the fixture ships a wedge hook for every probe tool and
+# the suite only ever set half of them. An unused hook is an unpinned bound: the
+# per-probe timeout on these readers could be deleted and nothing would fail.
+declare_process_controls() {
+  set_posture_controls '[
+    {"id":"oversight","description":"The OverSight monitor process","tier":"verify","reader":"pgrep_oversight","expect":"running","remedy":"Launch OverSight"},
+    {"id":"lulu_extension","description":"The LuLu system extension process","tier":"verify","reader":"pgrep_lulu_extension","expect":"running","remedy":"Reinstall LuLu and approve its system extension"}
+  ]'
+}
+
+process_healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","oversight":"running","oversight:expect":"running","lulu_extension":"running","lulu_extension:expect":"running"}'
+
+@test "T-PCTL-pgrep-oversight-hang-pages-gap: a wedged pgrep is killed at the bound and gaps the OverSight control" {
+  seed_baseline "$process_healthy_seed"
+  declare_process_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_PGREP_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps oversight "$started"
+}
+
+@test "T-PCTL-pgrep-lulu-hang-pages-gap: a wedged pgrep for the LuLu extension is killed at the bound and gaps that control" {
+  seed_baseline "$process_healthy_seed"
+  declare_process_controls
+  snapshot_baseline
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export OSQUERY_POSTURE_TIMEOUT=1
+  export POLLER_PGREP_LULU_SLEEP=30
+
+  local started=$SECONDS
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_bounded_hang_gaps lulu_extension "$started"
+}
+
 @test "T-PCTL-defaults-hang-pages-gap: a wedged defaults read is killed at the bound and gaps the autologin control" {
   seed_baseline "$healthy_seed"
   declare_posture_controls


### PR DESCRIPTION
## Context

The posture poller reads several macOS security controls on a timer. Each read runs through
`run_bounded`, a timeout wrapper, so one hung system tool cannot stall the whole tick. Its test
fixture stubs every probe tool and gives each stub a "wedge" hook: set an environment variable and
that tool hangs, letting a test prove the poller kills it at the bound and reports a monitoring gap
rather than blocking.

The fixture author built that hook for all ten stubbed tools. The suite only ever used five of them.

## Summary

- Pins the timeout bound on all four unbounded posture probes.
- Five real surviving mutations are now caught.
- Uses wedge hooks the fixture already shipped, rather than adding machinery.
- Declares the new controls separately, so no existing test's expectations move.

Key file: `test/integration/osquery-poller-posture-fields.bats`

## What was uncovered

The poller supports eight readers. Four had a hang test. Four did not:

| Reader | Wedge hook | Covered before |
| --- | --- | --- |
| `pgrep_oversight` | `POLLER_PGREP_SLEEP` | no |
| `pgrep_lulu_extension` | `POLLER_PGREP_LULU_SLEEP` | no |
| `lulu_rule_present` | `POLLER_PLUTIL_SLEEP` | no |
| `lulu_rule_resolved_present` | `POLLER_PLUTIL_PREFS_SLEEP`, `POLLER_READLINK_SLEEP` | no |

All four are covered here. Every reader the poller supports now has a hang test, and every wedge hook
the fixture ships is exercised.

An unused wedge hook is an unpinned bound. Delete `run_bounded` from one of those readers and nothing
fails.

## Verified as real, not theoretical

Both mutations were confirmed to survive on `origin/main` before the tests existed, and to die after:

| Mutation | Result |
| --- | --- |
| drop `run_bounded` from the OverSight `pgrep` | caught |
| drop `run_bounded` from the LuLu-extension `pgrep` | caught |
| drop `run_bounded` from the LuLu preferences read | caught |
| drop `run_bounded` from the LuLu rules-archive read | caught |
| drop `run_bounded` from the readlink resolution | caught |
| unmutated control | passes |

The poller was confirmed byte-identical to pristine afterward. Gates: `just T`, `just lint-check`,
`just s` and `nix flake check --all-systems` all exit 0.

## Why the controls are declared separately

`declare_posture_controls` is the four-control set that every other test's healthy baseline seed was
written against. Adding two controls there would have changed what those tests observe, so a coverage
addition would have quietly rewritten unrelated expectations. A separate helper with its own seed
keeps the blast radius at zero.

## The fixture that turned out not to be needed

The `lulu_rule` readers looked like they would need a rules-archive fixture, because they return
`indeterminate` unless the archive is authoritative. They do not. The stub is already programmable,
and its DEFAULT preferences plist carries no `currentProfile` key, which is precisely the state
`lulu_base_rules_authoritative` requires. The archive and readlink wedges were reachable as-is.

One real wrinkle did surface. The readlink test declares only the resolved control, because with both
rule controls declared the plain one still completes its archive read, correctly finds no rule for the
target, and pages that as a genuine divergence. The tick then emits two pages and the count assertion
fails on a second page that is not a defect.

## Effect of merging

Test-only. No production file changes, so applying this to a machine does nothing.
