### PR TITLE
test(skills-roster): pin the hermes-owned registry set

### DIFF
--- a/test/unit/skills-roster-fanout.sh
+++ b/test/unit/skills-roster-fanout.sh
@@ -28,11 +28,12 @@
 #      disjoint and their union equals the roster exactly (every roster skill
 #      has exactly one provenance).
 #   6. The lock's hermesRegistry table (skills hermes OWNS from a registry and
-#      the weekly phase updates) is a subset of the roster, each entry is
-#      well-formed (non-empty profiles array, source skills.sh|clawhub|
-#      official, non-empty identifier + lockKey), and it is DISJOINT from the
-#      store-symlinked set: no skill is both hermes-owned and store-symlinked
-#      (a store-fed skill must never be `hermes skills update`d).
+#      the weekly phase updates) holds exactly the pinned hermes-owned set, is
+#      a subset of the roster, each entry is well-formed (non-empty profiles
+#      array, source skills.sh|clawhub|official, non-empty identifier +
+#      lockKey), and it is DISJOINT from the store-symlinked set: no skill is
+#      both hermes-owned and store-symlinked (a store-fed skill must never be
+#      `hermes skills update`d).
 #   7. The hermes symlink declarations equal the non-empty hermesProfiles map
 #      exactly: each store-symlinked skill is declared in exactly its mapped
 #      skills dirs ("default" = dot_hermes/skills, any other profile =
@@ -194,8 +195,38 @@ if [[ $union_sorted != "$roster_sorted" ]]; then
   exit 1
 fi
 
-# --- Rule 6: hermesRegistry is a well-formed, roster-scoped, disjoint set ---
+# --- Rule 6: hermesRegistry is the pinned, well-formed, disjoint set --------
 registry_keys="$(jq -r '.hermesRegistry // {} | keys[]' "$LOCK" | sort)"
+
+# The hermes-owned set, pinned literally like the collision names and the forks
+# exemptions. Every other check in this rule validates the entries that ARE
+# there, so an emptied or wholesale-deleted table satisfied all of them
+# vacuously, and so did dropping a single row: the weekly
+# `hermes -p <profile> skills update <lockKey>` phase would simply stop
+# refreshing those skills, with nothing red anywhere. Adding or removing a
+# hermes-owned skill is a deliberate edit here, in the same commit as the lock.
+HERMES_REGISTRY_EXPECTED=(
+  conventional-commits
+  faceless-explainer
+  general-video
+  hyperframes
+  hyperframes-keyframes
+  hyperframes-registry
+  motion-graphics
+  tiktok-crawling
+  video-transcript-downloader
+)
+# Checked before the set comparison purely for the message: a missing table and
+# a wrong table are different mistakes, and the diff below cannot say which.
+[[ -n $registry_keys ]] ||
+  fail "the lock has no hermesRegistry entries; the weekly hermes registry-update phase would refresh nothing (restore the table, or drop HERMES_REGISTRY_EXPECTED in the same commit if hermes really owns no skills)"
+expected_registry="$(printf '%s\n' "${HERMES_REGISTRY_EXPECTED[@]}" | sort)"
+if [[ $registry_keys != "$expected_registry" ]]; then
+  printf "FAIL: the lock's hermesRegistry table does not hold exactly the pinned hermes-owned set:\n" >&2
+  diff <(printf '%s\n' "$expected_registry") <(printf '%s\n' "$registry_keys") >&2 || true
+  exit 1
+fi
+
 stray_registry="$(comm -23 <(printf '%s\n' "$registry_keys") <(printf '%s\n' "$roster_sorted"))"
 [[ -z $stray_registry ]] || fail "hermesRegistry names a non-roster skill: $stray_registry"
 bad_registry="$(jq -r '.hermesRegistry // {} | to_entries[]


### PR DESCRIPTION
## Context

This chezmoi dotfiles repo keeps its agent-skill delivery in one lock file,
`dot_agents/custom-skill-lock.json`, and one guard test, `test/unit/skills-roster-fanout.sh`, which
fails the build whenever the lock, the skill store and the per-harness symlink declarations stop
agreeing. One of the lock's tables, `hermesRegistry`, lists the skills that hermes (one of the three
agent harnesses this repo provisions, alongside Claude Code and Codex) installed from a registry and
owns itself. The weekly `~/.local/bin/update-skills.sh` run refreshes exactly those entries, calling
`hermes -p <profile> skills update <lockKey>` once per entry.

