### PR TITLE
fix(macos-defaults): refuse a malformed data file before the first write

### DIFF
--- a/dot_local/bin/executable_macos-defaults-apply.sh
+++ b/dot_local/bin/executable_macos-defaults-apply.sh
@@ -4,13 +4,31 @@
 # Same defaults-write loop as the Tier 1 chezmoiscript runner, but invocable
 # on demand without bumping the chezmoi hash gate. Use after fiddling in
 # System Settings to revert disk state to the YAML.
+#
+# The file is applied WHOLE or not at all. macos_defaults.yaml describes what the
+# machine should be, so applying part of it leaves the Mac in a state neither the
+# old file nor the new one describes, with no record of where the run stopped.
+# That is why every record is validated and resolved before the first write, in
+# two passes below: the runner template has always worked this way (a complete
+# validation pass, then a render, and chezmoi runs nothing if the render failed),
+# and this tool bypasses the render, so it has to hold the same line itself.
+#
+# Exit codes:
+#   0: every enforce record was applied
+#   2: the data file is missing, unreadable, or carries a record that failed
+#      validation. Nothing was written.
+#   other: a `defaults` write itself failed; earlier writes stand.
 
 set -euo pipefail
-# Note: no `shopt -s lastpipe` here, the while loops below don't mutate
+# Note: no `shopt -s lastpipe` here, the loops below don't mutate
 # outer-scope state (no counter to preserve, unlike drift.sh).
 
 # shellcheck source=dot_local/bin/macos-defaults-lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/macos-defaults-lib.sh"
+
+# The status every refusal exits with, named once: the shared "data file missing,
+# unreadable, or carrying an unusable record" code the sibling tools also use.
+DATA_FILE_UNUSABLE_STATUS=2
 
 DATA_FILE="$(macos_defaults_data_file)" || exit $?
 require_readable_data_file "$DATA_FILE" || exit $?
@@ -18,44 +36,103 @@ require_readable_data_file "$DATA_FILE" || exit $?
 # Pre-flight: close System Settings if open (same reason as runner).
 osascript -e 'tell application "System Settings" to quit' 2>/dev/null || true
 
-# Main loop: one `defaults write` per ENFORCE record. The tier decides what
-# happens, before any payload field is even looked at: verify records are
-# read-only by declaration and manual records are runbook-applied, so both are
-# skipped without a write, and an unrecognized tier refuses the run (the
-# stream already refused the whole file; the case here keeps this loop from
+# format_planned_write <kind> <target> <key> <type> <value>, print one resolved
+# write as a single line for the plan below. The five fields are joined with the
+# same ASCII unit separator the record stream uses, which is safe BY
+# CONSTRUCTION rather than by convention: the stream refuses any record carrying
+# that byte or a newline in a field, so a plan line splits back into exactly the
+# five fields that went into it. The reader is the fixed-arity `read` in the
+# write pass; fixed arity is what preserves an empty trailing value, which
+# `read -a` drops.
+format_planned_write() { # <kind> <target> <key> <type> <value>
+  local unit_separator=$'\x1f'
+  printf '%s%s%s%s%s%s%s%s%s' \
+    "$1" "$unit_separator" "$2" "$unit_separator" "$3" "$unit_separator" \
+    "$4" "$unit_separator" "$5"
+}
+
+# The whole file, read and validated before anything is written. Held in a
+# variable rather than piped into the loop for two reasons: the stream's REFUSAL
+# status arrives here instead of being swallowed by a pipeline, and a refused
+# stream emits nothing at all, so there is no partial record list to act on.
+record_stream="$(defaults_records_unit_separated "$DATA_FILE")" || exit $?
+
+# PASS 1, PLAN. Every record is classified, validated, and resolved into the
+# exact write it will become. Nothing is written here, so a record that fails
+# validation ends the run with the machine untouched, whatever its position in
+# the file.
+#
+# The tier decides what happens before any payload field is looked at: verify
+# records are read-only by declaration and manual records are runbook-applied, so
+# both are skipped without a write, and an unrecognized tier refuses the run (the
+# stream already refused the whole file; the case here keeps this planner from
 # ever failing open into a write if the stream's rules drift). A system-scope
-# record goes through sudo to its resolved plist path; user-scope records
-# write exactly as before. A record that fails validation (unknown scope, a
-# meaningless field pairing, a relative plist_path) aborts the run with the
-# data-file status 2 before anything is written for it.
-defaults_records_unit_separated "$DATA_FILE" |
-  while IFS=$'\x1f' read -r domain key type value host scope plist_path tier; do
-    [[ -z $domain ]] && continue
-    case "$tier" in
-      enforce) ;;
-      verify | manual)
-        continue
+# record resolves to a plist path and must clear the write-time allowlist, which
+# is apply's own gate: drift reads records it must never write, so gating reads
+# would hide rows instead of reporting them.
+planned_writes=()
+while IFS= read -r record_line; do
+  [[ -z $record_line ]] && continue
+  IFS=$'\x1f' read -r domain key value_type value host scope plist_path tier <<<"$record_line"
+  case "$tier" in
+    enforce) ;;
+    verify | manual)
+      continue
+      ;;
+    *)
+      printf 'error: unrecognized tier %q on record %s %s; refusing to write\n' \
+        "$tier" "$domain" "$key" >&2
+      exit "$DATA_FILE_UNUSABLE_STATUS"
+      ;;
+  esac
+  validate_defaults_record "$domain" "$key" "$value_type" "$value" \
+    "$host" "$scope" "$plist_path" "$tier" || exit "$DATA_FILE_UNUSABLE_STATUS"
+  if [[ $scope == system ]]; then
+    resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" ||
+      exit "$DATA_FILE_UNUSABLE_STATUS"
+    # The same write-directory allowlist the render enforces, at the tool that
+    # bypasses the render: apply reads the YAML directly, so this is the only
+    # gate between a hand-edited record and a root write.
+    require_system_plist_path_permitted "$resolved_plist_path" ||
+      exit "$DATA_FILE_UNUSABLE_STATUS"
+    planned_writes+=("$(format_planned_write system "$resolved_plist_path" "$key" "$value_type" "$value")")
+  elif [[ -n $host ]]; then
+    planned_writes+=("$(format_planned_write currenthost "$domain" "$key" "$value_type" "$value")")
+  else
+    planned_writes+=("$(format_planned_write user "$domain" "$key" "$value_type" "$value")")
+  fi
+done <<<"$record_stream"
+
+# PASS 2, WRITE. Nothing about the DATA is decided here: every record was
+# validated and every target resolved above, so this loop only runs plans. The
+# kind is one of three words this script itself wrote a few lines up, never a
+# field from the data file, and its refusal arm exists so an impossible fourth
+# value cannot fall through into a write.
+#
+# The emptiness guard is not cosmetic: under `set -u` an older bash treats
+# "${array[@]}" on an empty array as an unbound variable, and a file with no
+# enforce records is a legitimate file.
+if [[ ${#planned_writes[@]} -gt 0 ]]; then
+  for planned_write in "${planned_writes[@]}"; do
+    IFS=$'\x1f' read -r write_kind write_target write_key write_type write_value <<<"$planned_write"
+    case "$write_kind" in
+      user)
+        defaults write "$write_target" "$write_key" "-$write_type" "$write_value"
+        ;;
+      currenthost)
+        defaults -currentHost write "$write_target" "$write_key" "-$write_type" "$write_value"
+        ;;
+      system)
+        system_defaults_write "$write_target" "$write_key" "$write_type" "$write_value"
         ;;
       *)
-        printf 'error: unrecognized tier %q on record %s %s; refusing to write\n' \
-          "$tier" "$domain" "$key" >&2
-        exit 2
+        printf 'error: planned write %q carries an unrecognized kind %q; refusing to write\n' \
+          "$planned_write" "$write_kind" >&2
+        exit "$DATA_FILE_UNUSABLE_STATUS"
         ;;
     esac
-    scope="$(validate_record_scope "$scope" "$host" "$plist_path")" || exit 2
-    if [[ $scope == system ]]; then
-      resolved_plist_path="$(resolve_system_plist_path "$domain" "$plist_path")" || exit 2
-      # The same write-directory allowlist the render enforces, at the tool
-      # that bypasses the render: apply reads the YAML directly, so this is
-      # the only gate between a hand-edited record and a root write.
-      require_system_plist_path_permitted "$resolved_plist_path" || exit 2
-      system_defaults_write "$resolved_plist_path" "$key" "$type" "$value"
-    elif [[ -n $host ]]; then
-      defaults -currentHost write "$domain" "$key" "-$type" "$value"
-    else
-      defaults write "$domain" "$key" "-$type" "$value"
-    fi
   done
+fi
 
 # Post-loop: restart processes per killall list.
 yq eval -r '.macos.killall[]' "$DATA_FILE" |

--- a/dot_local/bin/executable_macos-defaults-drift.sh
+++ b/dot_local/bin/executable_macos-defaults-drift.sh
@@ -69,11 +69,14 @@ print_header() {
 # THREE read outcomes: the value, <unset> (genuinely not set, compared as
 # drift like any other value), and <unreadable> (indeterminate: reported as
 # its own row, counted separately, never as drift and never skipped).
-# Note: yq emits a single newline for an empty array; the inline guard below
-# skips that empty row so the script exits 0 cleanly when nothing is tracked.
+# A record with no domain or no key aborts too, rather than being skipped: the
+# stream refuses such a file already, and a silent skip here would report "no
+# drift" for a control nobody actually read. An empty stream is not that case,
+# and needs no guard: the stream emits no line at all when nothing is tracked, so
+# this loop simply never runs and the script exits 0.
 defaults_records_unit_separated "$DATA_FILE" |
   while IFS=$'\x1f' read -r domain key type value host scope plist_path tier; do
-    [[ -z $domain ]] && continue
+    validate_record_identity "$domain" "$key" || exit 2
     case "$tier" in
       enforce | verify) ;;
       manual)

--- a/dot_local/bin/macos-defaults-lib.sh
+++ b/dot_local/bin/macos-defaults-lib.sh
@@ -253,7 +253,8 @@ defaults_records_raw_stream() { # <path>
 defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
   local data_file="$1" declared_record_count="$2" raw_records="$3"
   local line field_count checked_line_count=0
-  local record_domain record_key record_tier
+  local record_domain record_key record_type record_value
+  local record_host record_scope record_plist_path record_tier
   while IFS= read -r line; do
     # yq prints a single empty line for an empty array; that is not a record.
     [[ -z $line ]] && continue
@@ -269,7 +270,8 @@ defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
     # same refusal, so absent, blank, and unrecognized all fail closed. The
     # refusal covers the WHOLE file, because a caller must not act on the
     # records beside one it cannot classify.
-    IFS=$'\x1f' read -r record_domain record_key _ _ _ _ _ record_tier <<<"$line"
+    IFS=$'\x1f' read -r record_domain record_key record_type record_value \
+      record_host record_scope record_plist_path record_tier <<<"$line"
     case "$record_tier" in
       enforce | verify | manual) ;;
       *)
