### PR TITLE
refactor(macos): separate record-stream validation from emission

### DIFF
--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -41,6 +41,16 @@ with `map has no entry for key "scope"` on that form when a record omits the
 key, which turns a loud, specific refusal into an opaque template panic. Any
 violation ABORTS the render via fail, so chezmoi refuses the whole apply:
 no warning, no skipped record, no partial best-effort script. */ -}}
+{{- /* The SHAPE, before any record. `range` accepts a map as readily as a list
+and iterates it in sorted KEY order, while macos-defaults-lib.sh reads the same
+file through yq in DOCUMENT order. Both would accept a map, silently, and apply
+the records in different orders; order is what decides which write lands last
+when two records share a domain and key. Refused rather than reconciled, because
+a map is not the declared schema and standardizing on one order would leave the
+other reader's agreement a coincidence. The library refuses the same shape. */ -}}
+{{ if ne (kindOf .macos.defaults) "slice" -}}
+{{ fail (printf "macos_defaults.yaml: .macos.defaults is a %s, but it must be a LIST of records; a map is iterated in sorted key order here and in document order by macos-defaults-lib.sh, so the two would apply records in different orders" (kindOf .macos.defaults)) -}}
+{{ end -}}
 {{ range .macos.defaults -}}
 {{ $record := . -}}
 {{- /* Identity first. The domain and key name the record in every error

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -146,7 +146,15 @@ defaults_records_locate_malformed() { # <path> <declared-count>
   printf 'a record this locator could not identify'
 }
 
-# defaults_records_unit_separated <path>, emit each tracked record as one line
+# THE RECORD STREAM. Four functions below share this contract, split so each has
+# one job: defaults_records_declared_count validates the file's shape and size,
+# defaults_records_raw_stream reads it, defaults_records_validate_stream is a
+# PREDICATE over what was read, and defaults_records_unit_separated emits. They
+# were one function, in which the validation loop accumulated the very lines it
+# was checking and then printed them, so asking "is this file usable" was
+# inseparable from producing its output.
+#
+# The contract: emit each tracked record as one line
 # of EIGHT fields joined by the ASCII unit separator (0x1f):
 #   domain, key, type, value, host, scope, plist_path, tier
 # host, plist_path, and (on manual records) type and value are empty when
@@ -180,9 +188,9 @@ defaults_records_locate_malformed() { # <path> <declared-count>
 # offending record, and emits NOTHING: a caller must not act on part of a stream
 # it has just been told is malformed. A legitimate multi-line preference value is
 # therefore refused loudly rather than silently corrupted.
-defaults_records_unit_separated() { # <path>
+defaults_records_declared_count() { # <path>, print the validated record count
   local data_file="$1"
-  local declared_record_count raw_records
+  local declared_record_count records_kind
   if ! declared_record_count="$(yq eval -r '(.macos.defaults // []) | length' "$data_file")"; then
     printf 'error: cannot count the records in %s\n' "$data_file" >&2
     return 2
@@ -210,7 +218,6 @@ defaults_records_unit_separated() { # <path>
   # Refused rather than reconciled: a map is not the declared schema, and
   # standardizing on one order would leave the other reader's agreement a
   # coincidence instead of a guarantee. The template refuses the same shape.
-  local records_kind
   if ! records_kind="$(yq eval -r '(.macos.defaults // []) | tag' "$data_file")"; then
     printf 'error: cannot determine the shape of .macos.defaults in %s\n' "$data_file" >&2
     return 2
@@ -220,14 +227,33 @@ defaults_records_unit_separated() { # <path>
       "$data_file" "$records_kind" >&2
     return 2
   fi
-  if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
+  printf '%s\n' "$declared_record_count"
+}
+
+# defaults_records_raw_stream <path>, the unvalidated joined records from yq.
+# Separated so the reader can fail on its own terms; every check that follows
+# assumes it has the whole stream, and a partial read must never reach them.
+defaults_records_raw_stream() { # <path>
+  local data_file="$1"
+  if ! yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2
   fi
+}
 
-  local line field_count emitted_line_count=0
+# defaults_records_validate_stream <path> <declared-count> <raw-stream>, a
+# PREDICATE: 0 when every line is well-formed and the line count matches what the
+# file declares, 2 otherwise, naming the offending record on stderr.
+#
+# It emits no records, deliberately. Validation used to accumulate the very lines
+# it was checking and then print them, which meant the only way to ask "is this
+# file usable" was to also produce its output. A caller that just wants to know
+# now asks a question instead of running a producer, and the emission below has
+# one job.
+defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
+  local data_file="$1" declared_record_count="$2" raw_records="$3"
+  local line field_count checked_line_count=0
   local record_domain record_key record_tier
-  local -a validated_lines=()
   while IFS= read -r line; do
     # yq prints a single empty line for an empty array; that is not a record.
     [[ -z $line ]] && continue
@@ -241,8 +267,8 @@ defaults_records_unit_separated() { # <path>
     # The tier gate. Only the three declared tiers pass; a record whose tier
     # is missing or blank arrives here as the empty string and lands in the
     # same refusal, so absent, blank, and unrecognized all fail closed. The
-    # refusal covers the WHOLE file (nothing has been emitted yet), because a
-    # caller must not act on the records beside one it cannot classify.
+    # refusal covers the WHOLE file, because a caller must not act on the
+    # records beside one it cannot classify.
     IFS=$'\x1f' read -r record_domain record_key _ _ _ _ _ record_tier <<<"$line"
     case "$record_tier" in
       enforce | verify | manual) ;;
@@ -252,20 +278,30 @@ defaults_records_unit_separated() { # <path>
         return 2
         ;;
     esac
-    validated_lines+=("$line")
-    emitted_line_count=$((emitted_line_count + 1))
+    checked_line_count=$((checked_line_count + 1))
   done <<<"$raw_records"
 
-  if [[ $emitted_line_count -ne $declared_record_count ]]; then
+  if [[ $checked_line_count -ne $declared_record_count ]]; then
     printf 'error: %s declares %s record(s) but the record stream has %s line(s); %s contains a newline\n' \
-      "$data_file" "$declared_record_count" "$emitted_line_count" \
+      "$data_file" "$declared_record_count" "$checked_line_count" \
       "$(defaults_records_locate_malformed "$data_file" "$declared_record_count")" >&2
     return 2
   fi
+}
 
-  if [[ ${#validated_lines[@]} -gt 0 ]]; then
-    printf '%s\n' "${validated_lines[@]}"
-  fi
+defaults_records_unit_separated() { # <path>
+  local data_file="$1"
+  local declared_record_count raw_records line
+  declared_record_count="$(defaults_records_declared_count "$data_file")" || return 2
+  raw_records="$(defaults_records_raw_stream "$data_file")" || return 2
+  defaults_records_validate_stream "$data_file" "$declared_record_count" "$raw_records" || return 2
+  # Emission, and only emission, and only once the WHOLE file has passed. A
+  # caller must never act on part of a stream it is about to be told is
+  # malformed, which is why nothing is printed before the predicate returns.
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    printf '%s\n' "$line"
+  done <<<"$raw_records"
 }
 
 # validate_record_scope <scope> <host> <plist_path>, print the validated scope.

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -200,6 +200,26 @@ defaults_records_unit_separated() { # <path>
       "$data_file" "$declared_record_count" >&2
     return 2
   fi
+  # The SHAPE, before the content. `.macos.defaults[]` yields values from a map
+  # just as happily as from a list, and `length` counts a map's keys, so every
+  # check above passes on a map and the stream comes out in document order. The
+  # runner template reads the same file with Go's `range`, which iterates a map
+  # in sorted KEY order. Two readers, two orders, neither complaining, and order
+  # decides which write lands last when records share a domain and key.
+  #
+  # Refused rather than reconciled: a map is not the declared schema, and
+  # standardizing on one order would leave the other reader's agreement a
+  # coincidence instead of a guarantee. The template refuses the same shape.
+  local records_kind
+  if ! records_kind="$(yq eval -r '(.macos.defaults // []) | tag' "$data_file")"; then
+    printf 'error: cannot determine the shape of .macos.defaults in %s\n' "$data_file" >&2
+    return 2
+  fi
+  if [[ $records_kind != '!!seq' ]]; then
+    printf 'error: %s declares .macos.defaults as %s, but it must be a LIST of records; a map is read in sorted key order by the runner template and in document order here, so the two would apply records in different orders\n' \
+      "$data_file" "$records_kind" >&2
+    return 2
+  fi
   if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2

--- a/test/integration/macos-defaults-shape-agreement.sh
+++ b/test/integration/macos-defaults-shape-agreement.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# macos-defaults-shape-agreement.sh, the runner template and the shared library
+# must read the SAME records in the SAME order from the same data file, or refuse
+# it together.
+#
+# Two independent readers exist for `.macos.defaults`: the chezmoi runner
+# template, which applies the settings, and macos-defaults-lib.sh, which the
+# apply, capture and drift tools stream records through. Nothing forced them to
+# agree, and they did not.
+#
+# A MAP-valued `.macos.defaults` was accepted by both and read in OPPOSITE
+# orders. Go's `range` over a map iterates in sorted KEY order; the library's yq
+# stream yields document order. Two readers, two orders, no complaint from
+# either. Order decides which write lands last when records touch the same
+# domain and key, so this is a silent divergence in what the machine ends up
+# holding.
+#
+# The shape is refused on both sides rather than reconciled. A map is not the
+# declared schema, and picking one order to standardize on would leave the other
+# reader's behavior a coincidence rather than a guarantee.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH; this suite renders a real template and cannot be meaningfully skipped"
+done
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+[[ -f $LIB ]] || fail "missing library: $LIB"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# render_template <fixture-file> -> prints the render, returns chezmoi's status
+render_template() {
+  local src="$work/src"
+  rm -rf "$src"
+  mkdir -p "$src/.chezmoiscripts" "$src/.chezmoidata" "$work/home"
+  cp "$TEMPLATE" "$src/.chezmoiscripts/runner.tmpl"
+  cp "$1" "$src/.chezmoidata/macos_defaults.yaml"
+  HOME="$work/home" CI=1 chezmoi --source "$src" execute-template --no-tty \
+    <"$src/.chezmoiscripts/runner.tmpl" 2>&1
+}
+
+# library_stream <fixture-file> -> prints the record stream, returns its status
+library_stream() {
+  (
+    # shellcheck source=/dev/null
+    source "$LIB" >/dev/null 2>&1
+    defaults_records_unit_separated "$1" 2>&1
+  )
+}
+
+# ---- the table -------------------------------------------------------------
+# Each fixture is written once and put through BOTH readers. A reader-specific
+# expectation is what let these two drift in the first place, so the assertions
+# below are about agreement, not about either reader's private behavior.
+
+cat >"$work/seq.yaml" <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    - {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+cat >"$work/map.yaml" <<'EOF'
+macos:
+  defaults:
+    zebra: {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    alpha: {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+# ---- 1: a LIST is accepted by both, in declaration order --------------------
+# Declared zebra first, alpha second. Sorted key order would invert them, so the
+# order assertion is what distinguishes "read the list" from "sorted something".
+lib_out="$(library_stream "$work/seq.yaml")" ||
+  fail "the library refused a well-formed list of records: $lib_out"
+lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+[[ $lib_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "library read a list out of declaration order: [$lib_domains]"
+
+tmpl_out="$(render_template "$work/seq.yaml")" ||
+  fail "the template refused a well-formed list of records: $tmpl_out"
+tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+[[ $tmpl_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "template read a list out of declaration order: [$tmpl_domains]"
+
+# The point of the whole file: same input, same order, from two readers.
+[[ $lib_domains == "$tmpl_domains" ]] ||
+  fail "the two readers disagree on record order for a list: library [$lib_domains] vs template [$tmpl_domains]"
+
+# ---- 2: a MAP is refused by both -------------------------------------------
+# Refused, not reconciled. Accepting it means one reader sorts and the other does
+# not, and the disagreement decides which write lands last.
+if lib_out="$(library_stream "$work/map.yaml")"; then
+  lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+  fail "the library ACCEPTED a map-valued .macos.defaults and emitted [$lib_domains]; the template reads the same file in sorted key order, so the two apply records in different orders"
+fi
+
+if tmpl_out="$(render_template "$work/map.yaml")"; then
+  tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+  fail "the template ACCEPTED a map-valued .macos.defaults and rendered [$tmpl_domains]; a map is not the declared schema and Go's range sorts its keys"
+fi
+
+# Each refusal must name the shape, or an operator sees a generic parse failure
+# and edits the wrong thing.
+printf '%s' "$lib_out" | grep -qiE 'list|sequence|map' ||
+  fail "the library refused the map without naming the shape problem: $lib_out"
+printf '%s' "$tmpl_out" | grep -qiE 'list|sequence|map' ||
+  fail "the template refused the map without naming the shape problem: $tmpl_out"
+
+printf 'macos-defaults-shape-agreement: OK (both readers take a list in declaration order and both refuse a map, naming the shape)\n'


### PR DESCRIPTION
## Context

`macos-defaults-lib.sh` turns the declared macOS settings into a record stream that the apply, capture
and drift tools all consume. One function, `defaults_records_unit_separated`, had grown to 87 lines
and four jobs.

The awkward part was not the length. Its validation loop accumulated the very lines it was checking
into an array and then printed them, so there was no way to ask "is this file usable" without also
producing its output.

Stacked on #108.

## Summary

- Splits one 87-line function into four, each with a single job.
- Validation is now a predicate that emits nothing.
- The emitter is 14 lines and does only that.
- No behavior change, verified by mutating every guard.

Key file: `dot_local/bin/macos-defaults-lib.sh`

## The split

| Function | Job |
| --- | --- |
| `defaults_records_declared_count` | validate the file's shape and size, print the count |
| `defaults_records_raw_stream` | read it, and fail on its own terms |
| `defaults_records_validate_stream` | a predicate over what was read, emitting nothing |
| `defaults_records_unit_separated` | orchestrate, then emit |

The property worth keeping is that a caller never acts on part of a stream it is about to be told is
malformed. That used to hold because emission and validation shared an accumulator. It now holds by
construction: nothing prints until the predicate has returned for the whole file.

## How "no behavior change" was established

The full suite passes unchanged. On its own that only shows nothing broke loudly, so each of the four
guards was mutated in turn to confirm the split had not quietly dropped one:

| Guard | Removing it |
| --- | --- |
| list-shape | caught |
| tier | caught |
| declared-vs-emitted line count | caught |
| numeric record count | **not caught, see below** |

## A pre-existing gap the mutation pass found

The numeric record-count guard can be deleted and the entire suite stays green. That is not something
this change introduced, and it is not fixed here so this stays a pure refactor. It is filed with the
detail needed to write the test, including why the obvious input does not exercise it: the guard's own
comment notes that a multi-document file is caught by the field-count check first, so an assertion
using one would prove nothing about this guard.

## A note on the verification itself

The first mutation matrix run reported a clean sweep of caught guards. Its control also failed, which
made the whole table meaningless, because one test path pointed at `test/integration` for a file that
lives in `test/unit`. A control that fails turns every FAIL into noise, and a sweep of FAILs looks
exactly like success.

A later run timed out partway and left a mutation in the working tree. The library was restored from
the pristine copy and re-verified before committing.

Gates: `just T`, `just lint-check`, `just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

None at runtime. Same records, same order, same refusals, same messages.
