### PR TITLE
perf(hooks): drop the test suite from pre-push, add an explicit just ship

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Pre-push gate (test pyramid, operator 2026-07-11): everything the fast
-# commit gate deliberately skips runs here, before anything leaves the
-# machine. CI runs the same checks again as the final backstop.
+# Pre-push gate. Cheap checks only.
+#
+# This hook used to run `just test`, every camp, on every push. Measured
+# 2026-07-29: a push cost 7m20s to 7m37s, of which roughly 6m30s was the
+# integration, e2e and test-system camps. CI then ran the identical `just test`
+# recipe again 10 to 12 minutes later, and the commit hook had already run the
+# unit camp a third time. Three runs of one suite per push, and every round of
+# rework paid for all three: a nine-line test fix on PR #116 cost about 37
+# minutes of waiting.
+#
+# CI is the authority on the suite. It is what blocks the merge, and it tests
+# the COMMIT, while this hook tests the working tree. Those are different
+# artifacts, which is why the local copy cannot substitute: on PR #116 this gate
+# passed and CI failed, on an edit that was never staged.
+#
+# What stays is the 21-second format and flake drift check, worth catching
+# before the push rather than 11 minutes later on CI.
+#
+# Run the whole suite deliberately with `just ship` before a PR you care about.
 #
 # Invoked by the user-wide pre-push dispatcher
 # (dot_config/git/hooks/executable_pre-push) with git's ref list on stdin;
@@ -16,10 +32,4 @@ if ! just lint-check; then
   exit 1
 fi
 
-# All test camps: unit + integration + e2e (+ bats suites when present).
-if ! just test; then
-  printf "\n%s\n" "❌ Tests failed! Fix the failing test(s) above and push again."
-  exit 1
-fi
-
-printf "%s\n" "✅ All pre-push checks passed!"
+printf "%s\n" "✅ Pre-push checks passed (lint only). CI runs the suite; 'just ship' runs it here."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ just test-unit          # Unit suite only (fast commit gate, ~2s)
 just test-integration   # Integration suite only
 just test-e2e           # End-to-end suite only
 just test-system        # The suite that tests the checker and runner themselves
-just test               # All four suites (pre-push and CI run this)
+just test               # All four suites (CI runs this)
+just ship               # lint-check + all four suites, the explicit pre-PR sweep
 ```
 
 Tests live in suites by DESIGN: `test/unit/` (single component, stub/fixture driven, no flows, no sleeps,
@@ -63,8 +64,9 @@ The **commit** gate runs `just test-unit` only, kept fast on purpose: it runs th
 (`test/run-test-suite.sh`) with `--shuffle --warn-slow-ms 200`, so order is seed-shuffled each run
 (replay a failure with `TEST_SEED=<seed>`, printed every run, since Bats 1.11 has no native shuffle) and
 a WARN-ONLY performance summary lists any test over the threshold as a refactor-or-move-suite candidate;
-warnings never fail the run. The **pre-push** hook and **CI** run `just test`, which is exactly the four
-suite recipes; each suite's runner executes its own `.sh` and `.bats` once (bats via
+warnings never fail the run. **CI** runs `just test`, which is exactly the four suite recipes, and
+`just ship` runs the same thing plus the lint gate on demand. The pre-push hook deliberately does NOT run
+it (see Git Hooks). Each suite's runner executes its own `.sh` and `.bats` once (bats via
 `nix develop .#run --command bats --jobs 4` when the host lacks bats, and the checker's placement rules
 keep any bats from hiding outside a suite). So a commit can briefly carry an integration or e2e
 regression; push and CI block it before `main`.
