### PR TITLE
fix(gitconfig): make merge.tool, core.excludesfile and the url rewrites name real things

### DIFF
--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -1,0 +1,15 @@
+# Global git ignores.
+#
+# git reads this path by default: core.excludesFile defaults to
+# $XDG_CONFIG_HOME/git/ignore, and both dot_bashrc.tmpl and dot_profile export
+# XDG_CONFIG_HOME=$HOME/.config. dot_gitconfig.tmpl therefore sets no
+# core.excludesfile key; setting one would shadow this file.
+#
+# What belongs here: artifacts of THIS machine and of the tools run on it, which
+# turn up in every repository and are nobody's project content. What does not:
+# anything a project should carry for every contributor. That goes in the
+# project's own .gitignore.
+
+# Per-machine Claude Code overrides. A session writes this into whichever
+# repository it runs in, including repositories owned by other people.
+**/.claude/settings.local.json

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -60,15 +60,23 @@
 # (LOCAL BASE REMOTE MERGED) and lets git read the resolution back out of
 # MERGED. A two-file `nvim -d "$LOCAL" "$REMOTE"` never opens MERGED, so nothing
 # done in it would reach the conflicted file.
+#
+# There is deliberately no mergetool.nvimdiff.path either, and adding one is a
+# regression, not hardening. Read from git-mergetool--lib (get_merge_tool_path)
+# and mergetools/vimdiff (translate_merge_tool_path) on git 2.55.0, then
+# measured on a real conflict:
+#   without the key, git translates the tool name nvimdiff to a bare `nvim` and
+#     resolves it with `type`, i.e. a $PATH lookup, which is the same assumption
+#     core.editor = nvim above already makes;
+#   with the key, that $PATH lookup is replaced by a literal filesystem path and
+#     there is no fallback, so a different Homebrew prefix aborts the merge with
+#     "The merge tool nvimdiff is not available as '<path>'" even when a working
+#     nvim is on $PATH, leaving the file conflicted.
+# The key changes nothing in diff mode: difftool.nvimdiff.cmd below is non-empty,
+# which is what makes git skip the availability check there entirely.
 [difftool "nvimdiff"]
   # Shadows the built-in nvimdiff diff command, for `git difftool` only.
   cmd = /opt/homebrew/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"
-
-[mergetool "nvimdiff"]
-  # The built-in resolves its binary as a bare `nvim` on $PATH and aborts with
-  # "The merge tool nvimdiff is not available as 'nvim'" when that misses. Pin
-  # the same absolute path the difftool command above spells out.
-  path = /opt/homebrew/bin/nvim
 
 [diff]
   submodule = log

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -15,7 +15,14 @@
 [core]
   editor = nvim
   autocrlf = input
-  excludesfile = ~/.gitignore_global
+  # No core.excludesfile on purpose. It used to name ~/.gitignore_global, which
+  # nothing in this repo deploys and which does not exist on the machine, and a
+  # missing excludesfile does not fall back: measured with `git check-ignore -v`,
+  # the setting suppressed global ignores entirely and shadowed the patterns
+  # already sitting in ~/.config/git/ignore. Leaving the key unset lets git use
+  # its documented default, $XDG_CONFIG_HOME/git/ignore, which both
+  # dot_bashrc.tmpl and dot_profile resolve to ~/.config, and which this repo now
+  # ships as dot_config/git/ignore.
   pager = delta
   hooksPath = ~/.config/git/hooks
   fsmonitor = true

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -72,8 +72,12 @@
 #     there is no fallback, so a different Homebrew prefix aborts the merge with
 #     "The merge tool nvimdiff is not available as '<path>'" even when a working
 #     nvim is on $PATH, leaving the file conflicted.
-# The key changes nothing in diff mode: difftool.nvimdiff.cmd below is non-empty,
-# which is what makes git skip the availability check there entirely.
+# A difftool.<name>.path key is inert here only for as long as the
+# difftool.nvimdiff.cmd below stays non-empty, since a non-empty cmd is what
+# makes git skip the availability check in diff mode. Remove the cmd and the same
+# abort appears on that side too (measured: git difftool exits 128 with "The diff
+# tool nvimdiff is not available as '<path>'"), so neither key is safe to add.
+# test/unit/gitconfig-tool-and-url-hygiene.sh asserts that both stay absent.
 [difftool "nvimdiff"]
   # Shadows the built-in nvimdiff diff command, for `git difftool` only.
   cmd = /opt/homebrew/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -133,28 +133,36 @@
   helper =
   helper = !/opt/homebrew/bin/gh auth git-credential
 
-# Reference: https://github.com/jessfraz/dotfiles/blob/30c4d026bfc71df60f7b05d0bdbb3cc34049c017/.gitconfig#L159
-[url "git@github.com:github"]
-  insteadOf = "https://github.com/github"
-  insteadOf = "github:github"
-  insteadOf = "git://github.com/github"
-
+# Shorthand and legacy-URL rewrites. Every one of them lands on SSH, because SSH
+# and HTTPS are the only transports GitHub still answers. GitHub permanently
+# disabled the unauthenticated git:// protocol on 2022-03-15: "The deprecated
+# MACs, ciphers, and unencrypted Git protocol will be permanently disabled"
+# (https://github.blog/security/application-security/improving-git-protocol-security-github/).
+#
+# What this replaces, traced with `git remote -v` and `git ls-remote --get-url`
+# over every input the old sections matched:
+#   - `github:` and `gist:` rewrote to git:// on FETCH while pushing over SSH, so
+#     both shorthands could push to a repository they could never clone.
+#   - A literal git:// URL was rewritten on PUSH only, which is the one direction
+#     git:// never supported; the fetch that actually breaks was left alone.
+#   - A separate [url "git@github.com:github"] section mapped the github org
+#     specially. Under the generic rules below each of its three inputs resolves
+#     to the identical URL, so it was doing nothing.
+#
+# insteadOf rewrites BOTH directions, and each base here accepts pushes, so the
+# pushInsteadOf lines these replace are unnecessary: measured over all nine
+# inputs, the resulting push URLs are unchanged. insteadOf also still applies
+# when a remote sets an explicit pushurl, which pushInsteadOf is documented to
+# skip.
 [url "git@github.com:"]
-  pushInsteadOf = "https://github.com/"
-  pushInsteadOf = "github:"
-  pushInsteadOf = "git://github.com/"
   insteadOf = https://github.com/
-
-[url "git://github.com/"]
   insteadOf = "github:"
+  insteadOf = "git://github.com/"
 
 [url "git@gist.github.com:"]
-  insteadOf = "gst:"
-  pushInsteadOf = "gist:"
-  pushInsteadOf = "git://gist.github.com/"
-
-[url "git://gist.github.com/"]
   insteadOf = "gist:"
+  insteadOf = "gst:"
+  insteadOf = "git://gist.github.com/"
 
 [include]
   path = ~/.config/delta/themes.gitconfig

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -36,8 +36,32 @@
 [status]
   submodulesummary = true
 
+# diff.tool and merge.tool take a tool NAME, never a command. Measured on git
+# 2.55.0: with a command string in merge.tool, `git mergetool` prints
+#     git config option merge.tool set to unknown tool: <the whole string>
+#     Resetting to default...
+# then guesses a tool and offers `vimdiff`, so conflicts open in Vim rather than
+# Neovim. A command belongs in <difftool|mergetool>.<name>.cmd instead.
+#
+# `nvimdiff` is a git built-in name (`git mergetool --tool-help`), used below for
+# both modes. Git resolves the two modes from separate keys, so the difftool cmd
+# here governs `git difftool` alone and merges never see it:
+#   diff mode : difftool.<name>.cmd, else mergetool.<name>.cmd, else the built-in
+#   merge mode: mergetool.<name>.cmd, else the built-in
+# There is deliberately NO mergetool.nvimdiff.cmd. A cmd key replaces the
+# built-in outright, and the built-in is what opens all four buffers
+# (LOCAL BASE REMOTE MERGED) and lets git read the resolution back out of
+# MERGED. A two-file `nvim -d "$LOCAL" "$REMOTE"` never opens MERGED, so nothing
+# done in it would reach the conflicted file.
 [difftool "nvimdiff"]
+  # Shadows the built-in nvimdiff diff command, for `git difftool` only.
   cmd = /opt/homebrew/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"
+
+[mergetool "nvimdiff"]
+  # The built-in resolves its binary as a bare `nvim` on $PATH and aborts with
+  # "The merge tool nvimdiff is not available as 'nvim'" when that misses. Pin
+  # the same absolute path the difftool command above spells out.
+  path = /opt/homebrew/bin/nvim
 
 [diff]
   submodule = log
@@ -47,7 +71,7 @@
 
 [merge]
   conflictstyle = zdiff3
-  tool = /opt/homebrew/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"
+  tool = nvimdiff
 
 # Union-merges the committed graphify map (wired via .gitattributes in the
 # dotfiles repo: graphify-out/graph.json merge=graphify-union).

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19611,7 +19611,7 @@
       "label": "GIT_CONFIG_NOSYSTEM",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19625,7 +19625,7 @@
       "label": "GIT_PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19639,7 +19639,7 @@
       "label": "PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19653,7 +19653,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L54",
+      "source_location": "L80",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19667,7 +19667,7 @@
       "label": "list_chezmoi_delivered_target_paths()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L64",
+      "source_location": "L90",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19681,7 +19681,7 @@
       "label": "chezmoi_delivers_target_path()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L73",
+      "source_location": "L99",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19692,10 +19692,38 @@
       "norm_label": "chezmoi_delivers_target_path()"
     },
     {
+      "label": "is_tool_binary_path_key()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L106",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
+      "community": 365,
+      "norm_label": "is_tool_binary_path_key()"
+    },
+    {
+      "label": "classify_core_excludesfile()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L114",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_classify_core_excludesfile",
+      "community": 365,
+      "norm_label": "classify_core_excludesfile()"
+    },
+    {
       "label": "git_resolves_tool_name()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L79",
+      "source_location": "L129",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -64868,7 +64896,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L73",
+      "source_location": "L99",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
@@ -64878,7 +64906,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L54",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_core_excludesfile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L80",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
@@ -64888,7 +64926,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_config_nosystem",
@@ -64898,7 +64936,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_pager",
@@ -64908,7 +64946,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L79",
+      "source_location": "L129",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
@@ -64918,7 +64956,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L64",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L90",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_list_chezmoi_delivered_target_paths",
@@ -64928,7 +64976,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L52",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_pager",
@@ -64948,7 +64996,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L131",
+      "source_location": "L184",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -64959,7 +65007,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L88",
+      "source_location": "L138",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -64970,11 +65018,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L118",
+      "source_location": "L168",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L174",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
       "confidence_score": 1.0
     },
     {
@@ -87365,5 +87424,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "ecfbf88b44f09f5e0141845a4fc03a9838c1a2ec"
+  "built_at_commit": "aee33ef48b99feb72caee0282381c9b16e397f53"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -19611,7 +19611,7 @@
       "label": "GIT_CONFIG_NOSYSTEM",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L97",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19625,7 +19625,7 @@
       "label": "GIT_PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L97",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19639,7 +19639,7 @@
       "label": "PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L97",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -19653,7 +19653,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L80",
+      "source_location": "L99",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19667,7 +19667,7 @@
       "label": "list_chezmoi_delivered_target_paths()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L90",
+      "source_location": "L109",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19678,24 +19678,80 @@
       "norm_label": "list_chezmoi_delivered_target_paths()"
     },
     {
-      "label": "chezmoi_delivers_target_path()",
+      "label": "listing_contains_target_path()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L99",
+      "source_location": "L119",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_listing_contains_target_path",
       "community": 365,
-      "norm_label": "chezmoi_delivers_target_path()"
+      "norm_label": "listing_contains_target_path()"
+    },
+    {
+      "label": "classify_path_resolution()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L130",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_classify_path_resolution",
+      "community": 365,
+      "norm_label": "classify_path_resolution()"
+    },
+    {
+      "label": "classify_delivered_target_path()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L152",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
+      "community": 365,
+      "norm_label": "classify_delivered_target_path()"
+    },
+    {
+      "label": "explain_rejected_delivery()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L168",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_explain_rejected_delivery",
+      "community": 365,
+      "norm_label": "explain_rejected_delivery()"
+    },
+    {
+      "label": "require_delivered_readable_file()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L198",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
+      "community": 365,
+      "norm_label": "require_delivered_readable_file()"
     },
     {
       "label": "is_tool_binary_path_key()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L106",
+      "source_location": "L208",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19709,7 +19765,7 @@
       "label": "classify_core_excludesfile()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L114",
+      "source_location": "L216",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19723,7 +19779,7 @@
       "label": "git_resolves_tool_name()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L129",
+      "source_location": "L231",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19732,6 +19788,48 @@
       "id": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
       "community": 365,
       "norm_label": "git_resolves_tool_name()"
+    },
+    {
+      "label": "assert_path_resolution()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L301",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
+      "community": 365,
+      "norm_label": "assert_path_resolution()"
+    },
+    {
+      "label": "assert_delivered_classification()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L318",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
+      "community": 365,
+      "norm_label": "assert_delivered_classification()"
+    },
+    {
+      "label": "assert_guard_verdict()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L337",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
+      "community": 365,
+      "norm_label": "assert_guard_verdict()"
     },
     {
       "label": "herdr-build-input-hashing.sh",
@@ -64896,17 +64994,37 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L99",
+      "source_location": "L318",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
-      "target": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L114",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L301",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L216",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_core_excludesfile",
@@ -64916,7 +65034,37 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L80",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_path_resolution",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L168",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_explain_rejected_delivery",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L99",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
@@ -64926,7 +65074,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L97",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_config_nosystem",
@@ -64936,7 +65084,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L97",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_pager",
@@ -64946,7 +65094,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L129",
+      "source_location": "L231",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
@@ -64956,7 +65104,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L106",
+      "source_location": "L208",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
@@ -64966,7 +65114,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L90",
+      "source_location": "L109",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_list_chezmoi_delivered_target_paths",
@@ -64976,10 +65124,30 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L78",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_listing_contains_target_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L97",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_pager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
       "confidence_score": 1.0
     },
     {
@@ -64996,18 +65164,40 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L184",
+      "source_location": "L325",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
-      "target": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L138",
+      "source_location": "L349",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L307",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L240",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -65018,7 +65208,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L168",
+      "source_location": "L275",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -65029,11 +65219,99 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L174",
+      "source_location": "L281",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L358",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L323",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L347",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L305",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L203",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L154",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_listing_contains_target_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L159",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_path_resolution",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L342",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
       "confidence_score": 1.0
     },
     {
@@ -87424,5 +87702,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "aee33ef48b99feb72caee0282381c9b16e397f53"
+  "built_at_commit": "c761394a19e8c4844e47ff3ca5370563ef887ac8"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -4,32 +4,60 @@
   "graph": {},
   "nodes": [
     {
-      "label": "run_after_05-osquery-pipeline-manifest.sh",
+      "label": "run_after_05-osquery-known-good-manifests.sh",
       "file_type": "code",
-      "source_file": ".chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
       "source_location": "L1",
       "metadata": {
         "language": "bash",
         "kind": "file"
       },
       "_origin": "ast",
-      "id": "chezmoiscripts_run_after_05_osquery_pipeline_manifest",
-      "community": 354,
-      "norm_label": "run_after_05-osquery-pipeline-manifest.sh"
+      "id": "chezmoiscripts_run_after_05_osquery_known_good_manifests",
+      "community": 381,
+      "norm_label": "run_after_05-osquery-known-good-manifests.sh"
     },
     {
-      "label": "run_after_05-osquery-pipeline-manifest.sh script",
+      "label": "run_after_05-osquery-known-good-manifests.sh script",
       "file_type": "code",
-      "source_file": ".chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
       "source_location": "L1",
       "metadata": {
         "language": "bash",
         "kind": "bash_entrypoint"
       },
       "_origin": "ast",
-      "id": "chezmoiscripts_run_after_05_osquery_pipeline_manifest_sh__entry",
-      "community": 354,
-      "norm_label": "run_after_05-osquery-pipeline-manifest.sh script"
+      "id": "chezmoiscripts_run_after_05_osquery_known_good_manifests_sh__entry",
+      "community": 381,
+      "norm_label": "run_after_05-osquery-known-good-manifests.sh script"
+    },
+    {
+      "label": "intended_perm",
+      "file_type": "code",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
+      "source_location": "L258",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "chezmoiscripts_run_after_05_osquery_known_good_manifests_intended_perm",
+      "community": 381,
+      "norm_label": "intended_perm"
+    },
+    {
+      "label": "refresh_manifest()",
+      "file_type": "code",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
+      "source_location": "L293",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "chezmoiscripts_run_after_05_osquery_known_good_manifests_refresh_manifest",
+      "community": 381,
+      "norm_label": "refresh_manifest()"
     },
     {
       "label": ".install-password-manager.sh",
@@ -1151,7 +1179,7 @@
       "label": "usage()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L23",
+      "source_location": "L33",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1193,7 +1221,7 @@
       "label": "normalize()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L25",
+      "source_location": "L32",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1207,7 +1235,7 @@
       "label": "print_header()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L41",
+      "source_location": "L52",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1342,6 +1370,608 @@
       "id": "dot_local_bin_executable_ssh_hardening_sh__entry",
       "community": 263,
       "norm_label": "executable_ssh-hardening.sh script"
+    },
+    {
+      "label": "die()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L180",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_die",
+      "community": 263,
+      "norm_label": "die()"
+    },
+    {
+      "label": "warn()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L185",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_warn",
+      "community": 263,
+      "norm_label": "warn()"
+    },
+    {
+      "label": "run_privileged()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L189",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_run_privileged",
+      "community": 263,
+      "norm_label": "run_privileged()"
+    },
+    {
+      "label": "dropin_path()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L197",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_dropin_path",
+      "community": 263,
+      "norm_label": "dropin_path()"
+    },
+    {
+      "label": "print_config()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L201",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_print_config",
+      "community": 263,
+      "norm_label": "print_config()"
+    },
+    {
+      "label": "run_verify_child()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L280",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_run_verify_child",
+      "community": 263,
+      "norm_label": "run_verify_child()"
+    },
+    {
+      "label": "verify_skip_allowed()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L294",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
+      "community": 263,
+      "norm_label": "verify_skip_allowed()"
+    },
+    {
+      "label": "add_failure()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L305",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "community": 263,
+      "norm_label": "add_failure()"
+    },
+    {
+      "label": "canonical_key()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L332",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_canonical_key",
+      "community": 263,
+      "norm_label": "canonical_key()"
+    },
+    {
+      "label": "required_value()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L343",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_required_value",
+      "community": 263,
+      "norm_label": "required_value()"
+    },
+    {
+      "label": "assert_output_hardened()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L359",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
+      "community": 263,
+      "norm_label": "assert_output_hardened()"
+    },
+    {
+      "label": "check_global()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L377",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_check_global",
+      "community": 263,
+      "norm_label": "check_global()"
+    },
+    {
+      "label": "trim_trailing_line_whitespace()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L471",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_trim_trailing_line_whitespace",
+      "community": 263,
+      "norm_label": "trim_trailing_line_whitespace()"
+    },
+    {
+      "label": "skip_keyword_separators()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L482",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_skip_keyword_separators",
+      "community": 263,
+      "norm_label": "skip_keyword_separators()"
+    },
+    {
+      "label": "consume_keyword_separator()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L498",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
+      "community": 263,
+      "norm_label": "consume_keyword_separator()"
+    },
+    {
+      "label": "read_keyword_token()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L510",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
+      "community": 263,
+      "norm_label": "read_keyword_token()"
+    },
+    {
+      "label": "skip_argument_separators()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L551",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_skip_argument_separators",
+      "community": 263,
+      "norm_label": "skip_argument_separators()"
+    },
+    {
+      "label": "read_argument_token()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L563",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_read_argument_token",
+      "community": 263,
+      "norm_label": "read_argument_token()"
+    },
+    {
+      "label": "read_token_with_progress_guard()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L639",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_read_token_with_progress_guard",
+      "community": 263,
+      "norm_label": "read_token_with_progress_guard()"
+    },
+    {
+      "label": "next_keyword_token()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L648",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
+      "community": 263,
+      "norm_label": "next_keyword_token()"
+    },
+    {
+      "label": "next_argument_token()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L652",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_next_argument_token",
+      "community": 263,
+      "norm_label": "next_argument_token()"
+    },
+    {
+      "label": "parse_config_line()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L661",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "community": 263,
+      "norm_label": "parse_config_line()"
+    },
+    {
+      "label": "include_bracket_opens_a_set()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L737",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_include_bracket_opens_a_set",
+      "community": 263,
+      "norm_label": "include_bracket_opens_a_set()"
+    },
+    {
+      "label": "unescape_include_pattern()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L774",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
+      "community": 263,
+      "norm_label": "unescape_include_pattern()"
+    },
+    {
+      "label": "scan_included_files()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L827",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_scan_included_files",
+      "community": 263,
+      "norm_label": "scan_included_files()"
+    },
+    {
+      "label": "scan_config_file()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L884",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "community": 263,
+      "norm_label": "scan_config_file()"
+    },
+    {
+      "label": "check_match_scan()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L940",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_check_match_scan",
+      "community": 263,
+      "norm_label": "check_match_scan()"
+    },
+    {
+      "label": "check_connection_specs()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L985",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
+      "community": 263,
+      "norm_label": "check_connection_specs()"
+    },
+    {
+      "label": "verify()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1014",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_verify",
+      "community": 263,
+      "norm_label": "verify()"
+    },
+    {
+      "label": "rollback_install()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1064",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_rollback_install",
+      "community": 263,
+      "norm_label": "rollback_install()"
+    },
+    {
+      "label": "install_dropin()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1087",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "community": 263,
+      "norm_label": "install_dropin()"
+    },
+    {
+      "label": "recovery_instructions()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1181",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_recovery_instructions",
+      "community": 263,
+      "norm_label": "recovery_instructions()"
+    },
+    {
+      "label": "probe_sshd_service()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1200",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_probe_sshd_service",
+      "community": 263,
+      "norm_label": "probe_sshd_service()"
+    },
+    {
+      "label": "validate_readiness_knobs()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1230",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
+      "community": 263,
+      "norm_label": "validate_readiness_knobs()"
+    },
+    {
+      "label": "resolve_probe_ports()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1278",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
+      "community": 263,
+      "norm_label": "resolve_probe_ports()"
+    },
+    {
+      "label": "banner_output_names_host_key()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1332",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_banner_output_names_host_key",
+      "community": 263,
+      "norm_label": "banner_output_names_host_key()"
+    },
+    {
+      "label": "wait_for_ssh_banner()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1347",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
+      "community": 263,
+      "norm_label": "wait_for_ssh_banner()"
+    },
+    {
+      "label": "reload_sshd()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1373",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "community": 263,
+      "norm_label": "reload_sshd()"
+    },
+    {
+      "label": "check_password_channel()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1500",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_check_password_channel",
+      "community": 263,
+      "norm_label": "check_password_channel()"
+    },
+    {
+      "label": "confirm_password_access_restored()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1542",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "community": 263,
+      "norm_label": "confirm_password_access_restored()"
+    },
+    {
+      "label": "rollback_dropin()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1581",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "community": 263,
+      "norm_label": "rollback_dropin()"
+    },
+    {
+      "label": "usage()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1599",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_usage",
+      "community": 263,
+      "norm_label": "usage()"
+    },
+    {
+      "label": "main()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1622",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_main",
+      "community": 263,
+      "norm_label": "main()"
     },
     {
       "label": "executable_update-skills.sh",
@@ -2506,6 +3136,272 @@
       "norm_label": "check_fork_drift()"
     },
     {
+      "label": "macos-defaults-lib.sh",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib",
+      "community": 351,
+      "norm_label": "macos-defaults-lib.sh"
+    },
+    {
+      "label": "macos-defaults-lib.sh script",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_sh__entry",
+      "community": 351,
+      "norm_label": "macos-defaults-lib.sh script"
+    },
+    {
+      "label": "resolve_source_dir()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L45",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_resolve_source_dir",
+      "community": 351,
+      "norm_label": "resolve_source_dir()"
+    },
+    {
+      "label": "macos_defaults_data_file()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L81",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_macos_defaults_data_file",
+      "community": 351,
+      "norm_label": "macos_defaults_data_file()"
+    },
+    {
+      "label": "require_readable_data_file()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L94",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_require_readable_data_file",
+      "community": 351,
+      "norm_label": "require_readable_data_file()"
+    },
+    {
+      "label": "defaults_records_join_expression()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L115",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_join_expression",
+      "community": 351,
+      "norm_label": "defaults_records_join_expression()"
+    },
+    {
+      "label": "defaults_records_field_count()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L124",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_field_count",
+      "community": 351,
+      "norm_label": "defaults_records_field_count()"
+    },
+    {
+      "label": "defaults_records_locate_malformed()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L133",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_locate_malformed",
+      "community": 351,
+      "norm_label": "defaults_records_locate_malformed()"
+    },
+    {
+      "label": "defaults_records_declared_count()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L191",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_declared_count",
+      "community": 351,
+      "norm_label": "defaults_records_declared_count()"
+    },
+    {
+      "label": "defaults_records_raw_stream()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L236",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_raw_stream",
+      "community": 351,
+      "norm_label": "defaults_records_raw_stream()"
+    },
+    {
+      "label": "defaults_records_validate_stream()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L253",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_validate_stream",
+      "community": 351,
+      "norm_label": "defaults_records_validate_stream()"
+    },
+    {
+      "label": "defaults_records_unit_separated()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L292",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
+      "community": 351,
+      "norm_label": "defaults_records_unit_separated()"
+    },
+    {
+      "label": "validate_record_scope()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L318",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_record_scope",
+      "community": 351,
+      "norm_label": "validate_record_scope()"
+    },
+    {
+      "label": "validate_system_domain()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L351",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_system_domain",
+      "community": 351,
+      "norm_label": "validate_system_domain()"
+    },
+    {
+      "label": "validate_explicit_plist_path()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L384",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_explicit_plist_path",
+      "community": 351,
+      "norm_label": "validate_explicit_plist_path()"
+    },
+    {
+      "label": "resolve_system_plist_path()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L416",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
+      "community": 351,
+      "norm_label": "resolve_system_plist_path()"
+    },
+    {
+      "label": "require_system_plist_path_permitted()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L445",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_require_system_plist_path_permitted",
+      "community": 351,
+      "norm_label": "require_system_plist_path_permitted()"
+    },
+    {
+      "label": "system_defaults_write()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L492",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_system_defaults_write",
+      "community": 351,
+      "norm_label": "system_defaults_write()"
+    },
+    {
+      "label": "system_defaults_read_actual()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L523",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_system_defaults_read_actual",
+      "community": 351,
+      "norm_label": "system_defaults_read_actual()"
+    },
+    {
       "label": "executable_alert-dispatch.sh",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
@@ -2845,7 +3741,7 @@
       "label": "_osquery_notify_local_durable()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L817",
+      "source_location": "L829",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2859,7 +3755,7 @@
       "label": "_osquery_hex_to_text()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L850",
+      "source_location": "L862",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2873,7 +3769,7 @@
       "label": "_osquery_pending_local_notification_rows()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L864",
+      "source_location": "L876",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2887,7 +3783,7 @@
       "label": "_osquery_epoch_to_iso8601()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L877",
+      "source_location": "L889",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2901,7 +3797,7 @@
       "label": "_osquery_delete_local_notification_row()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L889",
+      "source_location": "L901",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2915,7 +3811,7 @@
       "label": "_osquery_expire_over_age_local_notifications()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L916",
+      "source_location": "L928",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2929,7 +3825,7 @@
       "label": "_redeliver_pending_local_notification()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L953",
+      "source_location": "L965",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2943,7 +3839,7 @@
       "label": "_drain_pending_local_notifications()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L987",
+      "source_location": "L999",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2957,7 +3853,7 @@
       "label": "_read_webhook_secret()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1004",
+      "source_location": "L1016",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2971,7 +3867,7 @@
       "label": "_post_alert_to_webhook()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1017",
+      "source_location": "L1029",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2985,7 +3881,7 @@
       "label": "retry_undelivered_alerts()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1032",
+      "source_location": "L1044",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2999,7 +3895,7 @@
       "label": "osquery_pending_alert_count()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1069",
+      "source_location": "L1081",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3013,7 +3909,7 @@
       "label": "osquery_dead_letter_count()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1078",
+      "source_location": "L1090",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3027,7 +3923,7 @@
       "label": "_build_webhook_body()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1089",
+      "source_location": "L1101",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3041,7 +3937,7 @@
       "label": "_derive_request_id()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1099",
+      "source_location": "L1111",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3055,7 +3951,7 @@
       "label": "_attempt_alert_delivery()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1108",
+      "source_location": "L1120",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3069,7 +3965,7 @@
       "label": "send_alert()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1150",
+      "source_location": "L1162",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3111,7 +4007,7 @@
       "label": "usage()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L26",
+      "source_location": "L36",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3125,7 +4021,7 @@
       "label": "take_allowlist_write_lock()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L47",
+      "source_location": "L57",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3139,7 +4035,7 @@
       "label": "entry_label()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L63",
+      "source_location": "L73",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3153,7 +4049,7 @@
       "label": "_without_label()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L67",
+      "source_location": "L77",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3164,10 +4060,52 @@
       "norm_label": "_without_label()"
     },
     {
+      "label": "allowlist_source_path()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L118",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_allowlist_allowlist_source_path",
+      "community": 291,
+      "norm_label": "allowlist_source_path()"
+    },
+    {
+      "label": "manifest_runner_path()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L124",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_allowlist_manifest_runner_path",
+      "community": 291,
+      "norm_label": "manifest_runner_path()"
+    },
+    {
+      "label": "publish_allowlist()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L150",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_allowlist_publish_allowlist",
+      "community": 291,
+      "norm_label": "publish_allowlist()"
+    },
+    {
       "label": "is_valid_label()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L85",
+      "source_location": "L189",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3181,7 +4119,7 @@
       "label": "allow_label()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L94",
+      "source_location": "L198",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3195,7 +4133,7 @@
       "label": "deny_label()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L143",
+      "source_location": "L254",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3209,7 +4147,7 @@
       "label": "list_entries()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L164",
+      "source_location": "L283",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3293,7 +4231,7 @@
       "label": "numeric_or()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L31",
+      "source_location": "L35",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3307,7 +4245,7 @@
       "label": "rotated_work_file()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L40",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3321,7 +4259,7 @@
       "label": "restore_batch()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L49",
+      "source_location": "L53",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3335,7 +4273,7 @@
       "label": "rotate_to_last()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L58",
+      "source_location": "L62",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3349,7 +4287,7 @@
       "label": "digest_title()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L69",
+      "source_location": "L73",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3363,7 +4301,7 @@
       "label": "render_digest_body()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L91",
+      "source_location": "L95",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3377,7 +4315,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L145",
+      "source_location": "L149",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3419,7 +4357,7 @@
       "label": "take_single_instance_lock()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L57",
+      "source_location": "L59",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3433,7 +4371,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L71",
+      "source_location": "L103",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3542,10 +4480,178 @@
       "norm_label": "executable_firewall-gatekeeper-monitor.sh script"
     },
     {
+      "label": "sanitize()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L66",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sanitize",
+      "community": 296,
+      "norm_label": "sanitize()"
+    },
+    {
+      "label": "sanitize_span()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L85",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sanitize_span",
+      "community": 296,
+      "norm_label": "sanitize_span()"
+    },
+    {
+      "label": "run_bounded()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L106",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_run_bounded",
+      "community": 296,
+      "norm_label": "run_bounded()"
+    },
+    {
+      "label": "reader_domain()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L143",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_domain",
+      "community": 296,
+      "norm_label": "reader_domain()"
+    },
+    {
+      "label": "reader_requires_target()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L156",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_requires_target",
+      "community": 296,
+      "norm_label": "reader_requires_target()"
+    },
+    {
+      "label": "reader_reads_lulu_base_rules()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L168",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_reads_lulu_base_rules",
+      "community": 296,
+      "norm_label": "reader_reads_lulu_base_rules()"
+    },
+    {
+      "label": "classify_probe()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L185",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_probe",
+      "community": 296,
+      "norm_label": "classify_probe()"
+    },
+    {
+      "label": "classify_pgrep()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L220",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_pgrep",
+      "community": 296,
+      "norm_label": "classify_pgrep()"
+    },
+    {
+      "label": "lulu_base_rules_authoritative()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L246",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_base_rules_authoritative",
+      "community": 296,
+      "norm_label": "lulu_base_rules_authoritative()"
+    },
+    {
+      "label": "lulu_rule_in_archive()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L276",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_rule_in_archive",
+      "community": 296,
+      "norm_label": "lulu_rule_in_archive()"
+    },
+    {
+      "label": "read_control()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L316",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "community": 296,
+      "norm_label": "read_control()"
+    },
+    {
+      "label": "load_controls()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L451",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_load_controls",
+      "community": 296,
+      "norm_label": "load_controls()"
+    },
+    {
       "label": "page_gap_once()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L68",
+      "source_location": "L602",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3559,7 +4665,7 @@
       "label": "write_state()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L127",
+      "source_location": "L802",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3573,7 +4679,7 @@
       "label": "persist_baseline()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L143",
+      "source_location": "L818",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3587,7 +4693,7 @@
       "label": "page_crit_and_persist()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L162",
+      "source_location": "L837",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3598,10 +4704,24 @@
       "norm_label": "page_crit_and_persist()"
     },
     {
+      "label": "control_block()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L856",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_control_block",
+      "community": 296,
+      "norm_label": "control_block()"
+    },
+    {
       "label": "fw_to_text()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L204",
+      "source_location": "L911",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3615,7 +4735,7 @@
       "label": "gk_to_text()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L212",
+      "source_location": "L919",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3629,7 +4749,7 @@
       "label": "sl_to_text()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L219",
+      "source_location": "L926",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3671,7 +4791,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_heartbeat.sh",
-      "source_location": "L36",
+      "source_location": "L40",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3680,6 +4800,104 @@
       "id": "dot_local_libexec_osquery_executable_heartbeat_main",
       "community": 340,
       "norm_label": "main()"
+    },
+    {
+      "label": "executable_pipeline-audit.sh",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "community": 367,
+      "norm_label": "executable_pipeline-audit.sh"
+    },
+    {
+      "label": "executable_pipeline-audit.sh script",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_sh__entry",
+      "community": 367,
+      "norm_label": "executable_pipeline-audit.sh script"
+    },
+    {
+      "label": "_pipeline_audit_clamp()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L98",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_clamp",
+      "community": 367,
+      "norm_label": "_pipeline_audit_clamp()"
+    },
+    {
+      "label": "_pipeline_audit_now()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L113",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_now",
+      "community": 367,
+      "norm_label": "_pipeline_audit_now()"
+    },
+    {
+      "label": "_pipeline_audit_size()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L120",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_size",
+      "community": 367,
+      "norm_label": "_pipeline_audit_size()"
+    },
+    {
+      "label": "pipeline_audit_scan()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L170",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan",
+      "community": 367,
+      "norm_label": "pipeline_audit_scan()"
+    },
+    {
+      "label": "_pipeline_audit_scan_manifest()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L207",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan_manifest",
+      "community": 367,
+      "norm_label": "_pipeline_audit_scan_manifest()"
     },
     {
       "label": "executable_results-alerter.sh",
@@ -3895,7 +5113,7 @@
       "label": "write_state()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_uptime-watchdog.sh",
-      "source_location": "L68",
+      "source_location": "L92",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3909,7 +5127,7 @@
       "label": "field_raw()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_uptime-watchdog.sh",
-      "source_location": "L84",
+      "source_location": "L108",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3930,7 +5148,7 @@
       },
       "_origin": "ast",
       "id": "dot_local_libexec_osquery_results_alerter_allowlist_verdict",
-      "community": 323,
+      "community": 302,
       "norm_label": "allowlist-verdict.sh"
     },
     {
@@ -3944,7 +5162,7 @@
       },
       "_origin": "ast",
       "id": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_sh__entry",
-      "community": 323,
+      "community": 302,
       "norm_label": "allowlist-verdict.sh script"
     },
     {
@@ -3958,21 +5176,35 @@
       },
       "_origin": "ast",
       "id": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_verdict_expand_home",