@@ -278,6 +280,18 @@ defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
         return 2
         ;;
     esac
+    # The rest of the record's rules, for the WHOLE file, before the emission
+    # below prints a single line. This is the ordering the runner template has
+    # always had (a complete validation pass, then a render) and the ordering the
+    # tools lacked: apply validated scope and plist_path inside its own write
+    # loop, so a file whose second record was malformed had its first record
+    # written before anyone noticed, and a declarative settings file was left
+    # half applied.
+    if ! validate_defaults_record "$record_domain" "$record_key" "$record_type" \
+      "$record_value" "$record_host" "$record_scope" "$record_plist_path" "$record_tier"; then
+      printf 'error: %s: the record above is not usable; the whole file is refused\n' "$data_file" >&2
+      return 2
+    fi
     checked_line_count=$((checked_line_count + 1))
   done <<<"$raw_records"
 
@@ -289,12 +303,48 @@ defaults_records_validate_stream() { # <path> <declared-count> <raw-stream>
   fi
 }
 
+# defaults_records_declare_a_value <path>, a PREDICATE over the FILE: 0 when
+# every enforce and verify record DECLARES a value, 2 otherwise, naming the first
+# record that does not.
+#
+# Asked of the file rather than of the joined record line, because the line
+# cannot answer it. join renders an ABSENT value and an explicitly EMPTY one
+# identically, as the empty string, and the two are not the same record error:
+#   value: ""   is a legitimate empty string, which the runner template renders
+#               and which a `type: string` record may genuinely want;
+#   value:      (or no value key at all) is a record that names no value, and it
+#               reached `defaults write <domain> <key> -bool ''` here while the
+#               template refused the same record outright.
+# Reading presence from the file is what lets this reader refuse exactly what the
+# template refuses instead of narrowing to "empty is fatal", which would refuse a
+# file the template renders happily and teach the operator about it through a
+# broken drift report.
+#
+# Only enforce and verify records are asked: a manual record carries a runbook
+# pointer and no write payload, and the template forbids it a value entirely.
+defaults_records_declare_a_value() { # <path>
+  local data_file="$1"
+  local valueless_indices first_valueless_index
+  if ! valueless_indices="$(yq eval -r '.macos.defaults | to_entries | .[] | select(.value.tier == "enforce" or .value.tier == "verify") | select((.value | has("value") | not) or (.value.value == null)) | .key' "$data_file")"; then
+    printf 'error: cannot check which records in %s declare a value\n' "$data_file" >&2
+    return 2
+  fi
+  [[ -z $valueless_indices ]] && return 0
+  first_valueless_index="$(printf '%s\n' "$valueless_indices" | head -1)"
+  printf 'error: %s: record %s (domain %s, key %s) has a blank value; give it a value or remove the field\n' \
+    "$data_file" "$first_valueless_index" \
+    "$(yq eval -r ".macos.defaults[$first_valueless_index].domain" "$data_file" | head -1)" \
+    "$(yq eval -r ".macos.defaults[$first_valueless_index].key" "$data_file" | head -1)" >&2
+  return 2
+}
+
 defaults_records_unit_separated() { # <path>
   local data_file="$1"
   local declared_record_count raw_records line
   declared_record_count="$(defaults_records_declared_count "$data_file")" || return 2
   raw_records="$(defaults_records_raw_stream "$data_file")" || return 2
   defaults_records_validate_stream "$data_file" "$declared_record_count" "$raw_records" || return 2
+  defaults_records_declare_a_value "$data_file" || return 2
   # Emission, and only emission, and only once the WHOLE file has passed. A
   # caller must never act on part of a stream it is about to be told is
   # malformed, which is why nothing is printed before the predicate returns.
@@ -333,6 +383,69 @@ validate_record_scope() { # <scope> <host> <plist_path>
     return 1
   fi
   printf '%s\n' "$scope"
+}
+
+# validate_record_identity <domain> <key>, a PREDICATE over the two fields that
+# NAME a record: 0 when both carry text, 1 with a message otherwise. It applies
+# to every record whatever its tier, because a record with no domain or no key
+# names no control that any tool could act on or report.
+#
+# Refused, never skipped. apply and drift both used to `continue` past a record
+# with an empty domain, which turned a malformed record into a silent no-op: a
+# file whose second record had no domain applied its first record and exited 0,
+# reporting success for a file it had only partly applied. The runner template
+# refuses the same record outright.
+validate_record_identity() { # <domain> <key>
+  local domain="$1" key="$2"
+  if [[ -z $domain ]]; then
+    printf 'error: record with key %q has a blank domain; give it a value or remove the field\n' \
+      "$key" >&2
+    return 1
+  fi
+  if [[ -z $key ]]; then
+    printf 'error: record %q has a blank key; give it a value or remove the field\n' \
+      "$domain" >&2
+    return 1
+  fi
+}
+
+# The value types a record may declare. The SAME closed set the Tier 1 runner
+# template constrains .type to; test/integration/macos-defaults-validate-before-write.sh
+# pins the two lists identical, the way the system-scope suite pins the two
+# plist_path allowlists.
+#
+# Closed rather than free-form because the type is the one field BOTH readers put
+# into a command as a BARE option word (-bool, -int): the template renders it
+# into shell source unquoted, and the tools pass it to `defaults` as "-$type".
+# Quoting is not available (`defaults` needs a bare option word), so constraining
+# the set is what stands in for it. Plain assignment, not readonly, for the same
+# re-source reason as the read-status constants below.
+MACOS_DEFAULTS_SUPPORTED_TYPES=("array" "bool" "data" "date" "dict" "float" "int" "string")
+
+# validate_record_type <type> <domain> <key>, a PREDICATE over the declared type:
+# 0 when it names a supported type, 1 with a message otherwise. A blank type
+# lands in the same refusal as an unrecognized one; both name no type, and a
+# blank one reached `defaults write <domain> <key> - <value>` before this existed.
+validate_record_type() { # <type> <domain> <key>
+  local value_type="$1" domain="$2" key="$3" supported_type
+  for supported_type in "${MACOS_DEFAULTS_SUPPORTED_TYPES[@]}"; do
+    if [[ $value_type == "$supported_type" ]]; then
+      return 0
+    fi
+  done
+  printf 'error: unsupported type %q on record %s %s; expected one of %s\n' \
+    "$value_type" "$domain" "$key" "${MACOS_DEFAULTS_SUPPORTED_TYPES[*]}" >&2
+  return 1
+}
+
+# print_offending_record_reference <domain> <key>, name the record a refusal
+# belongs to. The scope and plist_path predicates judge ONE field each and are
+# pure functions of it, so they cannot name the record the field came from;
+# without this, a refusal reads "unknown scope bogus" and the operator has
+# nothing to search the data file for. The predicates that already name the
+# record do not get a second reference.
+print_offending_record_reference() { # <domain> <key>
+  printf 'error: the refusal above is on record (domain %s, key %s)\n' "$1" "$2" >&2
 }
 
 # resolve_system_plist_path <domain> <plist_path>, print the plist path a
@@ -452,6 +565,73 @@ require_system_plist_path_permitted() { # <plist_path>
   printf 'error: plist_path %q is outside every permitted plist directory (%s); grant the directory deliberately in BOTH the Tier 1 template and macos-defaults-lib.sh, or use the default /Library/Preferences form\n' \
     "$plist_path" "${MACOS_DEFAULTS_PLIST_PATH_ALLOWED_DIRECTORIES[*]}" >&2
   return 1
+}
+
+# validate_defaults_record <domain> <key> <type> <value> <host> <scope>
+# <plist_path> <tier>, THE per-record gate: 0 when the record is usable, 1 with a
+# message on stderr otherwise. Its eight arguments are one record stream line, in
+# stream order.
+#
+# A PREDICATE, and it prints nothing on stdout. That matters: the two functions
+# it composes which DO print (validate_record_scope, resolve_system_plist_path)
+# are called with their output discarded here, so no caller can mistake this for
+# a producer and read a resolved value off a record that was just refused.
+#
+# Composing the record's rules in one place is what lets a caller ask the
+# question ONCE PER FILE, before acting on any record. The tools used to ask it
+# one record at a time inside their own consuming loops, which meant a file whose
+# second record was malformed had its first record applied before the second was
+# even looked at.
+#
+# The rules are grouped by what the DECLARED tier means, mirroring the runner
+# template's validation pass:
+#   - identity applies to every record; a record with no domain or no key names
+#     no control, whatever its tier;
+#   - enforce and verify records carry the read/write payload, so the type,
+#     scope, host and plist_path rules apply to them. For enforce the payload is
+#     the write; for verify it is the read the drift checker compares.
+#   - manual records carry a runbook pointer and no payload, so only identity
+#     applies. Their runbook rules (a runbook is REQUIRED, and no write field may
+#     appear) live in the runner template alone: the runbook is not one of the
+#     eight fields the record stream carries, so this gate cannot see it.
+#
+# Two rules are deliberately NOT here:
+#   - the value rule, which needs to tell an absent value from an empty one and
+#     so is asked of the FILE, by defaults_records_declare_a_value;
+#   - the write-time plist_path allowlist. Reads are not gated (drift consulting
+#     an odd path mutates nothing, and refusing it would hide the row instead of
+#     reporting it), so that rule belongs to apply, ahead of apply's first write.
+validate_defaults_record() { # <domain> <key> <type> <value> <host> <scope> <plist_path> <tier>
+  # The fourth argument, the record's value, is deliberately not read: telling an
+  # absent value from a legitimately empty one is impossible from the joined
+  # line, so that rule is asked of the file instead. The argument stays in the
+  # signature so callers pass a whole record rather than a subset of one.
+  local domain="$1" key="$2" value_type="$3" host="$5"
+  local scope="$6" plist_path="$7" tier="$8"
+  validate_record_identity "$domain" "$key" || return 1
+  case "$tier" in
+    manual) return 0 ;;
+    enforce | verify) ;;
+    *)
+      # Unreachable while the stream's tier gate holds, and fail-closed so that
+      # if it ever stops holding this gate refuses rather than falling through
+      # to "no payload rule applies to this tier".
+      printf 'error: record %s %s has an unrecognized tier %q; declare tier: enforce, verify, or manual\n' \
+        "$domain" "$key" "$tier" >&2
+      return 1
+      ;;
+  esac
+  validate_record_type "$value_type" "$domain" "$key" || return 1
+  if ! validate_record_scope "$scope" "$host" "$plist_path" >/dev/null; then
+    print_offending_record_reference "$domain" "$key"
+    return 1
+  fi
+  if [[ $scope == system ]]; then
+    if ! resolve_system_plist_path "$domain" "$plist_path" >/dev/null; then
+      print_offending_record_reference "$domain" "$key"
+      return 1
+    fi
+  fi
 }
 
 # The three outcomes of reading a system-scope setting, carried as an exit STATUS

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1344,6 +1344,20 @@
       "norm_label": "executable_macos-defaults-apply.sh script"
     },
     {
+      "label": "format_planned_write()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_macos-defaults-apply.sh",
+      "source_location": "L47",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_macos_defaults_apply_format_planned_write",
+      "community": 261,
+      "norm_label": "format_planned_write()"
+    },
+    {
       "label": "executable_macos-defaults-capture.sh",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_macos-defaults-capture.sh",
@@ -3724,10 +3738,24 @@
       "norm_label": "defaults_records_validate_stream()"
     },
     {
+      "label": "defaults_records_declare_a_value()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L325",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_defaults_records_declare_a_value",
+      "community": 351,
+      "norm_label": "defaults_records_declare_a_value()"
+    },
+    {
       "label": "defaults_records_unit_separated()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L292",
+      "source_location": "L341",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3741,7 +3769,7 @@
       "label": "validate_record_scope()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L318",
+      "source_location": "L368",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3752,10 +3780,52 @@
       "norm_label": "validate_record_scope()"
     },
     {
+      "label": "validate_record_identity()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L398",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_record_identity",
+      "community": 351,
+      "norm_label": "validate_record_identity()"
+    },
+    {
+      "label": "validate_record_type()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L429",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_record_type",
+      "community": 351,
+      "norm_label": "validate_record_type()"
+    },
+    {
+      "label": "print_offending_record_reference()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L447",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_print_offending_record_reference",
+      "community": 351,
+      "norm_label": "print_offending_record_reference()"
+    },
+    {
       "label": "validate_system_domain()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L351",
+      "source_location": "L464",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3769,7 +3839,7 @@
       "label": "validate_explicit_plist_path()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L384",
+      "source_location": "L497",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3783,7 +3853,7 @@
       "label": "resolve_system_plist_path()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L416",
+      "source_location": "L529",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3797,7 +3867,7 @@
       "label": "require_system_plist_path_permitted()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L445",
+      "source_location": "L558",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3808,10 +3878,24 @@
       "norm_label": "require_system_plist_path_permitted()"
     },
     {
+      "label": "validate_defaults_record()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L604",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "community": 351,
+      "norm_label": "validate_defaults_record()"
+    },
+    {
       "label": "system_defaults_write()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L492",
+      "source_location": "L672",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3825,7 +3909,7 @@
       "label": "system_defaults_read_actual()",
       "file_type": "code",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L523",
+      "source_location": "L703",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -13138,6 +13222,146 @@
       "id": "test_integration_macos_defaults_system_scope_run_tool",
       "community": 359,
       "norm_label": "run_tool()"
+    },
+    {
+      "label": "macos-defaults-validate-before-write.sh",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write",
+      "community": 420,
+      "norm_label": "macos-defaults-validate-before-write.sh"
+    },
+    {
+      "label": "macos-defaults-validate-before-write.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "community": 420,
+      "norm_label": "macos-defaults-validate-before-write.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L53",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_fail",
+      "community": 420,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "assert_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L60",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_assert_file_contains",
+      "community": 420,
+      "norm_label": "assert_file_contains()"
+    },
+    {
+      "label": "refute_file_contains()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L64",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_refute_file_contains",
+      "community": 420,
+      "norm_label": "refute_file_contains()"
+    },
+    {
+      "label": "make_source_dir()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L109",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_make_source_dir",
+      "community": 420,
+      "norm_label": "make_source_dir()"
+    },
+    {
+      "label": "run_tool()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L117",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_run_tool",
+      "community": 420,
+      "norm_label": "run_tool()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L125",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_render_template",
+      "community": 420,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "stream_records()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L130",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_stream_records",
+      "community": 420,
+      "norm_label": "stream_records()"
+    },
+    {
+      "label": "assert_refused_before_any_write()",
+      "file_type": "code",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L202",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "community": 420,
+      "norm_label": "assert_refused_before_any_write()"
     },
     {
       "label": "macos-firewall-globalstate-order.sh",
@@ -22968,6 +23192,104 @@
       "norm_label": "fail()"
     },
     {
+      "label": "macos-defaults-record-validation.sh",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation",
+      "community": 421,
+      "norm_label": "macos-defaults-record-validation.sh"
+    },
+    {
+      "label": "macos-defaults-record-validation.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_sh__entry",
+      "community": 421,
+      "norm_label": "macos-defaults-record-validation.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L49",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_fail",
+      "community": 421,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "accept_record()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L67",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_accept_record",
+      "community": 421,
+      "norm_label": "accept_record()"
+    },
+    {
+      "label": "reject_record()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L79",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_reject_record",
+      "community": 421,
+      "norm_label": "reject_record()"
+    },
+    {
+      "label": "write_value_fixture()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L164",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_write_value_fixture",
+      "community": 421,
+      "norm_label": "write_value_fixture()"
+    },
+    {
+      "label": "declared_value_status()",
+      "file_type": "code",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L171",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_macos_defaults_record_validation_declared_value_status",
+      "community": 421,
+      "norm_label": "declared_value_status()"
+    },
+    {
       "label": "macos-defaults-scope-read.sh",
       "file_type": "code",
       "source_file": "test/unit/macos-defaults-scope-read.sh",
@@ -26959,7 +27281,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L7",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
       "community": 323,
       "norm_label": "claude.md"
     },
