### PR TITLE
test: stop reporting a broken darwin render as a skip

### DIFF
--- a/test/e2e/herdr-health-check-timeout.sh
+++ b/test/e2e/herdr-health-check-timeout.sh
@@ -94,6 +94,13 @@ a58_rendered="$work/a58-rendered.sh"
 HOME="$a58_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
   <"$AFTER_58" >"$a58_rendered" || fail "chezmoi failed to render $AFTER_58"
 if [[ ! -s $a58_rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/e2e/herdr-plugin-build-timeout.sh
+++ b/test/e2e/herdr-plugin-build-timeout.sh
@@ -150,6 +150,13 @@ run_one() {
   HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
     <"$template" >"$rendered" || fail "chezmoi failed to render $template"
   if [[ ! -s $rendered ]]; then
+    # An empty render is only legitimate OFF darwin. On darwin this template
+    # must produce output, so empty means the template broke, and skipping
+    # would report a broken render as a pass. Assert the host, do not infer it.
+    if [[ $(uname -s) == Darwin ]]; then
+      printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+      exit 1
+    fi
     printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
     exit 0
   fi

--- a/test/integration/claude-code-launchagent-retirement.sh
+++ b/test/integration/claude-code-launchagent-retirement.sh
@@ -54,6 +54,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/herdr-build-retry-refire.sh
+++ b/test/integration/herdr-build-retry-refire.sh
@@ -44,6 +44,13 @@ render() {
 rm -f "$marker"
 settled="$(render)" || fail "render failed (no marker)"
 [[ -n $settled ]] || {
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 }

--- a/test/integration/herdr-build-scripts-resilience.sh
+++ b/test/integration/herdr-build-scripts-resilience.sh
@@ -65,6 +65,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/herdr-migration-ordering.sh
+++ b/test/integration/herdr-migration-ordering.sh
@@ -47,6 +47,13 @@ mkdir -p "$render_home"
 HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/herdr-migration-verify.sh
+++ b/test/integration/herdr-migration-verify.sh
@@ -49,6 +49,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/homebrew-after58-skip-cleanup.sh
+++ b/test/integration/homebrew-after58-skip-cleanup.sh
@@ -95,6 +95,13 @@ run_render() {
       execute-template --no-tty <"$SCRIPT" >"$rendered" || fail "$name: render failed"
   fi
   if [[ ! -s $rendered ]]; then
+    # An empty render is only legitimate OFF darwin. On darwin this template
+    # must produce output, so empty means the template broke, and skipping
+    # would report a broken render as a pass. Assert the host, do not infer it.
+    if [[ $(uname -s) == Darwin ]]; then
+      printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+      exit 1
+    fi
     printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
     exit 0
   fi

--- a/test/integration/homebrew-before10-autoupdate-teardown.sh
+++ b/test/integration/homebrew-before10-autoupdate-teardown.sh
@@ -38,6 +38,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/homebrew-before10-bundle-split.sh
+++ b/test/integration/homebrew-before10-bundle-split.sh
@@ -37,6 +37,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/homebrew-before10-ecosystem-guards.sh
+++ b/test/integration/homebrew-before10-ecosystem-guards.sh
@@ -36,6 +36,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/homebrew-cleanup-guard.sh
+++ b/test/integration/homebrew-cleanup-guard.sh
@@ -38,6 +38,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/macos-control-tier-refusal.sh
+++ b/test/integration/macos-control-tier-refusal.sh
@@ -144,6 +144,13 @@ EOF
 render_template "$TIER1_TEMPLATE" "$probe_src" "$sandbox/rendered-probe" "$render_error" ||
   fail "the probe render must succeed (stderr: $(cat "$render_error"))"
 if [[ -z "$(tr -d '[:space:]' <"$sandbox/rendered-probe")" ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/macos-defaults-injection.sh
+++ b/test/integration/macos-defaults-injection.sh
@@ -110,6 +110,13 @@ EOF
 render_template "$probe_src" "$sandbox/rendered-probe" "$render_error" ||
   fail "the probe render must succeed (stderr: $(cat "$render_error"))"
 if [[ -z "$(tr -d '[:space:]' <"$sandbox/rendered-probe")" ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/macos-system-setup-sudo-guard.sh
+++ b/test/integration/macos-system-setup-sudo-guard.sh
@@ -81,6 +81,13 @@ HOME="$render_home" chezmoi --source "$source_dir" execute-template --no-tty \
   <"$TEMPLATE" >"$rendered" 2>"$render_error" ||
   fail "a record without a sudo key must render, not abort the template (stderr: $(cat "$render_error"))"
 if [[ -z "$(tr -d '[:space:]' <"$rendered")" ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/openclaw-services-retirement.sh
+++ b/test/integration/openclaw-services-retirement.sh
@@ -70,6 +70,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/integration/tailnet-pins.sh
+++ b/test/integration/tailnet-pins.sh
@@ -73,6 +73,13 @@ macos:
 EOF
 rendered="$work/pins.rendered"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/unit/homebrew-before10-skip-truthiness.sh
+++ b/test/unit/homebrew-before10-skip-truthiness.sh
@@ -48,6 +48,13 @@ render() {
 # subshell exit that leaves an assertion comparing SKIP text against "yes".
 probe="$(render __unset__)" || fail 'chezmoi failed to render before_10'
 if [[ -z ${probe//[[:space:]]/} ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi

--- a/test/unit/no-empty-render-skip-on-darwin.sh
+++ b/test/unit/no-empty-render-skip-on-darwin.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# no-empty-render-skip-on-darwin.sh, a REPO-WIDE guard: no test may treat an
+# empty template render as a reason to skip itself on darwin.
+#
+# The class this closes: nineteen tests carried
+#
+#   if [[ ! -s $rendered ]]; then
+#     printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
+#     exit 0
+#   fi
+#
+# The condition tests EMPTINESS while the message asserts a NON-DARWIN HOST.
+# Those are different claims. Off darwin the render is empty by design and the
+# skip is right. On darwin the template must produce output, so empty means the
+# template is broken, and the test reports that as a pass. Every one of these
+# suites runs on darwin in CI, which is exactly where the masking mattered.
+#
+# The fix at each site asserts the host rather than inferring it. This guard
+# exists so the next test written from an existing one as a template cannot
+# reintroduce the inference: a bare skip is invisible in a green run, so nothing
+# else would catch it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKIP_MESSAGE='SKIP: empty render'
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -d $REPO_ROOT/test ]] || fail "no test directory under $REPO_ROOT"
+
+unguarded=()
+while IFS= read -r file; do
+  # Every occurrence of the skip must sit under a darwin assertion. Checked per
+  # occurrence, not per file: a file can hold several render sites and guarding
+  # one says nothing about the others.
+  while IFS= read -r line_number; do
+    # The guard is emitted directly above the skip, so a short window is enough
+    # and a distant unrelated uname elsewhere in the file cannot vouch for it.
+    window_start=$((line_number > 8 ? line_number - 8 : 1))
+    if ! sed -n "${window_start},${line_number}p" "$file" | grep -q 'uname -s'; then
+      unguarded+=("$file:$line_number")
+    fi
+  done < <(grep -n -F "$SKIP_MESSAGE" "$file" | cut -d: -f1)
+  # This file quotes the pattern in its own prose and stores it in a variable,
+  # so scanning itself reports two sites that are documentation, not skips.
+done < <(grep -rl -F "$SKIP_MESSAGE" "$REPO_ROOT/test" 2>/dev/null | grep -vF "${BASH_SOURCE[0]##*/}" || true)
+
+if [[ ${#unguarded[@]} -gt 0 ]]; then
+  printf 'FAIL: %s test site(s) skip on an empty render without asserting the host:\n' "${#unguarded[@]}" >&2
+  printf '  %s\n' "${unguarded[@]}" >&2
+  printf 'On darwin an empty render is a BROKEN TEMPLATE, not a reason to skip. Assert the host with uname, do not infer it from emptiness.\n' >&2
+  exit 1
+fi
+
+guarded_count="$(grep -rc -F "$SKIP_MESSAGE" "$REPO_ROOT/test" 2>/dev/null | grep -vF "${BASH_SOURCE[0]##*/}" | awk -F: '{total += $2} END {print total + 0}')"
+# The guard must have something to guard. If every empty-render skip is ever
+# deleted this check turns into an assertion about nothing, passing forever
+# while proving nothing, so it refuses that state loudly instead.
+[[ $guarded_count -ge 1 ]] ||
+  fail "no empty-render skip sites found at all; this guard now asserts nothing and should be retired deliberately rather than left passing vacuously"
+
+printf 'no-empty-render-skip-on-darwin: OK (%s empty-render skip site(s), every one asserting the host)\n' "$guarded_count"

--- a/test/unit/tailscaled-status.sh
+++ b/test/unit/tailscaled-status.sh
@@ -48,6 +48,13 @@ HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty
   <"$SCRIPT" >"$rendered" || fail "chezmoi failed to render $SCRIPT"
 rm -rf "$render_home"
 if [[ ! -s $rendered ]]; then
+  # An empty render is only legitimate OFF darwin. On darwin this template
+  # must produce output, so empty means the template broke, and skipping
+  # would report a broken render as a pass. Assert the host, do not infer it.
+  if [[ $(uname -s) == Darwin ]]; then
+    printf 'FAIL: the render came back EMPTY on darwin, where this template must produce output; a broken darwin render must not pass as a skip\n' >&2
+    exit 1
+  fi
   printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
   exit 0
 fi


### PR DESCRIPTION
## Context

Many tests in this repo render a chezmoi template and then exercise the result. Several of those
templates produce nothing on Linux by design, so the tests learned to bail out when the render came
back empty.

The bail-out was written against the wrong signal, and it had spread to nineteen files.

## Summary

- Nineteen tests no longer report a broken darwin render as a skip.
- Each site asserts the host with `uname` instead of inferring it from emptiness.
- Adds a repo-wide guard so the next test cannot reintroduce the inference.
- Nothing newly fails, so these were dormant masks, not cover for live breakage.

Key file: `test/unit/no-empty-render-skip-on-darwin.sh`

## The defect

```bash
if [[ ! -s $rendered ]]; then
  printf 'SKIP: empty render (non-darwin host); nothing to exercise\n'
  exit 0
fi
```

The condition tests **emptiness**. The message asserts a **non-darwin host**. Those are different
claims, and the gap between them is the bug.

Off darwin the render really is empty by design, and skipping is correct. On darwin the template must
produce output, so an empty render means the template is broken. The test skipped, printed a
reassuring reason, and exited 0.

CI runs these on `macos-latest`, so darwin is precisely the case being masked.

## What changed at each site

The host is now asserted rather than inferred. On darwin an empty render fails and says why; off
darwin the skip is unchanged.

Verified against the full suite: nothing newly fails. So no template is currently broken, and this is
preventive rather than a repair. That is worth stating plainly, because "19 tests fixed" would imply
19 live failures were being hidden, and they were not.

## Why a guard as well as a fix

A bare skip is invisible in a green run. Nothing in a passing suite distinguishes "ran and passed"
from "skipped and said so", so the next test written by copying an existing one would reintroduce this
silently.

The guard checks each **occurrence**, not each file, because one file can hold several render sites
and guarding one says nothing about the others. It scans a short window above each occurrence so an
unrelated `uname` elsewhere in the file cannot vouch for it. It also refuses to pass vacuously: if
every empty-render skip is ever deleted, it fails rather than quietly asserting nothing forever.

Confirmed to fail against `origin/main`, naming all nineteen sites.

## Effect of merging

Test-only. No production file changes.