-      "community": 323,
+      "community": 302,
       "norm_label": "_allowlist_verdict_expand_home()"
+    },
+    {
+      "label": "_allowlist_path_is_manifest_vouched()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh",
+      "source_location": "L58",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_path_is_manifest_vouched",
+      "community": 302,
+      "norm_label": "_allowlist_path_is_manifest_vouched()"
     },
     {
       "label": "allowlist_verdict()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh",
-      "source_location": "L32",
+      "source_location": "L73",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
       "id": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_verdict",
-      "community": 323,
+      "community": 302,
       "norm_label": "allowlist_verdict()"
     },
     {
@@ -4007,7 +5239,7 @@
       "label": "digest_append()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/digest-store.sh",
-      "source_location": "L22",
+      "source_location": "L28",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4049,7 +5281,7 @@
       "label": "normalize_findings()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/normalize.sh",
-      "source_location": "L31",
+      "source_location": "L41",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4091,7 +5323,7 @@
       "label": "_pipeline_now()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L70",
+      "source_location": "L149",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4105,7 +5337,7 @@
       "label": "_pipeline_mtime()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L77",
+      "source_location": "L156",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4116,10 +5348,52 @@
       "norm_label": "_pipeline_mtime()"
     },
     {
+      "label": "_pipeline_change_time()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L169",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_change_time",
+      "community": 311,
+      "norm_label": "_pipeline_change_time()"
+    },
+    {
+      "label": "_pipeline_file_mode()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L187",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_file_mode",
+      "community": 311,
+      "norm_label": "_pipeline_file_mode()"
+    },
+    {
+      "label": "_pipeline_file_uid()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L198",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_file_uid",
+      "community": 311,
+      "norm_label": "_pipeline_file_uid()"
+    },
+    {
       "label": "_pipeline_manifest_is_trustworthy()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L92",
+      "source_location": "L226",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4130,10 +5404,24 @@
       "norm_label": "_pipeline_manifest_is_trustworthy()"
     },
     {
+      "label": "_pipeline_manifest_for()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L278",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_for",
+      "community": 311,
+      "norm_label": "_pipeline_manifest_for()"
+    },
+    {
       "label": "_pipeline_manifest_has_tuple()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L112",
+      "source_location": "L285",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4144,24 +5432,24 @@
       "norm_label": "_pipeline_manifest_has_tuple()"
     },
     {
-      "label": "_pipeline_content_is_known_good()",
+      "label": "_pipeline_deployed_state_is_known_good()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L132",
+      "source_location": "L327",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_content_is_known_good",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_deployed_state_is_known_good",
       "community": 311,
-      "norm_label": "_pipeline_content_is_known_good()"
+      "norm_label": "_pipeline_deployed_state_is_known_good()"
     },
     {
       "label": "_pipeline_tuple_settles()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L146",
+      "source_location": "L350",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4175,7 +5463,7 @@
       "label": "_pipeline_is_tracked()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L184",
+      "source_location": "L396",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4186,10 +5474,24 @@
       "norm_label": "_pipeline_is_tracked()"
     },
     {
+      "label": "_managed_bin_is_tracked()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L434",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_managed_bin_is_tracked",
+      "community": 311,
+      "norm_label": "_managed_bin_is_tracked()"
+    },
+    {
       "label": "pipeline_verdict()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L199",
+      "source_location": "L453",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6112,10 +7414,24 @@
       "norm_label": "setup_allowlist_harness()"
     },
     {
+      "label": "setup_allowlist_chezmoi()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_allowlist_lib_setup_allowlist_chezmoi",
+      "community": 292,
+      "norm_label": "setup_allowlist_chezmoi()"
+    },
+    {
       "label": "teardown_allowlist_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L47",
+      "source_location": "L98",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6129,7 +7445,7 @@
       "label": "run_allowlist()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L52",
+      "source_location": "L103",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6140,10 +7456,52 @@
       "norm_label": "run_allowlist()"
     },
     {
+      "label": "source_entry_lines()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L115",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_allowlist_lib_source_entry_lines",
+      "community": 292,
+      "norm_label": "source_entry_lines()"
+    },
+    {
+      "label": "assert_manifest_refreshed()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L120",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_allowlist_lib_assert_manifest_refreshed",
+      "community": 292,
+      "norm_label": "assert_manifest_refreshed()"
+    },
+    {
+      "label": "refute_manifest_refreshed()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L127",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_allowlist_lib_refute_manifest_refreshed",
+      "community": 292,
+      "norm_label": "refute_manifest_refreshed()"
+    },
+    {
       "label": "seed_allowlist_tuple()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L61",
+      "source_location": "L141",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6157,7 +7515,7 @@
       "label": "assert_allowlisted()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L68",
+      "source_location": "L148",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6171,7 +7529,7 @@
       "label": "assert_not_allowlisted()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L75",
+      "source_location": "L155",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6185,7 +7543,7 @@
       "label": "allowlist_lock_is_free()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L85",
+      "source_location": "L165",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6199,7 +7557,7 @@
       "label": "assert_allowlist_label_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L91",
+      "source_location": "L171",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6241,7 +7599,7 @@
       "label": "manifest_fixture_setup()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L15",
+      "source_location": "L20",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6255,7 +7613,7 @@
       "label": "manifest_fixture_teardown()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L49",
+      "source_location": "L57",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6269,7 +7627,7 @@
       "label": "manifest_fixture_add_script()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L55",
+      "source_location": "L63",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6280,10 +7638,24 @@
       "norm_label": "manifest_fixture_add_script()"
     },
     {
+      "label": "manifest_fixture_add_bin_script()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L72",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_bin_script",
+      "community": 187,
+      "norm_label": "manifest_fixture_add_bin_script()"
+    },
+    {
       "label": "manifest_fixture_add_plist()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L64",
+      "source_location": "L78",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6294,10 +7666,24 @@
       "norm_label": "manifest_fixture_add_plist()"
     },
     {
+      "label": "manifest_fixture_add_config()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L86",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_config",
+      "community": 187,
+      "norm_label": "manifest_fixture_add_config()"
+    },
+    {
       "label": "manifest_fixture_chezmoi()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L69",
+      "source_location": "L91",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6311,7 +7697,7 @@
       "label": "manifest_fixture_apply()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L77",
+      "source_location": "L99",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6325,7 +7711,7 @@
       "label": "manifest_fixture_apply_mode()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L81",
+      "source_location": "L103",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6339,7 +7725,7 @@
       "label": "manifest_fixture_run_runner()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L89",
+      "source_location": "L111",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6353,7 +7739,7 @@
       "label": "manifest_fixture_installed()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L103",
+      "source_location": "L126",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6367,7 +7753,7 @@
       "label": "manifest_hash_of()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L106",
+      "source_location": "L134",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6378,10 +7764,80 @@
       "norm_label": "manifest_hash_of()"
     },
     {
+      "label": "manifest_mode_of()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L139",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_manifest_mode_of",
+      "community": 187,
+      "norm_label": "manifest_mode_of()"
+    },
+    {
+      "label": "manifest_uid_of()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L144",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_manifest_uid_of",
+      "community": 187,
+      "norm_label": "manifest_uid_of()"
+    },
+    {
+      "label": "bin_manifest_hash_of()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L152",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_bin_manifest_hash_of",
+      "community": 187,
+      "norm_label": "bin_manifest_hash_of()"
+    },
+    {
+      "label": "bin_manifest_mode_of()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L158",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_bin_manifest_mode_of",
+      "community": 187,
+      "norm_label": "bin_manifest_mode_of()"
+    },
+    {
+      "label": "bin_manifest_uid_of()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L161",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_manifest_lib_bin_manifest_uid_of",
+      "community": 187,
+      "norm_label": "bin_manifest_uid_of()"
+    },
+    {
       "label": "verdict_says_page()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L115",
+      "source_location": "L170",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6423,7 +7879,7 @@
       "label": "set_posture()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L30",
+      "source_location": "L32",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6434,10 +7890,24 @@
       "norm_label": "set_posture()"
     },
     {
+      "label": "set_posture_controls()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L40",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_poller_lib_set_posture_controls",
+      "community": 227,
+      "norm_label": "set_posture_controls()"
+    },
+    {
       "label": "setup_poller_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L34",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6451,7 +7921,7 @@
       "label": "teardown_poller_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L110",
+      "source_location": "L424",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6465,7 +7935,7 @@
       "label": "run_poller()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L119",
+      "source_location": "L435",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6479,7 +7949,7 @@
       "label": "assert_mode()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L128",
+      "source_location": "L455",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6493,7 +7963,7 @@
       "label": "assert_osqueryi_call_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L139",
+      "source_location": "L466",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6507,7 +7977,7 @@
       "label": "assert_query_reads()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L151",
+      "source_location": "L478",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6521,7 +7991,7 @@
       "label": "assert_baseline_scalar()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L161",
+      "source_location": "L488",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6535,7 +8005,7 @@
       "label": "assert_no_page()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L172",
+      "source_location": "L499",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6549,7 +8019,7 @@
       "label": "seed_baseline()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L182",
+      "source_location": "L509",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6563,7 +8033,7 @@
       "label": "snapshot_baseline()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L190",
+      "source_location": "L517",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6577,7 +8047,7 @@
       "label": "assert_baseline_unchanged()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L196",
+      "source_location": "L523",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6591,7 +8061,7 @@
       "label": "assert_page_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L207",
+      "source_location": "L534",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6605,7 +8075,7 @@
       "label": "assert_page_severity_is()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L221",
+      "source_location": "L548",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6619,7 +8089,7 @@
       "label": "assert_page_body_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L235",
+      "source_location": "L562",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6633,7 +8103,7 @@
       "label": "assert_page_body_lacks()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L245",
+      "source_location": "L572",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6647,7 +8117,7 @@
       "label": "assert_page_saw_baseline()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L257",
+      "source_location": "L584",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6661,7 +8131,7 @@
       "label": "assert_gap_marker()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L266",
+      "source_location": "L593",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6675,7 +8145,7 @@
       "label": "assert_no_gap_marker()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L275",
+      "source_location": "L602",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6689,7 +8159,7 @@
       "label": "assert_no_baseline()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L284",
+      "source_location": "L611",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6698,6 +8168,62 @@
       "id": "test_fixtures_osquery_poller_lib_assert_no_baseline",
       "community": 227,
       "norm_label": "assert_no_baseline()"
+    },
+    {
+      "label": "assert_probe_calls()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L621",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_poller_lib_assert_probe_calls",
+      "community": 227,
+      "norm_label": "assert_probe_calls()"
+    },
+    {
+      "label": "assert_probe_argv()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L635",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_poller_lib_assert_probe_argv",
+      "community": 227,
+      "norm_label": "assert_probe_argv()"
+    },
+    {
+      "label": "assert_no_probe_calls()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L647",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_poller_lib_assert_no_probe_calls",
+      "community": 227,
+      "norm_label": "assert_no_probe_calls()"
+    },
+    {
+      "label": "assert_no_mutation_attempt()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L658",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_poller_lib_assert_no_mutation_attempt",
+      "community": 227,
+      "norm_label": "assert_no_mutation_attempt()"
     },
     {
       "label": "osquery-tailscale-lib.bash",
@@ -7165,7 +8691,7 @@
       "label": "setup_watchdog_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L39",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7179,7 +8705,7 @@
       "label": "teardown_watchdog_harness()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L183",
+      "source_location": "L220",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7193,7 +8719,7 @@
       "label": "set_agent()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L193",
+      "source_location": "L230",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7207,7 +8733,7 @@
       "label": "set_agent_raw_exit()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L203",
+      "source_location": "L240",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7221,7 +8747,7 @@
       "label": "set_agent_no_exit_field()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L212",
+      "source_location": "L249",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7235,7 +8761,7 @@
       "label": "unload_agent()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L219",
+      "source_location": "L256",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7249,7 +8775,7 @@
       "label": "seed_canary()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L229",
+      "source_location": "L266",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7263,7 +8789,7 @@
       "label": "seed_future_canary()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L239",
+      "source_location": "L276",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7277,7 +8803,7 @@
       "label": "clear_canary()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L249",
+      "source_location": "L286",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7291,7 +8817,7 @@
       "label": "seed_raw_canary()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L257",
+      "source_location": "L294",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7302,10 +8828,178 @@
       "norm_label": "seed_raw_canary()"
     },
     {
+      "label": "regenerate_pipeline_manifest()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L307",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_regenerate_pipeline_manifest",
+      "community": 223,
+      "norm_label": "regenerate_pipeline_manifest()"
+    },
+    {
+      "label": "regenerate_managed_bin_manifest()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L326",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_regenerate_managed_bin_manifest",
+      "community": 223,
+      "norm_label": "regenerate_managed_bin_manifest()"
+    },
+    {
+      "label": "tamper_managed_bin_file()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L339",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_tamper_managed_bin_file",
+      "community": 223,
+      "norm_label": "tamper_managed_bin_file()"
+    },
+    {
+      "label": "chmod_managed_bin_file_through_hard_link()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L348",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_chmod_managed_bin_file_through_hard_link",
+      "community": 223,
+      "norm_label": "chmod_managed_bin_file_through_hard_link()"
+    },
+    {
+      "label": "update_unmanaged_bin_shim()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L356",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_update_unmanaged_bin_shim",
+      "community": 223,
+      "norm_label": "update_unmanaged_bin_shim()"
+    },
+    {
+      "label": "remove_managed_bin_manifest()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L361",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_remove_managed_bin_manifest",
+      "community": 223,
+      "norm_label": "remove_managed_bin_manifest()"
+    },
+    {
+      "label": "tamper_manifested_file()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L369",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_tamper_manifested_file",
+      "community": 223,
+      "norm_label": "tamper_manifested_file()"
+    },
+    {
+      "label": "tamper_second_manifested_file()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L375",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_tamper_second_manifested_file",
+      "community": 223,
+      "norm_label": "tamper_second_manifested_file()"
+    },
+    {
+      "label": "chmod_manifested_file_through_hard_link()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L386",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_chmod_manifested_file_through_hard_link",
+      "community": 223,
+      "norm_label": "chmod_manifested_file_through_hard_link()"
+    },
+    {
+      "label": "restore_manifested_file()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L393",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_restore_manifested_file",
+      "community": 223,
+      "norm_label": "restore_manifested_file()"
+    },
+    {
+      "label": "symlink_manifested_file()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L400",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_symlink_manifested_file",
+      "community": 223,
+      "norm_label": "symlink_manifested_file()"
+    },
+    {
+      "label": "remove_pipeline_manifest()",
+      "file_type": "code",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L407",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_osquery_watchdog_lib_remove_pipeline_manifest",
+      "community": 223,
+      "norm_label": "remove_pipeline_manifest()"
+    },
+    {
       "label": "seed_watchdog_state()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L267",
+      "source_location": "L415",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7319,7 +9013,7 @@
       "label": "run_watchdog()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L278",
+      "source_location": "L426",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7333,7 +9027,7 @@
       "label": "_wd_sqlite3()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L292",
+      "source_location": "L442",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7347,7 +9041,7 @@
       "label": "seed_pending_alerts()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L303",
+      "source_location": "L453",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7361,7 +9055,7 @@
       "label": "seed_dead_letter_alerts()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L313",
+      "source_location": "L463",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7375,7 +9069,7 @@
       "label": "seed_corrupt_alert_db()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L326",
+      "source_location": "L476",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7389,7 +9083,7 @@
       "label": "refute_file_contains()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L338",
+      "source_location": "L488",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7403,7 +9097,7 @@
       "label": "assert_mode()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L348",
+      "source_location": "L498",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7417,7 +9111,7 @@
       "label": "assert_no_page()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L358",
+      "source_location": "L508",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7431,7 +9125,7 @@
       "label": "assert_page_count()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L368",
+      "source_location": "L518",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7445,7 +9139,7 @@
       "label": "assert_page_severity_is()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L382",
+      "source_location": "L532",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7459,7 +9153,7 @@
       "label": "assert_page_sound_nonempty()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L397",
+      "source_location": "L547",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7473,7 +9167,7 @@
       "label": "assert_page_body_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L411",
+      "source_location": "L561",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7487,7 +9181,7 @@
       "label": "assert_curl_probe_unsigned()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L422",
+      "source_location": "L572",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7501,7 +9195,7 @@
       "label": "assert_osqueryi_not_called()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L438",
+      "source_location": "L588",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7515,7 +9209,7 @@
       "label": "assert_file_absent()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L448",
+      "source_location": "L598",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7529,7 +9223,7 @@
       "label": "snapshot_watchdog_state()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L458",
+      "source_location": "L608",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7543,7 +9237,7 @@
       "label": "assert_watchdog_state_unchanged()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L462",
+      "source_location": "L612",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7557,7 +9251,7 @@
       "label": "assert_state_has()",
       "file_type": "code",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L472",
+      "source_location": "L622",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7566,6 +9260,328 @@
       "id": "test_fixtures_osquery_watchdog_lib_assert_state_has",
       "community": 223,
       "norm_label": "assert_state_has()"
+    },
+    {
+      "label": "ssh-hardening-lib.bash",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib",
+      "community": 354,
+      "norm_label": "ssh-hardening-lib.bash"
+    },
+    {
+      "label": "ssh-hardening-lib.bash script",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_bash__entry",
+      "community": 354,
+      "norm_label": "ssh-hardening-lib.bash script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L58",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_fail",
+      "community": 354,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L66",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_refute_contains",
+      "community": 354,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "ssh_sandbox_setup()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L81",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_ssh_sandbox_setup",
+      "community": 354,
+      "norm_label": "ssh_sandbox_setup()"
+    },
+    {
+      "label": "assert_no_escalation()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L104",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_assert_no_escalation",
+      "community": 354,
+      "norm_label": "assert_no_escalation()"
+    },
+    {
+      "label": "ssh_sandbox_teardown()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L112",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_ssh_sandbox_teardown",
+      "community": 354,
+      "norm_label": "ssh_sandbox_teardown()"
+    },
+    {
+      "label": "run_ssh_hardening()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L126",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_run_ssh_hardening",
+      "community": 354,
+      "norm_label": "run_ssh_hardening()"
+    },
+    {
+      "label": "run_ssh_hardening_bounded()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L143",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_bounded",
+      "community": 354,
+      "norm_label": "run_ssh_hardening_bounded()"
+    },
+    {
+      "label": "run_ssh_hardening_without()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L176",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_without",
+      "community": 354,
+      "norm_label": "run_ssh_hardening_without()"
+    },
+    {
+      "label": "write_hardened_dropin()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L196",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_write_hardened_dropin",
+      "community": 354,
+      "norm_label": "write_hardened_dropin()"
+    },
+    {
+      "label": "write_hostile_apple_conf()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L207",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_write_hostile_apple_conf",
+      "community": 354,
+      "norm_label": "write_hostile_apple_conf()"
+    },
+    {
+      "label": "effective_global_value()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L250",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_effective_global_value",
+      "community": 354,
+      "norm_label": "effective_global_value()"
+    },
+    {
+      "label": "effective_spec_value()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L263",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_effective_spec_value",
+      "community": 354,
+      "norm_label": "effective_spec_value()"
+    },
+    {
+      "label": "assert_no_sudo_and_no_sandbox_write()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L275",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_hardening_lib_assert_no_sudo_and_no_sandbox_write",
+      "community": 354,
+      "norm_label": "assert_no_sudo_and_no_sandbox_write()"
+    },
+    {
+      "label": "ssh-reload-lib.bash",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib",
+      "community": 362,
+      "norm_label": "ssh-reload-lib.bash"
+    },
+    {
+      "label": "ssh-reload-lib.bash script",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_bash__entry",
+      "community": 362,
+      "norm_label": "ssh-reload-lib.bash script"
+    },
+    {
+      "label": "reload_sandbox_setup()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L100",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_reload_sandbox_setup",
+      "community": 362,
+      "norm_label": "reload_sandbox_setup()"
+    },
+    {
+      "label": "run_ssh_reload()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L430",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_run_ssh_reload",
+      "community": 362,
+      "norm_label": "run_ssh_reload()"
+    },
+    {
+      "label": "assert_kickstart_attempted()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L460",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_assert_kickstart_attempted",
+      "community": 362,
+      "norm_label": "assert_kickstart_attempted()"
+    },
+    {
+      "label": "assert_seam_calls()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L473",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_assert_seam_calls",
+      "community": 362,
+      "norm_label": "assert_seam_calls()"
+    },
+    {
+      "label": "assert_no_kickstart()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L484",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_assert_no_kickstart",
+      "community": 362,
+      "norm_label": "assert_no_kickstart()"
+    },
+    {
+      "label": "config_tree_fingerprint()",
+      "file_type": "code",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L498",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_fixtures_ssh_reload_lib_config_tree_fingerprint",
+      "community": 362,
+      "norm_label": "config_tree_fingerprint()"
     },
     {
       "label": "build-dispatch-harness.sh",
@@ -7680,10 +9696,80 @@
       "norm_label": "assert_mode()"
     },
     {
+      "label": "_alerter_banner_line()",
+      "file_type": "code",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L121",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_helpers_build_dispatch_harness_alerter_banner_line",
+      "community": 290,
+      "norm_label": "_alerter_banner_line()"
+    },
+    {
+      "label": "assert_banner_sound()",
+      "file_type": "code",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L128",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_helpers_build_dispatch_harness_assert_banner_sound",
+      "community": 290,
+      "norm_label": "assert_banner_sound()"
+    },
+    {
+      "label": "refute_banner_sound()",
+      "file_type": "code",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L146",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_helpers_build_dispatch_harness_refute_banner_sound",
+      "community": 290,
+      "norm_label": "refute_banner_sound()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L165",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_helpers_build_dispatch_harness_refute_file_contains",
+      "community": 290,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "refute_tree_contains()",
+      "file_type": "code",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L176",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_helpers_build_dispatch_harness_refute_tree_contains",
+      "community": 290,
+      "norm_label": "refute_tree_contains()"
+    },
+    {
       "label": "assert_post_count()",
       "file_type": "code",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L119",
+      "source_location": "L186",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7697,7 +9783,7 @@
       "label": "assert_posted_to()",
       "file_type": "code",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L129",
+      "source_location": "L196",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7711,7 +9797,7 @@
       "label": "assert_no_post()",
       "file_type": "code",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L137",
+      "source_location": "L204",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7879,7 +9965,7 @@
       "label": "make_launchctl_stub()",
       "file_type": "code",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L73",
+      "source_location": "L80",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7893,7 +9979,7 @@
       "label": "marker_of()",
       "file_type": "code",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L99",
+      "source_location": "L106",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7907,7 +9993,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L105",
+      "source_location": "L112",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7921,7 +10007,7 @@
       "label": "bootout_count()",
       "file_type": "code",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L154",
+      "source_location": "L161",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -7991,7 +10077,7 @@
       "label": "run_rendered()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-retry-refire.sh",
-      "source_location": "L104",
+      "source_location": "L111",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8047,7 +10133,7 @@
       "label": "path_without_cargo()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L74",
+      "source_location": "L81",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8061,7 +10147,7 @@
       "label": "make_herdr_stub()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L94",
+      "source_location": "L101",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8075,7 +10161,7 @@
       "label": "make_cargo_stub()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L141",
+      "source_location": "L148",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8089,7 +10175,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L164",
+      "source_location": "L171",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8103,7 +10189,7 @@
       "label": "marker_present()",
       "file_type": "code",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L233",
+      "source_location": "L240",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8159,7 +10245,7 @@
       "label": "build_stub_prefix()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L57",
+      "source_location": "L64",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8173,7 +10259,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L84",
+      "source_location": "L91",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8187,7 +10273,7 @@
       "label": "cleanup_used()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L105",
+      "source_location": "L112",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8243,7 +10329,7 @@
       "label": "make_herdr_stub()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L75",
+      "source_location": "L82",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8257,7 +10343,7 @@
       "label": "make_brew_stub()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L148",
+      "source_location": "L155",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8271,7 +10357,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L176",
+      "source_location": "L183",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8285,7 +10371,7 @@
       "label": "cleanup_ran()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L198",
+      "source_location": "L205",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8299,7 +10385,7 @@
       "label": "herdr_contacted()",
       "file_type": "code",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L199",
+      "source_location": "L206",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8537,7 +10623,7 @@
       "label": "herdr_contacted()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L107",
+      "source_location": "L114",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8551,7 +10637,7 @@
       "label": "cleanup_ran()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L108",
+      "source_location": "L115",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8691,7 +10777,7 @@
       "label": "make_brew()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-before10-ecosystem-guards.sh",
-      "source_location": "L46",
+      "source_location": "L53",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8747,7 +10833,7 @@
       "label": "make_prefix()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L68",
+      "source_location": "L75",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8761,7 +10847,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L99",
+      "source_location": "L106",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8775,7 +10861,7 @@
       "label": "forced_ran()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L116",
+      "source_location": "L123",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8856,6 +10942,1224 @@
       "norm_label": "make_brew()"
     },
     {
+      "label": "lulu-policy-records.sh",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records",
+      "community": 356,
+      "norm_label": "lulu-policy-records.sh"
+    },
+    {
+      "label": "lulu-policy-records.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_sh__entry",
+      "community": 356,
+      "norm_label": "lulu-policy-records.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L78",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_fail",
+      "community": 356,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L85",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_refute_file_contains",
+      "community": 356,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "cleanup()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L116",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_cleanup",
+      "community": 356,
+      "norm_label": "cleanup()"
+    },
+    {
+      "label": "policy_expectations",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L130",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_policy_expectations",
+      "community": 356,
+      "norm_label": "policy_expectations"
+    },
+    {
+      "label": "make_defaults_source()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L187",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_make_defaults_source",
+      "community": 356,
+      "norm_label": "make_defaults_source()"
+    },
+    {
+      "label": "make_posture_source()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L240",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_make_posture_source",
+      "community": 356,
+      "norm_label": "make_posture_source()"
+    },
+    {
+      "label": "assert_posture_render_rejects()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L248",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_assert_posture_render_rejects",
+      "community": 356,
+      "norm_label": "assert_posture_render_rejects()"
+    },
+    {
+      "label": "assert_manual_record()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L308",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_assert_manual_record",
+      "community": 356,
+      "norm_label": "assert_manual_record()"
+    },
+    {
+      "label": "POLLER_PGREP_LULU_MODE",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L419",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_poller_pgrep_lulu_mode",
+      "community": 356,
+      "norm_label": "poller_pgrep_lulu_mode"
+    },
+    {
+      "label": "archive_xml_mentioning()",
+      "file_type": "code",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L467",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_lulu_policy_records_archive_xml_mentioning",
+      "community": 356,
+      "norm_label": "archive_xml_mentioning()"
+    },
+    {
+      "label": "macos-control-tier-refusal.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal",
+      "community": 357,
+      "norm_label": "macos-control-tier-refusal.sh"
+    },
+    {
+      "label": "macos-control-tier-refusal.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_sh__entry",
+      "community": 357,
+      "norm_label": "macos-control-tier-refusal.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L69",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_fail",
+      "community": 357,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L76",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_refute_file_contains",
+      "community": 357,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "refute_file_matches()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L82",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_refute_file_matches",
+      "community": 357,
+      "norm_label": "refute_file_matches()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L88",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "community": 357,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "make_defaults_source()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L111",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_make_defaults_source",
+      "community": 357,
+      "norm_label": "make_defaults_source()"
+    },
+    {
+      "label": "make_setup_source()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L119",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_make_setup_source",
+      "community": 357,
+      "norm_label": "make_setup_source()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L127",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_render_template",
+      "community": 357,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "assert_tier1_rejects()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L168",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "community": 357,
+      "norm_label": "assert_tier1_rejects()"
+    },
+    {
+      "label": "assert_tier2_rejects()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L183",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "community": 357,
+      "norm_label": "assert_tier2_rejects()"
+    },
+    {
+      "label": "run_tool()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L891",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_refusal_run_tool",
+      "community": 357,
+      "norm_label": "run_tool()"
+    },
+    {
+      "label": "macos-control-tier-render-stability.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_render_stability",
+      "community": 382,
+      "norm_label": "macos-control-tier-render-stability.sh"
+    },
+    {
+      "label": "macos-control-tier-render-stability.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_render_stability_sh__entry",
+      "community": 382,
+      "norm_label": "macos-control-tier-render-stability.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L40",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_render_stability_fail",
+      "community": 382,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "render_current()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L211",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_control_tier_render_stability_render_current",
+      "community": 382,
+      "norm_label": "render_current()"
+    },
+    {
+      "label": "macos-defaults-injection.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection",
+      "community": 360,
+      "norm_label": "macos-defaults-injection.sh"
+    },
+    {
+      "label": "macos-defaults-injection.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_sh__entry",
+      "community": 360,
+      "norm_label": "macos-defaults-injection.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L49",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_fail",
+      "community": 360,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L56",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_refute_file_contains",
+      "community": 360,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_assert_file_contains",
+      "community": 360,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "make_source_dir()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L82",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_make_source_dir",
+      "community": 360,
+      "norm_label": "make_source_dir()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L90",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_render_template",
+      "community": 360,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "assert_render_rejects()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L129",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "community": 360,
+      "norm_label": "assert_render_rejects()"
+    },
+    {
+      "label": "run_apply()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L513",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_injection_run_apply",
+      "community": 360,
+      "norm_label": "run_apply()"
+    },
+    {
+      "label": "macos-defaults-shape-agreement.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_shape_agreement",
+      "community": 376,
+      "norm_label": "macos-defaults-shape-agreement.sh"
+    },
+    {
+      "label": "macos-defaults-shape-agreement.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_shape_agreement_sh__entry",
+      "community": 376,
+      "norm_label": "macos-defaults-shape-agreement.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L27",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_shape_agreement_fail",
+      "community": 376,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L42",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_shape_agreement_render_template",
+      "community": 376,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "library_stream()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L53",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_shape_agreement_library_stream",
+      "community": 376,
+      "norm_label": "library_stream()"
+    },
+    {
+      "label": "macos-defaults-source-path.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path",
+      "community": 363,
+      "norm_label": "macos-defaults-source-path.sh"
+    },
+    {
+      "label": "macos-defaults-source-path.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_sh__entry",
+      "community": 363,
+      "norm_label": "macos-defaults-source-path.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L39",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_fail",
+      "community": 363,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L47",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_refute_file_contains",
+      "community": 363,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L53",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_assert_file_contains",
+      "community": 363,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "seed_data_file()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L80",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_seed_data_file",
+      "community": 363,
+      "norm_label": "seed_data_file()"
+    },
+    {
+      "label": "run_from_worktree()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L155",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_run_from_worktree",
+      "community": 363,
+      "norm_label": "run_from_worktree()"
+    },
+    {
+      "label": "assert_unreadable_exits_two()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L203",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "community": 363,
+      "norm_label": "assert_unreadable_exits_two()"
+    },
+    {
+      "label": "macos-defaults-system-scope.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope",
+      "community": 359,
+      "norm_label": "macos-defaults-system-scope.sh"
+    },
+    {
+      "label": "macos-defaults-system-scope.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_sh__entry",
+      "community": 359,
+      "norm_label": "macos-defaults-system-scope.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L52",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_fail",
+      "community": 359,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L60",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_refute_file_contains",
+      "community": 359,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L66",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_assert_file_contains",
+      "community": 359,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "make_source_dir()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L91",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_make_source_dir",
+      "community": 359,
+      "norm_label": "make_source_dir()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L101",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_render_template",
+      "community": 359,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "run_render_capturing_arguments()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L219",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_run_render_capturing_arguments",
+      "community": 359,
+      "norm_label": "run_render_capturing_arguments()"
+    },
+    {
+      "label": "write_defaults_stub()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L483",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_write_defaults_stub",
+      "community": 359,
+      "norm_label": "write_defaults_stub()"
+    },
+    {
+      "label": "run_tool()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L514",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_system_scope_run_tool",
+      "community": 359,
+      "norm_label": "run_tool()"
+    },
+    {
+      "label": "macos-firewall-globalstate-order.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order",
+      "community": 383,
+      "norm_label": "macos-firewall-globalstate-order.sh"
+    },
+    {
+      "label": "macos-firewall-globalstate-order.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "community": 383,
+      "norm_label": "macos-firewall-globalstate-order.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order_fail",
+      "community": 383,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "line_number_of_unique_line()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L163",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_firewall_globalstate_order_line_number_of_unique_line",
+      "community": 383,
+      "norm_label": "line_number_of_unique_line()"
+    },
+    {
+      "label": "macos-posture-controls-agreement.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_agreement",
+      "community": 392,
+      "norm_label": "macos-posture-controls-agreement.sh"
+    },
+    {
+      "label": "macos-posture-controls-agreement.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_agreement_sh__entry",
+      "community": 392,
+      "norm_label": "macos-posture-controls-agreement.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L30",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_agreement_fail",
+      "community": 392,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "macos-posture-controls-render.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render",
+      "community": 368,
+      "norm_label": "macos-posture-controls-render.sh"
+    },
+    {
+      "label": "macos-posture-controls-render.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_sh__entry",
+      "community": 368,
+      "norm_label": "macos-posture-controls-render.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L33",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_fail",
+      "community": 368,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L38",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_assert_file_contains",
+      "community": 368,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "make_source()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L60",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_make_source",
+      "community": 368,
+      "norm_label": "make_source()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L68",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_render_template",
+      "community": 368,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "assert_rejects()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L75",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_posture_controls_render_assert_rejects",
+      "community": 368,
+      "norm_label": "assert_rejects()"
+    },
+    {
+      "label": "macos-security-defaults-render.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render",
+      "community": 364,
+      "norm_label": "macos-security-defaults-render.sh"
+    },
+    {
+      "label": "macos-security-defaults-render.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_sh__entry",
+      "community": 364,
+      "norm_label": "macos-security-defaults-render.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L48",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_fail",
+      "community": 364,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L53",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_assert_file_contains",
+      "community": 364,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "write_logging_stub()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L110",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_write_logging_stub",
+      "community": 364,
+      "norm_label": "write_logging_stub()"
+    },
+    {
+      "label": "log_line()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L128",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_log_line",
+      "community": 364,
+      "norm_label": "log_line()"
+    },
+    {
+      "label": "write_drift_defaults_stub()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L315",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_write_drift_defaults_stub",
+      "community": 364,
+      "norm_label": "write_drift_defaults_stub()"
+    },
+    {
+      "label": "run_drift()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L340",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_security_defaults_render_run_drift",
+      "community": 364,
+      "norm_label": "run_drift()"
+    },
+    {
+      "label": "macos-system-setup-sudo-guard.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard",
+      "community": 377,
+      "norm_label": "macos-system-setup-sudo-guard.sh"
+    },
+    {
+      "label": "macos-system-setup-sudo-guard.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "community": 377,
+      "norm_label": "macos-system-setup-sudo-guard.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L27",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_fail",
+      "community": 377,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L34",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_refute_file_contains",
+      "community": 377,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "refute_file_matches()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L40",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_system_setup_sudo_guard_refute_file_matches",
+      "community": 377,
+      "norm_label": "refute_file_matches()"
+    },
+    {
       "label": "openclaw-services-retirement.sh",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
@@ -8901,7 +12205,7 @@
       "label": "LAUNCHCTL_LOG",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L107",
+      "source_location": "L114",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -8915,7 +12219,7 @@
       "label": "NPM_LOG",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L108",
+      "source_location": "L115",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -8929,7 +12233,7 @@
       "label": "RM_LOG",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L109",
+      "source_location": "L116",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -8943,7 +12247,7 @@
       "label": "LOADED_FILE",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L110",
+      "source_location": "L117",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -8957,7 +12261,7 @@
       "label": "NPM_FLAG",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L111",
+      "source_location": "L118",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -8971,7 +12275,7 @@
       "label": "run_script()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L199",
+      "source_location": "L206",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8985,7 +12289,7 @@
       "label": "report()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L216",
+      "source_location": "L223",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8999,7 +12303,7 @@
       "label": "assert_rc0()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L227",
+      "source_location": "L234",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9013,7 +12317,7 @@
       "label": "assert_log_exact()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L238",
+      "source_location": "L245",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9027,7 +12331,7 @@
       "label": "assert_empty_log()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L255",
+      "source_location": "L262",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9041,7 +12345,7 @@
       "label": "assert_absent()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L264",
+      "source_location": "L271",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9055,7 +12359,7 @@
       "label": "assert_present()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L273",
+      "source_location": "L280",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9069,7 +12373,7 @@
       "label": "assert_logged()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L285",
+      "source_location": "L292",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9083,7 +12387,7 @@
       "label": "assert_warned()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L294",
+      "source_location": "L301",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9097,7 +12401,7 @@
       "label": "assert_no_npm_uninstall()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L304",
+      "source_location": "L311",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9111,7 +12415,7 @@
       "label": "marker_of()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L312",
+      "source_location": "L319",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9125,7 +12429,7 @@
       "label": "assert_marker()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L313",
+      "source_location": "L320",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9139,7 +12443,7 @@
       "label": "assert_no_marker()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L320",
+      "source_location": "L327",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9153,7 +12457,7 @@
       "label": "seed_loaded()",
       "file_type": "code",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L328",
+      "source_location": "L335",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9265,7 +12569,7 @@
       "label": "render()",
       "file_type": "code",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L40",
+      "source_location": "L48",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9279,7 +12583,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L43",
+      "source_location": "L51",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9293,7 +12597,7 @@
       "label": "has_path()",
       "file_type": "code",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L59",
+      "source_location": "L67",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9556,6 +12860,62 @@
       "norm_label": "assert_contains()"
     },
     {
+      "label": "osquery-managed-bin-manifest.sh",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_managed_bin_manifest",
+      "community": 384,
+      "norm_label": "osquery-managed-bin-manifest.sh"
+    },
+    {
+      "label": "osquery-managed-bin-manifest.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_managed_bin_manifest_sh__entry",
+      "community": 384,
+      "norm_label": "osquery-managed-bin-manifest.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L38",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_managed_bin_manifest_fail",
+      "community": 384,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_manifest_lists()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L48",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_managed_bin_manifest_refute_manifest_lists",
+      "community": 384,
+      "norm_label": "refute_manifest_lists()"
+    },
+    {
       "label": "osquery-page-allowlist-seed.sh",
       "file_type": "code",
       "source_file": "test/integration/osquery-page-allowlist-seed.sh",
@@ -9629,7 +12989,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L32",
+      "source_location": "L46",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9643,7 +13003,7 @@
       "label": "OSQUERY_PIPELINE_MANIFEST",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L67",
+      "source_location": "L94",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9657,7 +13017,7 @@
       "label": "OSQUERY_PIPELINE_REHASH_DELAY",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L67",
+      "source_location": "L94",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9668,10 +13028,24 @@
       "norm_label": "osquery_pipeline_rehash_delay"
     },
     {
+      "label": "OSQUERY_MANAGED_BIN_MANIFEST",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L95",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_osquery_managed_bin_manifest",
+      "community": 302,
+      "norm_label": "osquery_managed_bin_manifest"
+    },
+    {
       "label": "OSQUERY_PIPELINE_SETTLE_SECONDS",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L68",
+      "source_location": "L96",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9685,7 +13059,7 @@
       "label": "hash_of()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L70",
+      "source_location": "L98",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9696,10 +13070,38 @@
       "norm_label": "hash_of()"
     },
     {
+      "label": "run_verdict()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L121",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_run_verdict",
+      "community": 302,
+      "norm_label": "run_verdict()"
+    },
+    {
+      "label": "tracked_rc()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L132",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_tracked_rc",
+      "community": 302,
+      "norm_label": "tracked_rc()"
+    },
+    {
       "label": "expect_verdict()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L72",
+      "source_location": "L139",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9708,6 +13110,48 @@
       "id": "test_integration_osquery_pipeline_manifest_agreement_expect_verdict",
       "community": 302,
       "norm_label": "expect_verdict()"
+    },
+    {
+      "label": "run_audit()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L172",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_run_audit",
+      "community": 302,
+      "norm_label": "run_audit()"
+    },
+    {
+      "label": "refute_line()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L188",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_refute_line",
+      "community": 302,
+      "norm_label": "refute_line()"
+    },
+    {
+      "label": "run_allowlist_verdict()",
+      "file_type": "code",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L496",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_osquery_pipeline_manifest_agreement_run_allowlist_verdict",
+      "community": 302,
+      "norm_label": "run_allowlist_verdict()"
     },
     {
       "label": "osquery-pipeline-manifest-generation.sh",
@@ -9741,7 +13185,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-generation.sh",
-      "source_location": "L32",
+      "source_location": "L37",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9783,7 +13227,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-install.sh",
-      "source_location": "L31",
+      "source_location": "L37",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9876,6 +13320,104 @@
       "id": "test_integration_osquery_queue_counts_wal_cleanup",
       "community": 305,
       "norm_label": "cleanup()"
+    },
+    {
+      "label": "oversight-posture.sh",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture",
+      "community": 369,
+      "norm_label": "oversight-posture.sh"
+    },
+    {
+      "label": "oversight-posture.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_sh__entry",
+      "community": 369,
+      "norm_label": "oversight-posture.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_fail",
+      "community": 369,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "POLLER_PGREP_MODE",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L107",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_poller_pgrep_mode",
+      "community": 369,
+      "norm_label": "poller_pgrep_mode"
+    },
+    {
+      "label": "POLLER_PGREP_OUTPUT",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L132",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_poller_pgrep_output",
+      "community": 369,
+      "norm_label": "poller_pgrep_output"
+    },
+    {
+      "label": "POLLER_PGREP_EXIT",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L132",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_poller_pgrep_exit",
+      "community": 369,
+      "norm_label": "poller_pgrep_exit"
+    },
+    {
+      "label": "run_indeterminate_case()",
+      "file_type": "code",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L186",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_oversight_posture_run_indeterminate_case",
+      "community": 369,
+      "norm_label": "run_indeterminate_case()"
     },
     {
       "label": "relay-agent.sh",
@@ -10312,6 +13854,692 @@
       "norm_label": "reset_key_dir()"
     },
     {
+      "label": "ssh-config-github-keepalive.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_config_github_keepalive",
+      "community": 385,
+      "norm_label": "ssh-config-github-keepalive.sh"
+    },
+    {
+      "label": "ssh-config-github-keepalive.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_config_github_keepalive_sh__entry",
+      "community": 385,
+      "norm_label": "ssh-config-github-keepalive.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L25",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_config_github_keepalive_fail",
+      "community": 385,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "resolved()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L36",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_config_github_keepalive_resolved",
+      "community": 385,
+      "norm_label": "resolved()"
+    },
+    {
+      "label": "ssh-hardening-dropin-mode.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_dropin_mode",
+      "community": 386,
+      "norm_label": "ssh-hardening-dropin-mode.sh"
+    },
+    {
+      "label": "ssh-hardening-dropin-mode.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_dropin_mode_sh__entry",
+      "community": 386,
+      "norm_label": "ssh-hardening-dropin-mode.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L16",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_dropin_mode_fail",
+      "community": 386,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "file_mode()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L30",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_dropin_mode_file_mode",
+      "community": 386,
+      "norm_label": "file_mode()"
+    },
+    {
+      "label": "ssh-hardening-include-following.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following",
+      "community": 370,
+      "norm_label": "ssh-hardening-include-following.sh"
+    },
+    {
+      "label": "ssh-hardening-include-following.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following_sh__entry",
+      "community": 370,
+      "norm_label": "ssh-hardening-include-following.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L45",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following_fail",
+      "community": 370,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "assert_resolves()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L72",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following_assert_resolves",
+      "community": 370,
+      "norm_label": "assert_resolves()"
+    },
+    {
+      "label": "assert_verify_fails_naming()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L81",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following_assert_verify_fails_naming",
+      "community": 370,
+      "norm_label": "assert_verify_fails_naming()"
+    },
+    {
+      "label": "assert_verify_passes_again()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L93",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_following_assert_verify_passes_again",
+      "community": 370,
+      "norm_label": "assert_verify_passes_again()"
+    },
+    {
+      "label": "ssh-hardening-include-precedence.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence",
+      "community": 393,
+      "norm_label": "ssh-hardening-include-precedence.sh"
+    },
+    {
+      "label": "ssh-hardening-include-precedence.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "community": 393,
+      "norm_label": "ssh-hardening-include-precedence.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L26",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_include_precedence_fail",
+      "community": 393,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "ssh-hardening-install-safety.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety",
+      "community": 371,
+      "norm_label": "ssh-hardening-install-safety.sh"
+    },
+    {
+      "label": "ssh-hardening-install-safety.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety_sh__entry",
+      "community": 371,
+      "norm_label": "ssh-hardening-install-safety.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L32",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety_fail",
+      "community": 371,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety_refute_contains",
+      "community": 371,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "working_file_leftovers()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L51",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety_working_file_leftovers",
+      "community": 371,
+      "norm_label": "working_file_leftovers()"
+    },
+    {
+      "label": "file_fingerprint()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_safety_file_fingerprint",
+      "community": 371,
+      "norm_label": "file_fingerprint()"
+    },
+    {
+      "label": "ssh-hardening-install-strictness.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness",
+      "community": 372,
+      "norm_label": "ssh-hardening-install-strictness.sh"
+    },
+    {
+      "label": "ssh-hardening-install-strictness.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "community": 372,
+      "norm_label": "ssh-hardening-install-strictness.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L30",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness_fail",
+      "community": 372,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L35",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness_refute_contains",
+      "community": 372,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "reset_tree()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L51",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness_reset_tree",
+      "community": 372,
+      "norm_label": "reset_tree()"
+    },
+    {
+      "label": "assert_install_no_weaker_than_verify()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L57",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "community": 372,
+      "norm_label": "assert_install_no_weaker_than_verify()"
+    },
+    {
+      "label": "ssh-hardening-match-reenable.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_match_reenable",
+      "community": 387,
+      "norm_label": "ssh-hardening-match-reenable.sh"
+    },
+    {
+      "label": "ssh-hardening-match-reenable.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_match_reenable_sh__entry",
+      "community": 387,
+      "norm_label": "ssh-hardening-match-reenable.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L66",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_match_reenable_fail",
+      "community": 387,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "run_reenable_case()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L99",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_match_reenable_run_reenable_case",
+      "community": 387,
+      "norm_label": "run_reenable_case()"
+    },
+    {
+      "label": "ssh-hardening-reload-failclosed.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed",
+      "community": 388,
+      "norm_label": "ssh-hardening-reload-failclosed.sh"
+    },
+    {
+      "label": "ssh-hardening-reload-failclosed.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "community": 388,
+      "norm_label": "ssh-hardening-reload-failclosed.sh script"
+    },
+    {
+      "label": "SSH_HARDENING_READY_ATTEMPTS",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L44",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_ssh_hardening_ready_attempts",
+      "community": 388,
+      "norm_label": "ssh_hardening_ready_attempts"
+    },
+    {
+      "label": "SSH_HARDENING_READY_INTERVAL",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L45",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_reload_failclosed_ssh_hardening_ready_interval",
+      "community": 388,
+      "norm_label": "ssh_hardening_ready_interval"
+    },
+    {
+      "label": "ssh-hardening-rollback.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_rollback",
+      "community": 394,
+      "norm_label": "ssh-hardening-rollback.sh"
+    },
+    {
+      "label": "ssh-hardening-rollback.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_rollback_sh__entry",
+      "community": 394,
+      "norm_label": "ssh-hardening-rollback.sh script"
+    },
+    {
+      "label": "assert_no_reload_side_effects()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L48",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_rollback_assert_no_reload_side_effects",
+      "community": 394,
+      "norm_label": "assert_no_reload_side_effects()"
+    },
+    {
+      "label": "ssh-hardening-sshd-validate.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate",
+      "community": 389,
+      "norm_label": "ssh-hardening-sshd-validate.sh"
+    },
+    {
+      "label": "ssh-hardening-sshd-validate.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "community": 389,
+      "norm_label": "ssh-hardening-sshd-validate.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L27",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_fail",
+      "community": 389,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L32",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_sshd_validate_refute_contains",
+      "community": 389,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "ssh-hardening-tokenizer-differential.sh",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_tokenizer_differential",
+      "community": 378,
+      "norm_label": "ssh-hardening-tokenizer-differential.sh"
+    },
+    {
+      "label": "ssh-hardening-tokenizer-differential.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_tokenizer_differential_sh__entry",
+      "community": 378,
+      "norm_label": "ssh-hardening-tokenizer-differential.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L51",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_tokenizer_differential_fail",
+      "community": 378,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "resolve_unsafe_directives()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L181",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_tokenizer_differential_resolve_unsafe_directives",
+      "community": 378,
+      "norm_label": "resolve_unsafe_directives()"
+    },
+    {
+      "label": "differential_case()",
+      "file_type": "code",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L200",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_ssh_hardening_tokenizer_differential_differential_case",
+      "community": 378,
+      "norm_label": "differential_case()"
+    },
+    {
       "label": "tailnet-pins.sh",
       "file_type": "code",
       "source_file": "test/integration/tailnet-pins.sh",
@@ -10343,7 +14571,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L30",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10357,7 +14585,7 @@
       "label": "render_fixture()",
       "file_type": "code",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L49",
+      "source_location": "L63",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10368,10 +14596,24 @@
       "norm_label": "render_fixture()"
     },
     {
+      "label": "render_fixture_must_fail()",
+      "file_type": "code",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L79",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_tailnet_pins_render_fixture_must_fail",
+      "community": 188,
+      "norm_label": "render_fixture_must_fail()"
+    },
+    {
       "label": "run_pin_command()",
       "file_type": "code",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L108",
+      "source_location": "L211",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10380,6 +14622,62 @@
       "id": "test_integration_tailnet_pins_run_pin_command",
       "community": 188,
       "norm_label": "run_pin_command()"
+    },
+    {
+      "label": "run_against()",
+      "file_type": "code",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L217",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_tailnet_pins_run_against",
+      "community": 188,
+      "norm_label": "run_against()"
+    },
+    {
+      "label": "run_expect_refusal()",
+      "file_type": "code",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L226",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_tailnet_pins_run_expect_refusal",
+      "community": 188,
+      "norm_label": "run_expect_refusal()"
+    },
+    {
+      "label": "run_with_shims()",
+      "file_type": "code",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L236",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_tailnet_pins_run_with_shims",
+      "community": 188,
+      "norm_label": "run_with_shims()"
+    },
+    {
+      "label": "file_mode()",
+      "file_type": "code",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L244",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_tailnet_pins_file_mode",
+      "community": 188,
+      "norm_label": "file_mode()"
     },
     {
       "label": "update-skills-additive-clone-all.sh",
@@ -14907,7 +19205,7 @@
       "label": "probe()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L54",
+      "source_location": "L61",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14921,7 +19219,7 @@
       "label": "run_guard()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L63",
+      "source_location": "L70",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14935,7 +19233,7 @@
       "label": "create_flagged_tree_fixtures()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L75",
+      "source_location": "L83",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14949,7 +19247,7 @@
       "label": "create_clean_tree_fixtures()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L132",
+      "source_location": "L197",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14963,7 +19261,7 @@
       "label": "create_no_candidate_fixture()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L181",
+      "source_location": "L266",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14977,7 +19275,7 @@
       "label": "create_boundary_tree_fixtures()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L192",
+      "source_location": "L276",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14991,7 +19289,7 @@
       "label": "assert_flagged_tree_rejected()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L208",
+      "source_location": "L321",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15005,7 +19303,7 @@
       "label": "assert_clean_tree_passes()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L241",
+      "source_location": "L368",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15019,7 +19317,7 @@
       "label": "assert_no_candidate_tree_passes()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L251",
+      "source_location": "L378",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15033,7 +19331,7 @@
       "label": "assert_grep_failure_fails_guard()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L261",
+      "source_location": "L388",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15047,7 +19345,7 @@
       "label": "grep()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L266",
+      "source_location": "L393",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15061,7 +19359,7 @@
       "label": "assert_awk_failure_fails_guard()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L283",
+      "source_location": "L410",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15075,7 +19373,7 @@
       "label": "awk()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L288",
+      "source_location": "L415",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15089,7 +19387,7 @@
       "label": "assert_out_of_scope_cases_pass()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L304",
+      "source_location": "L432",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15103,7 +19401,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L311",
+      "source_location": "L439",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15280,6 +19578,132 @@
       "id": "test_unit_claude_retirement_ordering_after_number",
       "community": 235,
       "norm_label": "after_number()"
+    },
+    {
+      "label": "gitconfig-tool-and-url-hygiene.sh",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene",
+      "community": 365,
+      "norm_label": "gitconfig-tool-and-url-hygiene.sh"
+    },
+    {
+      "label": "gitconfig-tool-and-url-hygiene.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "community": 365,
+      "norm_label": "gitconfig-tool-and-url-hygiene.sh script"
+    },
+    {
+      "label": "GIT_CONFIG_NOSYSTEM",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_git_config_nosystem",
+      "community": 365,
+      "norm_label": "git_config_nosystem"
+    },
+    {
+      "label": "GIT_PAGER",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_git_pager",
+      "community": 365,
+      "norm_label": "git_pager"
+    },
+    {
+      "label": "PAGER",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_pager",
+      "community": 365,
+      "norm_label": "pager"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L54",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "community": 365,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "list_chezmoi_delivered_target_paths()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L64",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_list_chezmoi_delivered_target_paths",
+      "community": 365,
+      "norm_label": "list_chezmoi_delivered_target_paths()"
+    },
+    {
+      "label": "chezmoi_delivers_target_path()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L73",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "community": 365,
+      "norm_label": "chezmoi_delivers_target_path()"
+    },
+    {
+      "label": "git_resolves_tool_name()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L79",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
+      "community": 365,
+      "norm_label": "git_resolves_tool_name()"
     },
     {
       "label": "herdr-build-input-hashing.sh",
@@ -15551,7 +19975,7 @@
       "label": "render_has_skip()",
       "file_type": "code",
       "source_file": "test/unit/homebrew-before10-skip-truthiness.sh",
-      "source_location": "L57",
+      "source_location": "L64",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15660,6 +20084,580 @@
       "norm_label": "assert_kv()"
     },
     {
+      "label": "lulu-rule-existence-reader.sh",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader",
+      "community": 358,
+      "norm_label": "lulu-rule-existence-reader.sh"
+    },
+    {
+      "label": "lulu-rule-existence-reader.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_sh__entry",
+      "community": 358,
+      "norm_label": "lulu-rule-existence-reader.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L47",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_fail",
+      "community": 358,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "cleanup()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_cleanup",
+      "community": 358,
+      "norm_label": "cleanup()"
+    },
+    {
+      "label": "archive_xml_mentioning()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L69",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_archive_xml_mentioning",
+      "community": 358,
+      "norm_label": "archive_xml_mentioning()"
+    },
+    {
+      "label": "rule_control()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L78",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_rule_control",
+      "community": 358,
+      "norm_label": "rule_control()"
+    },
+    {
+      "label": "run_reader_case()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L85",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_run_reader_case",
+      "community": 358,
+      "norm_label": "run_reader_case()"
+    },
+    {
+      "label": "run_plutil_failure_case()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L138",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_run_plutil_failure_case",
+      "community": 358,
+      "norm_label": "run_plutil_failure_case()"
+    },
+    {
+      "label": "POLLER_READLINK_OUTPUT",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L175",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_poller_readlink_output",
+      "community": 358,
+      "norm_label": "poller_readlink_output"
+    },
+    {
+      "label": "POLLER_READLINK_EXIT",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L203",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_poller_readlink_exit",
+      "community": 358,
+      "norm_label": "poller_readlink_exit"
+    },
+    {
+      "label": "preferences_xml_with_profile()",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L223",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_preferences_xml_with_profile",
+      "community": 358,
+      "norm_label": "preferences_xml_with_profile()"
+    },
+    {
+      "label": "POLLER_PLUTIL_PREFS_EXIT",
+      "file_type": "code",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L258",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_lulu_rule_existence_reader_poller_plutil_prefs_exit",
+      "community": 358,
+      "norm_label": "poller_plutil_prefs_exit"
+    },
+    {
+      "label": "macos-defaults-count-guard.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_count_guard",
+      "community": 395,
+      "norm_label": "macos-defaults-count-guard.sh"
+    },
+    {
+      "label": "macos-defaults-count-guard.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_count_guard_sh__entry",
+      "community": 395,
+      "norm_label": "macos-defaults-count-guard.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L29",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_count_guard_fail",
+      "community": 395,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "macos-defaults-scope-read.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read",
+      "community": 373,
+      "norm_label": "macos-defaults-scope-read.sh"
+    },
+    {
+      "label": "macos-defaults-scope-read.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read_sh__entry",
+      "community": 373,
+      "norm_label": "macos-defaults-scope-read.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L46",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read_fail",
+      "community": 373,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "call_function()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read_call_function",
+      "community": 373,
+      "norm_label": "call_function()"
+    },
+    {
+      "label": "reject_resolved_path()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L106",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read_reject_resolved_path",
+      "community": 373,
+      "norm_label": "reject_resolved_path()"
+    },
+    {
+      "label": "write_defaults_read_stub()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L207",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_scope_read_write_defaults_read_stub",
+      "community": 373,
+      "norm_label": "write_defaults_read_stub()"
+    },
+    {
+      "label": "macos-defaults-source-path-propagation.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation",
+      "community": 366,
+      "norm_label": "macos-defaults-source-path-propagation.sh"
+    },
+    {
+      "label": "macos-defaults-source-path-propagation.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "community": 366,
+      "norm_label": "macos-defaults-source-path-propagation.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L21",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_fail",
+      "community": 366,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L28",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_refute_file_contains",
+      "community": 366,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "write_git_stub()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L64",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_write_git_stub",
+      "community": 366,
+      "norm_label": "write_git_stub()"
+    },
+    {
+      "label": "write_chezmoi_stub()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L93",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_write_chezmoi_stub",
+      "community": 366,
+      "norm_label": "write_chezmoi_stub()"
+    },
+    {
+      "label": "call_lib()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L133",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_call_lib",
+      "community": 366,
+      "norm_label": "call_lib()"
+    },
+    {
+      "label": "call_lib_with_override()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L142",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_source_path_propagation_call_lib_with_override",
+      "community": 366,
+      "norm_label": "call_lib_with_override()"
+    },
+    {
+      "label": "macos-posture-indeterminate.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_posture_indeterminate",
+      "community": 390,
+      "norm_label": "macos-posture-indeterminate.sh"
+    },
+    {
+      "label": "macos-posture-indeterminate.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_posture_indeterminate_sh__entry",
+      "community": 390,
+      "norm_label": "macos-posture-indeterminate.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L28",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_posture_indeterminate_fail",
+      "community": 390,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "run_case()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L41",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_posture_indeterminate_run_case",
+      "community": 390,
+      "norm_label": "run_case()"
+    },
+    {
+      "label": "moshi-hook-bounce-on-upgrade.sh",
+      "file_type": "code",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_moshi_hook_bounce_on_upgrade",
+      "community": 379,
+      "norm_label": "moshi-hook-bounce-on-upgrade.sh"
+    },
+    {
+      "label": "moshi-hook-bounce-on-upgrade.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_moshi_hook_bounce_on_upgrade_sh__entry",
+      "community": 379,
+      "norm_label": "moshi-hook-bounce-on-upgrade.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L17",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_moshi_hook_bounce_on_upgrade_fail",
+      "community": 379,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "run_case()",
+      "file_type": "code",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L38",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_moshi_hook_bounce_on_upgrade_run_case",
+      "community": 379,
+      "norm_label": "run_case()"
+    },
+    {
+      "label": "kickstarted()",
+      "file_type": "code",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L76",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_moshi_hook_bounce_on_upgrade_kickstarted",
+      "community": 379,
+      "norm_label": "kickstarted()"
+    },
+    {
+      "label": "no-empty-render-skip-on-darwin.sh",
+      "file_type": "code",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_no_empty_render_skip_on_darwin",
+      "community": 396,
+      "norm_label": "no-empty-render-skip-on-darwin.sh"
+    },
+    {
+      "label": "no-empty-render-skip-on-darwin.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_no_empty_render_skip_on_darwin_sh__entry",
+      "community": 396,
+      "norm_label": "no-empty-render-skip-on-darwin.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L27",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_no_empty_render_skip_on_darwin_fail",
+      "community": 396,
+      "norm_label": "fail()"
+    },
+    {
       "label": "osquery-alert-drainer-launchagent.sh",
       "file_type": "code",
       "source_file": "test/unit/osquery-alert-drainer-launchagent.sh",
@@ -15747,7 +20745,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-allowlist-verdict.sh",
-      "source_location": "L34",
+      "source_location": "L35",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -15756,6 +20754,34 @@
       "id": "test_unit_osquery_allowlist_verdict_fail",
       "community": 350,
       "norm_label": "fail()"
+    },
+    {
+      "label": "write_bound_manifest()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-allowlist-verdict.sh",
+      "source_location": "L87",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_allowlist_verdict_write_bound_manifest",
+      "community": 350,
+      "norm_label": "write_bound_manifest()"
+    },
+    {
+      "label": "verdict_with()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-allowlist-verdict.sh",
+      "source_location": "L230",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_allowlist_verdict_verdict_with",
+      "community": 350,
+      "norm_label": "verdict_with()"
     },
     {
       "label": "osquery-digest-launchagent.sh",
@@ -16346,6 +21372,132 @@
       "norm_label": "b4_enrich_path()"
     },
     {
+      "label": "osquery-pipeline-audit.sh",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit",
+      "community": 361,
+      "norm_label": "osquery-pipeline-audit.sh"
+    },
+    {
+      "label": "osquery-pipeline-audit.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_sh__entry",
+      "community": 361,
+      "norm_label": "osquery-pipeline-audit.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L36",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_fail",
+      "community": 361,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "sha_of()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L66",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_sha_of",
+      "community": 361,
+      "norm_label": "sha_of()"
+    },
+    {
+      "label": "write_manifest()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L91",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_write_manifest",
+      "community": 361,
+      "norm_label": "write_manifest()"
+    },
+    {
+      "label": "write_bin_manifest()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L115",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_write_bin_manifest",
+      "community": 361,
+      "norm_label": "write_bin_manifest()"
+    },
+    {
+      "label": "run_scan()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L124",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_run_scan",
+      "community": 361,
+      "norm_label": "run_scan()"
+    },
+    {
+      "label": "expect_rc()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L138",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_expect_rc",
+      "community": 361,
+      "norm_label": "expect_rc()"
+    },
+    {
+      "label": "expect_out()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L141",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_pipeline_audit_expect_out",
+      "community": 361,
+      "norm_label": "expect_out()"
+    },
+    {
       "label": "osquery-pipeline-verdict.sh",
       "file_type": "code",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
@@ -16377,7 +21529,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
-      "source_location": "L33",
+      "source_location": "L48",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16391,7 +21543,7 @@
       "label": "sha_of()",
       "file_type": "code",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
-      "source_location": "L48",
+      "source_location": "L65",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16738,6 +21890,62 @@
       "norm_label": "page_cap_hard_limits_length()"
     },
     {
+      "label": "osquery-route-emit-failure.sh",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_emit_failure",
+      "community": 391,
+      "norm_label": "osquery-route-emit-failure.sh"
+    },
+    {
+      "label": "osquery-route-emit-failure.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_emit_failure_sh__entry",
+      "community": 391,
+      "norm_label": "osquery-route-emit-failure.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L25",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_emit_failure_fail",
+      "community": 391,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "run_gate()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L60",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_emit_failure_run_gate",
+      "community": 391,
+      "norm_label": "run_gate()"
+    },
+    {
       "label": "osquery-route-enrichment.sh",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-enrichment.sh",
@@ -16769,7 +21977,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L22",
+      "source_location": "L23",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16783,7 +21991,7 @@
       "label": "mk_plist()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L51",
+      "source_location": "L53",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16797,7 +22005,7 @@
       "label": "signing_of()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L89",
+      "source_location": "L102",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16811,7 +22019,7 @@
       "label": "in_page()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L90",
+      "source_location": "L103",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16867,7 +22075,7 @@
       "label": "classify()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-gate.sh",
-      "source_location": "L94",
+      "source_location": "L102",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16965,7 +22173,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L26",
+      "source_location": "L27",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16979,7 +22187,7 @@
       "label": "in_page()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L73",
+      "source_location": "L87",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17021,7 +22229,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L23",
+      "source_location": "L29",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17035,7 +22243,7 @@
       "label": "fe()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L41",
+      "source_location": "L48",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17049,7 +22257,7 @@
       "label": "run_gate()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L47",
+      "source_location": "L55",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17060,32 +22268,116 @@
       "norm_label": "run_gate()"
     },
     {
-      "label": "in_a()",
+      "label": "assert_paged()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
+      "source_location": "L74",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_pipeline_assert_paged",
+      "community": 303,
+      "norm_label": "assert_paged()"
+    },
+    {
+      "label": "refute_paged()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-pipeline.sh",
+      "source_location": "L77",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_pipeline_refute_paged",
+      "community": 303,
+      "norm_label": "refute_paged()"
+    },
+    {
+      "label": "osquery-route-severity-shortfall.sh",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_severity_shortfall",
+      "community": 374,
+      "norm_label": "osquery-route-severity-shortfall.sh"
+    },
+    {
+      "label": "osquery-route-severity-shortfall.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_severity_shortfall_sh__entry",
+      "community": 374,
+      "norm_label": "osquery-route-severity-shortfall.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L31",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_severity_shortfall_fail",
+      "community": 374,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L38",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_severity_shortfall_refute_contains",
+      "community": 374,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "assert_contains()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L42",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_route_severity_shortfall_assert_contains",
+      "community": 374,
+      "norm_label": "assert_contains()"
+    },
+    {
+      "label": "run_gate()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
       "source_location": "L75",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_unit_osquery_route_pipeline_in_a",
-      "community": 303,
-      "norm_label": "in_a()"
-    },
-    {
-      "label": "in_b()",
-      "file_type": "code",
-      "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L96",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_unit_osquery_route_pipeline_in_b",
-      "community": 303,
-      "norm_label": "in_b()"
+      "id": "test_unit_osquery_route_severity_shortfall_run_gate",
+      "community": 374,
+      "norm_label": "run_gate()"
     },
     {
       "label": "osquery-route-severity.sh",
@@ -17511,7 +22803,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L57",
+      "source_location": "L58",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17525,7 +22817,7 @@
       "label": "target_name()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L67",
+      "source_location": "L68",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17539,7 +22831,7 @@
       "label": "vendored_dirs()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L75",
+      "source_location": "L76",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17553,7 +22845,7 @@
       "label": "roster()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L82",
+      "source_location": "L83",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17567,7 +22859,7 @@
       "label": "claude_declarations()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L92",
+      "source_location": "L93",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17581,7 +22873,7 @@
       "label": "hermes_declaration_dirs()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L235",
+      "source_location": "L236",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17590,6 +22882,230 @@
       "id": "test_unit_skills_roster_fanout_hermes_declaration_dirs",
       "community": 106,
       "norm_label": "hermes_declaration_dirs()"
+    },
+    {
+      "label": "ssh-hardening-dropin.sh",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin",
+      "community": 397,
+      "norm_label": "ssh-hardening-dropin.sh"
+    },
+    {
+      "label": "ssh-hardening-dropin.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_sh__entry",
+      "community": 397,
+      "norm_label": "ssh-hardening-dropin.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L28",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_dropin_fail",
+      "community": 397,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "ssh-hardening-harness-wallclock.sh",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-harness-wallclock.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_harness_wallclock",
+      "community": 398,
+      "norm_label": "ssh-hardening-harness-wallclock.sh"
+    },
+    {
+      "label": "ssh-hardening-harness-wallclock.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-harness-wallclock.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_harness_wallclock_sh__entry",
+      "community": 398,
+      "norm_label": "ssh-hardening-harness-wallclock.sh script"
+    },
+    {
+      "label": "ssh-hardening-include-glob-unescape.sh",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape",
+      "community": 375,
+      "norm_label": "ssh-hardening-include-glob-unescape.sh"
+    },
+    {
+      "label": "ssh-hardening-include-glob-unescape.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape_sh__entry",
+      "community": 375,
+      "norm_label": "ssh-hardening-include-glob-unescape.sh script"
+    },
+    {
+      "label": "hostile_target()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L80",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape_hostile_target",
+      "community": 375,
+      "norm_label": "hostile_target()"
+    },
+    {
+      "label": "run_include_case()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L125",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape_run_include_case",
+      "community": 375,
+      "norm_label": "run_include_case()"
+    },
+    {
+      "label": "assert_scan_reaches()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L133",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches",
+      "community": 375,
+      "norm_label": "assert_scan_reaches()"
+    },
+    {
+      "label": "assert_scan_reaches_nothing()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L152",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches_nothing",
+      "community": 375,
+      "norm_label": "assert_scan_reaches_nothing()"
+    },
+    {
+      "label": "ssh-hardening-verify-failclosed.sh",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_verify_failclosed",
+      "community": 380,
+      "norm_label": "ssh-hardening-verify-failclosed.sh"
+    },
+    {
+      "label": "ssh-hardening-verify-failclosed.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_verify_failclosed_sh__entry",
+      "community": 380,
+      "norm_label": "ssh-hardening-verify-failclosed.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L26",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_verify_failclosed_fail",
+      "community": 380,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute_contains()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L33",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_verify_failclosed_refute_contains",
+      "community": 380,
+      "norm_label": "refute_contains()"
+    },
+    {
+      "label": "assert_named_failure()",
+      "file_type": "code",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L150",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_ssh_hardening_verify_failclosed_assert_named_failure",
+      "community": 380,
+      "norm_label": "assert_named_failure()"
     },
     {
       "label": "tailscaled-status.sh",
@@ -17637,7 +23153,7 @@
       "label": "make_fake()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L58",
+      "source_location": "L65",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17651,7 +23167,7 @@
       "label": "run_case()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L73",
+      "source_location": "L80",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17665,7 +23181,7 @@
       "label": "report()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L87",
+      "source_location": "L94",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17679,7 +23195,7 @@
       "label": "a0()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L109",
+      "source_location": "L116",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17693,7 +23209,7 @@
       "label": "am()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L112",
+      "source_location": "L119",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17707,7 +23223,7 @@
       "label": "an()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L115",
+      "source_location": "L122",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17721,7 +23237,7 @@
       "label": "asilent()",
       "file_type": "code",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L118",
+      "source_location": "L125",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17861,7 +23377,7 @@
       "label": "find_bsd_first_chains_in_file()",
       "file_type": "code",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L140",
+      "source_location": "L155",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17875,7 +23391,7 @@
       "label": "check_stat_order()",
       "file_type": "code",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L179",
+      "source_location": "L252",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17889,7 +23405,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L221",
+      "source_location": "L294",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -17963,7 +23479,7 @@
       "label": "Chezmoi Operations",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L78",
+      "source_location": "L80",
       "_origin": "ast",
       "id": "claude_chezmoi_operations",
       "community": 12,
@@ -17973,7 +23489,7 @@
       "label": "Claude Code Settings",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L106",
+      "source_location": "L108",
       "_origin": "ast",
       "id": "claude_claude_code_settings",
       "community": 12,
@@ -17983,7 +23499,7 @@
       "label": "Git Hooks",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L139",
+      "source_location": "L141",
       "_origin": "ast",
       "id": "claude_git_hooks",
       "community": 12,
@@ -17993,7 +23509,7 @@
       "label": "Architecture",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L182",
+      "source_location": "L195",
       "_origin": "ast",
       "id": "claude_architecture",
       "community": 12,
@@ -18003,7 +23519,7 @@
       "label": "Source-Only Files",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L184",
+      "source_location": "L197",
       "_origin": "ast",
       "id": "claude_source_only_files",
       "community": 12,
@@ -18013,7 +23529,7 @@
       "label": "Minimum Chezmoi Version",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L192",
+      "source_location": "L205",
       "_origin": "ast",
       "id": "claude_minimum_chezmoi_version",
       "community": 12,
@@ -18023,7 +23539,7 @@
       "label": "Secrets Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L196",
+      "source_location": "L209",
       "_origin": "ast",
       "id": "claude_secrets_management",
       "community": 12,
@@ -18033,7 +23549,7 @@
       "label": "System Package Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L203",
+      "source_location": "L216",
       "_origin": "ast",
       "id": "claude_system_package_management",
       "community": 12,
@@ -18043,7 +23559,7 @@
       "label": "macOS Defaults Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L228",
+      "source_location": "L241",
       "_origin": "ast",
       "id": "claude_macos_defaults_management",
       "community": 12,
@@ -18053,7 +23569,7 @@
       "label": "Template Files",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L273",
+      "source_location": "L286",
       "_origin": "ast",
       "id": "claude_template_files",
       "community": 12,
@@ -18063,7 +23579,7 @@
       "label": "Template Shellcheck Workaround",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L279",
+      "source_location": "L292",
       "_origin": "ast",
       "id": "claude_template_shellcheck_workaround",
       "community": 12,
@@ -18073,7 +23589,7 @@
       "label": "OS Targeting",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L300",
+      "source_location": "L313",
       "_origin": "ast",
       "id": "claude_os_targeting",
       "community": 12,
@@ -18083,7 +23599,7 @@
       "label": "Dev Environment (Nix Flake)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L305",
+      "source_location": "L318",
       "_origin": "ast",
       "id": "claude_dev_environment_nix_flake",
       "community": 12,
@@ -18093,7 +23609,7 @@
       "label": "CI",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L316",
+      "source_location": "L329",
       "_origin": "ast",
       "id": "claude_ci",
       "community": 12,
@@ -18103,7 +23619,7 @@
       "label": "Agent Skills (cross-harness store)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L326",
+      "source_location": "L339",
       "_origin": "ast",
       "id": "claude_agent_skills_cross_harness_store",
       "community": 12,
@@ -18113,7 +23629,7 @@
       "label": "Herdr Workspace Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L496",
+      "source_location": "L509",
       "_origin": "ast",
       "id": "claude_herdr_workspace_management",
       "community": 12,
@@ -18123,7 +23639,7 @@
       "label": "Git Worktrees (Worktrunk)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L516",
+      "source_location": "L529",
       "_origin": "ast",
       "id": "claude_git_worktrees_worktrunk",
       "community": 12,
@@ -18133,7 +23649,7 @@
       "label": "Bashrc Init Ordering",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L523",
+      "source_location": "L536",
       "_origin": "ast",
       "id": "claude_bashrc_init_ordering",
       "community": 12,
@@ -18143,7 +23659,7 @@
       "label": "Shell History (Atuin)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L531",
+      "source_location": "L544",
       "_origin": "ast",
       "id": "claude_shell_history_atuin",
       "community": 12,
@@ -18153,7 +23669,7 @@
       "label": "Happy Daemon (Remote Agent Control)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L560",
+      "source_location": "L573",
       "_origin": "ast",
       "id": "claude_happy_daemon_remote_agent_control",
       "community": 12,
@@ -18163,7 +23679,7 @@
       "label": "Tailscale (headless daemon)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L587",
+      "source_location": "L600",
       "_origin": "ast",
       "id": "claude_tailscale_headless_daemon",
       "community": 12,
@@ -18173,7 +23689,7 @@
       "label": "AI Commit Messages",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L624",
+      "source_location": "L637",
       "_origin": "ast",
       "id": "claude_ai_commit_messages",
       "community": 12,
@@ -18183,7 +23699,7 @@
       "label": "Long-running Command Notifier",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L637",
+      "source_location": "L650",
       "_origin": "ast",
       "id": "claude_long_running_command_notifier",
       "community": 12,
@@ -18193,7 +23709,7 @@
       "label": "Herdr Native Status",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L643",
+      "source_location": "L656",
       "_origin": "ast",
       "id": "claude_herdr_native_status",
       "community": 12,
@@ -18203,7 +23719,7 @@
       "label": "Code Style",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L649",
+      "source_location": "L662",
       "_origin": "ast",
       "id": "claude_code_style",
       "community": 12,
@@ -18213,7 +23729,7 @@
       "label": "Git Commits",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L675",
+      "source_location": "L688",
       "_origin": "ast",
       "id": "claude_git_commits",
       "community": 12,
@@ -18223,7 +23739,7 @@
       "label": "Security",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L682",
+      "source_location": "L695",
       "_origin": "ast",
       "id": "claude_security",
       "community": 12,
@@ -26670,10 +32186,70 @@
       "norm_label": "tcc privacy grants"
     },
     {
-      "label": "Hardware pairing",
+      "label": "OverSight notification delivery",
       "file_type": "document",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
       "source_location": "L45",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_oversight_notification_delivery",
+      "community": 49,
+      "norm_label": "oversight notification delivery"
+    },
+    {
+      "label": "LuLu system extension approval",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_lulu_system_extension_approval",
+      "community": 49,
+      "norm_label": "lulu system extension approval"
+    },
+    {
+      "label": "LuLu rule creation",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L82",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_lulu_rule_creation",
+      "community": 49,
+      "norm_label": "lulu rule creation"
+    },
+    {
+      "label": "LuLu preference changes",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L118",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_lulu_preference_changes",
+      "community": 49,
+      "norm_label": "lulu preference changes"
+    },
+    {
+      "label": "Firewall log diagnostics",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L150",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_firewall_log_diagnostics",
+      "community": 49,
+      "norm_label": "firewall log diagnostics"
+    },
+    {
+      "label": "SSH hardening: reload and the way back in",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L169",
+      "_origin": "ast",
+      "id": "docs_runbooks_macos_fresh_machine_quickstart_ssh_hardening_reload_and_the_way_back_in",
+      "community": 49,
+      "norm_label": "ssh hardening: reload and the way back in"
+    },
+    {
+      "label": "Hardware pairing",
+      "file_type": "document",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L190",
       "_origin": "ast",
       "id": "docs_runbooks_macos_fresh_machine_quickstart_hardware_pairing",
       "community": 49,
@@ -26683,7 +32259,7 @@
       "label": "App authentication",
       "file_type": "document",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L51",
+      "source_location": "L196",
       "_origin": "ast",
       "id": "docs_runbooks_macos_fresh_machine_quickstart_app_authentication",
       "community": 49,
@@ -26693,7 +32269,7 @@
       "label": "Login Items",
       "file_type": "document",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L57",
+      "source_location": "L202",
       "_origin": "ast",
       "id": "docs_runbooks_macos_fresh_machine_quickstart_login_items",
       "community": 49,
@@ -26703,7 +32279,7 @@
       "label": "Out-of-scope items (by design)",
       "file_type": "document",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L62",
+      "source_location": "L207",
       "_origin": "ast",
       "id": "docs_runbooks_macos_fresh_machine_quickstart_out_of_scope_items_by_design",
       "community": 49,
@@ -26713,7 +32289,7 @@
       "label": "Sanity checks after setup is complete",
       "file_type": "document",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L72",
+      "source_location": "L217",
       "_origin": "ast",
       "id": "docs_runbooks_macos_fresh_machine_quickstart_sanity_checks_after_setup_is_complete",
       "community": 49,
@@ -35300,10 +40876,20 @@
       "norm_label": "routing, lights, delivery"
     },
     {
+      "label": "moshi-hook integration, the harness hook contract",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
+      "source_location": "L737",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_moshi_hook_integration_the_harness_hook_contract",
+      "community": 10,
+      "norm_label": "moshi-hook integration, the harness hook contract"
+    },
+    {
       "label": "The empty-`(main) done` \"spam\", resolved",
       "file_type": "document",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L735",
+      "source_location": "L805",
       "_origin": "ast",
       "id": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_the_empty_main_done_spam_resolved",
       "community": 10,
@@ -35313,7 +40899,7 @@
       "label": "Bugs the rewrite must not reproduce (the shell findings are the failure spec)",
       "file_type": "document",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L743",
+      "source_location": "L813",
       "_origin": "ast",
       "id": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_bugs_the_rewrite_must_not_reproduce_the_shell_findings_are_the_failure_spec",
       "community": 10,
@@ -35323,7 +40909,7 @@
       "label": "Testing & design strategy (essential-feed, binding on *how*, not *what*)",
       "file_type": "document",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L750",
+      "source_location": "L820",
       "_origin": "ast",
       "id": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_testing_design_strategy_essential_feed_binding_on_how_not_what",
       "community": 10,
@@ -35333,11 +40919,551 @@
       "label": "Verification (extended sections)",
       "file_type": "document",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L807",
+      "source_location": "L877",
       "_origin": "ast",
       "id": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_verification_extended_sections",
       "community": 10,
       "norm_label": "verification (extended sections)"
+    },
+    {
+      "label": "2026-07-26-osquery-allowlist-boundary-design.md",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design",
+      "community": 355,
+      "norm_label": "2026-07-26-osquery-allowlist-boundary-design.md"
+    },
+    {
+      "label": "Design: making the page-launchd allowlist a real boundary",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "community": 355,
+      "norm_label": "design: making the page-launchd allowlist a real boundary"
+    },
+    {
+      "label": "Context",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_context",
+      "community": 355,
+      "norm_label": "context"
+    },
+    {
+      "label": "What I verified before designing",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_what_i_verified_before_designing",
+      "community": 355,
+      "norm_label": "what i verified before designing"
+    },
+    {
+      "label": "The reframe that facts 5 and 7 force",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_the_reframe_that_facts_5_and_7_force",
+      "community": 355,
+      "norm_label": "the reframe that facts 5 and 7 force"
+    },
+    {
+      "label": "Options",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "community": 355,
+      "norm_label": "options"
+    },
+    {
+      "label": "A. Root-own the allowlist with a privileged update path",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_a_root_own_the_allowlist_with_a_privileged_update_path",
+      "community": 355,
+      "norm_label": "a. root-own the allowlist with a privileged update path"
+    },
+    {
+      "label": "B. Manifest the allowlist and route the writer through chezmoi",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L102",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_b_manifest_the_allowlist_and_route_the_writer_through_chezmoi",
+      "community": 355,
+      "norm_label": "b. manifest the allowlist and route the writer through chezmoi"
+    },
+    {
+      "label": "C. Page on any allowlist mutation",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L131",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_c_page_on_any_allowlist_mutation",
+      "community": 355,
+      "norm_label": "c. page on any allowlist mutation"
+    },
+    {
+      "label": "D. Bind the allowlist's content to something the attacker cannot also edit",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L152",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_d_bind_the_allowlist_s_content_to_something_the_attacker_cannot_also_edit",
+      "community": 355,
+      "norm_label": "d. bind the allowlist's content to something the attacker cannot also edit"
+    },
+    {
+      "label": "E. Suppress own agents by manifest membership instead of by allowlist entry",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L184",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_e_suppress_own_agents_by_manifest_membership_instead_of_by_allowlist_entry",
+      "community": 355,
+      "norm_label": "e. suppress own agents by manifest membership instead of by allowlist entry"
+    },
+    {
+      "label": "Recommendation",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L208",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_recommendation",
+      "community": 355,
+      "norm_label": "recommendation"
+    },
+    {
+      "label": "What this does not defend against",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L243",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_what_this_does_not_defend_against",
+      "community": 355,
+      "norm_label": "what this does not defend against"
+    },
+    {
+      "label": "Open question for adjudication",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L283",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_open_question_for_adjudication",
+      "community": 355,
+      "norm_label": "open question for adjudication"
+    },
+    {
+      "label": "2026-07-26-s10-decomposition-design.md",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design",
+      "community": 266,
+      "norm_label": "2026-07-26-s10-decomposition-design.md"
+    },
+    {
+      "label": "S10 decomposition design",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "community": 266,
+      "norm_label": "s10 decomposition design"
+    },
+    {
+      "label": "Context",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_context",
+      "community": 266,
+      "norm_label": "context"
+    },
+    {
+      "label": "Goal",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_goal",
+      "community": 266,
+      "norm_label": "goal"
+    },
+    {
+      "label": "Constraints and standing policy",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L60",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_constraints_and_standing_policy",
+      "community": 266,
+      "norm_label": "constraints and standing policy"
+    },
+    {
+      "label": "Recurring bug classes every slice inherits",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L73",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_recurring_bug_classes_every_slice_inherits",
+      "community": 266,
+      "norm_label": "recurring bug classes every slice inherits"
+    },
+    {
+      "label": "Style conventions every slice inherits",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L95",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_style_conventions_every_slice_inherits",
+      "community": 266,
+      "norm_label": "style conventions every slice inherits"
+    },
+    {
+      "label": "The three-tier control model",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L112",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_three_tier_control_model",
+      "community": 266,
+      "norm_label": "the three-tier control model"
+    },
+    {
+      "label": "Where a tier is declared",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L116",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_where_a_tier_is_declared",
+      "community": 266,
+      "norm_label": "where a tier is declared"
+    },
+    {
+      "label": "How the runner enforces the distinction",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L136",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_how_the_runner_enforces_the_distinction",
+      "community": 266,
+      "norm_label": "how the runner enforces the distinction"
+    },
+    {
+      "label": "What this prevents",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L163",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_what_this_prevents",
+      "community": 266,
+      "norm_label": "what this prevents"
+    },
+    {
+      "label": "Known blockers",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L172",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_known_blockers",
+      "community": 266,
+      "norm_label": "known blockers"
+    },
+    {
+      "label": "Blocker one: duplicate hermes profile source directories",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L177",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_blocker_one_duplicate_hermes_profile_source_directories",
+      "community": 266,
+      "norm_label": "blocker one: duplicate hermes profile source directories"
+    },
+    {
+      "label": "Blocker two: `main` does not declare the endpoint-security casks (task #45)",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L217",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_blocker_two_main_does_not_declare_the_endpoint_security_casks_task_45",
+      "community": 266,
+      "norm_label": "blocker two: `main` does not declare the endpoint-security casks (task #45)"
+    },
+    {
+      "label": "The slice stack",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L237",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "community": 266,
+      "norm_label": "the slice stack"
+    },
+    {
+      "label": "Slice 0: declare the endpoint-security casks",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L260",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_0_declare_the_endpoint_security_casks",
+      "community": 266,
+      "norm_label": "slice 0: declare the endpoint-security casks"
+    },
+    {
+      "label": "Slice 1: macOS defaults shared library",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L308",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_1_macos_defaults_shared_library",
+      "community": 266,
+      "norm_label": "slice 1: macos defaults shared library"
+    },
+    {
+      "label": "Slice 2: system-domain support in the defaults tooling",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L357",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_2_system_domain_support_in_the_defaults_tooling",
+      "community": 266,
+      "norm_label": "slice 2: system-domain support in the defaults tooling"
+    },
+    {
+      "label": "Slice 3: the tiered control model",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L417",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_3_the_tiered_control_model",
+      "community": 266,
+      "norm_label": "slice 3: the tiered control model"
+    },
+    {
+      "label": "Slice 4: firewall baseline",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L470",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_4_firewall_baseline",
+      "community": 266,
+      "norm_label": "slice 4: firewall baseline"
+    },
+    {
+      "label": "Slice 5: security defaults baseline",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L523",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_5_security_defaults_baseline",
+      "community": 266,
+      "norm_label": "slice 5: security defaults baseline"
+    },
+    {
+      "label": "Slice 6: posture verification and alerting",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L575",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_6_posture_verification_and_alerting",
+      "community": 266,
+      "norm_label": "slice 6: posture verification and alerting"
+    },
+    {
+      "label": "Slice 7: SSH configuration generation",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L658",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_7_ssh_configuration_generation",
+      "community": 266,
+      "norm_label": "slice 7: ssh configuration generation"
+    },
+    {
+      "label": "Slice 8: SSH apply safety",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L744",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_8_ssh_apply_safety",
+      "community": 266,
+      "norm_label": "slice 8: ssh apply safety"
+    },
+    {
+      "label": "Slice 9: OverSight posture",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L818",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_9_oversight_posture",
+      "community": 266,
+      "norm_label": "slice 9: oversight posture"
+    },
+    {
+      "label": "Slice 10: LuLu policy and posture",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L874",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_10_lulu_policy_and_posture",
+      "community": 266,
+      "norm_label": "slice 10: lulu policy and posture"
+    },
+    {
+      "label": "The two gates, both resolved",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L906",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_two_gates_both_resolved",
+      "community": 266,
+      "norm_label": "the two gates, both resolved"
+    },
+    {
+      "label": "The enforce-tier policy controls, and why `allowLocalHost` is the critical one",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L956",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_enforce_tier_policy_controls_and_why_allowlocalhost_is_the_critical_one",
+      "community": 266,
+      "norm_label": "the enforce-tier policy controls, and why `allowlocalhost` is the critical one"
+    },
+    {
+      "label": "The allow-rule set, and a correction to how the alerting path egresses",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L988",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_allow_rule_set_and_a_correction_to_how_the_alerting_path_egresses",
+      "community": 266,
+      "norm_label": "the allow-rule set, and a correction to how the alerting path egresses"
+    },
+    {
+      "label": "The recovery story for slice 8",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1099",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "community": 266,
+      "norm_label": "the recovery story for slice 8"
+    },
+    {
+      "label": "The ways back in, in order of independence",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1105",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_ways_back_in_in_order_of_independence",
+      "community": 266,
+      "norm_label": "the ways back in, in order of independence"
+    },
+    {
+      "label": "How the recovery path is pinned by a test rather than asserted in a comment",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1123",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_how_the_recovery_path_is_pinned_by_a_test_rather_than_asserted_in_a_comment",
+      "community": 266,
+      "norm_label": "how the recovery path is pinned by a test rather than asserted in a comment"
+    },
+    {
+      "label": "What the tests can and cannot establish",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1140",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_what_the_tests_can_and_cannot_establish",
+      "community": 266,
+      "norm_label": "what the tests can and cannot establish"
+    },
+    {
+      "label": "The live drill, run before slice 8 merges",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1163",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_live_drill_run_before_slice_8_merges",
+      "community": 266,
+      "norm_label": "the live drill, run before slice 8 merges"
+    },
+    {
+      "label": "Per-slice process",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1180",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_per_slice_process",
+      "community": 266,
+      "norm_label": "per-slice process"
+    },
+    {
+      "label": "Verification",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1198",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_verification",
+      "community": 266,
+      "norm_label": "verification"
+    },
+    {
+      "label": "Risks and open items",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1219",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_risks_and_open_items",
+      "community": 266,
+      "norm_label": "risks and open items"
+    },
+    {
+      "label": "Work in pull request #53 the original eight-slice plan did not account for",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1221",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_work_in_pull_request_53_the_original_eight_slice_plan_did_not_account_for",
+      "community": 266,
+      "norm_label": "work in pull request #53 the original eight-slice plan did not account for"
+    },
+    {
+      "label": "Other risks",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1271",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_other_risks",
+      "community": 266,
+      "norm_label": "other risks"
+    },
+    {
+      "label": "Out of scope",
+      "file_type": "document",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1303",
+      "_origin": "ast",
+      "id": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_out_of_scope",
+      "community": 266,
+      "norm_label": "out of scope"
     },
     {
       "label": "SKILL.md",
@@ -36508,257 +42634,48 @@
       "id": "private_dot_claude_commands_pr_merge_safeguards",
       "community": 226,
       "norm_label": "safeguards"
-    },
-    {
-      "label": "slice-pipeline-manifest-plan.md",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan",
-      "community": 266,
-      "norm_label": "slice-pipeline-manifest-plan.md"
-    },
-    {
-      "label": "Slice 15 - Pipeline manifest (S9 re-land, final slice)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "community": 266,
-      "norm_label": "slice 15 - pipeline manifest (s9 re-land, final slice)"
-    },
-    {
-      "label": "What the manifest is (grounded in the spec + c69baab + current state)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L8",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_what_the_manifest_is_grounded_in_the_spec_c69baab_current_state",
-      "community": 266,
-      "norm_label": "what the manifest is (grounded in the spec + c69baab + current state)"
-    },
-    {
-      "label": "The pipeline file set the manifest must cover (real, on disk today)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L36",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_the_pipeline_file_set_the_manifest_must_cover_real_on_disk_today",
-      "community": 266,
-      "norm_label": "the pipeline file set the manifest must cover (real, on disk today)"
-    },
-    {
-      "label": "How it should be generated (the key design improvement over c69baab)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L54",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_how_it_should_be_generated_the_key_design_improvement_over_c69baab",
-      "community": 266,
-      "norm_label": "how it should be generated (the key design improvement over c69baab)"
-    },
-    {
-      "label": "Banked concern A - the digest self-page gap (verified bug) + completeness guard",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L90",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_banked_concern_a_the_digest_self_page_gap_verified_bug_completeness_guard",
-      "community": 266,
-      "norm_label": "banked concern a - the digest self-page gap (verified bug) + completeness guard"
-    },
-    {
-      "label": "Banked concern B - the FIM watch scope (fail-open over-paging) - NEEDS AN OPERATOR RULING",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L128",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_banked_concern_b_the_fim_watch_scope_fail_open_over_paging_needs_an_operator_ruling",
-      "community": 266,
-      "norm_label": "banked concern b - the fim watch scope (fail-open over-paging) - needs an operator ruling"
-    },
-    {
-      "label": "Behavior decomposition (ordered TDD behaviors)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L174",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_behavior_decomposition_ordered_tdd_behaviors",
-      "community": 266,
-      "norm_label": "behavior decomposition (ordered tdd behaviors)"
-    },
-    {
-      "label": "Files added / changed",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L216",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_files_added_changed",
-      "community": 266,
-      "norm_label": "files added / changed"
-    },
-    {
-      "label": "Dependencies",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L249",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_dependencies",
-      "community": 266,
-      "norm_label": "dependencies"
-    },
-    {
-      "label": "Durability / security invariants",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L257",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_durability_security_invariants",
-      "community": 266,
-      "norm_label": "durability / security invariants"
-    },
-    {
-      "label": "Open questions / operator rulings",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L274",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_plan_open_questions_operator_rulings",
-      "community": 266,
-      "norm_label": "open questions / operator rulings"
-    },
-    {
-      "label": "slice-pipeline-manifest-report.md",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report",
-      "community": 351,
-      "norm_label": "slice-pipeline-manifest-report.md"
-    },
-    {
-      "label": "Slice 15 - Pipeline manifest - full-branch chain-of-thought report",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L1",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "community": 351,
-      "norm_label": "slice 15 - pipeline manifest - full-branch chain-of-thought report"
-    },
-    {
-      "label": "Commit ledger (origin/main..HEAD)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L10",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_commit_ledger_origin_main_head",
-      "community": 351,
-      "norm_label": "commit ledger (origin/main..head)"
-    },
-    {
-      "label": "Step-by-step over `git diff 8809a39..HEAD`",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L22",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_step_by_step_over_git_diff_8809a39_head",
-      "community": 351,
-      "norm_label": "step-by-step over `git diff 8809a39..head`"
-    },
-    {
-      "label": "Invariants: stated, located, pinned",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L54",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_invariants_stated_located_pinned",
-      "community": 351,
-      "norm_label": "invariants: stated, located, pinned"
-    },
-    {
-      "label": "Test-harness defect found while fixing R3-F4",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L169",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_test_harness_defect_found_while_fixing_r3_f4",
-      "community": 351,
-      "norm_label": "test-harness defect found while fixing r3-f4"
-    },
-    {
-      "label": "Status-loss sweep (whole slice)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L181",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_status_loss_sweep_whole_slice",
-      "community": 351,
-      "norm_label": "status-loss sweep (whole slice)"
-    },
-    {
-      "label": "Corrections to the previous report",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L202",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_corrections_to_the_previous_report",
-      "community": 351,
-      "norm_label": "corrections to the previous report"
-    },
-    {
-      "label": "Adjudicated limits: what this layer does NOT cover, and why not here",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L215",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_adjudicated_limits_what_this_layer_does_not_cover_and_why_not_here",
-      "community": 351,
-      "norm_label": "adjudicated limits: what this layer does not cover, and why not here"
-    },
-    {
-      "label": "Documented, not fixed (filed as follow-ups)",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L247",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_documented_not_fixed_filed_as_follow_ups",
-      "community": 351,
-      "norm_label": "documented, not fixed (filed as follow-ups)"
-    },
-    {
-      "label": "Code-quality summary",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L258",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_code_quality_summary",
-      "community": 351,
-      "norm_label": "code-quality summary"
-    },
-    {
-      "label": "Gate evidence",
-      "file_type": "document",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L274",
-      "_origin": "ast",
-      "id": "slice_pipeline_manifest_report_gate_evidence",
-      "community": 351,
-      "norm_label": "gate evidence"
     }
   ],
   "links": [
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
+      "source_location": "L258",
+      "weight": 1.0,
+      "source": "chezmoiscripts_run_after_05_osquery_known_good_manifests",
+      "target": "chezmoiscripts_run_after_05_osquery_known_good_manifests_intended_perm",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
+      "source_location": "L293",
+      "weight": 1.0,
+      "source": "chezmoiscripts_run_after_05_osquery_known_good_manifests",
+      "target": "chezmoiscripts_run_after_05_osquery_known_good_manifests_refresh_manifest",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": ".chezmoiscripts/run_after_05-osquery-pipeline-manifest.sh",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
       "source_location": "L1",
       "weight": 1.0,
-      "source": "chezmoiscripts_run_after_05_osquery_pipeline_manifest",
-      "target": "chezmoiscripts_run_after_05_osquery_pipeline_manifest_sh__entry",
+      "source": "chezmoiscripts_run_after_05_osquery_known_good_manifests",
+      "target": "chezmoiscripts_run_after_05_osquery_known_good_manifests_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_after_05-osquery-known-good-manifests.sh",
+      "source_location": "L361",
+      "weight": 1.0,
+      "context": "call",
+      "source": "chezmoiscripts_run_after_05_osquery_known_good_manifests_sh__entry",
+      "target": "chezmoiscripts_run_after_05_osquery_known_good_manifests_refresh_manifest",
       "confidence_score": 1.0
     },
     {
@@ -37907,7 +43824,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L23",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_capture",
       "target": "dot_local_bin_executable_macos_defaults_capture_usage",
@@ -37917,7 +43834,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
-      "source_location": "L28",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_macos_defaults_capture_sh__entry",
@@ -37928,7 +43845,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L25",
+      "source_location": "L32",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_drift",
       "target": "dot_local_bin_executable_macos_defaults_drift_normalize",
@@ -37938,7 +43855,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L41",
+      "source_location": "L52",
       "weight": 1.0,
       "source": "dot_local_bin_executable_macos_defaults_drift",
       "target": "dot_local_bin_executable_macos_defaults_drift_print_header",
@@ -37958,7 +43875,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L61",
+      "source_location": "L96",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_macos_defaults_drift_sh__entry",
@@ -38017,6 +43934,336 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L305",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L359",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1332",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_banner_output_names_host_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L332",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_canonical_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L985",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L377",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_check_global",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L940",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_check_match_scan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1500",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_check_password_channel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1542",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L498",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L180",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_dropin_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L737",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_include_bracket_opens_a_set",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1087",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1622",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L652",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_next_argument_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L648",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L661",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_print_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1200",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_probe_sshd_service",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L563",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_read_argument_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L510",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L639",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_read_token_with_progress_guard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1181",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_recovery_instructions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1373",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L343",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_required_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1278",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1581",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1064",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_rollback_install",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_run_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L280",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_run_verify_child",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L884",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L827",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_scan_included_files",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
@@ -38024,6 +44271,777 @@
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L551",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_skip_argument_separators",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L482",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_skip_keyword_separators",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L471",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_trim_trailing_line_whitespace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L774",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1599",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_usage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1230",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1014",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_verify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L294",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1347",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L185",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_warn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1656",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
+      "target": "dot_local_bin_executable_ssh_hardening_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1549",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1102",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1388",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1283",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1590",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1233",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1365",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
+      "target": "dot_local_bin_executable_ssh_hardening_die",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1163",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_warn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1067",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_rollback_install",
+      "target": "dot_local_bin_executable_ssh_hardening_warn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1103",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_run_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1589",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_run_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1066",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_rollback_install",
+      "target": "dot_local_bin_executable_ssh_hardening_run_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1643",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_dropin_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1111",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_print_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1642",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_print_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1157",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_run_verify_child",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1415",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_run_verify_child",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1545",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1168",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1017",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_verify",
+      "target": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L368",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L991",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L383",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_global",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L961",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_match_scan",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L888",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L836",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_included_files",
+      "target": "dot_local_bin_executable_ssh_hardening_add_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L930",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "target": "dot_local_bin_executable_ssh_hardening_canonical_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L931",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "target": "dot_local_bin_executable_ssh_hardening_required_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1010",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
+      "target": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L386",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_global",
+      "target": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1024",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_verify",
+      "target": "dot_local_bin_executable_ssh_hardening_check_global",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L663",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "target": "dot_local_bin_executable_ssh_hardening_trim_trailing_line_whitespace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L499",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
+      "target": "dot_local_bin_executable_ssh_hardening_skip_keyword_separators",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L512",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
+      "target": "dot_local_bin_executable_ssh_hardening_skip_keyword_separators",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L521",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
+      "target": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L565",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_read_argument_token",
+      "target": "dot_local_bin_executable_ssh_hardening_skip_argument_separators",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L653",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_next_argument_token",
+      "target": "dot_local_bin_executable_ssh_hardening_read_token_with_progress_guard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L649",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
+      "target": "dot_local_bin_executable_ssh_hardening_read_token_with_progress_guard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L666",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "target": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L686",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "target": "dot_local_bin_executable_ssh_hardening_next_argument_token",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L910",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "target": "dot_local_bin_executable_ssh_hardening_parse_config_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L796",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
+      "target": "dot_local_bin_executable_ssh_hardening_include_bracket_opens_a_set",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L848",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_included_files",
+      "target": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L919",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "target": "dot_local_bin_executable_ssh_hardening_scan_included_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L981",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_check_match_scan",
+      "target": "dot_local_bin_executable_ssh_hardening_scan_config_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1025",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_verify",
+      "target": "dot_local_bin_executable_ssh_hardening_check_match_scan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1026",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_verify",
+      "target": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1644",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_verify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1112",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_rollback_install",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1647",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1425",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_probe_sshd_service",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1376",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1422",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1356",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
+      "target": "dot_local_bin_executable_ssh_hardening_banner_output_names_host_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1467",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "target": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1645",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_reload_sshd",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1551",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "target": "dot_local_bin_executable_ssh_hardening_check_password_channel",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1586",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "target": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1646",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1624",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_main",
+      "target": "dot_local_bin_executable_ssh_hardening_usage",
       "confidence_score": 1.0
     },
     {
@@ -40565,8 +47583,221 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L191",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_declared_count",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_field_count",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_join_expression",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_locate_malformed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L236",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_raw_stream",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L292",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_validate_stream",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_macos_defaults_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_require_readable_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L445",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_require_system_plist_path_permitted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_resolve_source_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L416",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L523",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_system_defaults_read_actual",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L492",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_system_defaults_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L384",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_explicit_plist_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L318",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_scope",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L351",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_system_domain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L297",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_validate_stream",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L418",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
+      "target": "dot_local_bin_macos_defaults_lib_validate_system_domain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L423",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
+      "target": "dot_local_bin_macos_defaults_lib_validate_explicit_plist_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1108",
+      "source_location": "L1120",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_attempt_alert_delivery",
@@ -40576,7 +47807,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1089",
+      "source_location": "L1101",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_build_webhook_body",
@@ -40596,7 +47827,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1099",
+      "source_location": "L1111",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_derive_request_id",
@@ -40616,7 +47847,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L987",
+      "source_location": "L999",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_drain_pending_local_notifications",
@@ -40686,7 +47917,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1078",
+      "source_location": "L1090",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_dead_letter_count",
@@ -40706,7 +47937,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L889",
+      "source_location": "L901",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_delete_local_notification_row",
@@ -40716,7 +47947,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L877",
+      "source_location": "L889",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_epoch_to_iso8601",
@@ -40726,7 +47957,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L916",
+      "source_location": "L928",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_expire_over_age_local_notifications",
@@ -40736,7 +47967,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L850",
+      "source_location": "L862",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_hex_to_text",
@@ -40756,7 +47987,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L817",
+      "source_location": "L829",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_notify_local_durable",
@@ -40766,7 +47997,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1069",
+      "source_location": "L1081",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_pending_alert_count",
@@ -40786,7 +48017,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L864",
+      "source_location": "L876",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_pending_local_notification_rows",
@@ -40886,7 +48117,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1017",
+      "source_location": "L1029",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_post_alert_to_webhook",
@@ -40896,7 +48127,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1004",
+      "source_location": "L1016",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_read_webhook_secret",
@@ -40906,7 +48137,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L953",
+      "source_location": "L965",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_redeliver_pending_local_notification",
@@ -40916,7 +48147,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1032",
+      "source_location": "L1044",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_retry_undelivered_alerts",
@@ -40926,7 +48157,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1150",
+      "source_location": "L1162",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_alert_dispatch",
       "target": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -40977,7 +48208,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L931",
+      "source_location": "L943",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_expire_over_age_local_notifications",
@@ -40988,7 +48219,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L826",
+      "source_location": "L838",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_notify_local_durable",
@@ -41010,7 +48241,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L959",
+      "source_location": "L971",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_redeliver_pending_local_notification",
@@ -41021,7 +48252,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1053",
+      "source_location": "L1065",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_retry_undelivered_alerts",
@@ -41032,7 +48263,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1186",
+      "source_location": "L1198",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -41076,7 +48307,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L896",
+      "source_location": "L908",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_delete_local_notification_row",
@@ -41098,7 +48329,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L871",
+      "source_location": "L883",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_pending_local_notification_rows",
@@ -41153,7 +48384,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L988",
+      "source_location": "L1000",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_drain_pending_local_notifications",
@@ -41175,7 +48406,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L830",
+      "source_location": "L842",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_notify_local_durable",
@@ -41219,7 +48450,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L975",
+      "source_location": "L987",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_redeliver_pending_local_notification",
@@ -41241,7 +48472,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1079",
+      "source_location": "L1091",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_dead_letter_count",
@@ -41252,7 +48483,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1070",
+      "source_location": "L1082",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_pending_alert_count",
@@ -41274,7 +48505,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1218",
+      "source_location": "L1230",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -41296,7 +48527,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1185",
+      "source_location": "L1197",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -41307,7 +48538,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1153",
+      "source_location": "L1165",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -41329,7 +48560,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L827",
+      "source_location": "L839",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_notify_local_durable",
@@ -41340,7 +48571,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L835",
+      "source_location": "L847",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_notify_local_durable",
@@ -41362,7 +48593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L972",
+      "source_location": "L984",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_redeliver_pending_local_notification",
@@ -41373,7 +48604,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1058",
+      "source_location": "L1070",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_retry_undelivered_alerts",
@@ -41384,7 +48615,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1191",
+      "source_location": "L1203",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_send_alert",
@@ -41395,7 +48626,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L930",
+      "source_location": "L942",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_osquery_expire_over_age_local_notifications",
@@ -41406,7 +48637,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L989",
+      "source_location": "L1001",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_drain_pending_local_notifications",
@@ -41417,7 +48648,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L995",
+      "source_location": "L1007",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_drain_pending_local_notifications",
@@ -41428,7 +48659,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_alert-dispatch.sh",
-      "source_location": "L1040",
+      "source_location": "L1052",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_alert_dispatch_retry_undelivered_alerts",
@@ -41439,7 +48670,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L94",
+      "source_location": "L198",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_allow_label",
@@ -41449,7 +48680,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L143",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_allowlist",
+      "target": "dot_local_libexec_osquery_executable_allowlist_allowlist_source_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L254",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_deny_label",
@@ -41459,7 +48700,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L63",
+      "source_location": "L73",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_entry_label",
@@ -41469,7 +48710,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L85",
+      "source_location": "L189",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_is_valid_label",
@@ -41479,10 +48720,30 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L164",
+      "source_location": "L283",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_list_entries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_allowlist",
+      "target": "dot_local_libexec_osquery_executable_allowlist_manifest_runner_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_allowlist",
+      "target": "dot_local_libexec_osquery_executable_allowlist_publish_allowlist",
       "confidence_score": 1.0
     },
     {
@@ -41499,7 +48760,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L47",
+      "source_location": "L57",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_take_allowlist_write_lock",
@@ -41509,7 +48770,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L26",
+      "source_location": "L36",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_usage",
@@ -41519,7 +48780,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L67",
+      "source_location": "L77",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_allowlist",
       "target": "dot_local_libexec_osquery_executable_allowlist_without_label",
@@ -41529,7 +48790,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L207",
+      "source_location": "L326",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_sh__entry",
@@ -41540,7 +48801,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L208",
+      "source_location": "L327",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_sh__entry",
@@ -41551,7 +48812,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L209",
+      "source_location": "L328",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_sh__entry",
@@ -41562,7 +48823,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L199",
+      "source_location": "L318",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_sh__entry",
@@ -41573,7 +48834,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L190",
+      "source_location": "L309",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_sh__entry",
@@ -41584,7 +48845,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L136",
+      "source_location": "L247",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_allow_label",
@@ -41595,7 +48856,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L157",
+      "source_location": "L276",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_deny_label",
@@ -41606,7 +48867,29 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L96",
+      "source_location": "L250",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_allowlist_allow_label",
+      "target": "dot_local_libexec_osquery_executable_allowlist_publish_allowlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L277",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_allowlist_deny_label",
+      "target": "dot_local_libexec_osquery_executable_allowlist_publish_allowlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
+      "source_location": "L200",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_allow_label",
@@ -41617,7 +48900,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_allowlist.sh",
-      "source_location": "L145",
+      "source_location": "L256",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_allowlist_deny_label",
@@ -41648,7 +48931,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L69",
+      "source_location": "L73",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_digest_title",
@@ -41658,7 +48941,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L145",
+      "source_location": "L149",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_main",
@@ -41668,7 +48951,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L31",
+      "source_location": "L35",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_numeric_or",
@@ -41678,7 +48961,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L91",
+      "source_location": "L95",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_render_digest_body",
@@ -41688,7 +48971,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L49",
+      "source_location": "L53",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_restore_batch",
@@ -41698,7 +48981,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L58",
+      "source_location": "L62",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_rotate_to_last",
@@ -41708,7 +48991,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L40",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_digest",
       "target": "dot_local_libexec_osquery_executable_digest_rotated_work_file",
@@ -41728,7 +49011,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L228",
+      "source_location": "L237",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_digest_sh__entry",
@@ -41739,7 +49022,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L220",
+      "source_location": "L229",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_digest_main",
@@ -41750,7 +49033,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_digest.sh",
-      "source_location": "L195",
+      "source_location": "L199",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_digest_main",
@@ -41761,7 +49044,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L71",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_drain_undelivered_alerts",
       "target": "dot_local_libexec_osquery_executable_drain_undelivered_alerts_main",
@@ -41781,7 +49064,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L57",
+      "source_location": "L59",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_drain_undelivered_alerts",
       "target": "dot_local_libexec_osquery_executable_drain_undelivered_alerts_take_single_instance_lock",
@@ -41791,7 +49074,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L80",
+      "source_location": "L115",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_drain_undelivered_alerts_sh__entry",
@@ -41802,7 +49085,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_drain-undelivered-alerts.sh",
-      "source_location": "L72",
+      "source_location": "L104",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_drain_undelivered_alerts_main",
@@ -41864,7 +49147,37 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L204",
+      "source_location": "L220",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_pgrep",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L185",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_probe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L856",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_control_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L911",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_fw_to_text",
@@ -41874,7 +49187,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L212",
+      "source_location": "L919",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_gk_to_text",
@@ -41884,7 +49197,37 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L162",
+      "source_location": "L451",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_load_controls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L246",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_base_rules_authoritative",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L276",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_rule_in_archive",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L837",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_page_crit_and_persist",
@@ -41894,7 +49237,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L68",
+      "source_location": "L602",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_page_gap_once",
@@ -41904,10 +49247,80 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L143",
+      "source_location": "L818",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_persist_baseline",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L316",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_domain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L168",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_reads_lulu_base_rules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_requires_target",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_run_bounded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sanitize",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sanitize_span",
       "confidence_score": 1.0
     },
     {
@@ -41924,7 +49337,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L219",
+      "source_location": "L926",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sl_to_text",
@@ -41934,7 +49347,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L127",
+      "source_location": "L802",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor",
       "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_write_state",
@@ -41944,7 +49357,29 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L199",
+      "source_location": "L553",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_load_controls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L579",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_base_rules_authoritative",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L906",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
@@ -41955,7 +49390,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L91",
+      "source_location": "L700",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
@@ -41966,7 +49401,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L196",
+      "source_location": "L903",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
@@ -41977,7 +49412,73 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L149",
+      "source_location": "L578",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_sh__entry",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_reads_lulu_base_rules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L523",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_load_controls",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_reader_requires_target",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L328",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_probe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L385",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_classify_pgrep",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L402",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_base_rules_authoritative",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L406",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_read_control",
+      "target": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_lulu_rule_in_archive",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
+      "source_location": "L824",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_persist_baseline",
@@ -41988,7 +49489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L144",
+      "source_location": "L819",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_persist_baseline",
@@ -41999,7 +49500,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh",
-      "source_location": "L172",
+      "source_location": "L847",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_firewall_gatekeeper_monitor_page_crit_and_persist",
@@ -42010,7 +49511,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_heartbeat.sh",
-      "source_location": "L36",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_heartbeat",
       "target": "dot_local_libexec_osquery_executable_heartbeat_main",
@@ -42030,11 +49531,82 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_heartbeat.sh",
-      "source_location": "L99",
+      "source_location": "L108",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_heartbeat_sh__entry",
       "target": "dot_local_libexec_osquery_executable_heartbeat_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L98",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_clamp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_now",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L120",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_size",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/executable_pipeline-audit.sh",
+      "source_location": "L198",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan",
+      "target": "dot_local_libexec_osquery_executable_pipeline_audit_pipeline_audit_scan_manifest",
       "confidence_score": 1.0
     },
     {
@@ -42261,7 +49833,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_uptime-watchdog.sh",
-      "source_location": "L84",
+      "source_location": "L108",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_uptime_watchdog",
       "target": "dot_local_libexec_osquery_executable_uptime_watchdog_field_raw",
@@ -42281,7 +49853,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_uptime-watchdog.sh",
-      "source_location": "L68",
+      "source_location": "L92",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_uptime_watchdog",
       "target": "dot_local_libexec_osquery_executable_uptime_watchdog_write_state",
@@ -42291,7 +49863,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_uptime-watchdog.sh",
-      "source_location": "L261",
+      "source_location": "L457",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_uptime_watchdog_sh__entry",
@@ -42302,7 +49874,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh",
-      "source_location": "L32",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_allowlist_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_path_is_manifest_vouched",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh",
+      "source_location": "L73",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_allowlist_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_verdict",
@@ -42329,10 +49911,32 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L502",
+      "weight": 1.0,
+      "context": "import",
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "dot_local_libexec_osquery_results_alerter_allowlist_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh",
+      "source_location": "L125",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_allowlist_verdict_allowlist_path_is_manifest_vouched",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/digest-store.sh",
-      "source_location": "L22",
+      "source_location": "L28",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_digest_store",
       "target": "dot_local_libexec_osquery_results_alerter_digest_store_digest_append",
@@ -42352,7 +49956,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/normalize.sh",
-      "source_location": "L31",
+      "source_location": "L41",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_normalize",
       "target": "dot_local_libexec_osquery_results_alerter_normalize_normalize_findings",
@@ -42372,17 +49976,57 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L132",
+      "source_location": "L434",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
-      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_content_is_known_good",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_managed_bin_is_tracked",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L184",
+      "source_location": "L169",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_change_time",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L327",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_deployed_state_is_known_good",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_file_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_file_uid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L396",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_is_tracked",
@@ -42392,7 +50036,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L112",
+      "source_location": "L278",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_for",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L285",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_has_tuple",
@@ -42402,7 +50056,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L92",
+      "source_location": "L226",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_is_trustworthy",
@@ -42412,7 +50066,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L77",
+      "source_location": "L156",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_mtime",
@@ -42422,7 +50076,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L70",
+      "source_location": "L149",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_now",
@@ -42432,7 +50086,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L146",
+      "source_location": "L350",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_tuple_settles",
@@ -42442,7 +50096,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L199",
+      "source_location": "L453",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_verdict",
@@ -42462,7 +50116,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L115",
+      "source_location": "L438",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_managed_bin_is_tracked",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_is_trustworthy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L289",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_has_tuple",
@@ -42473,10 +50138,10 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L136",
+      "source_location": "L335",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_content_is_known_good",
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_deployed_state_is_known_good",
       "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_manifest_has_tuple",
       "confidence_score": 1.0
     },