@@ -26969,7 +27291,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L11",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_what_this_is",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_what_this_is",
       "community": 323,
       "norm_label": "what this is"
     },
@@ -26979,7 +27301,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L18",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
       "community": 323,
       "norm_label": "key commands"
     },
@@ -26989,7 +27311,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L20",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_linting_formatting",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_linting_formatting",
       "community": 323,
       "norm_label": "linting & formatting"
     },
@@ -26999,7 +27321,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L46",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_testing",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_testing",
       "community": 323,
       "norm_label": "testing"
     },
@@ -27009,7 +27331,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L86",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_chezmoi_operations",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_chezmoi_operations",
       "community": 323,
       "norm_label": "chezmoi operations"
     },
@@ -27019,7 +27341,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L114",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_code_settings",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_code_settings",
       "community": 323,
       "norm_label": "claude code settings"
     },
@@ -27029,7 +27351,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L147",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_hooks",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_hooks",
       "community": 323,
       "norm_label": "git hooks"
     },
@@ -27039,7 +27361,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L214",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
       "community": 323,
       "norm_label": "architecture"
     },
@@ -27049,7 +27371,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L216",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_source_only_files",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_source_only_files",
       "community": 323,
       "norm_label": "source-only files"
     },
@@ -27059,7 +27381,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L224",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_minimum_chezmoi_version",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_minimum_chezmoi_version",
       "community": 323,
       "norm_label": "minimum chezmoi version"
     },
@@ -27069,7 +27391,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L228",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_secrets_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_secrets_management",
       "community": 323,
       "norm_label": "secrets management"
     },
@@ -27079,7 +27401,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L235",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_system_package_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_system_package_management",
       "community": 323,
       "norm_label": "system package management"
     },
@@ -27089,7 +27411,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L260",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_macos_defaults_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_macos_defaults_management",
       "community": 323,
       "norm_label": "macos defaults management"
     },
@@ -27099,7 +27421,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L305",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_template_files",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_template_files",
       "community": 323,
       "norm_label": "template files"
     },
@@ -27109,7 +27431,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L311",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_template_shellcheck_workaround",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_template_shellcheck_workaround",
       "community": 323,
       "norm_label": "template shellcheck workaround"
     },
@@ -27119,7 +27441,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L332",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_os_targeting",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_os_targeting",
       "community": 323,
       "norm_label": "os targeting"
     },
@@ -27129,7 +27451,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L337",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_dev_environment_nix_flake",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_dev_environment_nix_flake",
       "community": 323,
       "norm_label": "dev environment (nix flake)"
     },
@@ -27139,7 +27461,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L348",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_ci",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_ci",
       "community": 323,
       "norm_label": "ci"
     },
@@ -27149,7 +27471,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L358",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_agent_skills_cross_harness_store",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_agent_skills_cross_harness_store",
       "community": 323,
       "norm_label": "agent skills (cross-harness store)"
     },
@@ -27159,7 +27481,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L528",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_herdr_workspace_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_herdr_workspace_management",
       "community": 323,
       "norm_label": "herdr workspace management"
     },
@@ -27169,7 +27491,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L548",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_worktrees_worktrunk",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_worktrees_worktrunk",
       "community": 323,
       "norm_label": "git worktrees (worktrunk)"
     },
@@ -27179,7 +27501,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L555",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_bashrc_init_ordering",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_bashrc_init_ordering",
       "community": 323,
       "norm_label": "bashrc init ordering"
     },
@@ -27189,7 +27511,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L563",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_shell_history_atuin",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_shell_history_atuin",
       "community": 323,
       "norm_label": "shell history (atuin)"
     },
@@ -27199,7 +27521,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L592",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_happy_daemon_remote_agent_control",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_happy_daemon_remote_agent_control",
       "community": 323,
       "norm_label": "happy daemon (remote agent control)"
     },
@@ -27209,7 +27531,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L619",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_tailscale_headless_daemon",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_tailscale_headless_daemon",
       "community": 323,
       "norm_label": "tailscale (headless daemon)"
     },
@@ -27219,7 +27541,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L656",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_ai_commit_messages",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_ai_commit_messages",
       "community": 323,
       "norm_label": "ai commit messages"
     },
@@ -27229,7 +27551,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L669",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_long_running_command_notifier",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_long_running_command_notifier",
       "community": 323,
       "norm_label": "long-running command notifier"
     },
@@ -27239,7 +27561,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L675",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_herdr_native_status",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_herdr_native_status",
       "community": 323,
       "norm_label": "herdr native status"
     },
@@ -27249,7 +27571,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L681",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_code_style",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_code_style",
       "community": 323,
       "norm_label": "code style"
     },
@@ -27259,7 +27581,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L707",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_commits",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_commits",
       "community": 323,
       "norm_label": "git commits"
     },
@@ -27269,8 +27591,338 @@
       "source_file": "AGENTS.md",
       "source_location": "L714",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_security",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_security",
       "community": 323,