@@ -144,19 +146,30 @@ All four hooks live in the **user-wide** hooks dir (`core.hooksPath = ~/.config/
 - **`prepare-commit-msg`: user-wide AI commit messages.** Prepopulates a Conventional Commits message via
   Claude Sonnet (internals under **AI Commit Messages** below). Bails on `-m`/merge/rebase; bypass with
   `SKIP_AI_COMMIT=1`.
+
 - **`pre-commit`: per-repo FAST gate (unit tests + secret scan), via a dispatcher.**
   `dot_config/git/hooks/executable_pre-commit` runs in every repo but only acts when the repository
   tracks an executable `.githooks/pre-commit`, which it then `exec`s. This repo's `.githooks/pre-commit`
   runs `just test-unit` (the unit suite only, see Testing) then `gitleaks git --staged --redact` (blocks
   any staged plaintext secret; gitleaks is provisioned as a Homebrew formula, and the stage is skipped
   when the binary is absent). Both must pass; a failure blocks the commit. Lint drift, the integration
-  and e2e suites, and the full flake check moved to pre-push (below) to keep the commit loop fast. No
-  install step: the dispatcher is user-wide and the repo hook is committed with its executable bit.
-- **`pre-push`: per-repo full gate, via a dispatcher.** `dot_config/git/hooks/executable_pre-push`
+  and e2e suites, and the full flake check moved out of the commit loop to keep it fast: the flake check
+  runs at pre-push, the integration and e2e suites at CI or via `just ship`. No install step: the
+  dispatcher is user-wide and the repo hook is committed with its executable bit.
+
+- **`pre-push`: per-repo lint gate only, via a dispatcher.** `dot_config/git/hooks/executable_pre-push`
   mirrors the pre-commit dispatcher (user-wide, exec's the repo's executable `.githooks/pre-push` when
   present, no-op otherwise). This repo's `.githooks/pre-push` runs `just lint-check` (the treefmt drift
-  gate) then `just test` (all suites), so everything the commit gate skips runs before anything leaves
-  the machine; CI runs the same as the final backstop.
+  gate, 21s) and nothing else. **CI is the authority on the test suite.** Run the suite locally on demand
+  with `just ship`.
+
+  It used to run `just test` as well. Measured 2026-07-29, that made a push cost 7m20s to 7m37s, of which
+  about 6m30s was integration + e2e + test-system (integration alone is 216s across 102 files, run
+  serially). CI then ran the identical recipe 10 to 12 minutes later and the commit hook had already run
+  the unit camp, so one suite ran three times per push and every round of rework paid for all three. It
+  also could not do the job it was there for: this hook tests the WORKING TREE while CI tests the COMMIT,
+  and on PR #116 the local gate passed while CI failed, on an edit that was never staged.
+
 - **`post-commit`: per-repo hooks, via a dispatcher.** `dot_config/git/hooks/executable_post-commit`
   mirrors the pre-commit dispatcher (user-wide, exec's the repo's executable `.githooks/post-commit` when
   present, no-op otherwise). Nothing global runs graphify anymore; a repo that wants a knowledge-graph

--- a/justfile
+++ b/justfile
@@ -105,10 +105,17 @@ test-system: validate-tests
 validate-tests:
   ./test/validate-tests.sh
 
-# All suites: what pre-push and CI run. Each suite recipe runs its own *.sh
-# and *.bats via the runner, and the checker's placement rules reject any bats
-# outside a suite, so no separate bats backstop is needed here.
+# All suites: what CI runs. Each suite recipe runs its own *.sh and *.bats via
+# the runner, and the checker's placement rules reject any bats outside a suite,
+# so no separate bats backstop is needed here.
 test: test-unit test-integration test-e2e test-system
+
+# The explicit ship step: everything CI will run, run here first. Use it before
+# opening a PR you care about. Pre-push deliberately does NOT run this, because
+# doing so cost 6m30s on every push to rehearse what CI runs 11 minutes later;
+# see the comment in .githooks/pre-push. Note this checks the WORKING TREE,
+# while CI checks the commit, so a green ship is not a promise about CI.
+ship: lint-check test
 
 # Run the weekly Homebrew upgrade by hand (formulae + casks + Mac App Store +
 # cleanup). Same job the Monday-noon com.webdavis.homebrew-weekly-upgrade


### PR DESCRIPTION
## Context

This repository gates pushes with a per-repo `pre-push` hook. It ran `just lint-check` followed by
`just test`, meaning every camp: unit, integration, e2e and test-system.

That made pushing expensive enough to shape how the work felt. A push cost 7m20s to 7m37s, measured
over two real pushes today, and every round of rework paid it again.

## Summary

- Pre-push now runs only the 21-second treefmt drift gate. Measured effect: a push went from 440-457s
  to **23s**, on this PR's own push.
- Adds `just ship` (`lint-check` + `test`) for running the full sweep locally on purpose.
- CI is now the single authority on the test suite, which it already effectively was.
- `CLAUDE.md` said the old thing in four places; all four now match the hooks, and the pre-push
  section records the measurements so the suite does not get quietly added back.

## What changed

`.githooks/pre-push` drops the `just test` block. `justfile` gains `ship: lint-check test`.

Per-camp timings behind the decision:

| camp | files | time |
|---|---|---|
| unit | 52 | 32s |
| integration | 102 | 216s |
| e2e | 18 | 136s |
| test-system | 7 | 7s |
| lint-check | | 21s |

The unit camp still runs at commit time, so the fast feedback loop is unchanged. What moved to CI is
the 6m30s of slow camps that CI was going to run anyway.

## Why the local run was not buying much

The same suite ran three times per push: unit at commit, everything at push, everything again on CI
10 to 12 minutes later. A nine-line test fix on PR #116 cost about 37 minutes of waiting for that
reason.

It also could not do the job it was there for. This hook tests the **working tree**; CI tests the
**commit**. On PR #116 the local gate passed and CI failed, on an edit that was never staged. A local
copy of a check cannot substitute for one that examines a different artifact.

## Effect of merging

Pushes get ~7 minutes cheaper, and rework rounds get ~7 minutes cheaper each. Coverage is unchanged:
every test that ran before still runs on CI before anything reaches `main`.

The tradeoff is that a broken integration or e2e test is now discovered on CI rather than before the
push. That was already true for anyone who ran `git push --no-verify`, and `just ship` covers the case
where local confirmation is wanted first.