The guard validated every entry the table contained and said nothing about entries it lacked.
Emptying the table, deleting it outright, or dropping a single row satisfied the roster-subset,
well-formedness and disjointness rules vacuously, so the weekly phase would stop refreshing those
skills with nothing red anywhere. Task #94 asked for the hole to be closed in the test alone.

## Summary

- `test/unit/skills-roster-fanout.sh` pins the nine hermes-owned names in a
  `HERMES_REGISTRY_EXPECTED` array and fails when the lock's `hermesRegistry` keys differ, so
  dropping or adding a row stays red until the guard is edited in the same commit.
- A missing or empty `hermesRegistry` fails with its own message naming the weekly registry-update
  phase, because a table that is gone and a table that is wrong are different mistakes.
- The two new checks run before rule 6's existing roster-subset, well-formedness and disjointness
  checks, so a wrong table reports the specific problem instead of a cascade.
- Rule 6's header comment at the top of the same file now states the pin, so the file's own summary
  matches what it enforces.
- Test-only: no production script, no lock entry and no chezmoi declaration changed.

## How it was verified

Every mutation ran against a sandbox copy of the tree with the lock rewritten by `jq`. The committed
lock was never edited.

Blind spot before the change, `jq 'del(.hermesRegistry)'`:

```
skills-roster-fanout: OK (36 skills; 28 npx-tracked; 3 clawhub-tracked; 0 hermes-owned; 13 store->hermes symlinks; 3 drift-watched upstreams)
=== exit=0 (GREEN)
```

(a) Whole table deleted, `jq 'del(.hermesRegistry)'`:

```
FAIL: the lock has no hermesRegistry entries; the weekly hermes registry-update phase would refresh nothing (restore the table, or drop HERMES_REGISTRY_EXPECTED in the same commit if hermes really owns no skills)
=== exit=1 (RED)
```

Emptying it to `{}` fails identically.

(b) One entry deleted, `jq 'del(.hermesRegistry["tiktok-crawling"])'`:

```
FAIL: the lock's hermesRegistry table does not hold exactly the pinned hermes-owned set:
8d7
< tiktok-crawling
=== exit=1 (RED)
```

(c) Intact lock:

```
skills-roster-fanout: OK (36 skills; 28 npx-tracked; 3 clawhub-tracked; 9 hermes-owned; 13 store->hermes symlinks; 3 drift-watched upstreams)
=== exit=0 (GREEN)
```

The same sandbox with an unmutated lock is green as well, so the reds above come from the mutations
and not from the sandbox. Two further mutations: adding an entry without editing the pin fails with
`7a8 > new-hub-skill`, and mapping `conventional-commits` into a hermes profile still trips the
pre-existing disjointness rule.

## Effect of merging

A lock edit that empties `hermesRegistry`, deletes it, or drops one of its rows now fails
`just test-unit`, at the commit hook and in CI. Nothing changes on the live machine: no skill is
installed, moved or refreshed by this pull request, and `dot_local/bin/executable_update-skills.sh`
is untouched.

## Review guide

One file matters, `test/unit/skills-roster-fanout.sh`, rule 6. Compare the pinned names against
`jq -r '.hermesRegistry | keys[]' dot_agents/custom-skill-lock.json`, then check the ordering: the
non-empty check has to precede the set comparison, and both have to precede the older subset and
well-formedness checks, or the failure messages stop naming the actual mistake.

Two further checks were weighed and left out. A string-type rule on `lockKey` and `identifier`, the
one the forks table gets from its `unusable()` helper, guards against an unquoted value read back
through `jq -r`; the slip that motivated it there is an all-digit tree hash, and a skill name is
never all digits. A boolean-type rule on the optional `held` field would not change any outcome
either: the updater compares `held`'s `tostring` against `"true"`, so `"true"` still means held and
every other mistyping leaves the skill being updated, which is the safe direction.