+      "norm_label": "security"
+    },
+    {
+      "label": "CLAUDE.md",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "claude",
+      "community": 419,
+      "norm_label": "claude.md"
+    },
+    {
+      "label": "CLAUDE.md",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "claude_claude_md",
+      "community": 419,
+      "norm_label": "claude.md"
+    },
+    {
+      "label": "What This Is",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "claude_what_this_is",
+      "community": 419,
+      "norm_label": "what this is"
+    },
+    {
+      "label": "Key Commands",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L18",
+      "_origin": "ast",
+      "id": "claude_key_commands",
+      "community": 419,
+      "norm_label": "key commands"
+    },
+    {
+      "label": "Linting & Formatting",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "claude_linting_formatting",
+      "community": 419,
+      "norm_label": "linting & formatting"
+    },
+    {
+      "label": "Testing",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "claude_testing",
+      "community": 419,
+      "norm_label": "testing"
+    },
+    {
+      "label": "Chezmoi Operations",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L86",
+      "_origin": "ast",
+      "id": "claude_chezmoi_operations",
+      "community": 419,
+      "norm_label": "chezmoi operations"
+    },
+    {
+      "label": "Claude Code Settings",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L114",
+      "_origin": "ast",
+      "id": "claude_claude_code_settings",
+      "community": 419,
+      "norm_label": "claude code settings"
+    },
+    {
+      "label": "Git Hooks",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L147",
+      "_origin": "ast",
+      "id": "claude_git_hooks",
+      "community": 419,
+      "norm_label": "git hooks"
+    },
+    {
+      "label": "Architecture",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L214",
+      "_origin": "ast",
+      "id": "claude_architecture",
+      "community": 419,
+      "norm_label": "architecture"
+    },
+    {
+      "label": "Source-Only Files",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L216",
+      "_origin": "ast",
+      "id": "claude_source_only_files",
+      "community": 419,
+      "norm_label": "source-only files"
+    },
+    {
+      "label": "Minimum Chezmoi Version",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L224",
+      "_origin": "ast",
+      "id": "claude_minimum_chezmoi_version",
+      "community": 419,
+      "norm_label": "minimum chezmoi version"
+    },
+    {
+      "label": "Secrets Management",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L228",
+      "_origin": "ast",
+      "id": "claude_secrets_management",
+      "community": 419,
+      "norm_label": "secrets management"
+    },
+    {
+      "label": "System Package Management",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L235",
+      "_origin": "ast",
+      "id": "claude_system_package_management",
+      "community": 419,
+      "norm_label": "system package management"
+    },
+    {
+      "label": "macOS Defaults Management",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L260",
+      "_origin": "ast",
+      "id": "claude_macos_defaults_management",
+      "community": 419,
+      "norm_label": "macos defaults management"
+    },
+    {
+      "label": "Template Files",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L305",
+      "_origin": "ast",
+      "id": "claude_template_files",
+      "community": 419,
+      "norm_label": "template files"
+    },
+    {
+      "label": "Template Shellcheck Workaround",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L311",
+      "_origin": "ast",
+      "id": "claude_template_shellcheck_workaround",
+      "community": 419,
+      "norm_label": "template shellcheck workaround"
+    },
+    {
+      "label": "OS Targeting",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L332",
+      "_origin": "ast",
+      "id": "claude_os_targeting",
+      "community": 419,
+      "norm_label": "os targeting"
+    },
+    {
+      "label": "Dev Environment (Nix Flake)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L337",
+      "_origin": "ast",
+      "id": "claude_dev_environment_nix_flake",
+      "community": 419,
+      "norm_label": "dev environment (nix flake)"
+    },
+    {
+      "label": "CI",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L348",
+      "_origin": "ast",
+      "id": "claude_ci",
+      "community": 419,
+      "norm_label": "ci"
+    },
+    {
+      "label": "Agent Skills (cross-harness store)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L358",
+      "_origin": "ast",
+      "id": "claude_agent_skills_cross_harness_store",
+      "community": 419,
+      "norm_label": "agent skills (cross-harness store)"
+    },
+    {
+      "label": "Herdr Workspace Management",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L528",
+      "_origin": "ast",
+      "id": "claude_herdr_workspace_management",
+      "community": 419,
+      "norm_label": "herdr workspace management"
+    },
+    {
+      "label": "Git Worktrees (Worktrunk)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L548",
+      "_origin": "ast",
+      "id": "claude_git_worktrees_worktrunk",
+      "community": 419,
+      "norm_label": "git worktrees (worktrunk)"
+    },
+    {
+      "label": "Bashrc Init Ordering",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L555",
+      "_origin": "ast",
+      "id": "claude_bashrc_init_ordering",
+      "community": 419,
+      "norm_label": "bashrc init ordering"
+    },
+    {
+      "label": "Shell History (Atuin)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L563",
+      "_origin": "ast",
+      "id": "claude_shell_history_atuin",
+      "community": 419,
+      "norm_label": "shell history (atuin)"
+    },
+    {
+      "label": "Happy Daemon (Remote Agent Control)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L592",
+      "_origin": "ast",
+      "id": "claude_happy_daemon_remote_agent_control",
+      "community": 419,
+      "norm_label": "happy daemon (remote agent control)"
+    },
+    {
+      "label": "Tailscale (headless daemon)",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L619",
+      "_origin": "ast",
+      "id": "claude_tailscale_headless_daemon",
+      "community": 419,
+      "norm_label": "tailscale (headless daemon)"
+    },
+    {
+      "label": "AI Commit Messages",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L656",
+      "_origin": "ast",
+      "id": "claude_ai_commit_messages",
+      "community": 419,
+      "norm_label": "ai commit messages"
+    },
+    {
+      "label": "Long-running Command Notifier",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L669",
+      "_origin": "ast",
+      "id": "claude_long_running_command_notifier",
+      "community": 419,
+      "norm_label": "long-running command notifier"
+    },
+    {
+      "label": "Herdr Native Status",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L675",
+      "_origin": "ast",
+      "id": "claude_herdr_native_status",
+      "community": 419,
+      "norm_label": "herdr native status"
+    },
+    {
+      "label": "Code Style",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L681",
+      "_origin": "ast",
+      "id": "claude_code_style",
+      "community": 419,
+      "norm_label": "code style"
+    },
+    {
+      "label": "Git Commits",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L707",
+      "_origin": "ast",
+      "id": "claude_git_commits",
+      "community": 419,
+      "norm_label": "git commits"
+    },
+    {
+      "label": "Security",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L714",
+      "_origin": "ast",
+      "id": "claude_security",
+      "community": 419,
       "norm_label": "security"
     },
     {
@@ -47558,6 +48210,16 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_macos-defaults-apply.sh",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_macos_defaults_apply",
+      "target": "dot_local_bin_executable_macos_defaults_apply_format_planned_write",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-apply.sh",
@@ -47632,7 +48294,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_macos-defaults-drift.sh",
-      "source_location": "L96",
+      "source_location": "L99",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_macos_defaults_drift_sh__entry",
@@ -51743,6 +52405,16 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_declare_a_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
       "source_location": "L191",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
@@ -51793,7 +52465,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L292",
+      "source_location": "L341",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
@@ -51823,6 +52495,16 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_print_offending_record_reference",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
       "source_location": "L94",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
@@ -51833,7 +52515,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L445",
+      "source_location": "L558",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_require_system_plist_path_permitted",
@@ -51853,7 +52535,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L416",
+      "source_location": "L529",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
@@ -51873,7 +52555,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L523",
+      "source_location": "L703",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_system_defaults_read_actual",
@@ -51883,7 +52565,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L492",
+      "source_location": "L672",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_system_defaults_write",
@@ -51893,7 +52575,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L384",
+      "source_location": "L604",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L497",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_validate_explicit_plist_path",
@@ -51903,7 +52595,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L318",
+      "source_location": "L398",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_identity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L368",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_validate_record_scope",
@@ -51913,7 +52615,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L351",
+      "source_location": "L429",
+      "weight": 1.0,
+      "source": "dot_local_bin_macos_defaults_lib",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L464",
       "weight": 1.0,
       "source": "dot_local_bin_macos_defaults_lib",
       "target": "dot_local_bin_macos_defaults_lib_validate_system_domain",
@@ -51923,7 +52635,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L297",
+      "source_location": "L346",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
@@ -51934,7 +52646,73 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L418",
+      "source_location": "L290",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_defaults_records_validate_stream",
+      "target": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L347",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_defaults_records_unit_separated",
+      "target": "dot_local_bin_macos_defaults_lib_defaults_records_declare_a_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L625",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_scope",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L611",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_identity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L624",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "target": "dot_local_bin_macos_defaults_lib_validate_record_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L626",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "target": "dot_local_bin_macos_defaults_lib_print_offending_record_reference",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L531",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
@@ -51945,11 +52723,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/macos-defaults-lib.sh",
-      "source_location": "L423",
+      "source_location": "L536",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
       "target": "dot_local_bin_macos_defaults_lib_validate_explicit_plist_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/macos-defaults-lib.sh",
+      "source_location": "L630",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_macos_defaults_lib_validate_defaults_record",
+      "target": "dot_local_bin_macos_defaults_lib_resolve_system_plist_path",
       "confidence_score": 1.0
     },
     {
@@ -61828,6 +62617,228 @@
       "context": "call",
       "source": "test_integration_macos_defaults_system_scope_refute_file_contains",
       "target": "test_integration_macos_defaults_system_scope_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_make_source_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L117",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "test_integration_macos_defaults_validate_before_write",
+      "target": "test_integration_macos_defaults_validate_before_write_stream_records",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L243",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L72",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L409",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_refute_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L167",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L160",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_sh__entry",
+      "target": "test_integration_macos_defaults_validate_before_write_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L61",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_assert_file_contains",
+      "target": "test_integration_macos_defaults_validate_before_write_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L212",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "target": "test_integration_macos_defaults_validate_before_write_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L66",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_refute_file_contains",
+      "target": "test_integration_macos_defaults_validate_before_write_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L217",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "target": "test_integration_macos_defaults_validate_before_write_assert_file_contains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L209",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "target": "test_integration_macos_defaults_validate_before_write_run_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/macos-defaults-validate-before-write.sh",
+      "source_location": "L236",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_macos_defaults_validate_before_write_assert_refused_before_any_write",
+      "target": "test_integration_macos_defaults_validate_before_write_render_template",
       "confidence_score": 1.0
     },
     {
@@ -72322,6 +73333,132 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_accept_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L171",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_declared_value_status",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_reject_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "test_unit_macos_defaults_record_validation",
+      "target": "test_unit_macos_defaults_record_validation_write_value_fixture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_sh__entry",
+      "target": "test_unit_macos_defaults_record_validation_accept_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L54",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_sh__entry",
+      "target": "test_unit_macos_defaults_record_validation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L123",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_sh__entry",
+      "target": "test_unit_macos_defaults_record_validation_reject_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L179",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_sh__entry",
+      "target": "test_unit_macos_defaults_record_validation_write_value_fixture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L73",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_accept_record",
+      "target": "test_unit_macos_defaults_record_validation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/macos-defaults-record-validation.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_macos_defaults_record_validation_reject_record",
+      "target": "test_unit_macos_defaults_record_validation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/macos-defaults-scope-read.sh",
       "source_location": "L62",
       "weight": 1.0,
@@ -76680,7 +77817,7 @@
       "source_location": "L7",
       "weight": 1.0,
       "source": "agents",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
       "confidence_score": 1.0
     },
     {
@@ -76689,8 +77826,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L214",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
       "confidence_score": 1.0
     },
     {
@@ -76699,8 +77836,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L681",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_code_style",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_code_style",
       "confidence_score": 1.0
     },
     {
@@ -76709,8 +77846,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L707",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_commits",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_commits",
       "confidence_score": 1.0
     },
     {
@@ -76719,8 +77856,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L18",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
       "confidence_score": 1.0
     },
     {
@@ -76729,8 +77866,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L714",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_security",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_security",
       "confidence_score": 1.0
     },
     {
@@ -76739,8 +77876,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L11",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_what_this_is",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_what_this_is",
       "confidence_score": 1.0
     },
     {
@@ -76749,8 +77886,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L86",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_chezmoi_operations",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_chezmoi_operations",
       "confidence_score": 1.0
     },
     {
@@ -76759,8 +77896,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L114",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_claude_code_settings",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_claude_code_settings",
       "confidence_score": 1.0
     },
     {
@@ -76769,8 +77906,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L147",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_hooks",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_hooks",
       "confidence_score": 1.0
     },
     {
@@ -76779,8 +77916,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L20",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_linting_formatting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_linting_formatting",
       "confidence_score": 1.0
     },
     {
@@ -76789,8 +77926,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L46",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_testing",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_testing",
       "confidence_score": 1.0
     },
     {
@@ -76799,8 +77936,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L358",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_agent_skills_cross_harness_store",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_agent_skills_cross_harness_store",
       "confidence_score": 1.0
     },
     {
@@ -76809,8 +77946,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L656",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_ai_commit_messages",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_ai_commit_messages",
       "confidence_score": 1.0
     },
     {
@@ -76819,8 +77956,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L555",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_bashrc_init_ordering",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_bashrc_init_ordering",
       "confidence_score": 1.0
     },
     {
@@ -76829,8 +77966,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L348",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_ci",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_ci",
       "confidence_score": 1.0
     },
     {
@@ -76839,8 +77976,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L337",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_dev_environment_nix_flake",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_dev_environment_nix_flake",
       "confidence_score": 1.0
     },
     {
@@ -76849,8 +77986,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L548",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_git_worktrees_worktrunk",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_git_worktrees_worktrunk",
       "confidence_score": 1.0
     },
     {
@@ -76859,8 +77996,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L592",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_happy_daemon_remote_agent_control",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_happy_daemon_remote_agent_control",
       "confidence_score": 1.0
     },
     {
@@ -76869,8 +78006,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L675",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_herdr_native_status",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_herdr_native_status",
       "confidence_score": 1.0
     },
     {
@@ -76879,8 +78016,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L528",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_herdr_workspace_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_herdr_workspace_management",
       "confidence_score": 1.0
     },
     {
@@ -76889,8 +78026,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L669",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_long_running_command_notifier",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_long_running_command_notifier",
       "confidence_score": 1.0
     },
     {
@@ -76899,8 +78036,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L260",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_macos_defaults_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_macos_defaults_management",
       "confidence_score": 1.0
     },
     {
@@ -76909,8 +78046,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L224",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_minimum_chezmoi_version",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_minimum_chezmoi_version",
       "confidence_score": 1.0
     },
     {
@@ -76919,8 +78056,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L332",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_os_targeting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_os_targeting",
       "confidence_score": 1.0
     },
     {
@@ -76929,8 +78066,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L228",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_secrets_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_secrets_management",
       "confidence_score": 1.0
     },
     {
@@ -76939,8 +78076,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L563",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_shell_history_atuin",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_shell_history_atuin",
       "confidence_score": 1.0
     },
     {
@@ -76949,8 +78086,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L216",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_source_only_files",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_source_only_files",
       "confidence_score": 1.0
     },
     {
@@ -76959,8 +78096,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L235",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_system_package_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_system_package_management",
       "confidence_score": 1.0
     },
     {
@@ -76969,8 +78106,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L619",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_tailscale_headless_daemon",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_tailscale_headless_daemon",
       "confidence_score": 1.0
     },
     {
@@ -76979,8 +78116,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L305",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_template_files",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_template_files",
       "confidence_score": 1.0
     },
     {
@@ -76989,8 +78126,328 @@
       "source_file": "AGENTS.md",
       "source_location": "L311",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_log_rotation_agents_template_shellcheck_workaround",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_fu72_agents_template_shellcheck_workaround",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "claude",
+      "target": "claude_claude_md",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_architecture",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L681",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_code_style",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L707",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_git_commits",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_key_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L714",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_security",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "claude_claude_md",
+      "target": "claude_what_this_is",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L86",
+      "weight": 1.0,
+      "source": "claude_key_commands",
+      "target": "claude_chezmoi_operations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "claude_key_commands",
+      "target": "claude_claude_code_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "claude_key_commands",
+      "target": "claude_git_hooks",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "claude_key_commands",
+      "target": "claude_linting_formatting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "claude_key_commands",
+      "target": "claude_testing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L358",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_agent_skills_cross_harness_store",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L656",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_ai_commit_messages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L555",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_bashrc_init_ordering",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L348",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_ci",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_dev_environment_nix_flake",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L548",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_git_worktrees_worktrunk",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L592",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_happy_daemon_remote_agent_control",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L675",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_herdr_native_status",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L528",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_herdr_workspace_management",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L669",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_long_running_command_notifier",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L260",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_macos_defaults_management",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L224",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_minimum_chezmoi_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L332",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_os_targeting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_secrets_management",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L563",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_shell_history_atuin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_source_only_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L235",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_system_package_management",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L619",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_tailscale_headless_daemon",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L305",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_template_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L311",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_template_shellcheck_workaround",
       "confidence_score": 1.0
     },
     {
@@ -95205,5 +96662,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "ed911c55e8a6fcd58f9db92dfb2e329c8774bd6a"
+  "built_at_commit": "708205ea8aeb320d73f6feffa1b7093e0700c938"
 }