@@ -42484,18 +50149,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L148",
+      "source_location": "L352",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_tuple_settles",
-      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_content_is_known_good",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_deployed_state_is_known_good",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L214",
+      "source_location": "L472",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_verdict",
@@ -42506,7 +50171,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
-      "source_location": "L202",
+      "source_location": "L402",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_is_tracked",
+      "target": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_managed_bin_is_tracked",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh",
+      "source_location": "L456",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_results_alerter_pipeline_verdict_pipeline_verdict",
@@ -43984,7 +51660,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/herdr-plugin-build-timeout.sh",
-      "source_location": "L174",
+      "source_location": "L181",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_herdr_plugin_build_timeout_sh__entry",
@@ -44812,7 +52488,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L85",
+      "source_location": "L165",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_allowlist_lock_is_free",
@@ -44822,7 +52498,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L91",
+      "source_location": "L171",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_assert_allowlist_label_count",
@@ -44832,7 +52508,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L68",
+      "source_location": "L148",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_assert_allowlisted",
@@ -44842,7 +52518,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L75",
+      "source_location": "L120",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_allowlist_lib",
+      "target": "test_fixtures_osquery_allowlist_lib_assert_manifest_refreshed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L155",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_assert_not_allowlisted",
@@ -44862,7 +52548,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L52",
+      "source_location": "L127",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_allowlist_lib",
+      "target": "test_fixtures_osquery_allowlist_lib_refute_manifest_refreshed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_run_allowlist",
@@ -44872,10 +52568,20 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L61",
+      "source_location": "L141",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_seed_allowlist_tuple",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_allowlist_lib",
+      "target": "test_fixtures_osquery_allowlist_lib_setup_allowlist_chezmoi",
       "confidence_score": 1.0
     },
     {
@@ -44892,10 +52598,31 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-allowlist-lib.bash",
-      "source_location": "L47",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_allowlist_lib",
+      "target": "test_fixtures_osquery_allowlist_lib_source_entry_lines",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L98",
       "weight": 1.0,
       "source": "test_fixtures_osquery_allowlist_lib",
       "target": "test_fixtures_osquery_allowlist_lib_teardown_allowlist_harness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-allowlist-lib.bash",
+      "source_location": "L24",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_osquery_allowlist_lib_setup_allowlist_harness",
+      "target": "test_fixtures_osquery_allowlist_lib_setup_allowlist_chezmoi",
       "confidence_score": 1.0
     },
     {
@@ -44912,7 +52639,57 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L64",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_bin_manifest_hash_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L158",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_bin_manifest_mode_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L161",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_bin_manifest_uid_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_bin_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L86",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_plist",
@@ -44922,7 +52699,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L55",
+      "source_location": "L63",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_add_script",
@@ -44932,7 +52709,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L77",
+      "source_location": "L99",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_apply",
@@ -44942,7 +52719,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L81",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_apply_mode",
@@ -44952,7 +52729,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L69",
+      "source_location": "L91",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_chezmoi",
@@ -44962,7 +52739,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L103",
+      "source_location": "L126",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_installed",
@@ -44972,7 +52749,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L89",
+      "source_location": "L111",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_run_runner",
@@ -44982,7 +52759,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L15",
+      "source_location": "L20",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_setup",
@@ -44992,7 +52769,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L49",
+      "source_location": "L57",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_fixture_teardown",
@@ -45002,7 +52779,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L106",
+      "source_location": "L134",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_manifest_hash_of",
@@ -45012,7 +52789,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L115",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_manifest_mode_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_manifest_lib",
+      "target": "test_fixtures_osquery_manifest_lib_manifest_uid_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-manifest-lib.bash",
+      "source_location": "L170",
       "weight": 1.0,
       "source": "test_fixtures_osquery_manifest_lib",
       "target": "test_fixtures_osquery_manifest_lib_verdict_says_page",
@@ -45022,7 +52819,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L82",
+      "source_location": "L104",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_manifest_lib_manifest_fixture_apply_mode",
@@ -45033,7 +52830,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-manifest-lib.bash",
-      "source_location": "L78",
+      "source_location": "L100",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_manifest_lib_manifest_fixture_apply",
@@ -45044,7 +52841,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L161",
+      "source_location": "L488",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_baseline_scalar",
@@ -45054,7 +52851,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L196",
+      "source_location": "L523",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_baseline_unchanged",
@@ -45064,7 +52861,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L266",
+      "source_location": "L593",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_gap_marker",
@@ -45074,7 +52871,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L128",
+      "source_location": "L455",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_mode",
@@ -45084,7 +52881,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L284",
+      "source_location": "L611",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_no_baseline",
@@ -45094,7 +52891,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L275",
+      "source_location": "L602",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_no_gap_marker",
@@ -45104,7 +52901,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L172",
+      "source_location": "L658",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_poller_lib",
+      "target": "test_fixtures_osquery_poller_lib_assert_no_mutation_attempt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L499",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_no_page",
@@ -45114,7 +52921,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L139",
+      "source_location": "L647",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_poller_lib",
+      "target": "test_fixtures_osquery_poller_lib_assert_no_probe_calls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L466",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_osqueryi_call_count",
@@ -45124,7 +52941,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L235",
+      "source_location": "L562",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_page_body_has",
@@ -45134,7 +52951,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L245",
+      "source_location": "L572",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_page_body_lacks",
@@ -45144,7 +52961,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L207",
+      "source_location": "L534",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_page_count",
@@ -45154,7 +52971,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L257",
+      "source_location": "L584",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_page_saw_baseline",
@@ -45164,7 +52981,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L221",
+      "source_location": "L548",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_page_severity_is",
@@ -45174,7 +52991,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L151",
+      "source_location": "L635",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_poller_lib",
+      "target": "test_fixtures_osquery_poller_lib_assert_probe_argv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L621",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_poller_lib",
+      "target": "test_fixtures_osquery_poller_lib_assert_probe_calls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L478",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_assert_query_reads",
@@ -45194,7 +53031,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L119",
+      "source_location": "L435",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_run_poller",
@@ -45204,7 +53041,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L182",
+      "source_location": "L509",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_seed_baseline",
@@ -45214,7 +53051,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L30",
+      "source_location": "L32",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_set_posture",
@@ -45224,7 +53061,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L34",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_poller_lib",
+      "target": "test_fixtures_osquery_poller_lib_set_posture_controls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-poller-lib.bash",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_setup_poller_harness",
@@ -45234,7 +53081,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L190",
+      "source_location": "L517",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_snapshot_baseline",
@@ -45244,7 +53091,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L110",
+      "source_location": "L424",
       "weight": 1.0,
       "source": "test_fixtures_osquery_poller_lib",
       "target": "test_fixtures_osquery_poller_lib_teardown_poller_harness",
@@ -45254,7 +53101,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-poller-lib.bash",
-      "source_location": "L107",
+      "source_location": "L421",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_poller_lib_setup_poller_harness",
@@ -45598,7 +53445,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L422",
+      "source_location": "L572",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_curl_probe_unsigned",
@@ -45608,7 +53455,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L448",
+      "source_location": "L598",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_file_absent",
@@ -45618,7 +53465,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L348",
+      "source_location": "L498",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_mode",
@@ -45628,7 +53475,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L358",
+      "source_location": "L508",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_no_page",
@@ -45638,7 +53485,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L438",
+      "source_location": "L588",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_osqueryi_not_called",
@@ -45648,7 +53495,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L411",
+      "source_location": "L561",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_page_body_has",
@@ -45658,7 +53505,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L368",
+      "source_location": "L518",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_page_count",
@@ -45668,7 +53515,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L382",
+      "source_location": "L532",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_page_severity_is",
@@ -45678,7 +53525,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L397",
+      "source_location": "L547",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_page_sound_nonempty",
@@ -45688,7 +53535,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L472",
+      "source_location": "L622",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_state_has",
@@ -45698,7 +53545,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L462",
+      "source_location": "L612",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_assert_watchdog_state_unchanged",
@@ -45718,7 +53565,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L249",
+      "source_location": "L348",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_chmod_managed_bin_file_through_hard_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L386",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_chmod_manifested_file_through_hard_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L286",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_clear_canary",
@@ -45728,7 +53595,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L338",
+      "source_location": "L488",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_refute_file_contains",
@@ -45738,7 +53605,57 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L278",
+      "source_location": "L326",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_regenerate_managed_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L307",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_regenerate_pipeline_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L361",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_remove_managed_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L407",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_remove_pipeline_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L393",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_restore_manifested_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L426",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_run_watchdog",
@@ -45748,7 +53665,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L229",
+      "source_location": "L266",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_canary",
@@ -45758,7 +53675,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L326",
+      "source_location": "L476",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_corrupt_alert_db",
@@ -45768,7 +53685,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L313",
+      "source_location": "L463",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_dead_letter_alerts",
@@ -45778,7 +53695,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L239",
+      "source_location": "L276",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_future_canary",
@@ -45788,7 +53705,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L303",
+      "source_location": "L453",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_pending_alerts",
@@ -45798,7 +53715,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L257",
+      "source_location": "L294",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_raw_canary",
@@ -45808,7 +53725,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L267",
+      "source_location": "L415",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_seed_watchdog_state",
@@ -45818,7 +53735,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L193",
+      "source_location": "L230",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_set_agent",
@@ -45828,7 +53745,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L212",
+      "source_location": "L249",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_set_agent_no_exit_field",
@@ -45838,7 +53755,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L203",
+      "source_location": "L240",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_set_agent_raw_exit",
@@ -45848,7 +53765,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L39",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_setup_watchdog_harness",
@@ -45858,7 +53775,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L458",
+      "source_location": "L608",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_snapshot_watchdog_state",
@@ -45868,7 +53785,47 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L183",
+      "source_location": "L400",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_symlink_manifested_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L339",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_tamper_managed_bin_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L369",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_tamper_manifested_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L375",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_tamper_second_manifested_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L220",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_teardown_watchdog_harness",
@@ -45878,7 +53835,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L219",
+      "source_location": "L256",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_unload_agent",
@@ -45888,7 +53845,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L292",
+      "source_location": "L356",
+      "weight": 1.0,
+      "source": "test_fixtures_osquery_watchdog_lib",
+      "target": "test_fixtures_osquery_watchdog_lib_update_unmanaged_bin_shim",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L442",
       "weight": 1.0,
       "source": "test_fixtures_osquery_watchdog_lib",
       "target": "test_fixtures_osquery_watchdog_lib_wd_sqlite3",
@@ -45898,7 +53865,29 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L180",
+      "source_location": "L178",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_osquery_watchdog_lib_setup_watchdog_harness",
+      "target": "test_fixtures_osquery_watchdog_lib_regenerate_managed_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L165",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_osquery_watchdog_lib_setup_watchdog_harness",
+      "target": "test_fixtures_osquery_watchdog_lib_regenerate_pipeline_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/osquery-watchdog-lib.bash",
+      "source_location": "L217",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_watchdog_lib_setup_watchdog_harness",
@@ -45909,7 +53898,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L176",
+      "source_location": "L213",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_watchdog_lib_setup_watchdog_harness",
@@ -45920,7 +53909,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L315",
+      "source_location": "L465",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_watchdog_lib_seed_dead_letter_alerts",
@@ -45931,11 +53920,285 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/fixtures/osquery-watchdog-lib.bash",
-      "source_location": "L305",
+      "source_location": "L455",
       "weight": 1.0,
       "context": "call",
       "source": "test_fixtures_osquery_watchdog_lib_seed_pending_alerts",
       "target": "test_fixtures_osquery_watchdog_lib_wd_sqlite3",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L104",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_assert_no_escalation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L275",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_assert_no_sudo_and_no_sandbox_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_bash__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L250",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_effective_global_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L263",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_effective_spec_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_run_ssh_hardening",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_bounded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L176",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_without",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_ssh_sandbox_setup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L112",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_ssh_sandbox_teardown",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L196",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_write_hardened_dropin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_hardening_lib",
+      "target": "test_fixtures_ssh_hardening_lib_write_hostile_apple_conf",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L68",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_ssh_hardening_lib_refute_contains",
+      "target": "test_fixtures_ssh_hardening_lib_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L164",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_bounded",
+      "target": "test_fixtures_ssh_hardening_lib_assert_no_escalation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L190",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_without",
+      "target": "test_fixtures_ssh_hardening_lib_assert_no_escalation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-hardening-lib.bash",
+      "source_location": "L127",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_fixtures_ssh_hardening_lib_run_ssh_hardening",
+      "target": "test_fixtures_ssh_hardening_lib_run_ssh_hardening_bounded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L460",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_assert_kickstart_attempted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L484",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_assert_no_kickstart",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L473",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_assert_seam_calls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_bash__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L498",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_config_tree_fingerprint",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_reload_sandbox_setup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/fixtures/ssh-reload-lib.bash",
+      "source_location": "L430",
+      "weight": 1.0,
+      "source": "test_fixtures_ssh_reload_lib",
+      "target": "test_fixtures_ssh_reload_lib_run_ssh_reload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "test_helpers_build_dispatch_harness",
+      "target": "test_helpers_build_dispatch_harness_alerter_banner_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "test_helpers_build_dispatch_harness",
+      "target": "test_helpers_build_dispatch_harness_assert_banner_sound",
       "confidence_score": 1.0
     },
     {
@@ -45952,7 +54215,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L137",
+      "source_location": "L204",
       "weight": 1.0,
       "source": "test_helpers_build_dispatch_harness",
       "target": "test_helpers_build_dispatch_harness_assert_no_post",
@@ -45972,7 +54235,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L119",
+      "source_location": "L186",
       "weight": 1.0,
       "source": "test_helpers_build_dispatch_harness",
       "target": "test_helpers_build_dispatch_harness_assert_post_count",
@@ -45982,7 +54245,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/helpers/build-dispatch-harness.sh",
-      "source_location": "L129",
+      "source_location": "L196",
       "weight": 1.0,
       "source": "test_helpers_build_dispatch_harness",
       "target": "test_helpers_build_dispatch_harness_assert_posted_to",
@@ -45996,6 +54259,36 @@
       "weight": 1.0,
       "source": "test_helpers_build_dispatch_harness",
       "target": "test_helpers_build_dispatch_harness_build_dispatch_harness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "test_helpers_build_dispatch_harness",
+      "target": "test_helpers_build_dispatch_harness_refute_banner_sound",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L165",
+      "weight": 1.0,
+      "source": "test_helpers_build_dispatch_harness",
+      "target": "test_helpers_build_dispatch_harness_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/helpers/build-dispatch-harness.sh",
+      "source_location": "L176",
+      "weight": 1.0,
+      "source": "test_helpers_build_dispatch_harness",
+      "target": "test_helpers_build_dispatch_harness_refute_tree_contains",
       "confidence_score": 1.0
     },
     {
@@ -46124,7 +54417,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L154",
+      "source_location": "L161",
       "weight": 1.0,
       "source": "test_integration_claude_code_launchagent_retirement",
       "target": "test_integration_claude_code_launchagent_retirement_bootout_count",
@@ -46144,7 +54437,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L73",
+      "source_location": "L80",
       "weight": 1.0,
       "source": "test_integration_claude_code_launchagent_retirement",
       "target": "test_integration_claude_code_launchagent_retirement_make_launchctl_stub",
@@ -46154,7 +54447,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L99",
+      "source_location": "L106",
       "weight": 1.0,
       "source": "test_integration_claude_code_launchagent_retirement",
       "target": "test_integration_claude_code_launchagent_retirement_marker_of",
@@ -46164,7 +54457,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L105",
+      "source_location": "L112",
       "weight": 1.0,
       "source": "test_integration_claude_code_launchagent_retirement",
       "target": "test_integration_claude_code_launchagent_retirement_run_case",
@@ -46195,7 +54488,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L158",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_claude_code_launchagent_retirement_sh__entry",
@@ -46206,7 +54499,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L142",
+      "source_location": "L149",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_claude_code_launchagent_retirement_run_case",
@@ -46217,7 +54510,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/claude-code-launchagent-retirement.sh",
-      "source_location": "L117",
+      "source_location": "L124",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_claude_code_launchagent_retirement_run_case",
@@ -46248,7 +54541,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-retry-refire.sh",
-      "source_location": "L104",
+      "source_location": "L111",
       "weight": 1.0,
       "source": "test_integration_herdr_build_retry_refire",
       "target": "test_integration_herdr_build_retry_refire_run_rendered",
@@ -46279,7 +54572,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-retry-refire.sh",
-      "source_location": "L110",
+      "source_location": "L117",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_retry_refire_sh__entry",
@@ -46290,7 +54583,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-retry-refire.sh",
-      "source_location": "L106",
+      "source_location": "L113",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_retry_refire_run_rendered",
@@ -46301,7 +54594,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-retry-refire.sh",
-      "source_location": "L106",
+      "source_location": "L113",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_retry_refire_run_rendered",
@@ -46322,7 +54615,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L141",
+      "source_location": "L148",
       "weight": 1.0,
       "source": "test_integration_herdr_build_scripts_resilience",
       "target": "test_integration_herdr_build_scripts_resilience_make_cargo_stub",
@@ -46332,7 +54625,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L94",
+      "source_location": "L101",
       "weight": 1.0,
       "source": "test_integration_herdr_build_scripts_resilience",
       "target": "test_integration_herdr_build_scripts_resilience_make_herdr_stub",
@@ -46342,7 +54635,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L233",
+      "source_location": "L240",
       "weight": 1.0,
       "source": "test_integration_herdr_build_scripts_resilience",
       "target": "test_integration_herdr_build_scripts_resilience_marker_present",
@@ -46352,7 +54645,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L74",
+      "source_location": "L81",
       "weight": 1.0,
       "source": "test_integration_herdr_build_scripts_resilience",
       "target": "test_integration_herdr_build_scripts_resilience_path_without_cargo",
@@ -46362,7 +54655,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L164",
+      "source_location": "L171",
       "weight": 1.0,
       "source": "test_integration_herdr_build_scripts_resilience",
       "target": "test_integration_herdr_build_scripts_resilience_run_case",
@@ -46393,7 +54686,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L238",
+      "source_location": "L245",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_sh__entry",
@@ -46404,7 +54697,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L236",
+      "source_location": "L243",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_sh__entry",
@@ -46415,7 +54708,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L99",
+      "source_location": "L106",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_make_herdr_stub",
@@ -46426,7 +54719,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L202",
+      "source_location": "L209",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_run_case",
@@ -46437,7 +54730,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L177",
+      "source_location": "L184",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_run_case",
@@ -46448,7 +54741,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-build-scripts-resilience.sh",
-      "source_location": "L208",
+      "source_location": "L215",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_build_scripts_resilience_run_case",
@@ -46459,7 +54752,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L57",
+      "source_location": "L64",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_ordering",
       "target": "test_integration_herdr_migration_ordering_build_stub_prefix",
@@ -46469,7 +54762,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L105",
+      "source_location": "L112",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_ordering",
       "target": "test_integration_herdr_migration_ordering_cleanup_used",
@@ -46489,7 +54782,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L84",
+      "source_location": "L91",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_ordering",
       "target": "test_integration_herdr_migration_ordering_run_case",
@@ -46509,7 +54802,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L114",
+      "source_location": "L121",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_ordering_sh__entry",
@@ -46531,7 +54824,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L111",
+      "source_location": "L118",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_ordering_sh__entry",
@@ -46542,7 +54835,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-ordering.sh",
-      "source_location": "L92",
+      "source_location": "L99",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_ordering_run_case",
@@ -46553,7 +54846,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L198",
+      "source_location": "L205",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_verify",
       "target": "test_integration_herdr_migration_verify_cleanup_ran",
@@ -46573,7 +54866,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L199",
+      "source_location": "L206",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_verify",
       "target": "test_integration_herdr_migration_verify_herdr_contacted",
@@ -46583,7 +54876,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L148",
+      "source_location": "L155",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_verify",
       "target": "test_integration_herdr_migration_verify_make_brew_stub",
@@ -46593,7 +54886,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L75",
+      "source_location": "L82",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_verify",
       "target": "test_integration_herdr_migration_verify_make_herdr_stub",
@@ -46603,7 +54896,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L176",
+      "source_location": "L183",
       "weight": 1.0,
       "source": "test_integration_herdr_migration_verify",
       "target": "test_integration_herdr_migration_verify_run_case",
@@ -46623,7 +54916,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L207",
+      "source_location": "L214",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_verify_sh__entry",
@@ -46645,7 +54938,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L206",
+      "source_location": "L213",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_verify_sh__entry",
@@ -46656,7 +54949,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L204",
+      "source_location": "L211",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_verify_sh__entry",
@@ -46667,7 +54960,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L187",
+      "source_location": "L194",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_verify_run_case",
@@ -46678,7 +54971,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/herdr-migration-verify.sh",
-      "source_location": "L186",
+      "source_location": "L193",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_herdr_migration_verify_run_case",
@@ -46792,7 +55085,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L108",
+      "source_location": "L115",
       "weight": 1.0,
       "source": "test_integration_homebrew_after58_skip_cleanup",
       "target": "test_integration_homebrew_after58_skip_cleanup_cleanup_ran",
@@ -46812,7 +55105,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L107",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "test_integration_homebrew_after58_skip_cleanup",
       "target": "test_integration_homebrew_after58_skip_cleanup_herdr_contacted",
@@ -46862,7 +55155,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L114",
+      "source_location": "L121",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_after58_skip_cleanup_sh__entry",
@@ -46884,7 +55177,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L113",
+      "source_location": "L120",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_after58_skip_cleanup_sh__entry",
@@ -46895,7 +55188,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-after58-skip-cleanup.sh",
-      "source_location": "L111",
+      "source_location": "L118",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_after58_skip_cleanup_sh__entry",
@@ -47011,7 +55304,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-before10-ecosystem-guards.sh",
-      "source_location": "L46",
+      "source_location": "L53",
       "weight": 1.0,
       "source": "test_integration_homebrew_before10_ecosystem_guards",
       "target": "test_integration_homebrew_before10_ecosystem_guards_make_brew",
@@ -47042,7 +55335,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-before10-ecosystem-guards.sh",
-      "source_location": "L59",
+      "source_location": "L66",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_before10_ecosystem_guards_sh__entry",
@@ -47063,7 +55356,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L116",
+      "source_location": "L123",
       "weight": 1.0,
       "source": "test_integration_homebrew_cleanup_guard",
       "target": "test_integration_homebrew_cleanup_guard_forced_ran",
@@ -47073,7 +55366,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L68",
+      "source_location": "L75",
       "weight": 1.0,
       "source": "test_integration_homebrew_cleanup_guard",
       "target": "test_integration_homebrew_cleanup_guard_make_prefix",
@@ -47083,7 +55376,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L99",
+      "source_location": "L106",
       "weight": 1.0,
       "source": "test_integration_homebrew_cleanup_guard",
       "target": "test_integration_homebrew_cleanup_guard_run_case",
@@ -47114,7 +55407,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L120",
+      "source_location": "L127",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_cleanup_guard_sh__entry",
@@ -47125,7 +55418,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L119",
+      "source_location": "L126",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_cleanup_guard_sh__entry",
@@ -47136,7 +55429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L113",
+      "source_location": "L120",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_cleanup_guard_run_case",
@@ -47147,7 +55440,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-cleanup-guard.sh",
-      "source_location": "L106",
+      "source_location": "L113",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_cleanup_guard_run_case",
@@ -47241,8 +55534,1627 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L467",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_archive_xml_mentioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L308",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_assert_manual_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L248",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_assert_posture_render_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_cleanup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_make_defaults_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L240",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_make_posture_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_policy_expectations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L451",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_poller_pgrep_lulu_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_lulu_policy_records",
+      "target": "test_integration_lulu_policy_records_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L262",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_sh__entry",
+      "target": "test_integration_lulu_policy_records_assert_posture_render_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_sh__entry",
+      "target": "test_integration_lulu_policy_records_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L181",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_sh__entry",
+      "target": "test_integration_lulu_policy_records_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L311",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_assert_manual_record",
+      "target": "test_integration_lulu_policy_records_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L255",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_assert_posture_render_rejects",
+      "target": "test_integration_lulu_policy_records_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/lulu-policy-records.sh",
+      "source_location": "L87",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_lulu_policy_records_refute_file_contains",
+      "target": "test_integration_lulu_policy_records_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L88",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L168",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L111",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_make_defaults_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_make_setup_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_refute_file_matches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L127",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L891",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_refusal",
+      "target": "test_integration_macos_control_tier_refusal_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L269",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L203",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L219",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L248",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L382",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_refute_file_matches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L144",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L903",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_sh__entry",
+      "target": "test_integration_macos_control_tier_refusal_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L89",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L176",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L191",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L78",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_refute_file_contains",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L84",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_refute_file_matches",
+      "target": "test_integration_macos_control_tier_refusal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L178",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "target": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L193",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "target": "test_integration_macos_control_tier_refusal_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L174",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier1_rejects",
+      "target": "test_integration_macos_control_tier_refusal_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-refusal.sh",
+      "source_location": "L189",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_refusal_assert_tier2_rejects",
+      "target": "test_integration_macos_control_tier_refusal_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_render_stability",
+      "target": "test_integration_macos_control_tier_render_stability_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L211",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_render_stability",
+      "target": "test_integration_macos_control_tier_render_stability_render_current",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_control_tier_render_stability",
+      "target": "test_integration_macos_control_tier_render_stability_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_render_stability_sh__entry",
+      "target": "test_integration_macos_control_tier_render_stability_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-control-tier-render-stability.sh",
+      "source_location": "L217",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_control_tier_render_stability_sh__entry",
+      "target": "test_integration_macos_control_tier_render_stability_render_current",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_make_source_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L513",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_run_apply",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_injection",
+      "target": "test_integration_macos_defaults_injection_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L295",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L150",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L73",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L309",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L110",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L538",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_sh__entry",
+      "target": "test_integration_macos_defaults_injection_run_apply",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L63",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_assert_file_contains",
+      "target": "test_integration_macos_defaults_injection_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L136",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "target": "test_integration_macos_defaults_injection_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_refute_file_contains",
+      "target": "test_integration_macos_defaults_injection_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L137",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "target": "test_integration_macos_defaults_injection_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-injection.sh",
+      "source_location": "L134",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_injection_assert_render_rejects",
+      "target": "test_integration_macos_defaults_injection_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_shape_agreement",
+      "target": "test_integration_macos_defaults_shape_agreement_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_shape_agreement",
+      "target": "test_integration_macos_defaults_shape_agreement_library_stream",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_shape_agreement",
+      "target": "test_integration_macos_defaults_shape_agreement_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_shape_agreement",
+      "target": "test_integration_macos_defaults_shape_agreement_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-shape-agreement.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_shape_agreement_sh__entry",
+      "target": "test_integration_macos_defaults_shape_agreement_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L155",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_run_from_worktree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_seed_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_source_path",
+      "target": "test_integration_macos_defaults_source_path_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L167",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L217",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L67",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L169",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L165",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_run_from_worktree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L98",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_sh__entry",
+      "target": "test_integration_macos_defaults_source_path_seed_data_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L54",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_assert_file_contains",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L212",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L49",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_refute_file_contains",
+      "target": "test_integration_macos_defaults_source_path_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L213",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "target": "test_integration_macos_defaults_source_path_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-source-path.sh",
+      "source_location": "L208",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_source_path_assert_unreadable_exits_two",
+      "target": "test_integration_macos_defaults_source_path_run_from_worktree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_make_source_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_run_render_capturing_arguments",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L514",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L483",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_system_scope",
+      "target": "test_integration_macos_defaults_system_scope_write_defaults_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L250",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L79",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L199",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L185",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L225",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_run_render_capturing_arguments",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L554",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L551",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_sh__entry",
+      "target": "test_integration_macos_defaults_system_scope_write_defaults_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L67",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_assert_file_contains",
+      "target": "test_integration_macos_defaults_system_scope_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-system-scope.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_system_scope_refute_file_contains",
+      "target": "test_integration_macos_defaults_system_scope_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_integration_macos_firewall_globalstate_order",
+      "target": "test_integration_macos_firewall_globalstate_order_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "test_integration_macos_firewall_globalstate_order",
+      "target": "test_integration_macos_firewall_globalstate_order_line_number_of_unique_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_firewall_globalstate_order",
+      "target": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L74",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_firewall_globalstate_order_sh__entry",
+      "target": "test_integration_macos_firewall_globalstate_order_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-firewall-globalstate-order.sh",
+      "source_location": "L166",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_firewall_globalstate_order_line_number_of_unique_line",
+      "target": "test_integration_macos_firewall_globalstate_order_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_agreement",
+      "target": "test_integration_macos_posture_controls_agreement_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_agreement",
+      "target": "test_integration_macos_posture_controls_agreement_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-agreement.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_agreement_sh__entry",
+      "target": "test_integration_macos_posture_controls_agreement_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_assert_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_make_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_posture_controls_render",
+      "target": "test_integration_macos_posture_controls_render_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L116",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_sh__entry",
+      "target": "test_integration_macos_posture_controls_render_assert_rejects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L48",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_sh__entry",
+      "target": "test_integration_macos_posture_controls_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_sh__entry",
+      "target": "test_integration_macos_posture_controls_render_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_assert_file_contains",
+      "target": "test_integration_macos_posture_controls_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L83",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_assert_rejects",
+      "target": "test_integration_macos_posture_controls_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_assert_rejects",
+      "target": "test_integration_macos_posture_controls_render_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-posture-controls-render.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_posture_controls_render_assert_rejects",
+      "target": "test_integration_macos_posture_controls_render_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_log_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L340",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_run_drift",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L315",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_write_drift_defaults_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "test_integration_macos_security_defaults_render",
+      "target": "test_integration_macos_security_defaults_render_write_logging_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L402",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L263",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_log_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L361",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_run_drift",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L359",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_write_drift_defaults_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L123",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_sh__entry",
+      "target": "test_integration_macos_security_defaults_render_write_logging_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-security-defaults-render.sh",
+      "source_location": "L54",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_security_defaults_render_assert_file_contains",
+      "target": "test_integration_macos_security_defaults_render_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_refute_file_matches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_system_setup_sudo_guard",
+      "target": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L50",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L100",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "target": "test_integration_macos_system_setup_sudo_guard_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_sh__entry",
+      "target": "test_integration_macos_system_setup_sudo_guard_refute_file_matches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L36",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_refute_file_contains",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-system-setup-sudo-guard.sh",
+      "source_location": "L42",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_system_setup_sudo_guard_refute_file_matches",
+      "target": "test_integration_macos_system_setup_sudo_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L264",
+      "source_location": "L271",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_absent",
@@ -47252,7 +57164,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L255",
+      "source_location": "L262",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_empty_log",
@@ -47262,7 +57174,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L238",
+      "source_location": "L245",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_log_exact",
@@ -47272,7 +57184,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L285",
+      "source_location": "L292",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_logged",
@@ -47282,7 +57194,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L313",
+      "source_location": "L320",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_marker",
@@ -47292,7 +57204,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L320",
+      "source_location": "L327",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_no_marker",
@@ -47302,7 +57214,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L304",
+      "source_location": "L311",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_no_npm_uninstall",
@@ -47312,7 +57224,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L273",
+      "source_location": "L280",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_present",
@@ -47322,7 +57234,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L227",
+      "source_location": "L234",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_rc0",
@@ -47332,7 +57244,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L294",
+      "source_location": "L301",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_assert_warned",
@@ -47352,7 +57264,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L107",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_launchctl_log",
@@ -47362,7 +57274,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L110",
+      "source_location": "L117",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_loaded_file",
@@ -47372,7 +57284,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L312",
+      "source_location": "L319",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_marker_of",
@@ -47382,7 +57294,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L111",
+      "source_location": "L118",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_npm_flag",
@@ -47392,7 +57304,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L108",
+      "source_location": "L115",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_npm_log",
@@ -47402,7 +57314,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L216",
+      "source_location": "L223",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_report",
@@ -47412,7 +57324,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L109",
+      "source_location": "L116",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_rm_log",
@@ -47422,7 +57334,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L199",
+      "source_location": "L206",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_run_script",
@@ -47432,7 +57344,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L328",
+      "source_location": "L335",
       "weight": 1.0,
       "source": "test_integration_openclaw_services_retirement",
       "target": "test_integration_openclaw_services_retirement_seed_loaded",
@@ -47452,7 +57364,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L378",
+      "source_location": "L385",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47463,7 +57375,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L391",
+      "source_location": "L398",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47474,7 +57386,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L356",
+      "source_location": "L363",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47485,7 +57397,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L379",
+      "source_location": "L386",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47496,7 +57408,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L386",
+      "source_location": "L393",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47507,7 +57419,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L445",
+      "source_location": "L452",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47518,7 +57430,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L454",
+      "source_location": "L461",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47529,7 +57441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L383",
+      "source_location": "L390",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47540,7 +57452,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L353",
+      "source_location": "L360",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47551,7 +57463,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L441",
+      "source_location": "L448",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47573,7 +57485,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L423",
+      "source_location": "L430",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47584,7 +57496,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L352",
+      "source_location": "L359",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47595,7 +57507,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L349",
+      "source_location": "L356",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_sh__entry",
@@ -47606,7 +57518,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L266",
+      "source_location": "L273",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_absent",
@@ -47617,7 +57529,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L257",
+      "source_location": "L264",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_empty_log",
@@ -47628,7 +57540,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L248",
+      "source_location": "L255",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_log_exact",
@@ -47639,7 +57551,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L287",
+      "source_location": "L294",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_logged",
@@ -47650,7 +57562,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L315",
+      "source_location": "L322",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_marker",
@@ -47661,7 +57573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L322",
+      "source_location": "L329",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_no_marker",
@@ -47672,7 +57584,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L306",
+      "source_location": "L313",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_no_npm_uninstall",
@@ -47683,7 +57595,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L275",
+      "source_location": "L282",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_present",
@@ -47694,7 +57606,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L229",
+      "source_location": "L236",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_rc0",
@@ -47705,7 +57617,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/openclaw-services-retirement.sh",
-      "source_location": "L296",
+      "source_location": "L303",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_openclaw_services_retirement_assert_warned",
@@ -47767,7 +57679,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L43",
+      "source_location": "L51",
       "weight": 1.0,
       "source": "test_integration_osquery_config_file_integrity",
       "target": "test_integration_osquery_config_file_integrity_fail",
@@ -47777,7 +57689,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L59",
+      "source_location": "L67",
       "weight": 1.0,
       "source": "test_integration_osquery_config_file_integrity",
       "target": "test_integration_osquery_config_file_integrity_has_path",
@@ -47787,7 +57699,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L40",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "test_integration_osquery_config_file_integrity",
       "target": "test_integration_osquery_config_file_integrity_render",
@@ -47807,7 +57719,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L50",
+      "source_location": "L58",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_config_file_integrity_sh__entry",
@@ -47818,7 +57730,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-config-file-integrity.sh",
-      "source_location": "L64",
+      "source_location": "L72",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_config_file_integrity_sh__entry",
@@ -48023,6 +57935,69 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "test_integration_osquery_managed_bin_manifest",
+      "target": "test_integration_osquery_managed_bin_manifest_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "test_integration_osquery_managed_bin_manifest",
+      "target": "test_integration_osquery_managed_bin_manifest_refute_manifest_lists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_osquery_managed_bin_manifest",
+      "target": "test_integration_osquery_managed_bin_manifest_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_managed_bin_manifest_sh__entry",
+      "target": "test_integration_osquery_managed_bin_manifest_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L122",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_managed_bin_manifest_sh__entry",
+      "target": "test_integration_osquery_managed_bin_manifest_refute_manifest_lists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-managed-bin-manifest.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_managed_bin_manifest_refute_manifest_lists",
+      "target": "test_integration_osquery_managed_bin_manifest_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-page-allowlist-seed.sh",
       "source_location": "L30",
       "weight": 1.0,
@@ -48055,7 +58030,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L72",
+      "source_location": "L139",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_expect_verdict",
@@ -48065,7 +58040,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L32",
+      "source_location": "L46",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_fail",
@@ -48075,7 +58050,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L70",
+      "source_location": "L98",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_hash_of",
@@ -48085,7 +58060,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L67",
+      "source_location": "L95",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_osquery_managed_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_osquery_pipeline_manifest",
@@ -48095,7 +58080,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L67",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_osquery_pipeline_rehash_delay",
@@ -48105,10 +58090,50 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L68",
+      "source_location": "L96",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_osquery_pipeline_settle_seconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_refute_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L496",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_allowlist_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L172",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_audit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_verdict",
       "confidence_score": 1.0
     },
     {
@@ -48122,10 +58147,20 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L132",
+      "weight": 1.0,
+      "source": "test_integration_osquery_pipeline_manifest_agreement",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_tracked_rc",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L79",
+      "source_location": "L146",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
@@ -48136,7 +58171,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L61",
+      "source_location": "L83",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
@@ -48147,7 +58182,40 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L75",
+      "source_location": "L199",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_refute_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L549",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_allowlist_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L393",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_verdict",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L142",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_agreement_expect_verdict",
@@ -48155,10 +58223,32 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L190",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_pipeline_manifest_agreement_refute_line",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_osquery_pipeline_manifest_agreement_expect_verdict",
+      "target": "test_integration_osquery_pipeline_manifest_agreement_run_verdict",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-generation.sh",
-      "source_location": "L32",
+      "source_location": "L37",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_generation",
       "target": "test_integration_osquery_pipeline_manifest_generation_fail",
@@ -48178,7 +58268,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-generation.sh",
-      "source_location": "L65",
+      "source_location": "L78",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_generation_sh__entry",
@@ -48189,7 +58279,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-install.sh",
-      "source_location": "L31",
+      "source_location": "L37",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_install",
       "target": "test_integration_osquery_pipeline_manifest_install_fail",
@@ -48209,7 +58299,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-install.sh",
-      "source_location": "L43",
+      "source_location": "L49",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_install_sh__entry",
@@ -48297,6 +58387,99 @@
       "context": "call",
       "source": "test_integration_osquery_queue_counts_wal_assert_eq",
       "target": "test_integration_osquery_queue_counts_wal_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L132",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_poller_pgrep_exit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L174",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_poller_pgrep_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L132",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_poller_pgrep_output",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_run_indeterminate_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_oversight_posture",
+      "target": "test_integration_oversight_posture_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L74",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_oversight_posture_sh__entry",
+      "target": "test_integration_oversight_posture_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L218",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_oversight_posture_sh__entry",
+      "target": "test_integration_oversight_posture_run_indeterminate_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/oversight-posture.sh",
+      "source_location": "L202",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_oversight_posture_run_indeterminate_case",
+      "target": "test_integration_oversight_posture_fail",
       "confidence_score": 1.0
     },
     {
@@ -48714,8 +58897,729 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/integration/tailnet-pins.sh",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "test_integration_ssh_config_github_keepalive",
+      "target": "test_integration_ssh_config_github_keepalive_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "test_integration_ssh_config_github_keepalive",
+      "target": "test_integration_ssh_config_github_keepalive_resolved",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_config_github_keepalive",
+      "target": "test_integration_ssh_config_github_keepalive_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-config-github-keepalive.sh",
       "source_location": "L30",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_config_github_keepalive_sh__entry",
+      "target": "test_integration_ssh_config_github_keepalive_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_dropin_mode",
+      "target": "test_integration_ssh_hardening_dropin_mode_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_dropin_mode",
+      "target": "test_integration_ssh_hardening_dropin_mode_file_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_dropin_mode",
+      "target": "test_integration_ssh_hardening_dropin_mode_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-dropin-mode.sh",
+      "source_location": "L40",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_dropin_mode_sh__entry",
+      "target": "test_integration_ssh_hardening_dropin_mode_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_following",
+      "target": "test_integration_ssh_hardening_include_following_assert_resolves",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_following",
+      "target": "test_integration_ssh_hardening_include_following_assert_verify_fails_naming",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_following",
+      "target": "test_integration_ssh_hardening_include_following_assert_verify_passes_again",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_following",
+      "target": "test_integration_ssh_hardening_include_following_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_following",
+      "target": "test_integration_ssh_hardening_include_following_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L106",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_sh__entry",
+      "target": "test_integration_ssh_hardening_include_following_assert_resolves",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L110",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_sh__entry",
+      "target": "test_integration_ssh_hardening_include_following_assert_verify_fails_naming",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L114",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_sh__entry",
+      "target": "test_integration_ssh_hardening_include_following_assert_verify_passes_again",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_sh__entry",
+      "target": "test_integration_ssh_hardening_include_following_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L75",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_assert_resolves",
+      "target": "test_integration_ssh_hardening_include_following_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L86",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_assert_verify_fails_naming",
+      "target": "test_integration_ssh_hardening_include_following_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-following.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_following_assert_verify_passes_again",
+      "target": "test_integration_ssh_hardening_include_following_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_precedence",
+      "target": "test_integration_ssh_hardening_include_precedence_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_include_precedence",
+      "target": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-include-precedence.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_include_precedence_sh__entry",
+      "target": "test_integration_ssh_hardening_include_precedence_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_safety",
+      "target": "test_integration_ssh_hardening_install_safety_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_safety",
+      "target": "test_integration_ssh_hardening_install_safety_file_fingerprint",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_safety",
+      "target": "test_integration_ssh_hardening_install_safety_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_safety",
+      "target": "test_integration_ssh_hardening_install_safety_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_safety",
+      "target": "test_integration_ssh_hardening_install_safety_working_file_leftovers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L80",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_safety_sh__entry",
+      "target": "test_integration_ssh_hardening_install_safety_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L94",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_safety_sh__entry",
+      "target": "test_integration_ssh_hardening_install_safety_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-safety.sh",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_safety_refute_contains",
+      "target": "test_integration_ssh_hardening_install_safety_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_strictness",
+      "target": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_strictness",
+      "target": "test_integration_ssh_hardening_install_strictness_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_strictness",
+      "target": "test_integration_ssh_hardening_install_strictness_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_strictness",
+      "target": "test_integration_ssh_hardening_install_strictness_reset_tree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_install_strictness",
+      "target": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "target": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L113",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "target": "test_integration_ssh_hardening_install_strictness_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "target": "test_integration_ssh_hardening_install_strictness_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L108",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_sh__entry",
+      "target": "test_integration_ssh_hardening_install_strictness_reset_tree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L79",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "target": "test_integration_ssh_hardening_install_strictness_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_refute_contains",
+      "target": "test_integration_ssh_hardening_install_strictness_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L87",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "target": "test_integration_ssh_hardening_install_strictness_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-install-strictness.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_install_strictness_assert_install_no_weaker_than_verify",
+      "target": "test_integration_ssh_hardening_install_strictness_reset_tree",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_match_reenable",
+      "target": "test_integration_ssh_hardening_match_reenable_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_match_reenable",
+      "target": "test_integration_ssh_hardening_match_reenable_run_reenable_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_match_reenable",
+      "target": "test_integration_ssh_hardening_match_reenable_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L83",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_match_reenable_sh__entry",
+      "target": "test_integration_ssh_hardening_match_reenable_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L121",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_match_reenable_sh__entry",
+      "target": "test_integration_ssh_hardening_match_reenable_run_reenable_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-match-reenable.sh",
+      "source_location": "L105",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_match_reenable_run_reenable_case",
+      "target": "test_integration_ssh_hardening_match_reenable_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_ssh_hardening_ready_attempts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-reload-failclosed.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_reload_failclosed",
+      "target": "test_integration_ssh_hardening_reload_failclosed_ssh_hardening_ready_interval",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_rollback",
+      "target": "test_integration_ssh_hardening_rollback_assert_no_reload_side_effects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_rollback",
+      "target": "test_integration_ssh_hardening_rollback_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-rollback.sh",
+      "source_location": "L86",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_rollback_sh__entry",
+      "target": "test_integration_ssh_hardening_rollback_assert_no_reload_side_effects",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_sshd_validate",
+      "target": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L55",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "target": "test_integration_ssh_hardening_sshd_validate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_sshd_validate_sh__entry",
+      "target": "test_integration_ssh_hardening_sshd_validate_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-sshd-validate.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_sshd_validate_refute_contains",
+      "target": "test_integration_ssh_hardening_sshd_validate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_tokenizer_differential",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_differential_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_tokenizer_differential",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_tokenizer_differential",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_resolve_unsafe_directives",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_ssh_hardening_tokenizer_differential",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L249",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_tokenizer_differential_sh__entry",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_differential_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L67",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_tokenizer_differential_sh__entry",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/ssh-hardening-tokenizer-differential.sh",
+      "source_location": "L209",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_ssh_hardening_tokenizer_differential_differential_case",
+      "target": "test_integration_ssh_hardening_tokenizer_differential_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "test_integration_tailnet_pins",
       "target": "test_integration_tailnet_pins_fail",
@@ -48725,7 +59629,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L49",
+      "source_location": "L244",
+      "weight": 1.0,
+      "source": "test_integration_tailnet_pins",
+      "target": "test_integration_tailnet_pins_file_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L63",
       "weight": 1.0,
       "source": "test_integration_tailnet_pins",
       "target": "test_integration_tailnet_pins_render_fixture",
@@ -48735,10 +59649,50 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L108",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "test_integration_tailnet_pins",
+      "target": "test_integration_tailnet_pins_render_fixture_must_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L217",
+      "weight": 1.0,
+      "source": "test_integration_tailnet_pins",
+      "target": "test_integration_tailnet_pins_run_against",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "test_integration_tailnet_pins",
+      "target": "test_integration_tailnet_pins_run_expect_refusal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L211",
       "weight": 1.0,
       "source": "test_integration_tailnet_pins",
       "target": "test_integration_tailnet_pins_run_pin_command",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L236",
+      "weight": 1.0,
+      "source": "test_integration_tailnet_pins",
+      "target": "test_integration_tailnet_pins_run_with_shims",
       "confidence_score": 1.0
     },
     {
@@ -48755,7 +59709,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L42",
+      "source_location": "L56",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_tailnet_pins_sh__entry",
@@ -48766,7 +59720,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L63",
+      "source_location": "L97",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_tailnet_pins_sh__entry",
@@ -48777,7 +59731,40 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L114",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_sh__entry",
+      "target": "test_integration_tailnet_pins_render_fixture_must_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L280",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_sh__entry",
+      "target": "test_integration_tailnet_pins_run_against",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L340",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_sh__entry",
+      "target": "test_integration_tailnet_pins_run_expect_refusal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L253",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_tailnet_pins_sh__entry",
@@ -48788,7 +59775,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L59",
+      "source_location": "L377",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_sh__entry",
+      "target": "test_integration_tailnet_pins_run_with_shims",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L73",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_tailnet_pins_render_fixture",
@@ -48799,7 +59797,40 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/tailnet-pins.sh",
-      "source_location": "L111",
+      "source_location": "L90",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_render_fixture_must_fail",
+      "target": "test_integration_tailnet_pins_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L220",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_run_against",
+      "target": "test_integration_tailnet_pins_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L230",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_tailnet_pins_run_expect_refusal",
+      "target": "test_integration_tailnet_pins_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/tailnet-pins.sh",
+      "source_location": "L214",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_tailnet_pins_run_pin_command",
@@ -53366,7 +64397,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L283",
+      "source_location": "L410",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_awk_failure_fails_guard",
@@ -53376,7 +64407,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L241",
+      "source_location": "L368",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_clean_tree_passes",
@@ -53386,7 +64417,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L208",
+      "source_location": "L321",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_flagged_tree_rejected",
@@ -53396,7 +64427,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L261",
+      "source_location": "L388",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_grep_failure_fails_guard",
@@ -53406,7 +64437,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L251",
+      "source_location": "L378",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_no_candidate_tree_passes",
@@ -53416,7 +64447,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L304",
+      "source_location": "L432",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_assert_out_of_scope_cases_pass",
@@ -53426,7 +64457,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L192",
+      "source_location": "L276",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_create_boundary_tree_fixtures",
@@ -53436,7 +64467,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L132",
+      "source_location": "L197",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_create_clean_tree_fixtures",
@@ -53446,7 +64477,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L75",
+      "source_location": "L83",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_create_flagged_tree_fixtures",
@@ -53456,7 +64487,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L181",
+      "source_location": "L266",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_create_no_candidate_fixture",
@@ -53466,7 +64497,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L311",
+      "source_location": "L439",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_main",
@@ -53476,7 +64507,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L54",
+      "source_location": "L61",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_probe",
@@ -53486,7 +64517,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L63",
+      "source_location": "L70",
       "weight": 1.0,
       "source": "test_test_system_stat_order",
       "target": "test_test_system_stat_order_run_guard",
@@ -53506,7 +64537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L340",
+      "source_location": "L468",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_sh__entry",
@@ -53517,7 +64548,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L243",
+      "source_location": "L370",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_clean_tree_passes",
@@ -53528,7 +64559,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L211",
+      "source_location": "L324",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_flagged_tree_rejected",
@@ -53539,7 +64570,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L253",
+      "source_location": "L380",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_no_candidate_tree_passes",
@@ -53550,7 +64581,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L306",
+      "source_location": "L434",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_out_of_scope_cases_pass",
@@ -53561,7 +64592,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L325",
+      "source_location": "L453",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53572,7 +64603,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L326",
+      "source_location": "L454",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53583,7 +64614,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L327",
+      "source_location": "L455",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53594,7 +64625,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L328",
+      "source_location": "L456",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53605,7 +64636,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L216",
+      "source_location": "L329",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_flagged_tree_rejected",
@@ -53616,7 +64647,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L330",
+      "source_location": "L458",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53627,7 +64658,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L331",
+      "source_location": "L459",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53638,7 +64669,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L332",
+      "source_location": "L460",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53649,7 +64680,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L266",
+      "source_location": "L393",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_grep_failure_fails_guard",
@@ -53660,7 +64691,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L333",
+      "source_location": "L461",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53671,7 +64702,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L297",
+      "source_location": "L424",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_assert_awk_failure_fails_guard",
@@ -53682,7 +64713,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L288",
+      "source_location": "L415",
       "weight": 1.0,
       "source": "test_test_system_stat_order_assert_awk_failure_fails_guard",
       "target": "test_test_system_stat_order_awk",
@@ -53692,7 +64723,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L334",
+      "source_location": "L462",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53703,7 +64734,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/test-system/stat-order.sh",
-      "source_location": "L335",
+      "source_location": "L463",
       "weight": 1.0,
       "context": "call",
       "source": "test_test_system_stat_order_main",
@@ -53831,6 +64862,119 @@
       "context": "call",
       "source": "test_unit_claude_retirement_ordering_sh__entry",
       "target": "test_unit_claude_retirement_ordering_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_git_config_nosystem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_git_pager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_list_chezmoi_delivered_target_paths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_pager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_tool_and_url_hygiene",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L131",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_chezmoi_delivers_target_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L88",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
+      "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
       "confidence_score": 1.0
     },
     {
@@ -54033,7 +65177,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/homebrew-before10-skip-truthiness.sh",
-      "source_location": "L57",
+      "source_location": "L64",
       "weight": 1.0,
       "source": "test_unit_homebrew_before10_skip_truthiness",
       "target": "test_unit_homebrew_before10_skip_truthiness_render_has_skip",
@@ -54157,6 +65301,577 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_archive_xml_mentioning",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_cleanup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L258",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_poller_plutil_prefs_exit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_poller_readlink_exit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L190",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_poller_readlink_output",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L223",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_preferences_xml_with_profile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_rule_control",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_run_plutil_failure_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_run_reader_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_lulu_rule_existence_reader",
+      "target": "test_unit_lulu_rule_existence_reader_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L97",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_lulu_rule_existence_reader_sh__entry",
+      "target": "test_unit_lulu_rule_existence_reader_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L164",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_lulu_rule_existence_reader_sh__entry",
+      "target": "test_unit_lulu_rule_existence_reader_run_plutil_failure_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_lulu_rule_existence_reader_sh__entry",
+      "target": "test_unit_lulu_rule_existence_reader_run_reader_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/lulu-rule-existence-reader.sh",
+      "source_location": "L151",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_lulu_rule_existence_reader_run_plutil_failure_case",
+      "target": "test_unit_lulu_rule_existence_reader_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_count_guard",
+      "target": "test_unit_macos_defaults_count_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_count_guard",
+      "target": "test_unit_macos_defaults_count_guard_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-count-guard.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_count_guard_sh__entry",
+      "target": "test_unit_macos_defaults_count_guard_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_scope_read",
+      "target": "test_unit_macos_defaults_scope_read_call_function",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_scope_read",
+      "target": "test_unit_macos_defaults_scope_read_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_scope_read",
+      "target": "test_unit_macos_defaults_scope_read_reject_resolved_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_scope_read",
+      "target": "test_unit_macos_defaults_scope_read_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_scope_read",
+      "target": "test_unit_macos_defaults_scope_read_write_defaults_read_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L344",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_scope_read_sh__entry",
+      "target": "test_unit_macos_defaults_scope_read_call_function",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_scope_read_sh__entry",
+      "target": "test_unit_macos_defaults_scope_read_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_scope_read_sh__entry",
+      "target": "test_unit_macos_defaults_scope_read_reject_resolved_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L235",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_scope_read_sh__entry",
+      "target": "test_unit_macos_defaults_scope_read_write_defaults_read_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-scope-read.sh",
+      "source_location": "L111",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_scope_read_reject_resolved_path",
+      "target": "test_unit_macos_defaults_scope_read_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_call_lib",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_call_lib_with_override",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_write_chezmoi_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_source_path_propagation",
+      "target": "test_unit_macos_defaults_source_path_propagation_write_git_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "target": "test_unit_macos_defaults_source_path_propagation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L212",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "target": "test_unit_macos_defaults_source_path_propagation_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L153",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "target": "test_unit_macos_defaults_source_path_propagation_write_chezmoi_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L152",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_sh__entry",
+      "target": "test_unit_macos_defaults_source_path_propagation_write_git_stub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-source-path-propagation.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_source_path_propagation_refute_file_contains",
+      "target": "test_unit_macos_defaults_source_path_propagation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "test_unit_macos_posture_indeterminate",
+      "target": "test_unit_macos_posture_indeterminate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "test_unit_macos_posture_indeterminate",
+      "target": "test_unit_macos_posture_indeterminate_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_posture_indeterminate",
+      "target": "test_unit_macos_posture_indeterminate_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L82",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_posture_indeterminate_sh__entry",
+      "target": "test_unit_macos_posture_indeterminate_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-posture-indeterminate.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_posture_indeterminate_run_case",
+      "target": "test_unit_macos_posture_indeterminate_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "test_unit_moshi_hook_bounce_on_upgrade",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "test_unit_moshi_hook_bounce_on_upgrade",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_kickstarted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "test_unit_moshi_hook_bounce_on_upgrade",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_moshi_hook_bounce_on_upgrade",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L22",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_moshi_hook_bounce_on_upgrade_sh__entry",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_moshi_hook_bounce_on_upgrade_sh__entry",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_kickstarted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/moshi-hook-bounce-on-upgrade.sh",
+      "source_location": "L80",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_moshi_hook_bounce_on_upgrade_sh__entry",
+      "target": "test_unit_moshi_hook_bounce_on_upgrade_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "test_unit_no_empty_render_skip_on_darwin",
+      "target": "test_unit_no_empty_render_skip_on_darwin_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_no_empty_render_skip_on_darwin",
+      "target": "test_unit_no_empty_render_skip_on_darwin_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/no-empty-render-skip-on-darwin.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_no_empty_render_skip_on_darwin_sh__entry",
+      "target": "test_unit_no_empty_render_skip_on_darwin_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-alert-drainer-launchagent.sh",
       "source_location": "L44",
       "weight": 1.0,
@@ -54221,7 +65936,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-allowlist-verdict.sh",
-      "source_location": "L34",
+      "source_location": "L35",
       "weight": 1.0,
       "source": "test_unit_osquery_allowlist_verdict",
       "target": "test_unit_osquery_allowlist_verdict_fail",
@@ -54238,14 +65953,45 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-allowlist-verdict.sh",
+      "source_location": "L230",
+      "weight": 1.0,
+      "source": "test_unit_osquery_allowlist_verdict",
+      "target": "test_unit_osquery_allowlist_verdict_verdict_with",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-allowlist-verdict.sh",
+      "source_location": "L87",
+      "weight": 1.0,
+      "source": "test_unit_osquery_allowlist_verdict",
+      "target": "test_unit_osquery_allowlist_verdict_write_bound_manifest",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-allowlist-verdict.sh",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_allowlist_verdict_sh__entry",
       "target": "test_unit_osquery_allowlist_verdict_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-allowlist-verdict.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_allowlist_verdict_sh__entry",
+      "target": "test_unit_osquery_allowlist_verdict_write_bound_manifest",
       "confidence_score": 1.0
     },
     {
@@ -54898,8 +66644,176 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_expect_out",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_expect_rc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_run_scan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_sha_of",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_write_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "test_unit_osquery_pipeline_audit",
+      "target": "test_unit_osquery_pipeline_audit_write_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L148",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_expect_out",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L147",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_expect_rc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L90",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_run_scan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_write_bin_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L98",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_sh__entry",
+      "target": "test_unit_osquery_pipeline_audit_write_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_expect_out",
+      "target": "test_unit_osquery_pipeline_audit_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-pipeline-audit.sh",
+      "source_location": "L139",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_pipeline_audit_expect_rc",
+      "target": "test_unit_osquery_pipeline_audit_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
-      "source_location": "L33",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "test_unit_osquery_pipeline_verdict",
       "target": "test_unit_osquery_pipeline_verdict_fail",
@@ -54919,7 +66833,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
-      "source_location": "L48",
+      "source_location": "L65",
       "weight": 1.0,
       "source": "test_unit_osquery_pipeline_verdict",
       "target": "test_unit_osquery_pipeline_verdict_sha_of",
@@ -54929,7 +66843,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-pipeline-verdict.sh",
-      "source_location": "L38",
+      "source_location": "L53",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_pipeline_verdict_sh__entry",
@@ -55337,8 +67251,49 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_emit_failure",
+      "target": "test_unit_osquery_route_emit_failure_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_emit_failure",
+      "target": "test_unit_osquery_route_emit_failure_run_gate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_emit_failure",
+      "target": "test_unit_osquery_route_emit_failure_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-emit-failure.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_emit_failure_sh__entry",
+      "target": "test_unit_osquery_route_emit_failure_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L22",
+      "source_location": "L23",
       "weight": 1.0,
       "source": "test_unit_osquery_route_enrichment",
       "target": "test_unit_osquery_route_enrichment_fail",
@@ -55348,7 +67303,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L90",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "test_unit_osquery_route_enrichment",
       "target": "test_unit_osquery_route_enrichment_in_page",
@@ -55358,7 +67313,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L51",
+      "source_location": "L53",
       "weight": 1.0,
       "source": "test_unit_osquery_route_enrichment",
       "target": "test_unit_osquery_route_enrichment_mk_plist",
@@ -55378,7 +67333,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L89",
+      "source_location": "L102",
       "weight": 1.0,
       "source": "test_unit_osquery_route_enrichment",
       "target": "test_unit_osquery_route_enrichment_signing_of",
@@ -55388,7 +67343,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L27",
+      "source_location": "L28",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_enrichment_sh__entry",
@@ -55399,7 +67354,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-enrichment.sh",
-      "source_location": "L93",
+      "source_location": "L106",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_enrichment_sh__entry",
@@ -55410,7 +67365,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-gate.sh",
-      "source_location": "L94",
+      "source_location": "L102",
       "weight": 1.0,
       "source": "test_unit_osquery_route_gate",
       "target": "test_unit_osquery_route_gate_classify",
@@ -55440,7 +67395,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-gate.sh",
-      "source_location": "L106",
+      "source_location": "L114",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_gate_sh__entry",
@@ -55462,7 +67417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-gate.sh",
-      "source_location": "L99",
+      "source_location": "L107",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_gate_classify",
@@ -55536,7 +67491,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L26",
+      "source_location": "L27",
       "weight": 1.0,
       "source": "test_unit_osquery_route_persistence_allowlist",
       "target": "test_unit_osquery_route_persistence_allowlist_fail",
@@ -55546,7 +67501,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L73",
+      "source_location": "L87",
       "weight": 1.0,
       "source": "test_unit_osquery_route_persistence_allowlist",
       "target": "test_unit_osquery_route_persistence_allowlist_in_page",
@@ -55566,7 +67521,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L31",
+      "source_location": "L32",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_persistence_allowlist_sh__entry",
@@ -55577,7 +67532,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-persistence-allowlist.sh",
-      "source_location": "L76",
+      "source_location": "L90",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_persistence_allowlist_sh__entry",
@@ -55588,7 +67543,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L23",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_pipeline",
+      "target": "test_unit_osquery_route_pipeline_assert_paged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-pipeline.sh",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_fail",
@@ -55598,7 +67563,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L41",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_fe",
@@ -55608,27 +67573,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L75",
+      "source_location": "L77",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
-      "target": "test_unit_osquery_route_pipeline_in_a",
+      "target": "test_unit_osquery_route_pipeline_refute_paged",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L96",
-      "weight": 1.0,
-      "source": "test_unit_osquery_route_pipeline",
-      "target": "test_unit_osquery_route_pipeline_in_b",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L47",
+      "source_location": "L55",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_run_gate",
@@ -55648,7 +67603,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L29",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_pipeline_sh__entry",
+      "target": "test_unit_osquery_route_pipeline_assert_paged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-pipeline.sh",
+      "source_location": "L35",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_sh__entry",
@@ -55659,22 +67625,138 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L76",
+      "source_location": "L99",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_sh__entry",
-      "target": "test_unit_osquery_route_pipeline_in_a",
+      "target": "test_unit_osquery_route_pipeline_refute_paged",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L97",
+      "source_location": "L75",
       "weight": 1.0,
       "context": "call",
-      "source": "test_unit_osquery_route_pipeline_sh__entry",
-      "target": "test_unit_osquery_route_pipeline_in_b",
+      "source": "test_unit_osquery_route_pipeline_assert_paged",
+      "target": "test_unit_osquery_route_pipeline_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-pipeline.sh",
+      "source_location": "L78",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_pipeline_refute_paged",
+      "target": "test_unit_osquery_route_pipeline_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_severity_shortfall",
+      "target": "test_unit_osquery_route_severity_shortfall_assert_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_severity_shortfall",
+      "target": "test_unit_osquery_route_severity_shortfall_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_severity_shortfall",
+      "target": "test_unit_osquery_route_severity_shortfall_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_severity_shortfall",
+      "target": "test_unit_osquery_route_severity_shortfall_run_gate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_osquery_route_severity_shortfall",
+      "target": "test_unit_osquery_route_severity_shortfall_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L101",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_severity_shortfall_sh__entry",
+      "target": "test_unit_osquery_route_severity_shortfall_assert_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_severity_shortfall_sh__entry",
+      "target": "test_unit_osquery_route_severity_shortfall_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L134",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_severity_shortfall_sh__entry",
+      "target": "test_unit_osquery_route_severity_shortfall_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L43",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_severity_shortfall_assert_contains",
+      "target": "test_unit_osquery_route_severity_shortfall_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-route-severity-shortfall.sh",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_route_severity_shortfall_refute_contains",
+      "target": "test_unit_osquery_route_severity_shortfall_fail",
       "confidence_score": 1.0
     },
     {
@@ -56001,7 +68083,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L92",
+      "source_location": "L93",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_claude_declarations",
@@ -56011,7 +68093,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L57",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_fail",
@@ -56021,7 +68103,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L235",
+      "source_location": "L236",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_hermes_declaration_dirs",
@@ -56031,7 +68113,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L82",
+      "source_location": "L83",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_roster",
@@ -56051,7 +68133,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L67",
+      "source_location": "L68",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_target_name",
@@ -56061,7 +68143,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L75",
+      "source_location": "L76",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_vendored_dirs",
@@ -56071,10 +68153,21 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L62",
+      "source_location": "L63",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_sh__entry",
+      "target": "test_unit_skills_roster_fanout_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/skills-roster-fanout.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_skills_roster_fanout_claude_declarations",
       "target": "test_unit_skills_roster_fanout_fail",
       "confidence_score": 1.0
     },
