### PR TITLE
fix(gitconfig): derive the Homebrew prefix instead of pinning /opt/homebrew

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,3 +1,6 @@
+{{- /* Homebrew prefix, derived from platform data rather than from a `brew --prefix` at apply time, which would need brew already installed to render this file. Every absolute Homebrew path below comes from it; test/unit/gitconfig-homebrew-prefix-derivation.sh fails if one is pinned to a literal again. */ -}}
+{{- $platform := printf "%s/%s" .chezmoi.os .chezmoi.arch -}}
+{{- $homebrewPrefix := index (dict "darwin/arm64" "/opt/homebrew" "darwin/amd64" "/usr/local") $platform | default "/home/linuxbrew/.linuxbrew" -}}
 [user]
   name = Stephen A. Davis
   email = 23553256+webdavis@users.noreply.github.com
@@ -10,7 +13,7 @@
   defaultBranch = main
 
 [gpg]
-  program = /opt/homebrew/bin/gpg
+  program = {{ $homebrewPrefix }}/bin/gpg
 
 [core]
   editor = nvim
@@ -80,7 +83,7 @@
 # test/unit/gitconfig-tool-and-url-hygiene.sh asserts that both stay absent.
 [difftool "nvimdiff"]
   # Shadows the built-in nvimdiff diff command, for `git difftool` only.
-  cmd = /opt/homebrew/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"
+  cmd = {{ $homebrewPrefix }}/bin/nvim -d -u ~/.config/nvim/init.lua \"$LOCAL\" \"$REMOTE\"
 
 [diff]
   submodule = log
@@ -139,11 +142,11 @@
 
 [credential "https://github.com"]
   helper =
-  helper = !/opt/homebrew/bin/gh auth git-credential
+  helper = !{{ $homebrewPrefix }}/bin/gh auth git-credential
 
 [credential "https://gist.github.com"]
   helper =
-  helper = !/opt/homebrew/bin/gh auth git-credential
+  helper = !{{ $homebrewPrefix }}/bin/gh auth git-credential
 
 # Shorthand and legacy-URL rewrites. Every one of them lands on SSH, because SSH
 # and HTTPS are the only transports GitHub still answers. GitHub permanently