--- a/test/integration/macos-defaults-validate-before-write.sh
+++ b/test/integration/macos-defaults-validate-before-write.sh
@@ -1,0 +1,491 @@
+#!/usr/bin/env bash
+# macos-defaults-validate-before-write.sh -- a malformed macos_defaults.yaml must
+# be refused ENTIRELY, before the first `defaults write`, by every tool that
+# reads it.
+#
+# macos_defaults.yaml is a DECLARATIVE description of the machine. Applying part
+# of it leaves the Mac in a state neither the old file nor the new one describes,
+# and the operator has no record of where the run stopped. Refusing outright is
+# strictly better, and it is what the Tier 1 runner template already does: its
+# validation pass covers every record before the render emits a single write, and
+# a rejected render produces no script at all.
+#
+# The shell reader did not hold that line. Three divergences, each reproduced
+# against a stubbed `defaults` before this suite existed:
+#
+#   1. A valid record followed by one with an unknown scope: the valid record was
+#      WRITTEN, then the run aborted with status 2. Scope validation sat inside
+#      the consuming loop, after earlier writes had already landed.
+#   2. A valid record followed by one with no domain: the valid record was
+#      written and the malformed one was SILENTLY SKIPPED, exit 0. A malformed
+#      file reported success.
+#   3. A valid record followed by one with no value: BOTH were written, the
+#      second with an empty value, exit 0. Same false success.
+#
+# Two more of the same class are pinned here because they are reachable the same
+# way: a record with no type (which reached `defaults write dom key - true`, exit
+# 0), and a system record whose plist_path is outside the write allowlist placed
+# behind a valid record.
+#
+# What each case asserts is the ABSENCE of the earlier write, not merely that the
+# run failed. A run that refuses AFTER writing the first record still passes a
+# status check, so the status alone pins nothing about ordering.
+#
+# The control row comes FIRST: a file whose records are all valid must apply
+# every one of them. Without it every assertion below is satisfied by an apply
+# that writes nothing, ever.
+#
+# Real chezmoi and yq; `defaults`, `sudo`, `osascript` and `killall` are stubbed.
+# Never runs real sudo, never touches /Library.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope, before any git or chezmoi call: a linked worktree
+# exports GIT_DIR to the hooks it runs, and the library's own override may be
+# exported on a developer machine.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.chezmoiscripts/run_onchange_after_30-macos-defaults.sh.tmpl"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+APPLY="$REPO_ROOT/dot_local/bin/executable_macos-defaults-apply.sh"
+DRIFT="$REPO_ROOT/dot_local/bin/executable_macos-defaults-drift.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A bare `! grep` is dead under `set -e` unless it happens to be the final
+# statement, so every negative goes through these helpers.
+assert_file_contains() { # <file> <fixed-string> <message>
+  grep -qF -- "$2" "$1" || fail "$3"
+}
+
+refute_file_contains() { # <file> <fixed-string> <message>
+  if grep -qF -- "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+for tool in chezmoi yq; do
+  command -v "$tool" >/dev/null 2>&1 ||
+    fail "$tool is not on PATH; this suite renders a real template and streams real YAML, so it cannot be meaningfully skipped"
+done
+for required_file in "$TEMPLATE" "$LIB" "$APPLY" "$DRIFT"; do
+  [[ -f $required_file ]] || fail "missing file: $required_file"
+done
+
+# Canonicalize away macOS's /var -> /private/var symlink.
+sandbox="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$sandbox"' EXIT
+mkdir -p "$sandbox/home" "$sandbox/render-home"
+
+defaults_log="$sandbox/defaults.log"
+sudo_log="$sandbox/sudo.log"
+render_error="$sandbox/render.err"
+
+stub_bin="$sandbox/bin"
+mkdir -p "$stub_bin"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/osascript"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/killall"
+cat >"$stub_bin/sudo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$sudo_log"
+exec "\$@"
+EOF
+# The stub records every invocation and answers reads with a value that DIFFERS
+# from every fixture's declared value, so the drift rows below are real rows a
+# truncated report would visibly lose.
+cat >"$stub_bin/defaults" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$defaults_log"
+if [[ \$1 == read ]]; then printf 'unexpected-live-value\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$stub_bin/osascript" "$stub_bin/killall" "$stub_bin/sudo" "$stub_bin/defaults"
+
+# make_source_dir -- create a chezmoi source tree whose macos_defaults.yaml is
+# read from stdin; print the tree's path.
+make_source_dir() {
+  local source_dir
+  source_dir="$(mktemp -d "$sandbox/src.XXXXXX")"
+  mkdir -p "$source_dir/.chezmoidata"
+  cat >"$source_dir/.chezmoidata/macos_defaults.yaml"
+  printf '%s\n' "$source_dir"
+}
+
+run_tool() { # <source-dir> <script>
+  (
+    cd "$sandbox" || exit 1
+    MACOS_DEFAULTS_SOURCE_DIR="$1" HOME="$sandbox/home" \
+      PATH="$stub_bin:$PATH" bash "$2"
+  )
+}
+
+render_template() { # <source-dir> <out-file>
+  HOME="$sandbox/render-home" chezmoi --source "$1" execute-template --no-tty \
+    <"$TEMPLATE" >"$2" 2>"$render_error"
+}
+
+stream_records() { # <source-dir> <err-file>
+  bash -c 'source "$1"; defaults_records_unit_separated "$2"' _ \
+    "$LIB" "$1/.chezmoidata/macos_defaults.yaml" 2>"$2"
+}
+
+# ---- control: a wholly valid file applies every record ------------------------
+
+# Two enforce records, the second reached only if the first did not end the run.
+# Every refusal case below asserts an EMPTY defaults log, and an apply that never
+# writes satisfies all of them, so this row is what proves the log observes
+# writes at all.
+control_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.controlfirst
+      key: ControlFirstKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.controlsecond
+      key: ControlSecondKey
+      type: bool
+      value: false
+      tier: enforce
+  killall: []
+EOF
+)"
+: >"$defaults_log"
+: >"$sudo_log"
+run_tool "$control_src" "$APPLY" 2>"$sandbox/control-apply.err" ||
+  fail "control: apply must succeed on a wholly valid file (stderr: $(cat "$sandbox/control-apply.err"))"
+assert_file_contains "$defaults_log" 'write com.example.controlfirst ControlFirstKey -bool true' \
+  "control: apply must write the first valid record (defaults log: $(cat "$defaults_log"))"
+assert_file_contains "$defaults_log" 'write com.example.controlsecond ControlSecondKey -bool false' \
+  "control: apply must write the second valid record (defaults log: $(cat "$defaults_log"))"
+
+render_template "$control_src" "$sandbox/rendered-control" ||
+  fail "control: the template must render a wholly valid file (stderr: $(cat "$render_error"))"
+assert_file_contains "$sandbox/rendered-control" \
+  "defaults write 'com.example.controlsecond' 'ControlSecondKey' -bool 'false'" \
+  "control: the render must carry the second record's write (render: $(cat "$sandbox/rendered-control"))"
+
+control_stream="$(stream_records "$control_src" "$sandbox/control-stream.err")" ||
+  fail "control: the record stream must accept a wholly valid file (stderr: $(cat "$sandbox/control-stream.err"))"
+[[ $(printf '%s\n' "$control_stream" | wc -l | tr -d ' ') -eq 2 ]] ||
+  fail "control: the record stream must emit both records (got: $(printf '%s' "$control_stream" | cat -v))"
+
+control_drift_status=0
+run_tool "$control_src" "$DRIFT" >"$sandbox/control-drift.out" 2>"$sandbox/control-drift.err" ||
+  control_drift_status=$?
+[[ $control_drift_status -eq 1 ]] ||
+  fail "control: drift must report drift (status 1) against the stub's differing live value (got $control_drift_status, stderr: $(cat "$sandbox/control-drift.err"))"
+assert_file_contains "$sandbox/control-drift.out" 'com.example.controlsecond' \
+  "control: drift must reach and report the SECOND record (stdout: $(cat "$sandbox/control-drift.out"))"
+
+# ---- the refusal table -------------------------------------------------------
+
+# assert_refused_before_any_write <label> <apply-stderr-fragment>
+#   (fixture on stdin)
+#
+# Every fixture puts a VALID enforce record first and the offending record
+# second, so "wrote nothing" is a statement about ordering and not about a file
+# that had nothing to write. Asserted per fixture:
+#   - apply exits 2, the tools' shared "data file unusable" status;
+#   - the defaults and sudo logs are EMPTY, so the valid FIRST record was not
+#     applied either;
+#   - apply's message names the offending record and the rule it broke;
+#   - the shared record stream emits nothing;
+#   - drift refuses the same file and reports no row;
+#   - the runner template refuses the same file, so one YAML cannot render
+#     cleanly and then make every tool refuse it.
+assert_refused_before_any_write() { # <label> <apply-stderr-fragment>
+  local label="$1" apply_stderr_fragment="$2"
+  local source_dir apply_status=0 drift_status=0 stream_status=0 stream_output
+  source_dir="$(make_source_dir)"
+
+  : >"$defaults_log"
+  : >"$sudo_log"
+  run_tool "$source_dir" "$APPLY" >"$sandbox/refused-apply.out" 2>"$sandbox/refused-apply.err" ||
+    apply_status=$?
+  [[ $apply_status -eq 2 ]] ||
+    fail "$label: apply must refuse the whole file with status 2 (got $apply_status, stderr: $(cat "$sandbox/refused-apply.err"))"
+  [[ ! -s $defaults_log ]] ||
+    fail "$label: apply must write NOTHING, including the valid record that precedes the offender (defaults log: $(cat "$defaults_log"))"
+  [[ ! -s $sudo_log ]] ||
+    fail "$label: apply must invoke no sudo at all on a file it refuses (sudo log: $(cat "$sudo_log"))"
+  assert_file_contains "$sandbox/refused-apply.err" "$apply_stderr_fragment" \
+    "$label: the refusal must name the rule that was broken (stderr: $(cat "$sandbox/refused-apply.err"))"
+  assert_file_contains "$sandbox/refused-apply.err" 'com.example.offender' \
+    "$label: the refusal must name the offending record (stderr: $(cat "$sandbox/refused-apply.err"))"
+
+  stream_output="$(stream_records "$source_dir" "$sandbox/refused-stream.err")" || stream_status=$?
+  [[ $stream_status -eq 2 ]] ||
+    fail "$label: the shared record stream must refuse the file with status 2 (got $stream_status, stderr: $(cat "$sandbox/refused-stream.err"))"
+  [[ -z $stream_output ]] ||
+    fail "$label: a refused stream must emit nothing a caller could act on (got: $(printf '%s' "$stream_output" | cat -v))"
+
+  : >"$defaults_log"
+  run_tool "$source_dir" "$DRIFT" >"$sandbox/refused-drift.out" 2>"$sandbox/refused-drift.err" ||
+    drift_status=$?
+  [[ $drift_status -eq 2 ]] ||
+    fail "$label: drift must refuse the same file with status 2 (got $drift_status, stderr: $(cat "$sandbox/refused-drift.err"))"
+  [[ ! -s $sandbox/refused-drift.out ]] ||
+    fail "$label: drift must report no row from a file it refuses (stdout: $(cat "$sandbox/refused-drift.out"))"
+
+  if render_template "$source_dir" "$sandbox/refused-render"; then
+    fail "$label: the runner template must refuse the same file, or one YAML renders cleanly and then makes every tool refuse it (render: $(cat "$sandbox/refused-render"))"
+  fi
+}
+
+# 1. Unknown scope on the second record. Validation used to sit inside the write
+#    loop, so the first record was already on disk when this was caught.
+assert_refused_before_any_write 'unknown scope behind a valid record' 'unknown scope' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.offender
+      key: OffenderKey
+      type: bool
+      value: true
+      tier: enforce
+      scope: bogus
+  killall: []
+EOF
+
+# 2. No domain on the second record. The write loop skipped it and the run
+#    reported success, which is worse than the partial apply above: a malformed
+#    file looked applied.
+assert_refused_before_any_write 'blank domain behind a valid record' 'blank domain' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - key: com.example.offender
+      type: bool
+      value: true
+      tier: enforce
+  killall: []
+EOF
+
+# 3. No value on the second record. BOTH records were written, the second with an
+#    empty value, and the run reported success.
+assert_refused_before_any_write 'blank value behind a valid record' 'blank value' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.offender
+      key: OffenderKey
+      type: bool
+      tier: enforce
+  killall: []
+EOF
+
+# 4. No type on the second record. Same class: the write went out as
+#    `defaults write com.example.offender OffenderKey - true`, exit 0.
+assert_refused_before_any_write 'blank type behind a valid record' 'unsupported type' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.offender
+      key: OffenderKey
+      value: true
+      tier: enforce
+  killall: []
+EOF
+
+# 5. A blank key is the other half of the identity rule. Pinned separately from
+#    the blank domain so neither half can be dropped without a test going red.
+assert_refused_before_any_write 'blank key behind a valid record' 'blank key' <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.offender
+      type: bool
+      value: true
+      tier: enforce
+  killall: []
+EOF
+
+# ---- the write-time allowlist is apply's own gate, and it moved too ------------
+
+# The plist_path write allowlist is deliberately NOT part of the shared stream:
+# drift only READS, and refusing an odd path there would hide the row instead of
+# reporting it. So it stays apply's own gate, which means apply must reach it
+# before its first write rather than in the middle of the loop.
+allowlist_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.leader
+      key: LeaderKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.offender
+      key: OffenderKey
+      type: bool
+      value: true
+      tier: enforce
+      scope: system
+      plist_path: /etc/example.evil.plist
+  killall: []
+EOF
+)"
+: >"$defaults_log"
+: >"$sudo_log"
+allowlist_status=0
+run_tool "$allowlist_src" "$APPLY" 2>"$sandbox/allowlist-apply.err" || allowlist_status=$?
+[[ $allowlist_status -eq 2 ]] ||
+  fail "out-of-allowlist plist_path: apply must refuse with status 2 (got $allowlist_status, stderr: $(cat "$sandbox/allowlist-apply.err"))"
+[[ ! -s $defaults_log ]] ||
+  fail "out-of-allowlist plist_path: the valid leading record must not be written either (defaults log: $(cat "$defaults_log"))"
+[[ ! -s $sudo_log ]] ||
+  fail "out-of-allowlist plist_path: apply must invoke no sudo at all (sudo log: $(cat "$sudo_log"))"
+assert_file_contains "$sandbox/allowlist-apply.err" 'permitted plist director' \
+  "out-of-allowlist plist_path: the refusal must name the containment rule (stderr: $(cat "$sandbox/allowlist-apply.err"))"
+
+# drift must still READ that same file: the allowlist is a write-time rule, and
+# a read of an odd path mutates nothing. Losing this row would turn a documented
+# asymmetry into an accident.
+allowlist_drift_status=0
+run_tool "$allowlist_src" "$DRIFT" >"$sandbox/allowlist-drift.out" 2>"$sandbox/allowlist-drift.err" ||
+  allowlist_drift_status=$?
+[[ $allowlist_drift_status -ne 2 ]] ||
+  fail "out-of-allowlist plist_path: drift must NOT refuse a read-only pass over it (stderr: $(cat "$sandbox/allowlist-drift.err"))"
+assert_file_contains "$sandbox/allowlist-drift.out" 'com.example.offender' \
+  "out-of-allowlist plist_path: drift must still report the record it cannot write (stdout: $(cat "$sandbox/allowlist-drift.out"))"
+
+# ---- the tools' OWN ordering, reached by bypassing the stream gate -------------
+
+# Everything above is satisfied by the shared stream refusing the file, which is
+# where the rule belongs. But apply keeps its own validation behind that gate as
+# defence in depth for the day the stream's rules drift, and defence that always
+# runs AFTER the first write is not defence at all: that is precisely the bug
+# this suite exists for. So reach it. Copy the tools beside a doctored library
+# whose stream emits a valid record FOLLOWED by one the real gate would refuse,
+# and require the tool's own pass to refuse before writing the valid one.
+bypass_dir="$sandbox/bypass-tools"
+mkdir -p "$bypass_dir"
+cp "$APPLY" "$bypass_dir/macos-defaults-apply.sh"
+cp "$DRIFT" "$bypass_dir/macos-defaults-drift.sh"
+cp "$LIB" "$bypass_dir/macos-defaults-lib.sh"
+cat >>"$bypass_dir/macos-defaults-lib.sh" <<'EOF'
+
+# TEST DOUBLE: a valid enforce record, then one carrying a scope the real gate
+# refuses. The caller's own validation is the only guard left standing, and WHEN
+# it runs is what decides whether the valid record was already on disk.
+defaults_records_unit_separated() {
+  printf 'com.example.bypassvalid\x1fBypassValidKey\x1fbool\x1ftrue\x1f\x1fuser\x1f\x1fenforce\n'
+  printf 'com.example.bypassbogus\x1fBypassBogusKey\x1fbool\x1ftrue\x1f\x1fbogus\x1f\x1fenforce\n'
+}
+EOF
+: >"$defaults_log"
+: >"$sudo_log"
+bypass_apply_status=0
+run_tool "$control_src" "$bypass_dir/macos-defaults-apply.sh" 2>"$sandbox/bypass-apply.err" ||
+  bypass_apply_status=$?
+[[ $bypass_apply_status -eq 2 ]] ||
+  fail "stream bypassed: apply's own validation must refuse with status 2 (got $bypass_apply_status, stderr: $(cat "$sandbox/bypass-apply.err"))"
+refute_file_contains "$defaults_log" 'com.example.bypassvalid' \
+  "stream bypassed: apply must validate EVERY record before writing ANY, so the valid record that precedes the offender must not reach disk (defaults log: $(cat "$defaults_log"))"
+assert_file_contains "$sandbox/bypass-apply.err" 'unknown scope' \
+  "stream bypassed: apply's own refusal must name the rule (stderr: $(cat "$sandbox/bypass-apply.err"))"
+
+# drift's own backstop: a record with no domain aborts the report instead of
+# being silently skipped. drift never writes, so the ordering question does not
+# arise for it; what matters is that an unreadable record is never quietly
+# dropped from a report whose whole job is to say what is out of line.
+cat >>"$bypass_dir/macos-defaults-lib.sh" <<'EOF'
+
+defaults_records_unit_separated() {
+  printf 'com.example.bypassnamed\x1fBypassNamedKey\x1fbool\x1ftrue\x1f\x1fuser\x1f\x1fenforce\n'
+  printf '\x1fBypassNamelessKey\x1fbool\x1ftrue\x1f\x1fuser\x1f\x1fenforce\n'
+}
+EOF
+bypass_drift_status=0
+run_tool "$control_src" "$bypass_dir/macos-defaults-drift.sh" \
+  >"$sandbox/bypass-drift.out" 2>"$sandbox/bypass-drift.err" || bypass_drift_status=$?
+[[ $bypass_drift_status -eq 2 ]] ||
+  fail "stream bypassed: drift's own validation must refuse a record with no domain (got $bypass_drift_status, stderr: $(cat "$sandbox/bypass-drift.err"))"
+refute_file_contains "$sandbox/bypass-drift.out" 'BypassNamelessKey' \
+  'stream bypassed: drift must not report a row for a record it could not identify'
+assert_file_contains "$sandbox/bypass-drift.err" 'blank domain' \
+  "stream bypassed: drift's refusal must name the rule (stderr: $(cat "$sandbox/bypass-drift.err"))"
+
+# ---- the type closed set is ONE list, held in two places -----------------------
+
+# The type is the one field both readers put into a command as a bare option
+# word, so neither can quote it and both constrain it to the same closed set.
+# Two lists that can drift apart is exactly how apply came to accept a record the
+# render refused, which is why the plist_path allowlists are pinned the same way
+# in the system-scope suite. Source-form pin, beside the behavioral rows above.
+template_supported_types="$(grep -F 'has .type (list' "$TEMPLATE" | grep -o '"[^"]*"' | tr -d '"' | LC_ALL=C sort)"
+library_supported_types="$(bash -c 'source "$1"; printf "%s\n" "${MACOS_DEFAULTS_SUPPORTED_TYPES[@]}"' _ "$LIB" | LC_ALL=C sort)"
+[[ -n $template_supported_types ]] ||
+  fail 'could not extract the supported-type set from the runner template'
+[[ -n $library_supported_types ]] ||
+  fail 'could not extract the supported-type set from the shared library'
+[[ $template_supported_types == "$library_supported_types" ]] ||
+  fail "the two readers' supported-type sets have drifted apart (template: $(printf '%s' "$template_supported_types" | tr '\n' ' '); library: $(printf '%s' "$library_supported_types" | tr '\n' ' '))"
+
+# ---- a legitimate mid-run write failure is NOT a validation failure ------------
+
+# Validation moving ahead of the writes must not change what happens when a write
+# itself fails: `defaults` failing on record two is a runtime failure, not a
+# malformed file, and the first record's write legitimately stands.
+runtime_failure_src="$(
+  make_source_dir <<'EOF'
+macos:
+  defaults:
+    - domain: com.example.writes
+      key: WritesKey
+      type: bool
+      value: true
+      tier: enforce
+    - domain: com.example.writefails
+      key: WriteFailsKey
+      type: bool
+      value: true
+      tier: enforce
+  killall: []
+EOF
+)"
+cat >"$stub_bin/defaults" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >>"$defaults_log"
+if [[ \$* == *WriteFailsKey* ]]; then exit 9; fi
+if [[ \$1 == read ]]; then printf 'unexpected-live-value\n'; exit 0; fi
+exit 0
+EOF
+chmod +x "$stub_bin/defaults"
+: >"$defaults_log"
+runtime_failure_status=0
+run_tool "$runtime_failure_src" "$APPLY" 2>"$sandbox/runtime-failure.err" || runtime_failure_status=$?
+[[ $runtime_failure_status -ne 0 ]] ||
+  fail 'a defaults write that fails must still end the run nonzero'
+assert_file_contains "$defaults_log" 'write com.example.writes WritesKey -bool true' \
+  "a validated record that wrote successfully before a later runtime failure must still have been written (defaults log: $(cat "$defaults_log"))"
+assert_file_contains "$defaults_log" 'write com.example.writefails WriteFailsKey -bool true' \
+  "the failing write must have been attempted (defaults log: $(cat "$defaults_log"))"
+
+printf 'macos-defaults-validate-before-write: OK (a valid file applies every record; an unknown scope, a blank domain, key, value or type, and an out-of-allowlist plist_path behind a valid record each refuse the WHOLE file with no write attempted, in apply, in drift and in the render; a runtime write failure is still a runtime failure)\n'