@@ -56086,17 +68179,6 @@
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_claude_declarations",
-      "target": "test_unit_skills_roster_fanout_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L97",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_unit_skills_roster_fanout_claude_declarations",
       "target": "test_unit_skills_roster_fanout_target_name",
       "confidence_score": 1.0
     },
@@ -56104,7 +68186,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L78",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_vendored_dirs",
@@ -56115,7 +68197,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L83",
+      "source_location": "L84",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_roster",
@@ -56125,8 +68207,260 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_dropin",
+      "target": "test_unit_ssh_hardening_dropin_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-dropin.sh",
+      "source_location": "L43",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_dropin_sh__entry",
+      "target": "test_unit_ssh_hardening_dropin_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-harness-wallclock.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_harness_wallclock",
+      "target": "test_unit_ssh_hardening_harness_wallclock_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_include_glob_unescape",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_include_glob_unescape",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches_nothing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_include_glob_unescape",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_hostile_target",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_include_glob_unescape",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_run_include_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_include_glob_unescape",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L175",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_include_glob_unescape_sh__entry",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L248",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_include_glob_unescape_sh__entry",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches_nothing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L111",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_include_glob_unescape_sh__entry",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_hostile_target",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L135",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_run_include_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-include-glob-unescape.sh",
+      "source_location": "L154",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_include_glob_unescape_assert_scan_reaches_nothing",
+      "target": "test_unit_ssh_hardening_include_glob_unescape_run_include_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_verify_failclosed",
+      "target": "test_unit_ssh_hardening_verify_failclosed_assert_named_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_verify_failclosed",
+      "target": "test_unit_ssh_hardening_verify_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_verify_failclosed",
+      "target": "test_unit_ssh_hardening_verify_failclosed_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_ssh_hardening_verify_failclosed",
+      "target": "test_unit_ssh_hardening_verify_failclosed_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L163",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_sh__entry",
+      "target": "test_unit_ssh_hardening_verify_failclosed_assert_named_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_sh__entry",
+      "target": "test_unit_ssh_hardening_verify_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_sh__entry",
+      "target": "test_unit_ssh_hardening_verify_failclosed_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L153",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_assert_named_failure",
+      "target": "test_unit_ssh_hardening_verify_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L35",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_refute_contains",
+      "target": "test_unit_ssh_hardening_verify_failclosed_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/ssh-hardening-verify-failclosed.sh",
+      "source_location": "L156",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_ssh_hardening_verify_failclosed_assert_named_failure",
+      "target": "test_unit_ssh_hardening_verify_failclosed_refute_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L109",
+      "source_location": "L116",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_a0",
@@ -56136,7 +68470,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L112",
+      "source_location": "L119",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_am",
@@ -56146,7 +68480,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L115",
+      "source_location": "L122",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_an",
@@ -56156,7 +68490,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L118",
+      "source_location": "L125",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_asilent",
@@ -56176,7 +68510,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L58",
+      "source_location": "L65",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_make_fake",
@@ -56186,7 +68520,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L87",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_report",
@@ -56196,7 +68530,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L73",
+      "source_location": "L80",
       "weight": 1.0,
       "source": "test_unit_tailscaled_status",
       "target": "test_unit_tailscaled_status_run_case",