--- a/test/unit/gitconfig-homebrew-prefix-derivation.sh
+++ b/test/unit/gitconfig-homebrew-prefix-derivation.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# gitconfig-homebrew-prefix-derivation.sh, dot_gitconfig.tmpl must reach every
+# Homebrew binary through one derived prefix rather than a literal /opt/homebrew.
+#
+# Why this file needs a guard of its own. The template names four absolute
+# Homebrew paths, and one of them is [gpg] program. commit.gpgSign is true here,
+# so on a machine whose Homebrew prefix is not /opt/homebrew (an Intel Mac at
+# /usr/local, Linuxbrew at /home/linuxbrew/.linuxbrew) git cannot find the
+# signing binary and EVERY commit aborts with "gpg failed to sign the data". The
+# other three cost one command each: git difftool, and GitHub credentials on
+# fetch and push.
+#
+# Why the checks render instead of grepping the paths. This template calls
+# keepassxc for the signing key, so treefmt's shellcheck-rendered-template
+# formatter excludes it and nothing else in this repo renders it either. A Go
+# template mistake in the derivation would therefore surface first at
+# `chezmoi apply`, against the operator's real ~/.gitconfig. The checks below
+# replace the one vault action with a literal before handing anything to chezmoi,
+# so no unlock is ever attempted and a broken derivation fails here instead.
+#
+# The invariants:
+#   1. No literal Homebrew prefix outside the mapping. Pinning a call site back
+#      to a literal is the regression this file exists to catch, and invariant 3
+#      catches it as well, from the other side: a pinned site keeps answering
+#      /opt/homebrew when the platform says otherwise.
+#   2. The mapping answers every platform this repo can be applied on, checked by
+#      rendering the mapping line itself against a list of platform strings. An
+#      unknown platform must fall back rather than resolve to nothing, since an
+#      empty prefix yields /bin/gpg, which exists on macOS and is not Homebrew's.
+#   3. Each of the four call sites resolves to <prefix>/bin/<binary>, checked by
+#      rendering the whole file with the platform forced to an Intel Mac and
+#      parsing the result with git config --file, the same parser git uses at
+#      runtime. Forcing the platform is what makes the answer identical on this
+#      machine, on CI, and on the flake's x86_64-linux, and it exercises the case
+#      the derivation exists for rather than the one this machine happens to be.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GITCONFIG_TEMPLATE="$REPO_ROOT/dot_gitconfig.tmpl"
+
+# The line that declares the platform string, and the line that maps it to a
+# prefix. Kept apart in the template so this test can force the platform without
+# touching the mapping, which is the part under test. Both are Go template source
+# searched for literally, so the `$` must not expand.
+# shellcheck disable=SC2016
+PLATFORM_DECLARATION='$platform :='
+# shellcheck disable=SC2016
+PREFIX_MAPPING='$homebrewPrefix :='
+
+# Every prefix Homebrew installs under, so invariant 1 can say "no literal
+# prefix, anywhere" rather than "no literal /opt/homebrew".
+HOMEBREW_PREFIXES=(/opt/homebrew /usr/local /home/linuxbrew/.linuxbrew)
+
+# What the mapping must answer, per platform. The two linux rows are not
+# redundant: Homebrew installs at the same prefix on both linux architectures,
+# and a mapping keyed on os/arch has to spell that out or leave one of them
+# unanswered. The last row is a platform nothing here targets, pinning the
+# fallback: an unmapped platform must still name a plausible prefix.
+PLATFORMS=(darwin/arm64 darwin/amd64 linux/amd64 linux/arm64 plan9/386)
+# The keys are quoted because an unquoted subscript is an arithmetic expression,
+# and shfmt rewrites the `/` in one as a division operator.
+declare -A EXPECTED_PREFIX_BY_PLATFORM=(
+  ["darwin/arm64"]=/opt/homebrew
+  ["darwin/amd64"]=/usr/local
+  ["linux/amd64"]=/home/linuxbrew/.linuxbrew
+  ["linux/arm64"]=/home/linuxbrew/.linuxbrew
+  ["plan9/386"]=/home/linuxbrew/.linuxbrew
+)
+
+# The platform invariant 3 renders at, and the prefix it must produce. An Intel
+# Mac is deliberately not this machine's platform.
+RENDER_PLATFORM=darwin/amd64
+RENDER_PREFIX=/usr/local
+
+# The four call sites, as git config keys, with the Homebrew binary each must
+# name. Config keys rather than line numbers, so the assertion survives any
+# reordering of the file and reads what git itself would read.
+CONFIG_KEYS=(
+  gpg.program
+  difftool.nvimdiff.cmd
+  'credential.https://github.com.helper'
+  'credential.https://gist.github.com.helper'
+)
+declare -A EXPECTED_BINARY_BY_CONFIG_KEY=(
+  [gpg.program]=gpg
+  [difftool.nvimdiff.cmd]=nvim
+  ['credential.https://github.com.helper']=gh
+  ['credential.https://gist.github.com.helper']=gh
+)
+
+# Stands in for the one keepassxc action, which cannot be rendered by automation.
+# A path-shaped literal, so it cannot be mistaken for a resolved prefix.
+VAULT_PLACEHOLDER=CHEZMOI_VAULT_PLACEHOLDER
+
+# Bug class 11: git exports GIT_DIR and friends into every hook, and a stale one
+# would redirect the config reads below at the wrong repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+  GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_COUNT GIT_PREFIX
+export GIT_CONFIG_NOSYSTEM=1 GIT_PAGER=cat PAGER=cat
+
+fail() {
+  printf 'gitconfig-homebrew-prefix-derivation: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+# Answers "which line numbers hold this fragment?", one per line. Fixed-string,
+# because every fragment here carries regex metacharacters.
+line_numbers_containing() { # <fragment> <file>
+  grep -nF -- "$1" "$2" | cut -d: -f1
+}
+
+# Answers "how many lines hold this fragment?".
+count_lines_containing() { # <fragment> <file>
+  line_numbers_containing "$1" "$2" | grep -c . || true
+}
+
+# Renders a template through chezmoi with an isolated HOME, so the authoring
+# machine's chezmoi configuration cannot change the answer. Read-only: it renders
+# what is handed to it and never touches the destination state.
+render_template() { # <input-file> <output-file>
+  HOME="$render_home" CI=1 chezmoi --source "$REPO_ROOT" \
+    execute-template --no-tty <"$1" >"$2"
+}
+
+# Answers "which prefix does one call site resolve to?", printing the binary path
+# the value starts with. A credential helper value carries git's `!` shell escape
+# in front of the path, and the difftool value carries arguments after it, so the
+# path is the first whitespace-separated token with any leading `!` removed. A
+# key can legitimately hold several values (the helpers reset the list with an
+# empty value first), and exactly one of them names a binary.
+site_binary_path() { # <rendered-config> <config-key>
+  local rendered="$1" key="$2" value token found="" matches=0
+  while IFS= read -r value; do
+    token="${value%%[[:space:]]*}"
+    token="${token#!}"
+    [[ $token == */bin/* ]] || continue
+    matches=$((matches + 1))
+    found="$token"
+  done < <(git config --file "$rendered" --get-all "$key" || true)
+  ((matches == 1)) || return 1
+  printf '%s\n' "$found"
+}
+
+[[ -f $GITCONFIG_TEMPLATE ]] || fail "missing template: $GITCONFIG_TEMPLATE"
+command -v git >/dev/null 2>&1 || fail "git is not on PATH"
+command -v chezmoi >/dev/null 2>&1 ||
+  fail "chezmoi is not on PATH; the derivation cannot be rendered, and grepping the template alone would not notice a Go template mistake in it"
+
+work="$(mktemp -d)"
+# `trash` is the operator's rule for interactive removals; a committed test has
+# to run on a bare CI runner, where only coreutils exist.
+trap 'rm -rf "$work"' EXIT
+render_home="$work/render-home"
+mkdir -p "$render_home"
+
+# ---- the derivation exists, once ------------------------------------------
+# Both halves are located before anything else runs, because every invariant
+# below is stated in terms of them and a missing or duplicated declaration would
+# otherwise surface as a confusing render failure.
+for fragment in "$PLATFORM_DECLARATION" "$PREFIX_MAPPING"; do
+  found="$(count_lines_containing "$fragment" "$GITCONFIG_TEMPLATE")"
+  ((found == 1)) ||
+    fail "expected exactly one line declaring '$fragment' in $GITCONFIG_TEMPLATE, found $found; the Homebrew prefix must be derived in one place and reused, so that no call site can drift onto a prefix of its own"
+done
+mapping_line_number="$(line_numbers_containing "$PREFIX_MAPPING" "$GITCONFIG_TEMPLATE")"
+
+# ---- 1: no literal Homebrew prefix outside the mapping --------------------
+for prefix in "${HOMEBREW_PREFIXES[@]}"; do
+  while IFS= read -r hit; do
+    ((hit == mapping_line_number)) ||
+      fail "$GITCONFIG_TEMPLATE:$hit pins a literal Homebrew prefix ($prefix). Every absolute Homebrew path in this file has to come from the mapping on line $mapping_line_number, or the file works on one machine's prefix only"
+  done < <(line_numbers_containing "$prefix" "$GITCONFIG_TEMPLATE")
+done
+
+# ---- 2: the mapping answers every platform --------------------------------
+# The mapping line is used verbatim, with the platform supplied by a range rather
+# than by the host, so one render covers every platform at once.
+mapping_probe="$work/mapping-probe.tmpl"
+# shellcheck disable=SC2016 # Go template variables, expanded by chezmoi, not here
+{
+  printf '{{ range $platform := list'
+  printf ' "%s"' "${PLATFORMS[@]}"
+  printf ' }}\n'
+  grep -F -- "$PREFIX_MAPPING" "$GITCONFIG_TEMPLATE"
+  printf '{{ $platform }} {{ $homebrewPrefix }}\n'
+  printf '{{ end }}\n'
+} >"$mapping_probe"
+
+mapping_answers="$work/mapping-answers"
+render_template "$mapping_probe" "$mapping_answers" ||
+  fail "chezmoi could not render the prefix mapping from $GITCONFIG_TEMPLATE:$mapping_line_number; that same mistake would abort chezmoi apply on the real ~/.gitconfig"
+
+for platform in "${PLATFORMS[@]}"; do
+  expected="${EXPECTED_PREFIX_BY_PLATFORM[$platform]}"
+  answered="$(awk -v want="$platform" '$1 == want { print $2 }' "$mapping_answers")"
+  [[ $answered == "$expected" ]] ||
+    fail "the mapping answers '$answered' for $platform, expected '$expected'; Homebrew's prefix on that platform is $expected, and a wrong or empty answer sends every path in this file at a directory Homebrew never installed to"
+done
+
+# ---- 3: every call site resolves through the mapping ----------------------
+# The whole file, with the platform forced and the vault action neutralized, so
+# the render needs no unlock and answers for a machine that is not this one.
+render_input="$work/gitconfig-forced-platform.tmpl"
+# shellcheck disable=SC2016 # a Go template variable, expanded by chezmoi, not here
+printf '{{- $platform := "%s" -}}\n' "$RENDER_PLATFORM" >"$render_input"
+grep -vF -- "$PLATFORM_DECLARATION" "$GITCONFIG_TEMPLATE" |
+  sed -E "s/\{\{[^}]*keepassxc[^}]*\}\}/$VAULT_PLACEHOLDER/g" >>"$render_input"
+grep -q 'keepassxc' "$render_input" &&
+  fail "a keepassxc action survived neutralization; refusing to render $GITCONFIG_TEMPLATE, since doing so would try to unlock the vault"
+
+rendered="$work/gitconfig-forced-platform"
+render_template "$render_input" "$rendered" ||
+  fail "chezmoi could not render $GITCONFIG_TEMPLATE for $RENDER_PLATFORM; that same mistake would abort chezmoi apply on the real ~/.gitconfig"
+git config --file "$rendered" --list >/dev/null 2>&1 ||
+  fail "the render of $GITCONFIG_TEMPLATE for $RENDER_PLATFORM is not parseable by git config --file"
+
+for key in "${CONFIG_KEYS[@]}"; do
+  binary="${EXPECTED_BINARY_BY_CONFIG_KEY[$key]}"
+  path="$(site_binary_path "$rendered" "$key")" ||
+    fail "$key does not name exactly one Homebrew binary in the $RENDER_PLATFORM render; expected one value naming $RENDER_PREFIX/bin/$binary"
+  [[ $path == "$RENDER_PREFIX/bin/$binary" ]] ||
+    fail "$key resolves to '$path' on $RENDER_PLATFORM, expected '$RENDER_PREFIX/bin/$binary'. A path that stayed at another prefix is pinned rather than derived, and on that machine this key names a binary that is not there"
+done
+
+printf 'gitconfig-homebrew-prefix-derivation: OK (one mapping, no literal prefixes, %d platforms mapped, %d call sites derived)\n' \
+  "${#PLATFORMS[@]}" "${#CONFIG_KEYS[@]}"

--- a/test/unit/gitconfig-tool-and-url-hygiene.sh
+++ b/test/unit/gitconfig-tool-and-url-hygiene.sh
@@ -83,6 +83,16 @@ PLACEHOLDER="CHEZMOI_TEMPLATE_PLACEHOLDER"
 # placeholder cannot stand in for one, so their presence means this test's
 # neutralizer no longer models the file and must be taught to.
 CONTROL_FLOW_ACTIONS='{{-?[[:space:]]*(if|else|end|range|with|block|define|template)\b'
+# Go template actions that EMIT NOTHING: a comment, and a variable assignment.
+# Both render to the empty string, so the neutralizer drops the whole line rather
+# than standing a literal in for it, since a bare placeholder on its own line is
+# not a config line git can parse. dot_gitconfig.tmpl derives the Homebrew prefix
+# this way, one step per line.
+NON_EMITTING_ACTION_LINE='^[[:space:]]*\{\{-?[[:space:]]*(/\*.*\*/|\$[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:=.*)[[:space:]]*-?\}\}[[:space:]]*$'
+# The same two actions sharing a line with config text. Dropping such a line would
+# take the config text with it, so the line-of-its-own shape above is required
+# rather than assumed.
+INLINE_NON_EMITTING_ACTION='\{\{[^}]*(:=|/\*)'
 
 # Bug class 11: git exports GIT_DIR and friends into every hook, and a stale one
 # would redirect the config reads below at the wrong repository. XDG_CONFIG_HOME
@@ -256,14 +266,21 @@ DELIVERED_SYMLINK_TARGET_PATHS="$(list_chezmoi_delivered_target_paths "$CHEZMOI_
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
+stripped="$work/gitconfig.tmpl"
 parsed="$work/gitconfig"
 
+# grep rather than sed, because the pattern carries the `/` of a comment
+# delimiter, which sed would read as the end of its address.
+grep -Ev "$NON_EMITTING_ACTION_LINE" "$GITCONFIG_TEMPLATE" >"$stripped"
 # Fail closed: neutralizing a control-flow action into a literal would silently
-# change which sections the parser sees.
-if grep -Eq "$CONTROL_FLOW_ACTIONS" "$GITCONFIG_TEMPLATE"; then
+# change which sections the parser sees, and an assignment or comment left inline
+# would have taken a config line with it had the line been dropped.
+if grep -Eq "$CONTROL_FLOW_ACTIONS" "$stripped"; then
   fail "$GITCONFIG_TEMPLATE now uses Go template control flow; this test's neutralizer only handles value actions and must be updated"
 fi
-sed -E "s/\{\{[^}]*\}\}/$PLACEHOLDER/g" "$GITCONFIG_TEMPLATE" >"$parsed"
+grep -Eq "$INLINE_NON_EMITTING_ACTION" "$stripped" &&
+  fail "$GITCONFIG_TEMPLATE now puts a Go template assignment or comment on a line that also carries config text; this test's neutralizer drops such actions by the line and must be updated"
+sed -E "s/\{\{[^}]*\}\}/$PLACEHOLDER/g" "$stripped" >"$parsed"
 grep -q '{{' "$parsed" && fail "template directives survived neutralization; the parsed config is not trustworthy"
 git config --file "$parsed" --list >/dev/null 2>&1 ||
   fail "the neutralized template is not parseable by git config --file"


### PR DESCRIPTION
## Context

This repository is a chezmoi dotfiles tree. `dot_gitconfig.tmpl` is the source template for
`~/.gitconfig`, and because it pulls a GPG (GNU Privacy Guard) signing subkey ID out of KeePassXC it can
only be rendered from an interactive terminal with the vault unlocked. Nothing in continuous integration
renders it either: treefmt's shellcheck-rendered-template formatter deliberately excludes every template
that calls `keepassxc`.

The file named `/opt/homebrew` in four places. That is the Homebrew prefix on Apple silicon and nowhere
else: an Intel Mac installs at `/usr/local` and Linuxbrew at `/home/linuxbrew/.linuxbrew`. One of the four
is `[gpg] program`, and `[commit] gpgSign` is `true`, so on either of those machines git cannot find the
signing binary and every commit aborts with "gpg failed to sign the data" before the rest of the workflow
is reached.

## Summary

- `dot_gitconfig.tmpl` now declares the Homebrew prefix once, at the top of the file, from `.chezmoi.os`
  and `.chezmoi.arch`: `darwin/arm64` maps to `/opt/homebrew`, `darwin/amd64` to `/usr/local`, and
  anything else falls back to `/home/linuxbrew/.linuxbrew`.
- The four sites that spelled out `/opt/homebrew` read that variable instead: `[gpg] program`,
  `[difftool "nvimdiff"] cmd`, and the `gh` credential helper under both
  `[credential "https://github.com"]` and `[credential "https://gist.github.com"]`.
- The prefix comes from chezmoi's platform data, not from a `brew --prefix` at apply time, so rendering
  the file does not depend on Homebrew being installed first.
- `test/unit/gitconfig-homebrew-prefix-derivation.sh` is a new guard: no literal Homebrew prefix outside
  the mapping, the mapping answers every platform, and each of the four call sites resolves to
  `<prefix>/bin/<binary>` in a render with the platform forced to an Intel Mac.
- `test/unit/gitconfig-tool-and-url-hygiene.sh` neutralizes this template so `git config --file` can parse
  it, and its neutralizer now drops Go template actions that emit nothing (comments and assignments)
  instead of substituting a literal for them, which would leave a line git cannot parse.

## How it was verified

One literal prefix remains in the file, on the mapping line:

```
$ grep -n "opt/homebrew\|usr/local\|linuxbrew" dot_gitconfig.tmpl
3:{{- $homebrewPrefix := index (dict "darwin/arm64" "/opt/homebrew" "darwin/amd64" "/usr/local") $platform | default "/home/linuxbrew/.linuxbrew" -}}
```

The guard was written before the template change and failed for the right reason, that the derivation did
not exist yet: `expected exactly one line declaring '$platform :=' in dot_gitconfig.tmpl, found 0`.

Three mutations, each against a green control (`OK (one mapping, no literal prefixes, 5 platforms mapped,
4 call sites derived)`), each reverted afterwards:

- `[gpg] program` pinned back to `/opt/homebrew/bin/gpg`:
  `FAIL -- dot_gitconfig.tmpl:16 pins a literal Homebrew prefix (/opt/homebrew)`.
- `[gpg] program` pointed at the platform variable instead of the prefix, which no grep would catch:
  `FAIL -- gpg.program resolves to 'darwin/amd64/bin/gpg' on darwin/amd64, expected '/usr/local/bin/gpg'`.
- `darwin/amd64` mapped to `/opt/homebrew` in the dict:
  `FAIL -- the mapping answers '/opt/homebrew' for darwin/amd64, expected '/usr/local'`.

A fourth mutation covers the neutralizer change: a Go template assignment placed on a line that also
carries config text makes `gitconfig-tool-and-url-hygiene` fail closed rather than drop the config text
with it.

Render check on this machine, with the one vault action replaced by a literal first so KeePassXC is never
touched: rendering before and after the change produces byte-identical output, 7320 bytes, `diff` exit 0.

`just l` reports 0 files changed. `just test` green.

## Effect of merging

Merging applies nothing. Nothing on this machine changes before the D1 cutover.

When it is applied, the rendered `~/.gitconfig` on this arm64 machine is intended to be identical to the
current one, byte for byte, and the render check above measured exactly that: `darwin/arm64` maps back to
`/opt/homebrew`, which is what the four sites spelled out before. The change is visible only on a machine
with a different Homebrew prefix, where those four paths now point at that machine's prefix instead of at
a directory it does not have.

## Review guide

The block to scrutinize is lines 1 to 3 of `dot_gitconfig.tmpl`, in particular whether the platform keys
and prefixes in the `dict` are right, and whether the `default` fallback is the wanted answer for a
platform the dict does not name. The four call sites it feeds are `[gpg] program` (line 16),
`[difftool "nvimdiff"] cmd` (line 86), and the two `gh` credential helpers (lines 145 and 149).

Second is the neutralizer change in `test/unit/gitconfig-tool-and-url-hygiene.sh`. It now deletes whole
lines before substituting, and what keeps that safe is the `INLINE_NON_EMITTING_ACTION` check, which fails
if such an action ever shares a line with config text.