--- a/test/unit/macos-defaults-record-validation.sh
+++ b/test/unit/macos-defaults-record-validation.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# macos-defaults-record-validation.sh -- unit coverage for the per-record gate in
+# macos-defaults-lib.sh: validate_defaults_record, the field predicates it
+# composes (validate_record_identity, validate_record_type), and the file-level
+# value rule beside it (defaults_records_declare_a_value).
+#
+# The gate exists so that per-record validation can run for the WHOLE file before
+# any consumer acts on any record. It is therefore a PREDICATE, not a producer:
+# it answers yes or no, prints its reason on stderr, and prints nothing at all on
+# stdout. Every case below asserts the empty stdout as well as the status,
+# because a caller that read a value off this function's stdout would be handed
+# something derived from a record that may have just been refused.
+#
+# The properties pinned here:
+#
+#   - Identity is required on every record, whatever its tier. An empty domain or
+#     an empty key is REFUSED, never skipped. apply and drift both used to
+#     `continue` past an empty domain, which turned a malformed record into a
+#     silent no-op and let the run exit 0 having applied only part of the file.
+#   - enforce and verify records must declare a type from the closed set the
+#     runner template constrains .type to. A record with none reached
+#     `defaults write dom key - true` before this gate existed.
+#   - manual records carry no write payload, so only identity applies to them.
+#   - The VALUE rule is asked of the FILE, not of the record, because the record
+#     stream renders an absent value and a legitimately empty one identically.
+#     defaults_records_declare_a_value refuses an absent or null value on an
+#     enforce or verify record while leaving "", false and 0 alone, which is what
+#     keeps this reader refusing exactly what the runner template refuses.
+#   - The scope, host and plist_path rules the tools already had are reached
+#     THROUGH this gate, so a caller gets one answer for the whole record rather
+#     than discovering the next problem one write later.
+#   - An unrecognized tier is refused here too. The record stream gates the tier
+#     before this is ever called; the arm keeps the gate from failing OPEN into
+#     "no payload rules apply" if that ever changes.
+#
+# Mostly pure bash: every record-level function under test is a predicate over
+# eight strings. The file-level value rule needs real yq, which is cheap enough
+# for this camp (the count-guard unit suite uses it the same way). No chezmoi and
+# no `defaults` anywhere.
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. A linked worktree exports GIT_DIR to the hooks it
+# runs, and the library's own override may be exported on a developer machine.
+unset MACOS_DEFAULTS_SOURCE_DIR GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIB="$REPO_ROOT/dot_local/bin/macos-defaults-lib.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $LIB ]] || fail "missing library: $LIB"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# shellcheck source=/dev/null
+source "$LIB"
+
+# The eight fields, in the order the record stream emits them. Named here once so
+# every case below reads as a record rather than as eight anonymous arguments.
+#   domain key type value host scope plist_path tier
+
+# accept_record <label> <domain> <key> <type> <value> <host> <scope> <plist_path> <tier>
+accept_record() {
+  local label="$1"
+  shift
+  local status=0 output
+  output="$(validate_defaults_record "$@" 2>"$work/err")" || status=$?
+  [[ $status -eq 0 ]] ||
+    fail "$label: a valid record must be accepted (got $status, stderr: $(cat "$work/err"))"
+  [[ -z $output ]] ||
+    fail "$label: the gate is a predicate and must print nothing on stdout (got '$output')"
+}
+
+# reject_record <label> <stderr-fragment> <domain> <key> <type> <value> <host> <scope> <plist_path> <tier>
+reject_record() {
+  local label="$1" expected_fragment="$2"
+  shift 2
+  local status=0 output
+  output="$(validate_defaults_record "$@" 2>"$work/err")" || status=$?
+  [[ $status -ne 0 ]] ||
+    fail "$label: the record must be refused (got 0, stdout: '$output')"
+  [[ -z $output ]] ||
+    fail "$label: a refused record must print nothing on stdout (got '$output')"
+  grep -qF -- "$expected_fragment" "$work/err" ||
+    fail "$label: the refusal must say '$expected_fragment' (stderr: $(cat "$work/err"))"
+}
+
+# ---- controls: valid records of every tier are accepted -----------------------
+
+# Without these rows every rejection below is satisfied by a gate that refuses
+# unconditionally, which would refuse the tracked data file too.
+accept_record 'user-scope enforce record' \
+  com.example.user UserKey bool true '' user '' enforce
+accept_record 'ByHost enforce record' \
+  com.example.byhost ByHostKey int 3 current user '' enforce
+accept_record 'system-scope enforce record, default path' \
+  com.example.sys SysKey bool false '' system '' enforce
+accept_record 'system-scope enforce record, explicit path' \
+  com.example.lulu LuLuKey string block '' system /Library/Objective-See/LuLu/preferences.plist enforce
+accept_record 'verify record' \
+  com.example.verify VerifyKey bool true '' user '' verify
+# A manual record streams with an empty type, value, host and plist_path: it
+# carries a runbook pointer and nothing else. Only identity applies.
+accept_record 'manual record carries no payload' \
+  com.example.manual ManualKey '' '' '' user '' manual
+
+# Every member of the supported-type set is accepted, asserted by enumeration
+# rather than by a count: a count matches just as happily when one member has
+# been swapped for a duplicate.
+for supported_type in "${MACOS_DEFAULTS_SUPPORTED_TYPES[@]}"; do
+  accept_record "supported type $supported_type" \
+    com.example.types TypeKey "$supported_type" somevalue '' user '' enforce
+done
+[[ ${#MACOS_DEFAULTS_SUPPORTED_TYPES[@]} -gt 0 ]] ||
+  fail 'the supported-type set must not be empty; an empty loop above would assert nothing'
+
+# ---- identity is required on every record, whatever its tier ------------------
+
+reject_record 'blank domain, enforce' 'blank domain' \
+  '' OrphanKey bool true '' user '' enforce
+reject_record 'blank key, enforce' 'blank key' \
+  com.example.nokey '' bool true '' user '' enforce
+# The tier does not exempt a record from having a name: a manual record with no
+# domain names no control either.
+reject_record 'blank domain, manual' 'blank domain' \
+  '' ManualKey '' '' '' user '' manual
+reject_record 'blank domain, verify' 'blank domain' \
+  '' VerifyKey bool true '' user '' verify
+
+# ---- enforce and verify records must declare a usable type ---------------------
+
+reject_record 'blank type' 'unsupported type' \
+  com.example.notype NoTypeKey '' true '' user '' enforce
+reject_record 'unsupported type' 'unsupported type' \
+  com.example.badtype BadTypeKey bogus true '' user '' enforce
+# The type is rendered as a bare option word by both readers, so a value that
+# smuggles shell syntax through it must be refused rather than quoted.
+reject_record 'injecting type' 'unsupported type' \
+  com.example.injecttype InjectTypeKey 'bool true; touch /tmp/pwned #' true '' user '' enforce
+# A verify record is compared, not written, but it is compared against the value
+# it declares, so the same rule applies to it.
+reject_record 'blank type on a verify record' 'unsupported type' \
+  com.example.noverifytype NoVerifyTypeKey '' true '' user '' verify
+
+# The VALUE rule is deliberately absent from this gate, and this row says so out
+# loud rather than leaving its absence to look like an oversight. The record
+# stream renders an absent value and a legitimately empty one identically, so the
+# gate cannot tell them apart and must not guess; the question is asked of the
+# FILE instead, by defaults_records_declare_a_value, exercised below.
+accept_record 'an empty value is not this gate to judge' \
+  com.example.emptyvalue EmptyValueKey string '' '' user '' enforce
+
+# ---- the value rule, asked of the file -----------------------------------------
+
+# write_value_fixture -- store the fixture on stdin as the file under test.
+# Kept separate from the call below so no heredoc ever sits inside a command
+# substitution: bash accepts that shape but warns about an unterminated
+# here-document on every one, and a suite that prints warnings trains its reader
+# to skim them.
+write_value_fixture() { # (fixture on stdin)
+  cat >"$work/values.yaml"
+}
+
+# declared_value_status -- run defaults_records_declare_a_value over the stored
+# fixture and print its status. stdout and stderr are captured, so a rule that
+# started printing records would be visible rather than mixed into the run.
+declared_value_status() {
+  local status=0
+  defaults_records_declare_a_value "$work/values.yaml" >"$work/out" 2>"$work/err" || status=$?
+  printf '%s' "$status"
+}
+
+# An absent value and an explicit null are the same record error and both are
+# refused, naming the record so it can be found in the file.
+write_value_fixture <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.ok, key: OkKey, type: bool, value: true, tier: enforce}
+    - {domain: com.example.novalue, key: NoValueKey, type: bool, tier: enforce}
+EOF
+value_status="$(declared_value_status)"
+[[ $value_status -eq 2 ]] ||
+  fail "an absent value must be refused with status 2 (got $value_status, stderr: $(cat "$work/err"))"
+grep -qF 'com.example.novalue' "$work/err" ||
+  fail "the refusal must name the record with no value (stderr: $(cat "$work/err"))"
+grep -qF 'blank value' "$work/err" ||
+  fail "the refusal must say the value is the problem (stderr: $(cat "$work/err"))"
+
+write_value_fixture <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.nullvalue, key: NullValueKey, type: bool, value: null, tier: verify}
+EOF
+value_status="$(declared_value_status)"
+[[ $value_status -eq 2 ]] ||
+  fail "an explicitly null value must be refused with status 2 (got $value_status)"
+
+# The distinctions this rule must NOT lose. An empty STRING is a legitimate
+# value, which the runner template renders; refusing it here would make one YAML
+# render cleanly and then make every tool refuse it. A `false` value is the most
+# common one in the tracked file, and it is exactly what a truthiness test eats.
+write_value_fixture <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.emptystring, key: EmptyStringKey, type: string, value: "", tier: enforce}
+    - {domain: com.example.false, key: FalseKey, type: bool, value: false, tier: enforce}
+    - {domain: com.example.zero, key: ZeroKey, type: int, value: 0, tier: verify}
+EOF
+value_status="$(declared_value_status)"
+[[ $value_status -eq 0 ]] ||
+  fail "an empty string, a false and a zero are values, not missing ones (got $value_status, stderr: $(cat "$work/err"))"
+
+# A manual record carries a runbook pointer and no payload, so it is not asked.
+write_value_fixture <<'EOF'
+macos:
+  defaults:
+    - {domain: com.example.manual, key: ManualKey, tier: manual, runbook: Some section}
+EOF
+value_status="$(declared_value_status)"
+[[ $value_status -eq 0 ]] ||
+  fail "a manual record must not be asked for a value (got $value_status, stderr: $(cat "$work/err"))"
+
+write_value_fixture <<'EOF'
+macos:
+  defaults: []
+EOF
+value_status="$(declared_value_status)"
+[[ $value_status -eq 0 ]] ||
+  fail "an empty record list must pass the value rule (got $value_status, stderr: $(cat "$work/err"))"
+
+# ---- the scope, host and plist_path rules are reached through the gate --------
+
+reject_record 'unknown scope' 'unknown scope' \
+  com.example.bogus BogusKey bool true '' bogus '' enforce
+reject_record 'set-but-empty scope' 'unknown scope' \
+  com.example.emptyscope EmptyScopeKey bool true '' '' '' enforce
+reject_record 'system scope with a host' 'ByHost storage is per-user' \
+  com.example.syshost SysHostKey bool true current system '' enforce
+reject_record 'user scope with a plist_path' 'only honored on scope system' \
+  com.example.userpath UserPathKey bool true '' user /Library/Preferences/x.plist enforce
+reject_record 'system-scope traversal domain' 'contains a slash' \
+  '../../tmp/owned' OwnedKey bool true '' system '' enforce
+reject_record 'system-scope relative plist_path' 'absolute path is required' \
+  com.example.rel RelKey bool true '' system 'Library/Preferences/rel.plist' enforce
+reject_record 'system-scope parent-directory plist_path' 'parent-directory component' \
+  com.example.parent ParentKey bool true '' system '/Library/Preferences/../../etc/x.plist' enforce
+
+# ---- an unrecognized tier fails closed ----------------------------------------
+
+# The record stream refuses an unknown tier before this is ever called. The arm
+# is here so that if that ever changes, the gate refuses rather than falling
+# through to "no payload rules apply to this tier".
+reject_record 'unrecognized tier' 'tier' \
+  com.example.mystery MysteryKey bool true '' user '' mystery
+
+# ---- the write-time allowlist is deliberately NOT part of this gate -----------
+
+# drift reads records it must never write, and refusing an odd path in the shared
+# gate would hide the row from the drift report instead of reporting it. The
+# allowlist stays apply's own check; assert the split so a later "tidy-up" that
+# folds it in has to turn this red first.
+accept_record 'out-of-allowlist path passes the shared gate' \
+  com.example.evil EvilKey bool true '' system /etc/example.evil.plist enforce
+allowlist_status=0
+require_system_plist_path_permitted /etc/example.evil.plist 2>"$work/err" || allowlist_status=$?
+[[ $allowlist_status -ne 0 ]] ||
+  fail 'the write-time allowlist must still refuse /etc/example.evil.plist'
+
+printf 'macos-defaults-record-validation: OK (identity is required on every tier; enforce and verify records need a supported type; the value rule is asked of the file and keeps "" false and 0 while refusing an absent value; scope, host and plist_path rules answer through the same gate; an unknown tier fails closed; the write-time allowlist stays outside it)\n'