@@ -56216,7 +68550,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L125",
+      "source_location": "L132",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_sh__entry",
@@ -56227,7 +68561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L130",
+      "source_location": "L137",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_sh__entry",
@@ -56238,7 +68572,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L131",
+      "source_location": "L138",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_sh__entry",
@@ -56249,7 +68583,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L126",
+      "source_location": "L133",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_sh__entry",
@@ -56271,7 +68605,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L124",
+      "source_location": "L131",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_sh__entry",
@@ -56282,7 +68616,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L78",
+      "source_location": "L85",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_run_case",
@@ -56293,7 +68627,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L110",
+      "source_location": "L117",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_a0",
@@ -56304,7 +68638,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L113",
+      "source_location": "L120",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_am",
@@ -56315,7 +68649,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L116",
+      "source_location": "L123",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_an",
@@ -56326,7 +68660,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/tailscaled-status.sh",
-      "source_location": "L119",
+      "source_location": "L126",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_tailscaled_status_asilent",
@@ -56398,7 +68732,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L179",
+      "source_location": "L252",
       "weight": 1.0,
       "source": "test_validate_tests",
       "target": "test_validate_tests_check_stat_order",
@@ -56418,7 +68752,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L140",
+      "source_location": "L155",
       "weight": 1.0,
       "source": "test_validate_tests",
       "target": "test_validate_tests_find_bsd_first_chains_in_file",
