### PR TITLE
fix(macos): refuse a map-valued .macos.defaults in both readers

### DIFF
--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -41,6 +41,16 @@ with `map has no entry for key "scope"` on that form when a record omits the
 key, which turns a loud, specific refusal into an opaque template panic. Any
 violation ABORTS the render via fail, so chezmoi refuses the whole apply:
 no warning, no skipped record, no partial best-effort script. */ -}}
+{{- /* The SHAPE, before any record. `range` accepts a map as readily as a list
+and iterates it in sorted KEY order, while macos-defaults-lib.sh reads the same
+file through yq in DOCUMENT order. Both would accept a map, silently, and apply
+the records in different orders; order is what decides which write lands last
+when two records share a domain and key. Refused rather than reconciled, because
+a map is not the declared schema and standardizing on one order would leave the
+other reader's agreement a coincidence. The library refuses the same shape. */ -}}
+{{ if ne (kindOf .macos.defaults) "slice" -}}
+{{ fail (printf "macos_defaults.yaml: .macos.defaults is a %s, but it must be a LIST of records; a map is iterated in sorted key order here and in document order by macos-defaults-lib.sh, so the two would apply records in different orders" (kindOf .macos.defaults)) -}}
+{{ end -}}
 {{ range .macos.defaults -}}
 {{ $record := . -}}
 {{- /* Identity first. The domain and key name the record in every error

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -200,6 +200,26 @@ defaults_records_unit_separated() { # <path>
       "$data_file" "$declared_record_count" >&2
     return 2
   fi
+  # The SHAPE, before the content. `.macos.defaults[]` yields values from a map
+  # just as happily as from a list, and `length` counts a map's keys, so every
+  # check above passes on a map and the stream comes out in document order. The
+  # runner template reads the same file with Go's `range`, which iterates a map
+  # in sorted KEY order. Two readers, two orders, neither complaining, and order
+  # decides which write lands last when records share a domain and key.
+  #
+  # Refused rather than reconciled: a map is not the declared schema, and
+  # standardizing on one order would leave the other reader's agreement a
+  # coincidence instead of a guarantee. The template refuses the same shape.
+  local records_kind
+  if ! records_kind="$(yq eval -r '(.macos.defaults // []) | tag' "$data_file")"; then
+    printf 'error: cannot determine the shape of .macos.defaults in %s\n' "$data_file" >&2
+    return 2
+  fi
+  if [[ $records_kind != '!!seq' ]]; then
+    printf 'error: %s declares .macos.defaults as %s, but it must be a LIST of records; a map is read in sorted key order by the runner template and in document order here, so the two would apply records in different orders\n' \
+      "$data_file" "$records_kind" >&2
+    return 2
+  fi
   if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2

--- a/test/integration/macos-defaults-shape-agreement.sh
+++ b/test/integration/macos-defaults-shape-agreement.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# macos-defaults-shape-agreement.sh, the runner template and the shared library
+# must read the SAME records in the SAME order from the same data file, or refuse
+# it together.
+#
+# Two independent readers exist for `.macos.defaults`: the chezmoi runner
+# template, which applies the settings, and macos-defaults-lib.sh, which the
+# apply, capture and drift tools stream records through. Nothing forced them to
+# agree, and they did not.
+#
+# A MAP-valued `.macos.defaults` was accepted by both and read in OPPOSITE
+# orders. Go's `range` over a map iterates in sorted KEY order; the library's yq
+# stream yields document order. Two readers, two orders, no complaint from
+# either. Order decides which write lands last when records touch the same
+# domain and key, so this is a silent divergence in what the machine ends up
+# holding.
+#
+# The shape is refused on both sides rather than reconciled. A map is not the
+# declared schema, and picking one order to standardize on would leave the other
+# reader's behavior a coincidence rather than a guarantee.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH; this suite renders a real template and cannot be meaningfully skipped"
+done
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+[[ -f $LIB ]] || fail "missing library: $LIB"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# render_template <fixture-file> -> prints the render, returns chezmoi's status
+render_template() {
+  local src="$work/src"
+  rm -rf "$src"
+  mkdir -p "$src/.chezmoiscripts" "$src/.chezmoidata" "$work/home"
+  cp "$TEMPLATE" "$src/.chezmoiscripts/runner.tmpl"
+  cp "$1" "$src/.chezmoidata/macos_defaults.yaml"
+  HOME="$work/home" CI=1 chezmoi --source "$src" execute-template --no-tty \
+    <"$src/.chezmoiscripts/runner.tmpl" 2>&1
+}
+
+# library_stream <fixture-file> -> prints the record stream, returns its status
+library_stream() {
+  (
+    # shellcheck source=/dev/null
+    source "$LIB" >/dev/null 2>&1
+    defaults_records_unit_separated "$1" 2>&1
+  )
+}
+
+# ---- the table -------------------------------------------------------------
+# Each fixture is written once and put through BOTH readers. A reader-specific
+# expectation is what let these two drift in the first place, so the assertions
+# below are about agreement, not about either reader's private behavior.
+
+cat >"$work/seq.yaml" <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    - {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+cat >"$work/map.yaml" <<'EOF'
+macos:
+  defaults:
+    zebra: {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    alpha: {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+# ---- 1: a LIST is accepted by both, in declaration order --------------------
+# Declared zebra first, alpha second. Sorted key order would invert them, so the
+# order assertion is what distinguishes "read the list" from "sorted something".
+lib_out="$(library_stream "$work/seq.yaml")" ||
+  fail "the library refused a well-formed list of records: $lib_out"
+lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+[[ $lib_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "library read a list out of declaration order: [$lib_domains]"
+
+tmpl_out="$(render_template "$work/seq.yaml")" ||
+  fail "the template refused a well-formed list of records: $tmpl_out"
+tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+[[ $tmpl_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "template read a list out of declaration order: [$tmpl_domains]"
+
+# The point of the whole file: same input, same order, from two readers.
+[[ $lib_domains == "$tmpl_domains" ]] ||
+  fail "the two readers disagree on record order for a list: library [$lib_domains] vs template [$tmpl_domains]"
+
+# ---- 2: a MAP is refused by both -------------------------------------------
+# Refused, not reconciled. Accepting it means one reader sorts and the other does
+# not, and the disagreement decides which write lands last.
+if lib_out="$(library_stream "$work/map.yaml")"; then
+  lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+  fail "the library ACCEPTED a map-valued .macos.defaults and emitted [$lib_domains]; the template reads the same file in sorted key order, so the two apply records in different orders"
+fi
+
+if tmpl_out="$(render_template "$work/map.yaml")"; then
+  tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+  fail "the template ACCEPTED a map-valued .macos.defaults and rendered [$tmpl_domains]; a map is not the declared schema and Go's range sorts its keys"
+fi
+
+# Each refusal must name the shape, or an operator sees a generic parse failure
+# and edits the wrong thing.
+printf '%s' "$lib_out" | grep -qiE 'list|sequence|map' ||
+  fail "the library refused the map without naming the shape problem: $lib_out"
+printf '%s' "$tmpl_out" | grep -qiE 'list|sequence|map' ||
+  fail "the template refused the map without naming the shape problem: $tmpl_out"
+
+printf 'macos-defaults-shape-agreement: OK (both readers take a list in declaration order and both refuse a map, naming the shape)\n'


### PR DESCRIPTION
## Context

macOS settings are declared as data in `macos_defaults.yaml`. Two independent readers consume that
file: the chezmoi runner template, which performs the `defaults write` calls, and
`macos-defaults-lib.sh`, which streams the same records to the apply, capture and drift tools.

Nothing forced the two to read the file the same way, and on one shape they did not.

## Summary

- A map-valued `.macos.defaults` is now refused by both readers instead of silently accepted.
- Closes a case where the two applied the same records in opposite orders.
- Each refusal names the shape it found.
- Adds an agreement test that puts one fixture through both readers.

Key files: `.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl`,
`dot_local/bin/macos-defaults-lib.sh`, `test/integration/macos-defaults-shape-agreement.sh`

## The divergence, measured

Records declared under the keys `zebra` then `alpha`:

| Reader | Order emitted |
| --- | --- |
| `macos-defaults-lib.sh` (yq) | `zebra`, `alpha` (document order) |
| runner template (Go `range`) | `alpha`, `zebra` (sorted key order) |

Both returned success. Neither said anything.

Order is not cosmetic. It decides which write lands last when two records touch the same domain and
key, so what the machine ends up holding depends on which reader ran.

## Why no existing guard caught it

The library already validates a great deal: record count, field count, tier, separator forgery. Every
one of those passes on a map. `length` counts a map's keys just as happily as a list's entries, and
`.macos.defaults[]` yields a map's values as readily as a list's. The shape was never asserted, only
assumed, so the checks built on top of it all agreed with each other while being wrong together.

## Refused, not reconciled

A map is not the declared schema. Standardizing on one order would have made the other reader's
agreement a coincidence rather than a guarantee, and the next reader added would be free to pick a
third order. Refusing on both sides means the shape cannot silently mean two things.

## The test is about agreement, not behavior

`macos-defaults-shape-agreement.sh` writes one fixture and puts it through both readers, then asserts
they match. That framing is the point: asserting each reader's private behavior in its own test file
is exactly what allowed these two to drift, because both tests passed the whole time.

| Mutation | Result |
| --- | --- |
| library accepts any shape | caught |
| template accepts any shape | caught |
| unmutated control | passes |

Both files were confirmed byte-identical to pristine afterward. Gates: `just T`, `just lint-check`,
`just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

No behavior change for the real data file, which already declares a list. What changes is that a
future edit to a map shape fails loudly at render time rather than producing two different orders.
