### PR TITLE
test(macos): pin the refusal of a multi-document defaults file

### DIFF
--- a/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl
@@ -41,6 +41,16 @@ with `map has no entry for key "scope"` on that form when a record omits the
 key, which turns a loud, specific refusal into an opaque template panic. Any
 violation ABORTS the render via fail, so chezmoi refuses the whole apply:
 no warning, no skipped record, no partial best-effort script. */ -}}
+{{- /* The SHAPE, before any record. `range` accepts a map as readily as a list
+and iterates it in sorted KEY order, while macos-defaults-lib.sh reads the same
+file through yq in DOCUMENT order. Both would accept a map, silently, and apply
+the records in different orders; order is what decides which write lands last
+when two records share a domain and key. Refused rather than reconciled, because
+a map is not the declared schema and standardizing on one order would leave the
+other reader's agreement a coincidence. The library refuses the same shape. */ -}}
+{{ if ne (kindOf .macos.defaults) "slice" -}}
+{{ fail (printf "macos_defaults.yaml: .macos.defaults is a %s, but it must be a LIST of records; a map is iterated in sorted key order here and in document order by macos-defaults-lib.sh, so the two would apply records in different orders" (kindOf .macos.defaults)) -}}
+{{ end -}}
 {{ range .macos.defaults -}}
 {{ $record := . -}}
 {{- /* Identity first. The domain and key name the record in every error

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -146,7 +146,15 @@ defaults_records_locate_malformed() { # <path> <declared-count>
   printf 'a record this locator could not identify'
 }
 
-# defaults_records_unit_separated <path>, emit each tracked record as one line
+# THE RECORD STREAM. Four functions below share this contract, split so each has
+# one job: defaults_records_declared_count validates the file's shape and size,
+# defaults_records_raw_stream reads it, defaults_records_validate_stream is a
+# PREDICATE over what was read, and defaults_records_unit_separated emits. They
+# were one function, in which the validation loop accumulated the very lines it
+# was checking and then printed them, so asking "is this file usable" was
+# inseparable from producing its output.
+#
+# The contract: emit each tracked record as one line
 # of EIGHT fields joined by the ASCII unit separator (0x1f):
 #   domain, key, type, value, host, scope, plist_path, tier
 # host, plist_path, and (on manual records) type and value are empty when
@@ -180,9 +188,9 @@ defaults_records_locate_malformed() { # <path> <declared-count>
 # offending record, and emits NOTHING: a caller must not act on part of a stream
 # it has just been told is malformed. A legitimate multi-line preference value is
 # therefore refused loudly rather than silently corrupted.
-defaults_records_unit_separated() { # <path>
+defaults_records_declared_count() { # <path>, print the validated record count
   local data_file="$1"
-  local declared_record_count raw_records
+  local declared_record_count records_kind
   if ! declared_record_count="$(yq eval -r '(.macos.defaults // []) | length' "$data_file")"; then
     printf 'error: cannot count the records in %s\n' "$data_file" >&2
     return 2
@@ -210,7 +218,6 @@ defaults_records_unit_separated() { # <path>
   # Refused rather than reconciled: a map is not the declared schema, and
   # standardizing on one order would leave the other reader's agreement a
   # coincidence instead of a guarantee. The template refuses the same shape.
-  local records_kind
   if ! records_kind="$(yq eval -r '(.macos.defaults // []) | tag' "$data_file")"; then
     printf 'error: cannot determine the shape of .macos.defaults in %s\n' "$data_file" >&2
     return 2
@@ -220,14 +227,33 @@ defaults_records_unit_separated() { # <path>
       "$data_file" "$records_kind" >&2
     return 2
   fi
-  if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
+  printf '%s\n' "$declared_record_count"
+}
+
+# defaults_records_raw_stream <path>, the unvalidated joined records from yq.
+# Separated so the reader can fail on its own terms; every check that follows
+# assumes it has the whole stream, and a partial read must never reach them.
+defaults_records_raw_stream() { # <path>
+  local data_file="$1"
+  if ! yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2
   fi
+}
 
-  local line field_count emitted_line_count=0
+# defaults_records_validate_stream <path> <declared-count> <raw-stream>, a
+# PREDICATE: 0 when every line is well-formed and the line count matches what the
+# file declares, 2 otherwise, naming the offending record on stderr.
+#
+# It emits no records, deliberately. Validation used to accumulate the very lines
+# it was checking and then print them, which meant the only way to ask "is this
+# file usable" was to also produce its output. A caller that just wants to know
+# now asks a question instead of running a producer, and the emission below has
+# one job.
+defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
+  local data_file="$1" declared_record_count="$2" raw_records="$3"
+  local line field_count checked_line_count=0
   local record_domain record_key record_tier
-  local -a validated_lines=()
   while IFS= read -r line; do
     # yq prints a single empty line for an empty array; that is not a record.
     [[ -z $line ]] && continue
@@ -241,8 +267,8 @@ defaults_records_unit_separated() { # <path>
     # The tier gate. Only the three declared tiers pass; a record whose tier
     # is missing or blank arrives here as the empty string and lands in the
     # same refusal, so absent, blank, and unrecognized all fail closed. The
-    # refusal covers the WHOLE file (nothing has been emitted yet), because a
-    # caller must not act on the records beside one it cannot classify.
+    # refusal covers the WHOLE file, because a caller must not act on the
+    # records beside one it cannot classify.
     IFS=$'\x1f' read -r record_domain record_key _ _ _ _ _ record_tier <<<"$line"
     case "$record_tier" in
       enforce | verify | manual) ;;
@@ -252,20 +278,30 @@ defaults_records_unit_separated() { # <path>
         return 2
         ;;
     esac
-    validated_lines+=("$line")
-    emitted_line_count=$((emitted_line_count + 1))
+    checked_line_count=$((checked_line_count + 1))
   done <<<"$raw_records"
 
-  if [[ $emitted_line_count -ne $declared_record_count ]]; then
+  if [[ $checked_line_count -ne $declared_record_count ]]; then
     printf 'error: %s declares %s record(s) but the record stream has %s line(s); %s contains a newline\n' \
-      "$data_file" "$declared_record_count" "$emitted_line_count" \
+      "$data_file" "$declared_record_count" "$checked_line_count" \
       "$(defaults_records_locate_malformed "$data_file" "$declared_record_count")" >&2
     return 2
   fi
+}
 
-  if [[ ${#validated_lines[@]} -gt 0 ]]; then
-    printf '%s\n' "${validated_lines[@]}"
-  fi
+defaults_records_unit_separated() { # <path>
+  local data_file="$1"
+  local declared_record_count raw_records line
+  declared_record_count="$(defaults_records_declared_count "$data_file")" || return 2
+  raw_records="$(defaults_records_raw_stream "$data_file")" || return 2
+  defaults_records_validate_stream "$data_file" "$declared_record_count" "$raw_records" || return 2
+  # Emission, and only emission, and only once the WHOLE file has passed. A
+  # caller must never act on part of a stream it is about to be told is
+  # malformed, which is why nothing is printed before the predicate returns.
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    printf '%s\n' "$line"
+  done <<<"$raw_records"
 }
 
 # validate_record_scope <scope> <host> <plist_path>, print the validated scope.

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -340,8 +340,16 @@ validate_record_scope() { # <scope> <host> <plist_path>
 # the default, /Library/Preferences/<domain>. A declared path must be
 # ABSOLUTE: a relative path would resolve against whatever directory the tool
 # happens to run from, so it is rejected, never resolved.
-resolve_system_plist_path() { # <domain> <plist_path>
-  local domain="$1" plist_path="$2"
+# validate_system_domain <domain>, a PREDICATE over the domain alone: 0 when it
+# can name a plist under /Library/Preferences, 1 with a message otherwise.
+#
+# Separated from resolution because the two rules below are properties of the
+# RECORD, true or false before anything is resolved, and they apply to every
+# system-scope record whether or not it declares an explicit plist_path. Folded
+# into the resolver they sat above an early return, which is the shape that once
+# let them apply to only one of the two branches.
+validate_system_domain() { # <domain>
+  local domain="$1"
   # A defaults domain is reverse-DNS and never legitimately contains a slash.
   # Rejecting one keeps the default construction inside /Library/Preferences BY
   # CONSTRUCTION: without it, a domain of ../../tmp/owned resolves to
@@ -367,10 +375,14 @@ resolve_system_plist_path() { # <domain> <plist_path>
       "$domain" >&2
     return 1
   fi
-  if [[ -z $plist_path ]]; then
-    printf '/Library/Preferences/%s\n' "$domain"
-    return 0
-  fi
+}
+
+# validate_explicit_plist_path <plist_path> <domain>, a PREDICATE over a declared
+# path: 0 when it names an absolute plist that cannot climb out of where it
+# appears to sit, 1 with a message otherwise. The domain is carried for the
+# messages only; it is validated separately, by validate_system_domain.
+validate_explicit_plist_path() { # <plist_path> <domain>
+  local plist_path="$1" domain="$2"
   if [[ $plist_path == / ]]; then
     printf 'error: plist_path %q (domain %s) is the filesystem root; it names no plist\n' \
       "$plist_path" "$domain" >&2
@@ -391,6 +403,24 @@ resolve_system_plist_path() { # <domain> <plist_path>
       "$plist_path" "$domain" >&2
     return 1
   fi
+}
+
+# resolve_system_plist_path <domain> <plist_path>, print the plist a system-scope
+# record writes to, or fail with a message.
+#
+# Resolution only. Each input is put to its own predicate first, and what remains
+# here is the one decision this function actually makes: an absent plist_path
+# means the default under /Library/Preferences, and a declared one is used as
+# given. Previously those two lines sat among five validation blocks, with the
+# default-path branch returning from the middle of them.
+resolve_system_plist_path() { # <domain> <plist_path>
+  local domain="$1" plist_path="$2"
+  validate_system_domain "$domain" || return 1
+  if [[ -z $plist_path ]]; then
+    printf '/Library/Preferences/%s\n' "$domain"
+    return 0
+  fi
+  validate_explicit_plist_path "$plist_path" "$domain" || return 1
   printf '%s\n' "$plist_path"
 }
 

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -200,6 +200,26 @@ defaults_records_unit_separated() { # <path>
       "$data_file" "$declared_record_count" >&2
     return 2
   fi
+  # The SHAPE, before the content. `.macos.defaults[]` yields values from a map
+  # just as happily as from a list, and `length` counts a map's keys, so every
+  # check above passes on a map and the stream comes out in document order. The
+  # runner template reads the same file with Go's `range`, which iterates a map
+  # in sorted KEY order. Two readers, two orders, neither complaining, and order
+  # decides which write lands last when records share a domain and key.
+  #
+  # Refused rather than reconciled: a map is not the declared schema, and
+  # standardizing on one order would leave the other reader's agreement a
+  # coincidence instead of a guarantee. The template refuses the same shape.
+  local records_kind
+  if ! records_kind="$(yq eval -r '(.macos.defaults // []) | tag' "$data_file")"; then
+    printf 'error: cannot determine the shape of .macos.defaults in %s\n' "$data_file" >&2
+    return 2
+  fi
+  if [[ $records_kind != '!!seq' ]]; then
+    printf 'error: %s declares .macos.defaults as %s, but it must be a LIST of records; a map is read in sorted key order by the runner template and in document order here, so the two would apply records in different orders\n' \
+      "$data_file" "$records_kind" >&2
+    return 2
+  fi
   if ! raw_records="$(yq eval -r "$(defaults_records_join_expression '.macos.defaults[]')" "$data_file")"; then
     printf 'error: cannot read the records in %s\n' "$data_file" >&2
     return 2

--- a/test/integration/macos-defaults-shape-agreement.sh
+++ b/test/integration/macos-defaults-shape-agreement.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# macos-defaults-shape-agreement.sh, the runner template and the shared library
+# must read the SAME records in the SAME order from the same data file, or refuse
+# it together.
+#
+# Two independent readers exist for `.macos.defaults`: the chezmoi runner
+# template, which applies the settings, and macos-defaults-lib.sh, which the
+# apply, capture and drift tools stream records through. Nothing forced them to
+# agree, and they did not.
+#
+# A MAP-valued `.macos.defaults` was accepted by both and read in OPPOSITE
+# orders. Go's `range` over a map iterates in sorted KEY order; the library's yq
+# stream yields document order. Two readers, two orders, no complaint from
+# either. Order decides which write lands last when records touch the same
+# domain and key, so this is a silent divergence in what the machine ends up
+# holding.
+#
+# The shape is refused on both sides rather than reconciled. A map is not the
+# declared schema, and picking one order to standardize on would leave the other
+# reader's behavior a coincidence rather than a guarantee.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH; this suite renders a real template and cannot be meaningfully skipped"
+done
+[[ -f $TEMPLATE ]] || fail "missing template: $TEMPLATE"
+[[ -f $LIB ]] || fail "missing library: $LIB"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# render_template <fixture-file> -> prints the render, returns chezmoi's status
+render_template() {
+  local src="$work/src"
+  rm -rf "$src"
+  mkdir -p "$src/.chezmoiscripts" "$src/.chezmoidata" "$work/home"
+  cp "$TEMPLATE" "$src/.chezmoiscripts/runner.tmpl"
+  cp "$1" "$src/.chezmoidata/macos_defaults.yaml"
+  HOME="$work/home" CI=1 chezmoi --source "$src" execute-template --no-tty \
+    <"$src/.chezmoiscripts/runner.tmpl" 2>&1
+}
+
+# library_stream <fixture-file> -> prints the record stream, returns its status
+library_stream() {
+  (
+    # shellcheck source=/dev/null
+    source "$LIB" >/dev/null 2>&1
+    defaults_records_unit_separated "$1" 2>&1
+  )
+}
+
+# ---- the table -------------------------------------------------------------
+# Each fixture is written once and put through BOTH readers. A reader-specific
+# expectation is what let these two drift in the first place, so the assertions
+# below are about agreement, not about either reader's private behavior.
+
+cat >"$work/seq.yaml" <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    - {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+cat >"$work/map.yaml" <<'EOF'
+macos:
+  defaults:
+    zebra: {domain: com.example.zebra, key: ZKey, value: "1", type: bool, tier: enforce}
+    alpha: {domain: com.example.alpha, key: AKey, value: "1", type: bool, tier: enforce}
+  killall: []
+EOF
+
+# ---- 1: a LIST is accepted by both, in declaration order --------------------
+# Declared zebra first, alpha second. Sorted key order would invert them, so the
+# order assertion is what distinguishes "read the list" from "sorted something".
+lib_out="$(library_stream "$work/seq.yaml")" ||
+  fail "the library refused a well-formed list of records: $lib_out"
+lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+[[ $lib_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "library read a list out of declaration order: [$lib_domains]"
+
+tmpl_out="$(render_template "$work/seq.yaml")" ||
+  fail "the template refused a well-formed list of records: $tmpl_out"
+tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+[[ $tmpl_domains == "com.example.zebra com.example.alpha " ]] ||
+  fail "template read a list out of declaration order: [$tmpl_domains]"
+
+# The point of the whole file: same input, same order, from two readers.
+[[ $lib_domains == "$tmpl_domains" ]] ||
+  fail "the two readers disagree on record order for a list: library [$lib_domains] vs template [$tmpl_domains]"
+
+# ---- 2: a MAP is refused by both -------------------------------------------
+# Refused, not reconciled. Accepting it means one reader sorts and the other does
+# not, and the disagreement decides which write lands last.
+if lib_out="$(library_stream "$work/map.yaml")"; then
+  lib_domains="$(printf '%s\n' "$lib_out" | cut -d$'\037' -f1 | tr '\n' ' ')"
+  fail "the library ACCEPTED a map-valued .macos.defaults and emitted [$lib_domains]; the template reads the same file in sorted key order, so the two apply records in different orders"
+fi
+
+if tmpl_out="$(render_template "$work/map.yaml")"; then
+  tmpl_domains="$(printf '%s\n' "$tmpl_out" | grep -oE 'com\.example\.[a-z]+' | tr '\n' ' ')"
+  fail "the template ACCEPTED a map-valued .macos.defaults and rendered [$tmpl_domains]; a map is not the declared schema and Go's range sorts its keys"
+fi
+
+# Each refusal must name the shape, or an operator sees a generic parse failure
+# and edits the wrong thing.
+printf '%s' "$lib_out" | grep -qiE 'list|sequence|map' ||
+  fail "the library refused the map without naming the shape problem: $lib_out"
+printf '%s' "$tmpl_out" | grep -qiE 'list|sequence|map' ||
+  fail "the template refused the map without naming the shape problem: $tmpl_out"
+
+printf 'macos-defaults-shape-agreement: OK (both readers take a list in declaration order and both refuse a map, naming the shape)\n'

--- a/test/unit/macos-defaults-count-guard.sh
+++ b/test/unit/macos-defaults-count-guard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# macos-defaults-count-guard.sh, a multi-document data file must be REFUSED, and
+# a well-formed one must still answer.
+#
+# yq answers once per document and separates the answers, so on a two-document
+# file the record "count" arrives as $'1\n---\n0' and the shape as
+# $'!!seq\n---\n!!seq'. Neither is usable, and the count in particular is about
+# to drive `((...))` loop bounds and the `-ne` comparison that catches a forged
+# record; bash arithmetic on a non-numeric string raises a syntax error and
+# evaluates FALSE, so the forgery check would fall through.
+#
+# This asserts the BEHAVIOUR, not one guard. `defaults_records_declared_count`
+# holds two checks that both reject a multi-document file, the numeric-count
+# check and the list-shape check, and either is sufficient on this input.
+# Measured: removing the numeric check alone leaves this test green, because the
+# shape check refuses the same file. So the numeric check is defence in depth
+# here rather than the sole barrier, and a test claiming to pin it specifically
+# would be claiming a guarantee it does not provide.
+#
+# What that leaves open is recorded in the follow-up: whether an input exists
+# that yields a non-numeric count with a clean !!seq shape. If none does, the
+# numeric check is redundant and should be kept or dropped deliberately rather
+# than left looking load-bearing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $LIB ]] || fail "missing library: $LIB"
+command -v yq >/dev/null 2>&1 || fail "yq is not on PATH; run inside the nix dev shell"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# shellcheck source=/dev/null
+source "$LIB" >/dev/null 2>&1
+
+# ---- 1: a multi-document file is REFUSED -----------------------------------
+cat >"$work/multi.yaml" <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.a, key: AKey, value: "1", type: bool, tier: enforce}
+---
+macos:
+  defaults: []
+EOF
+status=0
+output="$(defaults_records_declared_count "$work/multi.yaml" 2>&1)" || status=$?
+[[ $status -eq 2 ]] ||
+  fail "a multi-document data file must be refused with status 2, got $status (output: $output)"
+# The message must carry the offending value. Without it an operator sees only
+# "unusable" and has nothing to search the file for.
+printf '%s' "$output" | grep -q -- '---' ||
+  fail "the refusal does not show the unusable count, so it does not say what is wrong: $output"
+
+# ---- 2: a well-formed file still answers -----------------------------------
+# The guard must reject a shape, not everything. Without this the test would
+# still pass against a function that refuses unconditionally.
+cat >"$work/single.yaml" <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.a, key: AKey, value: "1", type: bool, tier: enforce}
+    - {domain: com.example.b, key: BKey, value: "1", type: bool, tier: enforce}
+EOF
+status=0
+count="$(defaults_records_declared_count "$work/single.yaml" 2>&1)" || status=$?
+[[ $status -eq 0 ]] || fail "a well-formed file must be accepted, got status $status ($count)"
+[[ $count == 2 ]] || fail "expected a count of 2, got: $count"
+
+# ---- 3: an empty record list is a valid count of zero ----------------------
+cat >"$work/empty.yaml" <<'EOF'
+macos:
+  defaults: []
+EOF
+status=0
+count="$(defaults_records_declared_count "$work/empty.yaml" 2>&1)" || status=$?
+[[ $status -eq 0 && $count == 0 ]] ||
+  fail "an empty record list must count as 0 and be accepted, got status $status ($count)"
+
+printf 'macos-defaults-count-guard: OK (a multi-document count is refused and named; single and empty files still answer)\n'


### PR DESCRIPTION
## Context

`macos-defaults-lib.sh` asks yq how many records the data file declares, then computes from that
number. A multi-document YAML file breaks the assumption underneath: yq answers once per document and
separates the answers, so the "count" arrives as `1\n---\n0` rather than a number.

That matters because the count drives `((...))` loop bounds and the `-ne` comparison that catches a
forged record. Bash arithmetic on a non-numeric string raises a syntax error and evaluates FALSE, so
the forgery check would fall through and emit the very stream it exists to reject.

Nothing asserted that such a file is refused. Stacked on #110.

## Summary

- Pins that a multi-document data file is refused, and that the refusal names the bad value.
- Pins that well-formed and empty files still answer, so a blanket refusal cannot pass.
- Reports honestly that two guards cover this input, not one.

Key file: `test/unit/macos-defaults-count-guard.sh`

## Why this was not testable before

The library's own comment records that a multi-document file "is caught earlier only because yq also
prints a separator line that trips the field-count check", and calls that "the guard holding by
accident of another tool's output format".

That was literally true: the count check could not be reached as the first failure. Splitting the
count into `defaults_records_declared_count` (#109) is what made it addressable, so it can now be
asked directly instead of through a pipeline that short-circuits ahead of it. The refactor paid for
itself here.

## What the mutation pass actually showed

The first version of this test claimed to pin the numeric-count guard. It does not:

| Mutation | Result |
| --- | --- |
| remove the numeric-count check only | **test still passes** |
| remove both the numeric-count and list-shape checks | caught |
| unmutated control | passes |

On a multi-document file the shape also comes back as `!!seq\n---\n!!seq`, so the list-shape check
added in #108 refuses the same input. The numeric check is defence in depth here, not the sole
barrier.

The test now asserts the behaviour rather than a specific guard, and its header says so. A comment
claiming to pin the numeric check would have been claiming a guarantee the test does not provide,
which is the kind of dishonest comment this repo treats as its own bug class.

## What stays open

Whether any input yields a non-numeric count with a clean `!!seq` shape. If none does, the numeric
check is redundant and should be kept or removed deliberately rather than left looking load-bearing.
Recorded in the follow-up rather than decided here.

Gates: `just T`, `just lint-check`, `just s` and `nix flake check --all-systems` all exit 0.

## Effect of merging

Test-only. No production file changes.