@@ -56428,7 +68762,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L221",
+      "source_location": "L294",
       "weight": 1.0,
       "source": "test_validate_tests",
       "target": "test_validate_tests_main",
@@ -56448,7 +68782,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L230",
+      "source_location": "L303",
       "weight": 1.0,
       "context": "call",
       "source": "test_validate_tests_sh__entry",
@@ -56459,7 +68793,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L225",
+      "source_location": "L298",
       "weight": 1.0,
       "context": "call",
       "source": "test_validate_tests_main",
@@ -56470,7 +68804,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L226",
+      "source_location": "L299",
       "weight": 1.0,
       "context": "call",
       "source": "test_validate_tests_main",
@@ -56481,7 +68815,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L200",
+      "source_location": "L273",
       "weight": 1.0,
       "context": "call",
       "source": "test_validate_tests_check_stat_order",
@@ -56492,7 +68826,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/validate-tests.sh",
-      "source_location": "L227",
+      "source_location": "L300",
       "weight": 1.0,
       "context": "call",
       "source": "test_validate_tests_main",
@@ -56513,7 +68847,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L182",
+      "source_location": "L195",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_architecture",
@@ -56523,7 +68857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L649",
+      "source_location": "L662",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_code_style",
@@ -56533,7 +68867,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L675",
+      "source_location": "L688",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_git_commits",
@@ -56553,7 +68887,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L682",
+      "source_location": "L695",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_security",
@@ -56573,7 +68907,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L78",
+      "source_location": "L80",
       "weight": 1.0,
       "source": "claude_key_commands",
       "target": "claude_chezmoi_operations",