### PR DESCRIPTION
## Context

macOS settings on this machine are declared in one YAML file and applied by two readers: a chezmoi
template that runs at apply time, and a shell script that can be run on demand. The file is meant to be
declarative, so a malformed file should change nothing.

It did not work that way. The shell reader validated some fields only as it reached each record, so a
bad record partway down the file was caught after the records above it had already been written.

## Summary

- A malformed settings file now writes nothing at all. Previously it applied every record above the bad
  one and then failed, leaving the machine in a state neither the old nor the new file described.
- Two shapes that reported **success** on a malformed file are now refused: a record missing its
  `domain` was silently skipped, and a record missing its `value` was written with an empty value.
- A third shape, found while fixing these, is also refused: a record missing its `type` was written as
  a malformed command and exited 0.
- Validation moved into the shared record stream that every tool reads from, so the drift checker and
  any future tool inherit the same refusal without having to remember to ask for it.
- Refusals now name the offending record by domain and key, rather than describing the problem without
  saying where it is.

## What changed

The fix is structural rather than a longer list of checks. The apply script now runs in two passes:
the first classifies and validates every record and resolves it into the exact write it will become,
and the second executes those plans and makes no decisions about data. Nothing can be written until
every record has been read and accepted.

Putting the per-record rules in the shared stream is what makes the two readers agree by construction.
The stream already emitted nothing until the whole file parsed, so adding the rules there means no
consumer can be handed record N without record N+1 having been checked.

One rule could not live there. An absent `value` and a legitimately empty `value: ""` look identical
once a record is joined into a line, and an empty value is a supported and tested case. Deciding it
from the joined line would have created files that render cleanly and then get refused by every tool.
The check asks the file directly instead, so the two readers agree exactly rather than approximately.

## How it was reviewed

The all-or-nothing property was measured rather than assumed, with the bad record placed first, in the
middle, last, and alone. All four write nothing and exit 2, while an all-valid file still writes, which
is the control that proves the measurement could have seen a write.

Twenty-four mutations ran against a passing control, with 21 killed by a named assertion, including
every mutation that made a refusal report success and every mutation that made validation reject
something legal.

Three behaviours of the tools involved were measured rather than taken from documentation, and one of
them changed the implementation: the YAML processor does not filter as expected after a binding, which
had made an earlier version of the presence check silently wrong.

## Effect of merging

No behaviour changes for a valid settings file. The current tracked file still produces all fifteen of
its records.

For a malformed file the behaviour changes from partial application to refusal, which is the point.
Three shapes that previously exited 0 now exit 2, so a file that appeared to apply cleanly may now be
reported as broken. That is the defect being fixed, not a regression.