@@ -56583,7 +68917,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L106",
+      "source_location": "L108",
       "weight": 1.0,
       "source": "claude_key_commands",
       "target": "claude_claude_code_settings",
@@ -56593,7 +68927,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L139",
+      "source_location": "L141",
       "weight": 1.0,
       "source": "claude_key_commands",
       "target": "claude_git_hooks",
@@ -56623,7 +68957,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L326",
+      "source_location": "L339",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_agent_skills_cross_harness_store",
@@ -56633,7 +68967,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L624",
+      "source_location": "L637",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_ai_commit_messages",
@@ -56643,7 +68977,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L523",
+      "source_location": "L536",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_bashrc_init_ordering",
@@ -56653,7 +68987,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L316",
+      "source_location": "L329",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_ci",
@@ -56663,7 +68997,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L305",
+      "source_location": "L318",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_dev_environment_nix_flake",
@@ -56673,7 +69007,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L516",
+      "source_location": "L529",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_git_worktrees_worktrunk",
@@ -56683,7 +69017,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L560",
+      "source_location": "L573",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_happy_daemon_remote_agent_control",
@@ -56693,7 +69027,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L643",
+      "source_location": "L656",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_herdr_native_status",
@@ -56703,7 +69037,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L496",
+      "source_location": "L509",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_herdr_workspace_management",
@@ -56713,7 +69047,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L637",
+      "source_location": "L650",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_long_running_command_notifier",
@@ -56723,7 +69057,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L228",
+      "source_location": "L241",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_macos_defaults_management",
@@ -56733,7 +69067,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L192",
+      "source_location": "L205",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_minimum_chezmoi_version",
@@ -56743,7 +69077,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L300",
+      "source_location": "L313",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_os_targeting",
@@ -56753,7 +69087,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L196",
+      "source_location": "L209",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_secrets_management",
@@ -56763,7 +69097,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L531",
+      "source_location": "L544",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_shell_history_atuin",
@@ -56773,7 +69107,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L184",
+      "source_location": "L197",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_source_only_files",
@@ -56783,7 +69117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L203",
+      "source_location": "L216",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_system_package_management",
@@ -56793,7 +69127,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L587",
+      "source_location": "L600",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_tailscale_headless_daemon",
@@ -56803,7 +69137,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L273",
+      "source_location": "L286",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_template_files",
@@ -56813,7 +69147,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L279",
+      "source_location": "L292",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_template_shellcheck_workaround",
@@ -64993,7 +77327,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L72",
+      "source_location": "L217",
       "weight": 1.0,
       "source": "docs_runbooks_macos_fresh_machine_quickstart_macos_fresh_machine_quickstart",
       "target": "docs_runbooks_macos_fresh_machine_quickstart_sanity_checks_after_setup_is_complete",
@@ -65013,7 +77347,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L51",
+      "source_location": "L196",
       "weight": 1.0,
       "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
       "target": "docs_runbooks_macos_fresh_machine_quickstart_app_authentication",
@@ -65023,7 +77357,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L45",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_firewall_log_diagnostics",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L190",
       "weight": 1.0,
       "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
       "target": "docs_runbooks_macos_fresh_machine_quickstart_hardware_pairing",
@@ -65033,7 +77377,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L57",
+      "source_location": "L202",
       "weight": 1.0,
       "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
       "target": "docs_runbooks_macos_fresh_machine_quickstart_login_items",
@@ -65043,10 +77387,60 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
-      "source_location": "L62",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_lulu_preference_changes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_lulu_rule_creation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_lulu_system_extension_approval",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L207",
       "weight": 1.0,
       "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
       "target": "docs_runbooks_macos_fresh_machine_quickstart_out_of_scope_items_by_design",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_oversight_notification_delivery",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/runbooks/macos-fresh-machine-quickstart.md",
+      "source_location": "L169",
+      "weight": 1.0,
+      "source": "docs_runbooks_macos_fresh_machine_quickstart_after_first_chezmoi_apply",
+      "target": "docs_runbooks_macos_fresh_machine_quickstart_ssh_hardening_reload_and_the_way_back_in",
       "confidence_score": 1.0
     },
     {
@@ -73133,7 +85527,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L750",
+      "source_location": "L820",
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_repo_modernization_roadmap_design",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_testing_design_strategy_essential_feed_binding_on_how_not_what",
@@ -73143,7 +85537,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L807",
+      "source_location": "L877",
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_repo_modernization_roadmap_design",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_verification_extended_sections",
@@ -73293,7 +85687,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L743",
+      "source_location": "L813",
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_sp3_notification_system_rust_verified_behavior_contract",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_bugs_the_rewrite_must_not_reproduce_the_shell_findings_are_the_failure_spec",
@@ -73307,6 +85701,16 @@
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_sp3_notification_system_rust_verified_behavior_contract",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_home_its_own_multi_signal_module",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
+      "source_location": "L737",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_sp3_notification_system_rust_verified_behavior_contract",
+      "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_moshi_hook_integration_the_harness_hook_contract",
       "confidence_score": 1.0
     },
     {
@@ -73333,7 +85737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/superpowers/specs/2026-07-02-repo-modernization-roadmap-design.md",
-      "source_location": "L735",
+      "source_location": "L805",
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_sp3_notification_system_rust_verified_behavior_contract",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_the_empty_main_done_spam_resolved",
@@ -73347,6 +85751,526 @@
       "weight": 1.0,
       "source": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_sp3_notification_system_rust_verified_behavior_contract",
       "target": "docs_superpowers_specs_2026_07_02_repo_modernization_roadmap_design_two_event_classes_both_always_reach_the_user",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L283",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_open_question_for_adjudication",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L208",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_recommendation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_the_reframe_that_facts_5_and_7_force",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_what_i_verified_before_designing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_design_making_the_page_launchd_allowlist_a_real_boundary",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_what_this_does_not_defend_against",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_a_root_own_the_allowlist_with_a_privileged_update_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L102",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_b_manifest_the_allowlist_and_route_the_writer_through_chezmoi",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L131",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_c_page_on_any_allowlist_mutation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_d_bind_the_allowlist_s_content_to_something_the_attacker_cannot_also_edit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-osquery-allowlist-boundary-design.md",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_options",
+      "target": "docs_superpowers_specs_2026_07_26_osquery_allowlist_boundary_design_e_suppress_own_agents_by_manifest_membership_instead_of_by_allowlist_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_constraints_and_standing_policy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_goal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L172",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_known_blockers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1303",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_out_of_scope",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1180",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_per_slice_process",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1219",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_risks_and_open_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1099",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L112",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_three_tier_control_model",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1198",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_s10_decomposition_design",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_verification",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_constraints_and_standing_policy",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_recurring_bug_classes_every_slice_inherits",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L95",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_constraints_and_standing_policy",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_style_conventions_every_slice_inherits",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_three_tier_control_model",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_how_the_runner_enforces_the_distinction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_three_tier_control_model",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_what_this_prevents",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_three_tier_control_model",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_where_a_tier_is_declared",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L177",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_known_blockers",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_blocker_one_duplicate_hermes_profile_source_directories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L217",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_known_blockers",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_blocker_two_main_does_not_declare_the_endpoint_security_casks_task_45",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L260",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_0_declare_the_endpoint_security_casks",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L874",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_10_lulu_policy_and_posture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L308",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_1_macos_defaults_shared_library",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L357",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_2_system_domain_support_in_the_defaults_tooling",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L417",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_3_the_tiered_control_model",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L470",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_4_firewall_baseline",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L523",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_5_security_defaults_baseline",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L575",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_6_posture_verification_and_alerting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L658",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_7_ssh_configuration_generation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L744",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_8_ssh_apply_safety",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L818",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_slice_stack",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_9_oversight_posture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L988",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_10_lulu_policy_and_posture",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_allow_rule_set_and_a_correction_to_how_the_alerting_path_egresses",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L956",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_10_lulu_policy_and_posture",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_enforce_tier_policy_controls_and_why_allowlocalhost_is_the_critical_one",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L906",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_slice_10_lulu_policy_and_posture",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_two_gates_both_resolved",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1123",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_how_the_recovery_path_is_pinned_by_a_test_rather_than_asserted_in_a_comment",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1163",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_live_drill_run_before_slice_8_merges",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1105",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_ways_back_in_in_order_of_independence",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1140",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_the_recovery_story_for_slice_8",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_what_the_tests_can_and_cannot_establish",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1271",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_risks_and_open_items",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_other_risks",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/superpowers/specs/2026-07-26-s10-decomposition-design.md",
+      "source_location": "L1221",
+      "weight": 1.0,
+      "source": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_risks_and_open_items",
+      "target": "docs_superpowers_specs_2026_07_26_s10_decomposition_design_work_in_pull_request_53_the_original_eight_slice_plan_did_not_account_for",
       "confidence_score": 1.0
     },
     {
@@ -74438,228 +87362,8 @@
       "source": "private_dot_claude_commands_pr_merge_pr_merge",
       "target": "private_dot_claude_commands_pr_merge_steps",
       "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L1",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan",
-      "target": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L90",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_banked_concern_a_the_digest_self_page_gap_verified_bug_completeness_guard",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L128",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_banked_concern_b_the_fim_watch_scope_fail_open_over_paging_needs_an_operator_ruling",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L174",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_behavior_decomposition_ordered_tdd_behaviors",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L249",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_dependencies",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L257",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_durability_security_invariants",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L216",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_files_added_changed",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L54",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_how_it_should_be_generated_the_key_design_improvement_over_c69baab",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L274",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_open_questions_operator_rulings",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L36",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_the_pipeline_file_set_the_manifest_must_cover_real_on_disk_today",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-plan.md",
-      "source_location": "L8",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_plan_slice_15_pipeline_manifest_s9_re_land_final_slice",
-      "target": "slice_pipeline_manifest_plan_what_the_manifest_is_grounded_in_the_spec_c69baab_current_state",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L1",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report",
-      "target": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L215",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_adjudicated_limits_what_this_layer_does_not_cover_and_why_not_here",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L258",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_code_quality_summary",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L10",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_commit_ledger_origin_main_head",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L202",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_corrections_to_the_previous_report",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L247",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_documented_not_fixed_filed_as_follow_ups",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L274",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_gate_evidence",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L54",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_invariants_stated_located_pinned",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L181",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_status_loss_sweep_whole_slice",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L22",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_step_by_step_over_git_diff_8809a39_head",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "slice-pipeline-manifest-report.md",
-      "source_location": "L169",
-      "weight": 1.0,
-      "source": "slice_pipeline_manifest_report_slice_15_pipeline_manifest_full_branch_chain_of_thought_report",
-      "target": "slice_pipeline_manifest_report_test_harness_defect_found_while_fixing_r3_f4",
-      "confidence_score": 1.0
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "173222935e48d7e2e654394b41b46a3626ac5fa5"
+  "built_at_commit": "ecfbf88b44f09f5e0141845a4fc03a9838c1a2ec"
 }

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -35,6 +35,11 @@ GITCONFIG_TEMPLATE="$REPO_ROOT/dot_gitconfig.tmpl"
 # and dot_bashrc.tmpl / dot_profile both export XDG_CONFIG_HOME=$HOME/.config.
 XDG_IGNORE_TARGET="$HOME/.config/git/ignore"
 XDG_IGNORE_SOURCE="dot_config/git/ignore"
+# The chezmoi entry types that put a readable file at a target path. Symlinks
+# count: git follows a symlinked ignore file (measured), so a symlink_ source
+# satisfies invariant 3 exactly as a plain file does. Directories and scripts do
+# not, which is why this is not simply `all`.
+CHEZMOI_FILE_DELIVERING_ENTRY_TYPES="files,symlinks"
 PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
 # Go template actions that produce control flow rather than a value. A literal
 # placeholder cannot stand in for one, so their presence means this test's
@@ -56,16 +61,16 @@ fail() {
   exit 1
 }
 
-# Answers "which absolute target paths does chezmoi deliver as files from this
-# source tree?". This is the authority on deployment: it applies .chezmoiignore
-# and every source-name prefix, neither of which a source-path existence test
-# can see. Read-only, and it lists the target state without rendering file
-# contents, so the keepassxc templates in this repo are never unlocked.
+# Answers "which absolute target paths does chezmoi deliver a readable file to
+# from this source tree?". This is the authority on deployment: it applies
+# .chezmoiignore and every source-name prefix, neither of which a source-path
+# existence test can see. Read-only, and it lists the target state without
+# rendering file contents, so the keepassxc templates here are never unlocked.
 list_chezmoi_delivered_target_paths() {
   chezmoi managed \
     --source "$REPO_ROOT" \
     --destination "$HOME" \
-    --include=files \
+    --include="$CHEZMOI_FILE_DELIVERING_ENTRY_TYPES" \
     --path-style=absolute
 }
 
@@ -95,7 +100,7 @@ command -v chezmoi >/dev/null 2>&1 ||
 DELIVERED_TARGET_PATHS="$(list_chezmoi_delivered_target_paths)" ||
   fail "chezmoi managed failed against source $REPO_ROOT; invariant 3 cannot be decided"
 [[ -n $DELIVERED_TARGET_PATHS ]] ||
-  fail "chezmoi managed listed no files at all for source $REPO_ROOT; invariant 3 cannot be decided"
+  fail "chezmoi managed listed no entries at all for source $REPO_ROOT; invariant 3 cannot be decided"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -22,9 +22,11 @@
 #      fine and deliberate: that rescues a legacy remote by rewriting it away.
 #   3. Global ignores resolve to a file this repo actually deploys. Either
 #      core.excludesfile names a deployed path, or the key is absent and the
-#      repo ships git's documented default, dot_config/git/ignore. Without this
-#      the setting can point at a file nothing creates and silently ignore
-#      nothing, which is what it did.
+#      repo deploys git's documented default, dot_config/git/ignore. Deployment
+#      is decided by `chezmoi managed`, not by the source file's presence on
+#      disk: a source file hidden behind .chezmoiignore is present but never
+#      delivered, and git would then load no global ignores at all, which is the
+#      failure this invariant exists to catch.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -40,7 +42,11 @@ PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
 CONTROL_FLOW_ACTIONS='{{-?[[:space:]]*(if|else|end|range|with|block|define|template)\b'
 
 # Bug class 11: git exports GIT_DIR and friends into every hook, and a stale one
-# would redirect the config reads below at the wrong repository.
+# would redirect the config reads below at the wrong repository. chezmoi needs no
+# equivalent scrub: it has no environment override for sourceDir or destDir
+# (measured: CHEZMOI_SOURCE_DIR is ignored), and both are passed explicitly
+# below, so the only environment input left is where its own config file is
+# found, which the listing does not depend on.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
   GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_COUNT GIT_PREFIX
 export GIT_CONFIG_NOSYSTEM=1 GIT_PAGER=cat PAGER=cat
@@ -50,18 +56,23 @@ fail() {
   exit 1
 }
 
-# Answers "does the repo deploy this target path?" for a $HOME-relative path,
-# by translating it back to its chezmoi source name (leading dot -> dot_ on
-# every path component).
-repo_deploys_target_path() {
-  local target="$1" relative source_path component
-  relative="${target#"$HOME"/}"
-  [[ $relative != "$target" ]] || return 1
-  source_path="$REPO_ROOT"
-  while IFS= read -r -d '/' component; do
-    source_path="$source_path/${component/#./dot_}"
-  done < <(printf '%s/' "$relative")
-  [[ -e $source_path ]]
+# Answers "which absolute target paths does chezmoi deliver as files from this
+# source tree?". This is the authority on deployment: it applies .chezmoiignore
+# and every source-name prefix, neither of which a source-path existence test
+# can see. Read-only, and it lists the target state without rendering file
+# contents, so the keepassxc templates in this repo are never unlocked.
+list_chezmoi_delivered_target_paths() {
+  chezmoi managed \
+    --source "$REPO_ROOT" \
+    --destination "$HOME" \
+    --include=files \
+    --path-style=absolute
+}
+
+# Answers "does chezmoi deliver exactly this target path?".
+chezmoi_delivers_target_path() {
+  local target="$1"
+  printf '%s\n' "$DELIVERED_TARGET_PATHS" | grep -Fxq -- "$target"
 }
 
 # Answers "can git resolve this tool name?" for the given mode, by asking git.
@@ -76,6 +87,15 @@ git_resolves_tool_name() {
 
 [[ -f $GITCONFIG_TEMPLATE ]] || fail "missing template: $GITCONFIG_TEMPLATE"
 command -v git >/dev/null 2>&1 || fail "git is not on PATH"
+command -v chezmoi >/dev/null 2>&1 ||
+  fail "chezmoi is not on PATH; invariant 3 cannot tell which target paths this repo delivers"
+
+# Fail closed: an unreadable or empty listing must not read as "nothing is
+# missing". Collected once, since both branches of invariant 3 consult it.
+DELIVERED_TARGET_PATHS="$(list_chezmoi_delivered_target_paths)" ||
+  fail "chezmoi managed failed against source $REPO_ROOT; invariant 3 cannot be decided"
+[[ -n $DELIVERED_TARGET_PATHS ]] ||
+  fail "chezmoi managed listed no files at all for source $REPO_ROOT; invariant 3 cannot be decided"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -108,11 +128,11 @@ done < <(git config --file "$parsed" --name-only --list)
 # ---- 3: global ignores resolve to a file this repo deploys ----------------
 excludes="$(git config --file "$parsed" --get core.excludesfile || true)"
 if [[ -n $excludes ]]; then
-  repo_deploys_target_path "${excludes/#\~/$HOME}" ||
-    fail "core.excludesfile = '$excludes' names a path this repo never deploys, so git would load no global ignores at all"
+  chezmoi_delivers_target_path "${excludes/#\~/$HOME}" ||
+    fail "core.excludesfile = '$excludes' names a path chezmoi does not deliver, so git would load no global ignores at all"
 else
-  [[ -f $REPO_ROOT/$XDG_IGNORE_SOURCE ]] ||
-    fail "core.excludesfile is unset, so git falls back to $XDG_IGNORE_TARGET, but this repo does not ship $XDG_IGNORE_SOURCE; global ignores would be empty on a fresh machine"
+  chezmoi_delivers_target_path "$XDG_IGNORE_TARGET" ||
+    fail "core.excludesfile is unset, so git falls back to $XDG_IGNORE_TARGET, but chezmoi does not deliver that path from $XDG_IGNORE_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
 fi
 
 printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no git:// rewrite target, global ignores are deployed)\n'

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# gitconfig-tool-and-url-hygiene.sh, three invariants of dot_gitconfig.tmpl that
+# git itself can answer, asserted by handing the file to git rather than by
+# grepping it.
+#
+# dot_gitconfig.tmpl calls keepassxc for the signing key, so it can never be
+# rendered by automation (that is also why the rendered-template shellcheck
+# formatter excludes it). This test does not render it: it neutralizes the
+# template directives into a literal placeholder and parses the result with
+# `git config --file`, which is the same parser git uses at runtime.
+#
+# The invariants:
+#   1. diff.tool and merge.tool name a tool git can RESOLVE. Both keys take a
+#      tool name; a command string in either makes git report an unknown tool,
+#      reset to its default, and guess a different editor. `git <mode>tool
+#      --tool-help` is the authority on the answer, and it lists built-ins
+#      (available or not) as `<name>` and user-defined tools as `<name>.cmd`,
+#      so one lookup covers both ways of being resolvable.
+#   2. No url rewrite TARGETS the git:// protocol. GitHub permanently disabled
+#      it on 2022-03-15, so a `[url "git://..."]` base sends fetches at a port
+#      that no longer answers. A git:// prefix on the insteadOf VALUE side is
+#      fine and deliberate: that rescues a legacy remote by rewriting it away.
+#   3. Global ignores resolve to a file this repo actually deploys. Either
+#      core.excludesfile names a deployed path, or the key is absent and the
+#      repo ships git's documented default, dot_config/git/ignore. Without this
+#      the setting can point at a file nothing creates and silently ignore
+#      nothing, which is what it did.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GITCONFIG_TEMPLATE="$REPO_ROOT/dot_gitconfig.tmpl"
+# git's documented default for core.excludesFile is $XDG_CONFIG_HOME/git/ignore,
+# and dot_bashrc.tmpl / dot_profile both export XDG_CONFIG_HOME=$HOME/.config.
+XDG_IGNORE_TARGET="$HOME/.config/git/ignore"
+XDG_IGNORE_SOURCE="dot_config/git/ignore"
+PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
+# Go template actions that produce control flow rather than a value. A literal
+# placeholder cannot stand in for one, so their presence means this test's
+# neutralizer no longer models the file and must be taught to.
+CONTROL_FLOW_ACTIONS='{{-?[[:space:]]*(if|else|end|range|with|block|define|template)\b'
+
+# Bug class 11: git exports GIT_DIR and friends into every hook, and a stale one
+# would redirect the config reads below at the wrong repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+  GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_COUNT GIT_PREFIX
+export GIT_CONFIG_NOSYSTEM=1 GIT_PAGER=cat PAGER=cat
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Answers "does the repo deploy this target path?" for a $HOME-relative path,
+# by translating it back to its chezmoi source name (leading dot -> dot_ on
+# every path component).
+repo_deploys_target_path() {
+  local target="$1" relative source_path component
+  relative="${target#"$HOME"/}"
+  [[ $relative != "$target" ]] || return 1
+  source_path="$REPO_ROOT"
+  while IFS= read -r -d '/' component; do
+    source_path="$source_path/${component/#./dot_}"
+  done < <(printf '%s/' "$relative")
+  [[ -e $source_path ]]
+}
+
+# Answers "can git resolve this tool name?" for the given mode, by asking git.
+git_resolves_tool_name() {
+  local mode="$1" name="$2" config="$3" first
+  while IFS= read -r first; do
+    [[ $first == "$name" || $first == "$name.cmd" ]] && return 0
+  done < <(GIT_CONFIG_GLOBAL="$config" git "${mode}tool" --tool-help 2>/dev/null |
+    awk '{print $1}')
+  return 1
+}
+
+[[ -f $GITCONFIG_TEMPLATE ]] || fail "missing template: $GITCONFIG_TEMPLATE"
+command -v git >/dev/null 2>&1 || fail "git is not on PATH"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+parsed="$work/gitconfig"
+
+# Fail closed: neutralizing a control-flow action into a literal would silently
+# change which sections the parser sees.
+if grep -Eq "$CONTROL_FLOW_ACTIONS" "$GITCONFIG_TEMPLATE"; then
+  fail "$GITCONFIG_TEMPLATE now uses Go template control flow; this test's neutralizer only handles value actions and must be updated"
+fi
+sed -E "s/\{\{[^}]*\}\}/$PLACEHOLDER/g" "$GITCONFIG_TEMPLATE" >"$parsed"
+grep -q '{{' "$parsed" && fail "template directives survived neutralization; the parsed config is not trustworthy"
+git config --file "$parsed" --list >/dev/null 2>&1 ||
+  fail "the neutralized template is not parseable by git config --file"
+
+# ---- 1: diff.tool and merge.tool name a tool git can resolve ---------------
+for mode in diff merge; do
+  tool="$(git config --file "$parsed" --get "$mode.tool" || true)"
+  [[ -n $tool ]] || fail "$mode.tool is unset; a resolvable tool name is expected"
+  git_resolves_tool_name "$mode" "$tool" "$parsed" ||
+    fail "$mode.tool = '$tool' is not a tool git can resolve; git ${mode}tool would report an unknown tool and guess a different editor. Use a built-in name, or add ${mode}tool.<name>.cmd"
+done
+
+# ---- 2: no url rewrite targets the dead git:// protocol --------------------
+while IFS= read -r key; do
+  [[ $key == url.git://* ]] &&
+    fail "a url rewrite targets the git:// protocol ($key); GitHub permanently disabled it on 2022-03-15, so fetches through this base cannot connect"
+done < <(git config --file "$parsed" --name-only --list)
+
+# ---- 3: global ignores resolve to a file this repo deploys ----------------
+excludes="$(git config --file "$parsed" --get core.excludesfile || true)"
+if [[ -n $excludes ]]; then
+  repo_deploys_target_path "${excludes/#\~/$HOME}" ||
+    fail "core.excludesfile = '$excludes' names a path this repo never deploys, so git would load no global ignores at all"
+else
+  [[ -f $REPO_ROOT/$XDG_IGNORE_SOURCE ]] ||
+    fail "core.excludesfile is unset, so git falls back to $XDG_IGNORE_TARGET, but this repo does not ship $XDG_IGNORE_SOURCE; global ignores would be empty on a fresh machine"
+fi
+
+printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no git:// rewrite target, global ignores are deployed)\n'

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -18,11 +18,14 @@
 #      so one lookup covers both ways of being resolvable.
 #   2. No tool is PINNED to a literal binary path. A <diff|merge>tool.<name>.path
 #      key drops git's $PATH lookup for a filesystem path that has no fallback,
-#      so any machine with a different install prefix loses the tool even with a
-#      working one on $PATH. This is a key-shape question, exactly like invariant
-#      3, and is answered from the same key listing: the regression is the
-#      PRESENCE of the key, so nothing here touches the filesystem and the answer
-#      cannot differ between this machine, CI, and the flake's x86_64-linux.
+#      so a machine with a different install prefix loses the tool even with a
+#      working one on $PATH, in whichever mode has no <mode>tool.<name>.cmd to
+#      make git skip the availability check. In the other mode the pin is
+#      dormant rather than harmless: deleting that cmd arms it. This is a
+#      key-shape question, exactly like invariant 3, and is answered from the
+#      same key listing: the regression is the PRESENCE of the key, so nothing
+#      here touches the filesystem and the answer cannot differ between this
+#      machine, CI, and the flake's x86_64-linux.
 #   3. No url rewrite TARGETS the git:// protocol. GitHub permanently disabled
 #      it on 2022-03-15, so a `[url "git://..."]` base sends fetches at a port
 #      that no longer answers. A git:// prefix on the insteadOf VALUE side is
@@ -276,7 +279,7 @@ done
 # ---- 2 and 3: key-shape prohibitions, decided from one key listing ---------
 while IFS= read -r key; do
   is_tool_binary_path_key "$key" &&
-    fail "$key pins a tool to a literal binary path, dropping git's \$PATH lookup for a path with no fallback. Measured on git 2.55.0 against a nonexistent path, with a working nvim on \$PATH the whole time: git mergetool exits 1 and leaves the file conflicted, git difftool exits 128, both reporting 'is not available as'. Let git resolve the tool name through \$PATH instead"
+    fail "$key pins a tool to a literal binary path, dropping git's \$PATH lookup for a path with no fallback. What it costs depends on the matching cmd key, because git skips the availability check whenever <mode>tool.<name>.cmd is non-empty (get_merge_tool_path in git-mergetool--lib). Measured on git 2.55.0 against a nonexistent path, with a working nvim on \$PATH the whole time: with no mergetool.<name>.cmd, git mergetool exits 1, reports 'is not available as', and leaves the file conflicted; with no difftool.<name>.cmd, git difftool exits 128 with the same report; with a non-empty cmd on either side, that mode skips the check, runs the cmd, and exits 0, so the pin is dormant there rather than harmless and deleting the cmd arms it. Let git resolve the tool name through \$PATH instead"
   [[ $key == url.git://* ]] &&
     fail "a url rewrite targets the git:// protocol ($key); GitHub permanently disabled it on 2022-03-15, so fetches through this base cannot connect"
 done < <(git config --file "$parsed" --name-only --list)

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gitconfig-tool-and-url-hygiene.sh, three invariants of dot_gitconfig.tmpl that
+# gitconfig-tool-and-url-hygiene.sh, four invariants of dot_gitconfig.tmpl that
 # git itself can answer, asserted by handing the file to git rather than by
 # grepping it.
 #
@@ -16,11 +16,18 @@
 #      --tool-help` is the authority on the answer, and it lists built-ins
 #      (available or not) as `<name>` and user-defined tools as `<name>.cmd`,
 #      so one lookup covers both ways of being resolvable.
-#   2. No url rewrite TARGETS the git:// protocol. GitHub permanently disabled
+#   2. No tool is PINNED to a literal binary path. A <diff|merge>tool.<name>.path
+#      key drops git's $PATH lookup for a filesystem path that has no fallback,
+#      so any machine with a different install prefix loses the tool even with a
+#      working one on $PATH. This is a key-shape question, exactly like invariant
+#      3, and is answered from the same key listing: the regression is the
+#      PRESENCE of the key, so nothing here touches the filesystem and the answer
+#      cannot differ between this machine, CI, and the flake's x86_64-linux.
+#   3. No url rewrite TARGETS the git:// protocol. GitHub permanently disabled
 #      it on 2022-03-15, so a `[url "git://..."]` base sends fetches at a port
 #      that no longer answers. A git:// prefix on the insteadOf VALUE side is
 #      fine and deliberate: that rescues a legacy remote by rewriting it away.
-#   3. Global ignores resolve to a file this repo actually deploys. git reads
+#   4. Global ignores resolve to a file this repo actually deploys. git reads
 #      THREE states out of core.excludesfile, not two, and this invariant covers
 #      all three: ABSENT loads git's documented default, SET loads exactly that
 #      path, and PRESENT-BUT-EMPTY loads nothing at all, reproducing the original
@@ -44,7 +51,7 @@ GIT_DEFAULT_EXCLUDES_SOURCE="dot_config/git/ignore"
 GIT_DEFAULT_EXCLUDES_TARGET="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
 # The chezmoi entry types that put a readable file at a target path. Symlinks
 # count: git follows a symlinked ignore file (measured), so a symlink_ source
-# satisfies invariant 3 exactly as a plain file does. Directories and scripts do
+# satisfies invariant 4 exactly as a plain file does. Directories and scripts do
 # not, which is why this is not simply `all`.
 CHEZMOI_FILE_DELIVERING_ENTRY_TYPES="files,symlinks"
 # `git config --get` exits 1 when the key is ABSENT and 0 when it is present,
@@ -94,6 +101,13 @@ chezmoi_delivers_target_path() {
   printf '%s\n' "$DELIVERED_TARGET_PATHS" | grep -Fxq -- "$target"
 }
 
+# Answers "does this config key pin a diff or merge tool to a literal binary
+# path?". Key shape alone decides it, so the verdict is the same everywhere.
+is_tool_binary_path_key() {
+  local key="$1"
+  [[ $key == difftool.*.path || $key == mergetool.*.path ]]
+}
+
 # Answers "which of git's three core.excludesfile states does this config hold?",
 # printing one of: absent, set, empty, unreadable. Separating absent from empty
 # is the point: they read identically on stdout and mean opposite things to git.
@@ -124,14 +138,14 @@ git_resolves_tool_name() {
 [[ -f $GITCONFIG_TEMPLATE ]] || fail "missing template: $GITCONFIG_TEMPLATE"
 command -v git >/dev/null 2>&1 || fail "git is not on PATH"
 command -v chezmoi >/dev/null 2>&1 ||
-  fail "chezmoi is not on PATH; invariant 3 cannot tell which target paths this repo delivers"
+  fail "chezmoi is not on PATH; invariant 4 cannot tell which target paths this repo delivers"
 
 # Fail closed: an unreadable or empty listing must not read as "nothing is
-# missing". Collected once, since every branch of invariant 3 consults it.
+# missing". Collected once, since every branch of invariant 4 consults it.
 DELIVERED_TARGET_PATHS="$(list_chezmoi_delivered_target_paths)" ||
-  fail "chezmoi managed failed against source $REPO_ROOT; invariant 3 cannot be decided"
+  fail "chezmoi managed failed against source $REPO_ROOT; invariant 4 cannot be decided"
 [[ -n $DELIVERED_TARGET_PATHS ]] ||
-  fail "chezmoi managed listed no entries at all for source $REPO_ROOT; invariant 3 cannot be decided"
+  fail "chezmoi managed listed no entries at all for source $REPO_ROOT; invariant 4 cannot be decided"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -155,13 +169,15 @@ for mode in diff merge; do
     fail "$mode.tool = '$tool' is not a tool git can resolve; git ${mode}tool would report an unknown tool and guess a different editor. Use a built-in name, or add ${mode}tool.<name>.cmd"
 done
 
-# ---- 2: no url rewrite targets the dead git:// protocol --------------------
+# ---- 2 and 3: key-shape prohibitions, decided from one key listing ---------
 while IFS= read -r key; do
+  is_tool_binary_path_key "$key" &&
+    fail "$key pins a tool to a literal binary path, dropping git's \$PATH lookup for a path with no fallback. Measured on git 2.55.0 against a nonexistent path, with a working nvim on \$PATH the whole time: git mergetool exits 1 and leaves the file conflicted, git difftool exits 128, both reporting 'is not available as'. Let git resolve the tool name through \$PATH instead"
   [[ $key == url.git://* ]] &&
     fail "a url rewrite targets the git:// protocol ($key); GitHub permanently disabled it on 2022-03-15, so fetches through this base cannot connect"
 done < <(git config --file "$parsed" --name-only --list)
 
-# ---- 3: global ignores resolve to a file this repo deploys ----------------
+# ---- 4: global ignores resolve to a file this repo deploys ----------------
 case "$(classify_core_excludesfile "$parsed")" in
   set)
     excludes="$(git config --file "$parsed" --get core.excludesfile)"
@@ -176,8 +192,8 @@ case "$(classify_core_excludesfile "$parsed")" in
       fail "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, but chezmoi does not deliver that path from $GIT_DEFAULT_EXCLUDES_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
     ;;
   *)
-    fail "core.excludesfile could not be read out of $parsed; invariant 3 cannot be decided"
+    fail "core.excludesfile could not be read out of $parsed; invariant 4 cannot be decided"
     ;;
 esac
 
-printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no git:// rewrite target, global ignores are deployed)\n'
+printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no tool pinned to a binary path, no git:// rewrite target, global ignores are deployed)\n'

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -20,13 +20,14 @@
 #      it on 2022-03-15, so a `[url "git://..."]` base sends fetches at a port
 #      that no longer answers. A git:// prefix on the insteadOf VALUE side is
 #      fine and deliberate: that rescues a legacy remote by rewriting it away.
-#   3. Global ignores resolve to a file this repo actually deploys. Either
-#      core.excludesfile names a deployed path, or the key is absent and the
-#      repo deploys git's documented default, dot_config/git/ignore. Deployment
-#      is decided by `chezmoi managed`, not by the source file's presence on
-#      disk: a source file hidden behind .chezmoiignore is present but never
-#      delivered, and git would then load no global ignores at all, which is the
-#      failure this invariant exists to catch.
+#   3. Global ignores resolve to a file this repo actually deploys. git reads
+#      THREE states out of core.excludesfile, not two, and this invariant covers
+#      all three: ABSENT loads git's documented default, SET loads exactly that
+#      path, and PRESENT-BUT-EMPTY loads nothing at all, reproducing the original
+#      defect this file dropped the key to fix. Deployment is decided by `chezmoi
+#      managed`, not by the source file's presence on disk: a source file hidden
+#      behind .chezmoiignore is present but never delivered, and git would then
+#      load no global ignores either.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -46,6 +47,11 @@ GIT_DEFAULT_EXCLUDES_TARGET="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
 # satisfies invariant 3 exactly as a plain file does. Directories and scripts do
 # not, which is why this is not simply `all`.
 CHEZMOI_FILE_DELIVERING_ENTRY_TYPES="files,symlinks"
+# `git config --get` exits 1 when the key is ABSENT and 0 when it is present,
+# including when its value is the empty string (measured). Both print nothing on
+# stdout, so this exit code is the only signal separating two states that mean
+# opposite things to git.
+GIT_CONFIG_KEY_ABSENT_EXIT_CODE=1
 PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
 # Go template actions that produce control flow rather than a value. A literal
 # placeholder cannot stand in for one, so their presence means this test's
@@ -88,6 +94,23 @@ chezmoi_delivers_target_path() {
   printf '%s\n' "$DELIVERED_TARGET_PATHS" | grep -Fxq -- "$target"
 }
 
+# Answers "which of git's three core.excludesfile states does this config hold?",
+# printing one of: absent, set, empty, unreadable. Separating absent from empty
+# is the point: they read identically on stdout and mean opposite things to git.
+classify_core_excludesfile() {
+  local config="$1" value exit_code=0
+  value="$(git config --file "$config" --get core.excludesfile)" || exit_code=$?
+  if ((exit_code == GIT_CONFIG_KEY_ABSENT_EXIT_CODE)); then
+    printf 'absent\n'
+  elif ((exit_code != 0)); then
+    printf 'unreadable\n'
+  elif [[ -z $value ]]; then
+    printf 'empty\n'
+  else
+    printf 'set\n'
+  fi
+}
+
 # Answers "can git resolve this tool name?" for the given mode, by asking git.
 git_resolves_tool_name() {
   local mode="$1" name="$2" config="$3" first
@@ -104,7 +127,7 @@ command -v chezmoi >/dev/null 2>&1 ||
   fail "chezmoi is not on PATH; invariant 3 cannot tell which target paths this repo delivers"
 
 # Fail closed: an unreadable or empty listing must not read as "nothing is
-# missing". Collected once, since both branches of invariant 3 consult it.
+# missing". Collected once, since every branch of invariant 3 consults it.
 DELIVERED_TARGET_PATHS="$(list_chezmoi_delivered_target_paths)" ||
   fail "chezmoi managed failed against source $REPO_ROOT; invariant 3 cannot be decided"
 [[ -n $DELIVERED_TARGET_PATHS ]] ||
@@ -139,13 +162,22 @@ while IFS= read -r key; do
 done < <(git config --file "$parsed" --name-only --list)
 
 # ---- 3: global ignores resolve to a file this repo deploys ----------------
-excludes="$(git config --file "$parsed" --get core.excludesfile || true)"
-if [[ -n $excludes ]]; then
-  chezmoi_delivers_target_path "${excludes/#\~/$HOME}" ||
-    fail "core.excludesfile = '$excludes' names a path chezmoi does not deliver, so git would load no global ignores at all"
-else
-  chezmoi_delivers_target_path "$GIT_DEFAULT_EXCLUDES_TARGET" ||
-    fail "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, but chezmoi does not deliver that path from $GIT_DEFAULT_EXCLUDES_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
-fi
+case "$(classify_core_excludesfile "$parsed")" in
+  set)
+    excludes="$(git config --file "$parsed" --get core.excludesfile)"
+    chezmoi_delivers_target_path "${excludes/#\~/$HOME}" ||
+      fail "core.excludesfile = '$excludes' names a path chezmoi does not deliver, so git would load no global ignores at all"
+    ;;
+  empty)
+    fail "core.excludesfile is present with an empty value, which git does not treat as absent: it loads no global ignores at all rather than falling back to $GIT_DEFAULT_EXCLUDES_TARGET (measured with git check-ignore), which is the exact defect this file dropped the key to fix. Remove the key, do not blank it"
+    ;;
+  absent)
+    chezmoi_delivers_target_path "$GIT_DEFAULT_EXCLUDES_TARGET" ||
+      fail "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, but chezmoi does not deliver that path from $GIT_DEFAULT_EXCLUDES_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
+    ;;
+  *)
+    fail "core.excludesfile could not be read out of $parsed; invariant 3 cannot be decided"
+    ;;
+esac
 
 printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no git:// rewrite target, global ignores are deployed)\n'

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -31,10 +31,16 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GITCONFIG_TEMPLATE="$REPO_ROOT/dot_gitconfig.tmpl"
-# git's documented default for core.excludesFile is $XDG_CONFIG_HOME/git/ignore,
-# and dot_bashrc.tmpl / dot_profile both export XDG_CONFIG_HOME=$HOME/.config.
-XDG_IGNORE_TARGET="$HOME/.config/git/ignore"
-XDG_IGNORE_SOURCE="dot_config/git/ignore"
+GIT_DEFAULT_EXCLUDES_SOURCE="dot_config/git/ignore"
+# Where git looks when core.excludesFile is unset. git consults XDG_CONFIG_HOME
+# only when it is set AND non-empty, and uses $HOME/.config otherwise, which is
+# precisely what bash's `:-` does (measured on git 2.55.0 with `git check-ignore`
+# for all three states of the variable: pointed elsewhere, set empty, unset).
+# Deriving the path instead of hardcoding $HOME/.config is what lets this test
+# notice an environment in which the file this repo deploys is not the file git
+# would read. dot_bashrc.tmpl and dot_profile both export $HOME/.config, so on a
+# machine this repo has deployed the two agree.
+GIT_DEFAULT_EXCLUDES_TARGET="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
 # The chezmoi entry types that put a readable file at a target path. Symlinks
 # count: git follows a symlinked ignore file (measured), so a symlink_ source
 # satisfies invariant 3 exactly as a plain file does. Directories and scripts do
@@ -47,7 +53,9 @@ PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
 CONTROL_FLOW_ACTIONS='{{-?[[:space:]]*(if|else|end|range|with|block|define|template)\b'
 
 # Bug class 11: git exports GIT_DIR and friends into every hook, and a stale one
-# would redirect the config reads below at the wrong repository. chezmoi needs no
+# would redirect the config reads below at the wrong repository. XDG_CONFIG_HOME
+# is deliberately NOT scrubbed: it is an input to the answer rather than a
+# redirection of it, and is read above through git's own rule. chezmoi needs no
 # equivalent scrub: it has no environment override for sourceDir or destDir
 # (measured: CHEZMOI_SOURCE_DIR is ignored), and both are passed explicitly
 # below, so the only environment input left is where its own config file is
@@ -136,8 +144,8 @@ if [[ -n $excludes ]]; then
   chezmoi_delivers_target_path "${excludes/#\~/$HOME}" ||
     fail "core.excludesfile = '$excludes' names a path chezmoi does not deliver, so git would load no global ignores at all"
 else
-  chezmoi_delivers_target_path "$XDG_IGNORE_TARGET" ||
-    fail "core.excludesfile is unset, so git falls back to $XDG_IGNORE_TARGET, but chezmoi does not deliver that path from $XDG_IGNORE_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
+  chezmoi_delivers_target_path "$GIT_DEFAULT_EXCLUDES_TARGET" ||
+    fail "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, but chezmoi does not deliver that path from $GIT_DEFAULT_EXCLUDES_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
 fi
 
 printf 'gitconfig-tool-and-url-hygiene: OK (diff.tool/merge.tool resolve, no git:// rewrite target, global ignores are deployed)\n'

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -34,7 +34,17 @@
 #      defect this file dropped the key to fix. Deployment is decided by `chezmoi
 #      managed`, not by the source file's presence on disk: a source file hidden
 #      behind .chezmoiignore is present but never delivered, and git would then
-#      load no global ignores either.
+#      load no global ignores either. Being LISTED by chezmoi is not enough on
+#      its own: the delivered path has to resolve to a readable regular file,
+#      because two of the shapes chezmoi can legitimately deliver are not one.
+#      Measured on git 2.55.0 with `git check-ignore -v` against a matching path:
+#        symlink -> regular file : the patterns apply, exit 0
+#        symlink -> missing      : nothing applies, exit 1, global ignores are
+#                                  dead and nothing on stderr says so
+#        symlink -> directory    : "fatal: cannot use <path> as an exclude file",
+#                                  exit 128
+#      So the delivered shape is classified, one arm per state, and anything that
+#      is not a readable regular file is a failure with its own message.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -49,11 +59,17 @@ GIT_DEFAULT_EXCLUDES_SOURCE="dot_config/git/ignore"
 # would read. dot_bashrc.tmpl and dot_profile both export $HOME/.config, so on a
 # machine this repo has deployed the two agree.
 GIT_DEFAULT_EXCLUDES_TARGET="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
-# The chezmoi entry types that put a readable file at a target path. Symlinks
-# count: git follows a symlinked ignore file (measured), so a symlink_ source
-# satisfies invariant 4 exactly as a plain file does. Directories and scripts do
-# not, which is why this is not simply `all`.
-CHEZMOI_FILE_DELIVERING_ENTRY_TYPES="files,symlinks"
+# The two chezmoi entry types that can put a readable file at a target path, kept
+# apart because they are answerable from different places. A `files` entry writes
+# a regular file, which is settled by the source state alone, so its verdict is
+# the same on this machine, in CI, and on a machine chezmoi has never run on. A
+# `symlinks` entry writes a symlink, and where that symlink lands is NOT in the
+# source state: git follows one to a regular file, reads nothing at all through a
+# dangling one, and refuses one that points at a directory, so it has to be
+# resolved on the machine. Every other entry type (dirs, scripts, remove) puts no
+# readable file anywhere, which is why this is not simply `all`.
+CHEZMOI_REGULAR_FILE_ENTRY_TYPE="files"
+CHEZMOI_SYMLINK_ENTRY_TYPE="symlinks"
 # `git config --get` exits 1 when the key is ABSENT and 0 when it is present,
 # including when its value is the empty string (measured). Both print nothing on
 # stdout, so this exit code is the only signal separating two states that mean
@@ -82,23 +98,106 @@ fail() {
   exit 1
 }
 
-# Answers "which absolute target paths does chezmoi deliver a readable file to
+# Answers "which absolute target paths does chezmoi deliver, of one entry type,
 # from this source tree?". This is the authority on deployment: it applies
 # .chezmoiignore and every source-name prefix, neither of which a source-path
 # existence test can see. Read-only, and it lists the target state without
 # rendering file contents, so the keepassxc templates here are never unlocked.
 list_chezmoi_delivered_target_paths() {
+  local entry_type="$1"
   chezmoi managed \
     --source "$REPO_ROOT" \
     --destination "$HOME" \
-    --include="$CHEZMOI_FILE_DELIVERING_ENTRY_TYPES" \
+    --include="$entry_type" \
     --path-style=absolute
 }
 
-# Answers "does chezmoi deliver exactly this target path?".
-chezmoi_delivers_target_path() {
-  local target="$1"
-  printf '%s\n' "$DELIVERED_TARGET_PATHS" | grep -Fxq -- "$target"
+# Answers "is this exact target path in this listing?".
+listing_contains_target_path() {
+  local listing="$1" target="$2"
+  printf '%s\n' "$listing" | grep -Fxq -- "$target"
+}
+
+# Answers "what does this path resolve to on this machine?", printing exactly one
+# of: readable-file, dangling-symlink, directory, missing, not-a-regular-file,
+# unreadable. Only readable-file is a file git can load as an exclude file; every
+# other state gets its own arm, so a shape nobody anticipated cannot fall through
+# to a pass. A symlink loop reports dangling-symlink, which is what it is in
+# effect: the path resolves to nothing.
+classify_path_resolution() {
+  local path="$1"
+  if [[ -L $path && ! -e $path ]]; then
+    printf 'dangling-symlink\n'
+  elif [[ ! -e $path ]]; then
+    printf 'missing\n'
+  elif [[ -d $path ]]; then
+    printf 'directory\n'
+  elif [[ ! -f $path ]]; then
+    printf 'not-a-regular-file\n'
+  elif [[ ! -r $path ]]; then
+    printf 'unreadable\n'
+  else
+    printf 'readable-file\n'
+  fi
+}
+
+# Answers "does this repo put a file git could load at this target path?",
+# printing readable-file when it does, not-delivered when chezmoi delivers
+# nothing there, and otherwise the resolution state that disqualifies it. The two
+# listings are arguments rather than globals so this stays a pure function of its
+# inputs and the fixtures below can hand it a listing of their own.
+classify_delivered_target_path() {
+  local regular_file_listing="$1" symlink_listing="$2" target="$3"
+  if listing_contains_target_path "$regular_file_listing" "$target"; then
+    # A regular-file entry needs no filesystem lookup: chezmoi writes a regular
+    # file at that path by construction, whether or not it has run here yet.
+    printf 'readable-file\n'
+  elif listing_contains_target_path "$symlink_listing" "$target"; then
+    classify_path_resolution "$target"
+  else
+    printf 'not-delivered\n'
+  fi
+}
+
+# Answers "why is this target path not a file git can load?" for one rejected
+# verdict. Separate from the classifier so the verdict stays a pure function of
+# the path and both invariant-4 arms share one set of explanations.
+explain_rejected_delivery() {
+  local verdict="$1" target="$2"
+  case "$verdict" in
+    not-delivered)
+      printf 'chezmoi delivers nothing to %s (present in the source tree is not enough; check .chezmoiignore)' "$target"
+      ;;
+    dangling-symlink)
+      printf 'chezmoi delivers %s as a symlink that points at nothing, and git reads no patterns through it at all: measured on git 2.55.0, check-ignore exits 1 and matches nothing, with no diagnostic' "$target"
+      ;;
+    directory)
+      printf 'chezmoi delivers %s as a symlink to a directory, which git refuses outright: measured on git 2.55.0, "fatal: cannot use %s as an exclude file"' "$target" "$target"
+      ;;
+    missing)
+      printf 'chezmoi delivers a symlink to %s but nothing exists there, so this machine cannot say what it resolves to; apply the symlink, then re-run' "$target"
+      ;;
+    not-a-regular-file)
+      printf '%s exists but is not a regular file, so git cannot read exclude patterns out of it' "$target"
+      ;;
+    unreadable)
+      printf '%s is a regular file this user cannot read, so git loads no patterns from it' "$target"
+      ;;
+    *)
+      printf 'the delivered shape of %s classified as an unrecognized verdict (%s); classify_delivered_target_path and explain_rejected_delivery have drifted apart' "$target" "$verdict"
+      ;;
+  esac
+}
+
+# Fails the test unless this repo puts a readable regular file at the target
+# path. The single place the passing verdict is named, so the two invariant-4
+# arms cannot drift apart on what counts as delivered.
+require_delivered_readable_file() {
+  local target="$1" preamble="$2" verdict
+  verdict="$(classify_delivered_target_path \
+    "$DELIVERED_REGULAR_FILE_TARGET_PATHS" "$DELIVERED_SYMLINK_TARGET_PATHS" "$target")"
+  [[ $verdict == readable-file ]] ||
+    fail "$preamble: $(explain_rejected_delivery "$verdict" "$target")"
 }
 
 # Answers "does this config key pin a diff or merge tool to a literal binary
@@ -141,11 +240,16 @@ command -v chezmoi >/dev/null 2>&1 ||
   fail "chezmoi is not on PATH; invariant 4 cannot tell which target paths this repo delivers"
 
 # Fail closed: an unreadable or empty listing must not read as "nothing is
-# missing". Collected once, since every branch of invariant 4 consults it.
-DELIVERED_TARGET_PATHS="$(list_chezmoi_delivered_target_paths)" ||
+# missing". Collected once, since every branch of invariant 4 consults them. Only
+# the regular-file listing is required to be non-empty: this repo certainly
+# delivers regular files, so an empty one means chezmoi read the wrong source
+# tree, while a repo with no symlink entries at all is a legitimate state.
+DELIVERED_REGULAR_FILE_TARGET_PATHS="$(list_chezmoi_delivered_target_paths "$CHEZMOI_REGULAR_FILE_ENTRY_TYPE")" ||
   fail "chezmoi managed failed against source $REPO_ROOT; invariant 4 cannot be decided"
-[[ -n $DELIVERED_TARGET_PATHS ]] ||
-  fail "chezmoi managed listed no entries at all for source $REPO_ROOT; invariant 4 cannot be decided"
+[[ -n $DELIVERED_REGULAR_FILE_TARGET_PATHS ]] ||
+  fail "chezmoi managed listed no file entries at all for source $REPO_ROOT; invariant 4 cannot be decided"
+DELIVERED_SYMLINK_TARGET_PATHS="$(list_chezmoi_delivered_target_paths "$CHEZMOI_SYMLINK_ENTRY_TYPE")" ||
+  fail "chezmoi managed failed to list symlink entries for source $REPO_ROOT; invariant 4 cannot be decided"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
@@ -177,19 +281,86 @@ while IFS= read -r key; do
     fail "a url rewrite targets the git:// protocol ($key); GitHub permanently disabled it on 2022-03-15, so fetches through this base cannot connect"
 done < <(git config --file "$parsed" --name-only --list)
 
-# ---- 4: global ignores resolve to a file this repo deploys ----------------
+# ---- 4a: the delivered-shape classifier discriminates ---------------------
+# The three symlink shapes chezmoi can legitimately deliver, one fixture each,
+# because only the first of them is an ignore file git can load and the other two
+# are the states a bare "is it listed?" test silently admitted. Two non-symlink
+# controls sit alongside them so a classifier that answered readable-file (or
+# directory) for everything is caught here too, at the predicate, rather than
+# twenty lines later as a mystery verdict from the real config.
+fixtures="$work/path-resolution-fixtures"
+mkdir -p "$fixtures/a-directory"
+printf 'ignored-pattern\n' >"$fixtures/a-regular-file"
+ln -s "$fixtures/a-regular-file" "$fixtures/symlink-to-file"
+ln -s "$fixtures/nothing-here" "$fixtures/symlink-to-missing"
+ln -s "$fixtures/a-directory" "$fixtures/symlink-to-directory"
+
+assert_path_resolution() {
+  local name="$1" expected="$2" actual
+  actual="$(classify_path_resolution "$fixtures/$name")"
+  [[ $actual == "$expected" ]] ||
+    fail "classify_path_resolution answered '$actual' for the $name fixture, expected '$expected'; the check that keeps a symlink-delivered core.excludesfile honest no longer discriminates the shapes git treats differently"
+}
+assert_path_resolution symlink-to-file readable-file
+assert_path_resolution symlink-to-missing dangling-symlink
+assert_path_resolution symlink-to-directory directory
+assert_path_resolution a-regular-file readable-file
+assert_path_resolution a-directory directory
+assert_path_resolution nothing-here missing
+
+# The same three shapes again, this time through the function invariant 4 calls,
+# with a synthetic chezmoi listing. Classifying a path correctly is worth nothing
+# if the delivery check never consults the classifier, which is exactly how a
+# widened `--include=files,symlinks` membership test passed a dangling symlink.
+assert_delivered_classification() {
+  local regular_file_listing="$1" symlink_listing="$2" name="$3" expected="$4" actual
+  actual="$(classify_delivered_target_path \
+    "$regular_file_listing" "$symlink_listing" "$fixtures/$name")"
+  [[ $actual == "$expected" ]] ||
+    fail "classify_delivered_target_path answered '$actual' for the $name fixture, expected '$expected'; a chezmoi entry is being accepted or rejected on membership alone rather than on what it resolves to"
+}
+assert_delivered_classification "" "$fixtures/symlink-to-file" symlink-to-file readable-file
+assert_delivered_classification "" "$fixtures/symlink-to-missing" symlink-to-missing dangling-symlink
+assert_delivered_classification "" "$fixtures/symlink-to-directory" symlink-to-directory directory
+assert_delivered_classification "" "" symlink-to-file not-delivered
+# A regular-file entry is trusted from the source state alone, deliberately: it
+# is what keeps the verdict identical on this machine, in CI, and on a machine
+# chezmoi has never run on. Pinned so the asymmetry stays a decision.
+assert_delivered_classification "$fixtures/nothing-here" "" nothing-here readable-file
+
+# The guard the two invariant-4 arms call must act on those verdicts. fail() exits,
+# so a subshell is the only way to observe that it fired; `if` runs the subshell
+# without set -e deciding the outcome for us.
+assert_guard_verdict() {
+  local symlink_listing="$1" name="$2" expected="$3" actual=accepted
+  if ! (
+    DELIVERED_REGULAR_FILE_TARGET_PATHS=""
+    DELIVERED_SYMLINK_TARGET_PATHS="$symlink_listing"
+    require_delivered_readable_file "$fixtures/$name" "fixture probe" 2>/dev/null
+  ); then
+    actual=rejected
+  fi
+  [[ $actual == "$expected" ]] ||
+    fail "require_delivered_readable_file $actual the $name fixture, expected $expected; invariant 4 no longer acts on the verdict it computes"
+}
+assert_guard_verdict "$fixtures/symlink-to-file" symlink-to-file accepted
+assert_guard_verdict "$fixtures/symlink-to-missing" symlink-to-missing rejected
+assert_guard_verdict "$fixtures/symlink-to-directory" symlink-to-directory rejected
+assert_guard_verdict "" symlink-to-file rejected
+
+# ---- 4b: global ignores resolve to a file this repo deploys ---------------
 case "$(classify_core_excludesfile "$parsed")" in
   set)
     excludes="$(git config --file "$parsed" --get core.excludesfile)"
-    chezmoi_delivers_target_path "${excludes/#\~/$HOME}" ||
-      fail "core.excludesfile = '$excludes' names a path chezmoi does not deliver, so git would load no global ignores at all"
+    require_delivered_readable_file "${excludes/#\~/$HOME}" \
+      "core.excludesfile = '$excludes' does not name a readable file this repo delivers, so git would load no global ignores at all"
     ;;
   empty)
     fail "core.excludesfile is present with an empty value, which git does not treat as absent: it loads no global ignores at all rather than falling back to $GIT_DEFAULT_EXCLUDES_TARGET (measured with git check-ignore), which is the exact defect this file dropped the key to fix. Remove the key, do not blank it"
     ;;
   absent)
-    chezmoi_delivers_target_path "$GIT_DEFAULT_EXCLUDES_TARGET" ||
-      fail "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, but chezmoi does not deliver that path from $GIT_DEFAULT_EXCLUDES_SOURCE (present in the source tree is not enough; check .chezmoiignore); global ignores would be empty on a fresh machine"
+    require_delivered_readable_file "$GIT_DEFAULT_EXCLUDES_TARGET" \
+      "core.excludesfile is unset, so git falls back to $GIT_DEFAULT_EXCLUDES_TARGET, which this repo ships from $GIT_DEFAULT_EXCLUDES_SOURCE, but global ignores would be empty on a fresh machine"
     ;;
   *)
     fail "core.excludesfile could not be read out of $parsed; invariant 4 cannot be decided"


### PR DESCRIPTION
## Context

`~/.gitconfig` on this machine is generated from `dot_gitconfig.tmpl`. Three settings in it name things
that do not exist, and one of them has been silently breaking a feature since February 2024.

This is one of the long-tail cleanup changes in the modernization work. It touches configuration only,
plus a test that keeps the three defects from coming back.

## Summary

- Fixes `core.excludesfile`, which pointed at `~/.gitignore_global`, a file this repo never deploys.
  Because the key was set, git did not fall back to its default location, so the working
  `~/.config/git/ignore` was never read and its `**/.claude/settings.local.json` pattern never applied.
- Fixes `merge.tool`, which held a full command string where git expects the name of a tool. Git
  responded by discarding the setting, guessing, and offering Vim at an interactive prompt.
- Removes URL rewrites that redirected clones through `git://`, a protocol GitHub permanently disabled
  in March 2022.
- Ships `dot_config/git/ignore`, so the global ignore file is deployed rather than assumed to exist on
  whatever machine applies this.
- Adds `test/unit/gitconfig-tool-and-url-hygiene.sh`, which asks git and chezmoi directly whether each
  of the three settings resolves to something real.

## What changed

The `core.excludesfile` defect is the one worth understanding, because the failure was invisible. Git
falls back to `$XDG_CONFIG_HOME/git/ignore` only when the key is **absent**. Setting it to a path that
does not exist is not the same as leaving it alone: it suppresses the fallback and yields no global
ignores at all, with no warning. Measured on this machine before the fix, `git check-ignore` reported
the pattern as not matching and `git status` showed the file as untracked in every repository.

The new test asks the real tools rather than pattern-matching the template. For tool names it calls
`git <mode>tool --tool-help` and checks the configured name appears. For the ignore file it calls
`chezmoi managed` and then resolves the delivered path, requiring it to end at a readable file. That
second part matters more than it sounds: an earlier version of this change accepted any path chezmoi
listed, which admitted a symlink pointing at nothing. All 45 symlink entries this repo delivers today
resolve to directories, which git refuses outright, so that check would have passed while global
ignores stayed dead.

The test also forbids `difftool.<name>.path` and `mergetool.<name>.path` keys. Those replace git's
`PATH` lookup with a literal path and have no fallback, so a machine with a different install prefix
loses the tool entirely. An earlier version of this change added exactly such a key before the rule
was in place.

## How it was reviewed

Every defect was reproduced against real git before being fixed, and each fix was then shown to fail
the test when reverted. Twenty mutations ran against a passing control, including four that disable
one new assertion at a time to confirm the corresponding fixture actually depends on it rather than
merely coexisting with it.

Three review rounds each found that the previous fix had reintroduced the same class of defect it was
addressing, which is why the delivery check now enumerates every state a path can be in and fails
closed on anything it does not recognize.

## Effect of merging

Nothing changes on this machine until `chezmoi apply` runs. On the next apply, the global ignore file
is deployed and `~/.claude/settings.local.json` stops appearing as untracked. `git mergetool` starts
resolving to Neovim rather than prompting for Vim.

Four hardcoded `/opt/homebrew` paths remain in this file, including one for `gpg.program` that would
break every commit on a machine with a different prefix. They are pre-existing and deliberately out of
scope here; they are tracked separately.
