### PR TITLE
feat(claude-commands): rebuild the git and pull request slash commands on gh-axi

### DIFF
--- a/private_dot_claude/commands/amend.md
+++ b/private_dot_claude/commands/amend.md
@@ -1,0 +1,46 @@
+---
+description: Amend the last commit, refusing to rewrite pushed history without explicit confirmation.
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(git log:*)
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - Bash(git rev-list:*)
+  - Skill
+  - Read
+---
+
+# Amend
+
+Fold the current changes into the last commit, keeping or regenerating its conventional message.
+
+## Steps
+
+1. Run `git log -1 --format='%h %s'` and `git status --short` so the target commit and the pending
+   changes are both on the table.
+1. Decide whether the commit is published: `git rev-parse --abbrev-ref '@{u}'` names the upstream,
+   and `git rev-list --count '@{u}'..HEAD` reports how many local commits sit above it. A count of
+   zero means HEAD is already on the remote, so amending rewrites published history.
+1. When HEAD is published, stop and say so. Amending it needs a follow-up force-push, so it takes
+   per-invocation confirmation from the operator. A yes given earlier does not carry over. Wait for
+   an explicit answer before touching anything.
+1. Stage the changes that belong in the commit, by path.
+1. Amend. Keep the existing message with `git commit --amend --no-edit` when the subject still
+   describes the commit. When it no longer does, invoke the `conventional-commits` skill, write a
+   fresh message, and pass it with `git commit --amend -m "<subject>"`.
+1. Report the rewritten commit's short SHA and subject, and, when it was published, the exact
+   force-push command the operator now needs.
+
+## Safeguards
+
+- The message never carries a `Co-Authored-By` trailer, any Claude or Anthropic co-author line, or a
+  "Generated with Claude Code" footer.
+- No em-dashes in the message.
+- Never amend a commit on `main`.
+- Never run the force-push yourself as part of this command. When one is needed it is
+  `git push --force-with-lease`, never `--force`, and it is the operator's call.
+- Bail when HEAD is a merge commit, when a rebase or cherry-pick is in progress, or when the
+  repository has no commits yet. Report which one blocked it.

--- a/private_dot_claude/commands/clean-gone.md
+++ b/private_dot_claude/commands/clean-gone.md
@@ -1,0 +1,44 @@
+---
+description: Prune local branches whose upstream is gone, worktrunk-aware, deleting nothing unconfirmed.
+allowed-tools:
+  - Bash(git fetch:*)
+  - Bash(git branch:*)
+  - Bash(git worktree:*)
+  - Bash(git status:*)
+  - Bash(git rev-parse:*)
+  - Bash(wt:*)
+---
+
+# Clean Gone Branches
+
+Delete local branches whose remote tracking branch is gone, without fighting worktrunk.
+
+Worktrunk owns the worktrees in this repository and sets `delete-branch = false`, so a branch ref
+that outlives its merged pull request is deliberate, not leftover garbage. Treat that config as
+correct and never change it from here.
+
+## Steps
+
+1. Run `git fetch --all --prune`.
+1. Run `git branch -vv` and collect every branch whose upstream is marked `[gone]`. Drop the current
+   branch and `main` from that list unconditionally.
+1. Run `git worktree list` and split the remaining branches into two groups: those with no worktree,
+   and those checked out in a worktree.
+1. Present both groups with the exact command proposed for each branch:
+   - no worktree: `git branch -D <branch>`
+   - has a worktree: `wt remove <branch> --force-delete`, which is worktrunk's own teardown and
+     removes the worktree along with the branch
+1. Ask the operator to confirm, and name the branches in the question. This is a destructive action
+   and it takes per-invocation confirmation; a yes given earlier in the session does not carry over.
+   Wait for an explicit answer.
+1. Run only the deletions that were confirmed, one command at a time, and report each result.
+
+## Safeguards
+
+- Never delete the current branch, `main`, or a branch whose upstream is not `[gone]`.
+- Never run `git worktree remove --force`, `git branch -D`, or `wt remove --force-delete` before the
+  confirmation in step 5. Each of those discards work that no remote holds.
+- A branch checked out in a worktree cannot be deleted by `git branch -D`. Route it through `wt`
+  rather than forcing git past the worktree.
+- Report a dirty worktree instead of forcing removal past it, and let the operator decide.
+- Do not edit worktrunk's config, and do not pass `--yes` to `wt` on the operator's behalf.

--- a/private_dot_claude/commands/commit-push-pr.md
+++ b/private_dot_claude/commands/commit-push-pr.md
@@ -1,0 +1,107 @@
+---
+description: Commit, push the branch, and open a pull request through gh-axi with a reviewed body.
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(git push:*)
+  - Bash(git switch:*)
+  - Bash(git branch:*)
+  - Bash(git log:*)
+  - Bash(git rev-parse:*)
+  - Bash(npx -y gh-axi:*)
+  - Skill
+  - Read
+  - Write
+---
+
+# Commit, Push, PR
+
+Commit the current work, push the branch, and open a pull request. Every GitHub operation runs
+through `npx -y gh-axi`. The bare `gh` CLI is never invoked directly; it exists only as gh-axi's
+runtime dependency.
+
+## Steps
+
+1. Run `git rev-parse --abbrev-ref HEAD`. When the branch is `main`, create a topic branch first with
+   `git switch -c <type>/<short-slug>` named after the change. Never commit to `main`.
+1. Stage one logical unit by path, invoke the `conventional-commits` skill for the message, and
+   commit. The message never carries a `Co-Authored-By` trailer, any Claude or Anthropic co-author
+   line, or a "Generated with Claude Code" footer.
+1. Push with `git push -u origin <branch>`.
+1. Draft the pull request body into a file (for example `/tmp/pr-body.md`) using the template in the
+   next section. Do not call gh-axi yet.
+
+## Pull request body template
+
+Write all five sections, in this order, into the body file:
+
+```
+## Context
+
+## Summary
+
+## How it was verified
+
+## Effect of merging
+
+## Review guide
+```
+
+- `## Context` says why the change exists: the problem and what prompted it. Two short paragraphs at
+  most, with any shorthand defined where it first appears.
+- `## Summary` says what changed: three to five short bullets, each one self-contained, so deleting
+  any bullet strips no context another bullet needs. Name key files by path. Add a `## What changed`
+  section only when the pull request is too large for `## Summary` to carry it.
+- `## How it was verified` lists the commands that were run and what they reported. Evidence, never
+  "should work".
+- `## Effect of merging` says what merging does and what it does not do, including whether anything
+  changes on a live machine.
+- `## Review guide` is triage, not enumeration: the reading order, which files are load-bearing and
+  which are mechanical churn, a behavioral note per load-bearing file, and where a second pair of
+  eyes helps most. On a small pull request one or two lines is the right length. It never describes
+  how the change was produced internally.
+
+## Review the draft before posting
+
+This step is mandatory and it runs before any gh-axi call. Re-read the drafted body and fix every
+violation of the two lists below, then re-read it once more.
+
+Structure:
+
+- All five headings are present, spelled exactly as above, in that order.
+- Every `## Summary` bullet stands alone.
+- `## How it was verified` names real commands and real results.
+
+Anti-AI-pattern checklist:
+
+- No em-dashes anywhere in the body.
+- No "not just X but Y" and no other negative parallelism.
+- No inflated significance: no "comprehensive", "robust", "seamless", "crucial", "game-changing".
+- No vague attribution: no "studies show", "it is widely considered", "best practice suggests".
+- No rule-of-three padding: three items only when there are exactly three things.
+- Never speak about the audience in the third person. Imperative directions such as "see the
+  coverage matrix" are fine; "a reader will find" is not.
+
+## Post the pull request
+
+Only once the review above passes:
+
+```
+npx -y gh-axi pr create --title "<conventional subject>" --body-file /tmp/pr-body.md
+```
+
+Pass the body with `--body-file`. Never pass it as an inline argument, which mangles newlines.
+Report the pull request number and URL.
+
+## Safeguards
+
+- Never post an unreviewed body. If the review step was skipped, redo it before creating anything.
+- Never invoke `gh` directly for any of this, and never allowlist it.
+- Never push to `main`, and never force-push to `main` under any circumstances.
+- A force-push to a topic branch uses `--force-with-lease`, never `--force`, and needs
+  per-invocation confirmation from the operator. A yes given earlier does not carry over.
+- If a hook rejects the commit or the push, report its output verbatim and stop. Never retry with
+  `--no-verify`.
+- Do not merge the pull request. Opening it is where this command stops.

--- a/private_dot_claude/commands/commit.md
+++ b/private_dot_claude/commands/commit.md
@@ -1,0 +1,38 @@
+---
+description: Stage one logical unit of work and create a single conventional commit. No push.
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(git log:*)
+  - Bash(git rev-parse:*)
+  - Skill
+  - Read
+---
+
+# Commit
+
+Create ONE conventional commit from the current changes. Never push.
+
+## Steps
+
+1. Run `git status --short` and `git diff --stat` to see what is uncommitted.
+1. Decide whether the changes are one logically distinct unit of work. If they are more than one,
+   list the units, ask which unit to commit now, and stage only that unit. Never fold unrelated
+   units into a single commit.
+1. Stage by path with `git add <path>...`. Use `git add -A` only when the whole working tree is the
+   one unit, and say so when you do.
+1. Invoke the `conventional-commits` skill and write the message to its specification: a
+   `type(scope): subject` line, an optional body saying why, optional footers.
+1. Commit with `git commit -m "<subject>"`, adding further `-m` arguments for body paragraphs.
+1. Report the new commit's short SHA and subject line.
+
+## Safeguards
+
+- The message never carries a `Co-Authored-By` trailer, any Claude or Anthropic co-author line, or a
+  "Generated with Claude Code" footer. The commit reads as the operator's own work.
+- No em-dashes in the subject, the body, or the footers.
+- Bail when nothing is staged and nothing can be staged; report the empty tree instead of committing.
+- Do not amend, reset, rebase, or push. This command only ever adds one commit.
+- If a hook rejects the commit, report its output verbatim and stop. Never retry with `--no-verify`.

--- a/private_dot_claude/commands/pr-merge.md
+++ b/private_dot_claude/commands/pr-merge.md
@@ -1,16 +1,28 @@
 # PR Merge
 
-Squash-merge the current PR, delete the remote branch, switch back to main, and pull latest.
+Merge the current PR with a merge commit, delete the remote branch, switch back to main, and pull
+latest. Every GitHub operation runs through `npx -y gh-axi`; the bare `gh` CLI is never invoked
+directly.
 
 ## Steps
 
-1. Run `gh pr merge --squash --delete-branch` for the current PR.
+1. Run `git rev-parse --abbrev-ref HEAD` for the current branch, then
+   `npx -y gh-axi pr list --head <branch>` to get its PR number.
+1. Merge it, substituting the real number and branch into both lines:
+
+```
+SUBJECT="Merge pull request #<number> from webdavis/<branch> (#<number>)"
+npx -y gh-axi pr merge <number> --merge --delete-branch --subject "$SUBJECT"
+```
+
 1. Run `git checkout main`.
 1. Run `git pull`.
-1. Report success or the specific failure mode if any step fails.
+1. Report success, quoting the merge commit subject, or the specific failure mode if any step fails.
 
 ## Safeguards
 
 - Bail if there's no PR associated with the current branch.
 - Bail if working tree isn't clean (report what's uncommitted).
 - Do not force-merge over failing checks, report them and wait for user direction.
+- The merge method is a merge commit. Do not substitute another method, and do not drop `--subject`;
+  the trailing `(#<number>)` is the convention this repository's history follows.

--- a/private_dot_claude/commands/pr.md
+++ b/private_dot_claude/commands/pr.md
@@ -1,0 +1,98 @@
+---
+description: Open a pull request for an already-pushed branch through gh-axi with a reviewed body.
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - Bash(npx -y gh-axi:*)
+  - Read
+  - Write
+---
+
+# PR
+
+Open a pull request for the branch that is already pushed. Every GitHub operation runs through
+`npx -y gh-axi`. The bare `gh` CLI is never invoked directly; it exists only as gh-axi's runtime
+dependency.
+
+## Steps
+
+1. Run `git rev-parse --abbrev-ref HEAD` and `git status --short`. Bail when the branch is `main`,
+   when the working tree is dirty, or when the branch has commits that are not pushed. Report which
+   of those blocked it.
+1. Read the branch's commits with `git log origin/main..HEAD` and its diff with
+   `git diff origin/main...HEAD --stat` so the body describes the real change.
+1. Draft the pull request body into a file (for example `/tmp/pr-body.md`) using the template in the
+   next section. Do not call gh-axi yet.
+
+## Pull request body template
+
+Write all five sections, in this order, into the body file:
+
+```
+## Context
+
+## Summary
+
+## How it was verified
+
+## Effect of merging
+
+## Review guide
+```
+
+- `## Context` says why the change exists: the problem and what prompted it. Two short paragraphs at
+  most, with any shorthand defined where it first appears.
+- `## Summary` says what changed: three to five short bullets, each one self-contained, so deleting
+  any bullet strips no context another bullet needs. Name key files by path. Add a `## What changed`
+  section only when the pull request is too large for `## Summary` to carry it.
+- `## How it was verified` lists the commands that were run and what they reported. Evidence, never
+  "should work".
+- `## Effect of merging` says what merging does and what it does not do, including whether anything
+  changes on a live machine.
+- `## Review guide` is triage, not enumeration: the reading order, which files are load-bearing and
+  which are mechanical churn, a behavioral note per load-bearing file, and where a second pair of
+  eyes helps most. On a small pull request one or two lines is the right length. It never describes
+  how the change was produced internally.
+
+## Review the draft before posting
+
+This step is mandatory and it runs before any gh-axi call. Re-read the drafted body and fix every
+violation of the two lists below, then re-read it once more.
+
+Structure:
+
+- All five headings are present, spelled exactly as above, in that order.
+- Every `## Summary` bullet stands alone.
+- `## How it was verified` names real commands and real results.
+
+Anti-AI-pattern checklist:
+
+- No em-dashes anywhere in the body.
+- No "not just X but Y" and no other negative parallelism.
+- No inflated significance: no "comprehensive", "robust", "seamless", "crucial", "game-changing".
+- No vague attribution: no "studies show", "it is widely considered", "best practice suggests".
+- No rule-of-three padding: three items only when there are exactly three things.
+- Never speak about the audience in the third person. Imperative directions such as "see the
+  coverage matrix" are fine; "a reader will find" is not.
+
+## Post the pull request
+
+Only once the review above passes:
+
+```
+npx -y gh-axi pr create --title "<conventional subject>" --body-file /tmp/pr-body.md
+```
+
+Pass the body with `--body-file`. Never pass it as an inline argument, which mangles newlines.
+Report the pull request number and URL.
+
+## Safeguards
+
+- Never post an unreviewed body. If the review step was skipped, redo it before creating anything.
+- Never invoke `gh` directly for any of this, and never allowlist it.
+- Bail rather than pushing on the operator's behalf; use `/commit-push-pr` when the branch still
+  needs a commit or a push.
+- Do not merge the pull request. Opening it is where this command stops.

--- a/private_dot_claude/commands/sync-worktrees.md
+++ b/private_dot_claude/commands/sync-worktrees.md
@@ -1,0 +1,28 @@
+---
+description: Rebase every worktree against its upstream by running worktrunk's `wt up`, then report.
+allowed-tools:
+  - Bash(wt:*)
+  - Bash(git worktree:*)
+  - Bash(git status:*)
+---
+
+# Sync Worktrees
+
+Bring every worktree up to date with its upstream. Worktrunk already owns this operation, so this
+command runs it and reports; it adds no logic of its own.
+
+## Steps
+
+1. Run `wt up`. That fetches with `--prune` and then rebases each worktree onto its own upstream,
+   skipping any worktree with no upstream and any worktree already mid-rebase, and aborting a rebase
+   that conflicts rather than leaving the worktree stuck.
+1. Report the outcome per worktree, quoting worktrunk's own lines verbatim for anything it skipped
+   or could not rebase.
+1. Run `wt list` when the output is ambiguous, and report that instead of guessing.
+
+## Safeguards
+
+- Do not resolve a conflict that worktrunk backed out of. Name the worktree and the branch and stop;
+  the operator picks that up in the worktree itself.
+- Do not pass `--yes`, and do not add flags worktrunk was not asked for.
+- Do not commit, push, or delete anything here. This command only rebases.

--- a/private_dot_claude/commands/uncommit.md
+++ b/private_dot_claude/commands/uncommit.md
@@ -1,0 +1,38 @@
+---
+description: Undo the last commit with a soft reset, keeping every change staged.
+allowed-tools:
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git reset:*)
+  - Bash(git branch:*)
+  - Bash(git rev-parse:*)
+  - Bash(git rev-list:*)
+---
+
+# Uncommit
+
+Move the last commit back into the staging area. The changes survive; only the commit goes away.
+
+## Steps
+
+1. Run `git log -1 --format='%h %s'` and show which commit is about to be undone.
+1. Decide whether the commit is published: `git rev-parse --abbrev-ref '@{u}'` names the upstream,
+   and `git rev-list --count '@{u}'..HEAD` reports how many local commits sit above it. A count of
+   zero means HEAD is already on the remote, so undoing it rewrites published history.
+1. When HEAD is published, stop and say so. Removing it needs a follow-up force-push, so it takes
+   per-invocation confirmation from the operator. A yes given earlier does not carry over. Wait for
+   an explicit answer before touching anything.
+1. Run `git reset --soft HEAD~1`.
+1. Run `git status --short` and report what is now staged, so the recovered changes are visible.
+
+## Safeguards
+
+- `--soft` only. Never `git reset --hard` and never `git reset --mixed` from this command; both
+  throw away work that no commit holds any more.
+- Never uncommit on `main`.
+- Never run the force-push yourself. When one is needed it is `git push --force-with-lease`, never
+  `--force`, and it is the operator's call.
+- Bail when HEAD is a merge commit, when a rebase or cherry-pick is in progress, or when HEAD is the
+  repository's only commit, and say which one blocked it.
+- Undo exactly one commit. For more than one, say how many and let the operator confirm the depth.

--- a/test/unit/claude-commands-govern.sh
+++ b/test/unit/claude-commands-govern.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# claude-commands-govern.sh, the custom slash commands under
+# private_dot_claude/commands/ are PROMPTS. Nothing executes them at apply time,
+# no formatter reads them (treefmt.nix excludes the whole directory from
+# mdformat so the YAML frontmatter survives), and the model that runs one has
+# only the file itself for context. So a rule that rots out of one of these
+# files fails silently, at the moment the operator invokes the command and the
+# wrong thing happens to a real repository. Every property asserted here is one
+# of those rules.
+#
+# WHY EACH GROUP EXISTS.
+#
+#   gh-axi. The operator's standing rule is that every GitHub operation goes
+#   through gh-axi and never through the bare `gh` CLI, which stays installed
+#   purely as gh-axi's runtime dependency. This is exactly what disqualified the
+#   commit-commands plugin these files replace: it hard-coded `gh pr create` and
+#   allowlisted `Bash(gh pr create:*)`. So the bare token is refused in the prose
+#   AND in the frontmatter allowlist, and the gh-axi form is required positively,
+#   because refusing a token no file contains would pass an empty file.
+#
+#   The five-section pull request template. The operator locked the structure
+#   (Context / Summary / How it was verified / Effect of merging / Review guide)
+#   and the order. A command that keeps the words but drops a section produces a
+#   body nobody notices is short, so the headings are pinned individually and
+#   their ORDER is pinned by line number.
+#
+#   The review step, and its position. The template alone is a suggestion. What
+#   makes it hold is a mandatory re-read of the draft against the structure and
+#   the anti-AI-pattern checklist BEFORE the body is posted. A prompt is read top
+#   to bottom, so a review instruction sitting after the create call is a review
+#   that never runs. That is why this file compares line numbers rather than only
+#   asserting both strings are present somewhere.
+#
+#   --body-file. Passing a multi-paragraph body as an inline argument mangles it.
+#   The body file is also what the review step reviews.
+#
+#   Destructive-action confirmation. CLAUDE.md requires per-invocation
+#   confirmation for branch deletion, force-push, worktree removal, and rewriting
+#   published history, and says a blanket yes does not carry over. Both halves are
+#   required here, because "ask first" without "a previous yes does not count" is
+#   the version that gets talked past.
+#
+#   Em-dashes. A hard operator rule, and these files are the prompts that teach
+#   the model what to write, so an em-dash here propagates into commit messages
+#   and pull request bodies.
+#
+#   The roster. The file list is asserted as a SET. Without that, a new GitHub
+#   command dropped into the directory would be governed by nothing at all, which
+#   is the drift this guard exists to prevent; adding one has to be a deliberate
+#   edit here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly COMMANDS_DIR="$REPO_ROOT/private_dot_claude/commands"
+
+# Every command file in the directory, without the .md suffix. This is the
+# complete set: a file present here and absent from disk, or on disk and absent
+# here, is a failure either way.
+readonly -a ALL_COMMANDS=(
+  'amend'
+  'clean-gone'
+  'commit'
+  'commit-push-pr'
+  'pr'
+  'pr-merge'
+  'sync-worktrees'
+  'uncommit'
+)
+
+# The commands that carry YAML frontmatter. pr-merge.md predates the convention
+# and is deliberately left as plain markdown, so it is not in this list; it is
+# still covered by every content rule below.
+readonly -a FRONTMATTER_COMMANDS=(
+  'amend'
+  'clean-gone'
+  'commit'
+  'commit-push-pr'
+  'pr'
+  'sync-worktrees'
+  'uncommit'
+)
+
+# The commands that talk to GitHub.
+readonly -a GITHUB_COMMANDS=(
+  'commit-push-pr'
+  'pr'
+  'pr-merge'
+)
+
+# The commands that open a pull request, so they carry the body template, the
+# review step, and the create call.
+readonly -a PR_CREATING_COMMANDS=(
+  'commit-push-pr'
+  'pr'
+)
+
+# The commands that write a commit message.
+readonly -a COMMIT_MESSAGE_COMMANDS=(
+  'amend'
+  'commit'
+  'commit-push-pr'
+)
+
+# The commands that can destroy work: branch deletion and worktree removal
+# (clean-gone), rewriting published history (amend, uncommit), force-push
+# (commit-push-pr).
+readonly -a DESTRUCTIVE_COMMANDS=(
+  'amend'
+  'clean-gone'
+  'commit-push-pr'
+  'uncommit'
+)
+
+# The five template headings, in the one order the operator locked.
+readonly -a TEMPLATE_HEADINGS=(
+  '## Context'
+  '## Summary'
+  '## How it was verified'
+  '## Effect of merging'
+  '## Review guide'
+)
+
+# The review step's heading, and the create call it has to precede.
+readonly REVIEW_STEP_HEADING='## Review the draft before posting'
+readonly PR_CREATE_CALL='gh-axi pr create'
+
+# Anti-AI-pattern items the review step checks the draft against. Named
+# individually so that gutting the checklist down to its heading fails here.
+readonly -a REVIEW_CHECKLIST_ITEMS=(
+  'em-dashes'
+  'not just X but Y'
+  'inflated significance'
+  'vague attribution'
+  'rule-of-three'
+  'third person'
+)
+
+# A bare `gh` invocation. The leading class keeps `gh-axi pr create` and any
+# other hyphenated or word-internal `gh` out of it; only `gh` standing alone and
+# followed by a GitHub subcommand matches.
+readonly BARE_GH_CALL_PATTERN='(^|[^-[:alnum:]_])gh[[:space:]]+(pr|issue|release)([[:space:]]|$)'
+
+# A Bash allowlist entry for the bare CLI. `Bash(npx -y gh-axi:*)` does not match:
+# the character after `gh` is a hyphen.
+readonly BARE_GH_ALLOWLIST_PATTERN='Bash\(gh([^-]|$)'
+
+# The inline body flag. `--body-file` does not match, its next character is a
+# hyphen.
+readonly INLINE_BODY_FLAG_PATTERN='--body([^-]|$)'
+
+# The merge subject convention, matching the placeholder form the command
+# documents and a filled-in one alike.
+readonly MERGE_SUBJECT_PATTERN='Merge pull request #[^ ]+ from webdavis/[^ ]+ \(#[^)]+\)'
+
+# Built rather than written literally: a test that forbids a character may not
+# contain it either.
+EM_DASH="$(printf '\xe2\x80\x94')"
+readonly EM_DASH
+
+failures=0
+assertions=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+command_path() { # <command>
+  printf '%s/%s.md' "$COMMANDS_DIR" "$1"
+}
+
+# require_pattern <command> <extended-regex> <what-it-means>
+require_pattern() {
+  assertions=$((assertions + 1))
+  grep -Eq -- "$2" "$(command_path "$1")" ||
+    fail "$1.md: $3 (nothing matches /$2/)"
+}
+
+# require_literal <command> <fixed-string> <what-it-means>
+require_literal() {
+  assertions=$((assertions + 1))
+  grep -Fq -- "$2" "$(command_path "$1")" ||
+    fail "$1.md: $3 (the text '$2' is absent)"
+}
+
+# refuse_pattern <command> <extended-regex> <what-it-means>
+refuse_pattern() {
+  assertions=$((assertions + 1))
+  local hits
+  hits="$(grep -En -- "$2" "$(command_path "$1")" || true)"
+  [[ -z $hits ]] || fail "$1.md: $3; found: $hits"
+}
+
+# refuse_literal <command> <fixed-string> <what-it-means>
+refuse_literal() {
+  assertions=$((assertions + 1))
+  local hits
+  hits="$(grep -Fn -- "$2" "$(command_path "$1")" || true)"
+  [[ -z $hits ]] || fail "$1.md: $3; found: $hits"
+}
+
+# A heading is asserted as a WHOLE LINE, not as a substring. Measured by
+# mutation: with a substring check, deleting `## Context` from the template
+# block still passed, because the prose bullet explaining that section mentions
+# the same words. Only the literal heading line is the template.
+#
+# require_heading <command> <heading-line> <what-it-means>
+require_heading() {
+  assertions=$((assertions + 1))
+  grep -Fxq -- "$2" "$(command_path "$1")" ||
+    fail "$1.md: $3 (no line reads exactly '$2')"
+}
+
+# literal_line_number <command> <fixed-string> -- the first line containing it,
+# or nothing when it is absent.
+literal_line_number() {
+  local hit
+  hit="$(grep -Fn -m1 -- "$2" "$(command_path "$1")")" || return 1
+  printf '%s' "${hit%%:*}"
+}
+
+# heading_line_number <command> <heading-line> -- the first line that IS it.
+heading_line_number() {
+  local hit
+  hit="$(grep -Fxn -m1 -- "$2" "$(command_path "$1")")" || return 1
+  printf '%s' "${hit%%:*}"
+}
+
+# The roster is a SET: everything declared is on disk, and nothing else is. A
+# per-file existence check alone would leave a new command governed by nothing.
+disk_commands=()
+for path in "$COMMANDS_DIR"/*.md; do
+  [[ -e $path ]] || fail "no command files at all under $COMMANDS_DIR"
+  base="$(basename "$path")"
+  disk_commands+=("${base%.md}")
+done
+declared_roster="$(printf '%s\n' "${ALL_COMMANDS[@]}" | sort)"
+disk_roster="$(printf '%s\n' ${disk_commands[@]+"${disk_commands[@]}"} | sort)"
+assertions=$((assertions + 1))
+[[ $declared_roster == "$disk_roster" ]] ||
+  fail "the declared roster and $COMMANDS_DIR disagree; declared [$(printf '%s ' "${ALL_COMMANDS[@]}")], on disk [$(printf '%s ' ${disk_commands[@]+"${disk_commands[@]}"})]"
+
+for name in "${ALL_COMMANDS[@]}"; do
+  path="$(command_path "$name")"
+  assertions=$((assertions + 1))
+  [[ -s $path ]] || {
+    fail "$name.md is missing or empty at $path"
+    continue
+  }
+
+  # An em-dash in a prompt propagates into whatever the prompt writes.
+  refuse_literal "$name" "$EM_DASH" 'contains an em-dash, which the operator forbids everywhere'
+
+  # Nobody allowlists the bare CLI, whatever the command does.
+  refuse_pattern "$name" "$BARE_GH_ALLOWLIST_PATTERN" \
+    'allowlists the bare gh CLI in its frontmatter; allowlist Bash(npx -y gh-axi:*) instead'
+done
+
+for name in "${FRONTMATTER_COMMANDS[@]}"; do
+  assertions=$((assertions + 1))
+  [[ $(head -n 1 "$(command_path "$name")") == '---' ]] ||
+    fail "$name.md does not open with a --- frontmatter fence, so Claude Code reads no metadata"
+  require_pattern "$name" '^description: .+' 'has no frontmatter description'
+  require_pattern "$name" '^allowed-tools:' \
+    'has no frontmatter allowed-tools, so its Bash is unscoped'
+  require_pattern "$name" '^  - [A-Za-z]' \
+    'declares no allowed-tools entries, so the allowlist is empty'
+done
+
+for name in "${GITHUB_COMMANDS[@]}"; do
+  require_literal "$name" 'npx -y gh-axi' 'never names gh-axi, so it has no sanctioned way to reach GitHub'
+  refuse_pattern "$name" "$BARE_GH_CALL_PATTERN" \
+    'invokes the bare gh CLI; every GitHub operation goes through npx -y gh-axi'
+done
+
+for name in "${PR_CREATING_COMMANDS[@]}"; do
+  require_literal "$name" 'Bash(npx -y gh-axi:*)' \
+    'does not allowlist gh-axi, so the create call it prescribes is not permitted'
+
+  # The five headings, each present, and in the locked order.
+  previous_line=0
+  previous_heading=''
+  for heading in "${TEMPLATE_HEADINGS[@]}"; do
+    require_heading "$name" "$heading" "omits the '$heading' section of the pull request template"
+    if heading_line="$(heading_line_number "$name" "$heading")"; then
+      assertions=$((assertions + 1))
+      if ((heading_line <= previous_line)); then
+        fail "$name.md: '$heading' (line $heading_line) does not follow '$previous_heading' (line $previous_line); the template order is locked"
+      fi
+      previous_line="$heading_line"
+      previous_heading="$heading"
+    fi
+  done
+
+  # The review step itself, and its checklist.
+  require_heading "$name" "$REVIEW_STEP_HEADING" \
+    'has no mandatory review step, so nothing checks the body before it is posted'
+  for item in "${REVIEW_CHECKLIST_ITEMS[@]}"; do
+    require_literal "$name" "$item" "review checklist no longer mentions '$item'"
+  done
+
+  # The review step must come BEFORE the create call: a prompt runs top to
+  # bottom, so a review below the create call is a review that never happens.
+  require_literal "$name" "$PR_CREATE_CALL" 'never calls gh-axi pr create, so it opens no pull request'
+  if review_line="$(heading_line_number "$name" "$REVIEW_STEP_HEADING")" &&
+    create_line="$(literal_line_number "$name" "$PR_CREATE_CALL")"; then
+    assertions=$((assertions + 1))
+    ((review_line < create_line)) ||
+      fail "$name.md: the create call (line $create_line) is at or above the review step (line $review_line), so the body can be posted unreviewed"
+  fi
+
+  # The body travels as a file, never as an inline argument.
+  require_literal "$name" '--body-file' 'does not pass the pull request body with --body-file'
+  refuse_pattern "$name" "$INLINE_BODY_FLAG_PATTERN" \
+    'passes the pull request body inline, which mangles a multi-paragraph body'
+done
+
+for name in "${COMMIT_MESSAGE_COMMANDS[@]}"; do
+  require_literal "$name" 'conventional-commits' \
+    'does not invoke the conventional-commits skill for the message'
+  require_pattern "$name" 'never[[:print:]]*Co-Authored-By' \
+    'does not forbid a Co-Authored-By trailer, which every commit here must be free of'
+done
+
+for name in "${DESTRUCTIVE_COMMANDS[@]}"; do
+  require_literal "$name" 'per-invocation confirmation' \
+    'does not demand per-invocation confirmation before a destructive action'
+  require_literal "$name" 'does not carry over' \
+    'does not say that an earlier yes stops counting, which is what makes the confirmation per-invocation'
+done
+
+# pr-merge.md was written for a squash convention this repository does not use.
+refuse_pattern 'pr-merge' '[Ss]quash' \
+  'still mentions squashing; the convention is a merge commit'
+require_pattern 'pr-merge' '(^|[[:space:]])--merge([[:space:]]|$)' \
+  'does not pass --merge, so it would take gh-axi default merge method'
+require_pattern 'pr-merge' "$MERGE_SUBJECT_PATTERN" \
+  'does not spell out the "Merge pull request #N from webdavis/<branch> (#N)" subject convention'
+
+if ((failures > 0)); then
+  printf '\nclaude-commands-govern: %d failure(s) across %d assertions\n' "$failures" "$assertions" >&2
+  exit 1
+fi
+
+printf 'PASS: %d assertions over %d command prompts in %s\n' \
+  "$assertions" "${#ALL_COMMANDS[@]}" 'private_dot_claude/commands'


### PR DESCRIPTION
## Context

Claude Code's `commit-commands` plugin ships convenient one-shot git commands, and it is installed here
but disabled for a concrete reason: its `/commit-push-pr` hard-codes `gh pr create` and allowlists
`Bash(gh pr create:*)`, which conflicts with the standing rule that every GitHub operation goes through
gh-axi (a wrapper CLI invoked as `npx -y gh-axi`) and never through the bare `gh` CLI.

This branch rebuilds the useful commands as custom slash commands in `private_dot_claude/commands/`
(chezmoi's source for `~/.claude/commands/`, which already held `pr-merge.md`), with the rules written
into each prompt rather than left to the executing model's recall of CLAUDE.md. The plugin stays
disabled.

## Summary

- Adds seven command prompts under `private_dot_claude/commands/`: `commit.md`, `commit-push-pr.md`,
  `pr.md`, `clean-gone.md`, `amend.md`, `uncommit.md`, and `sync-worktrees.md`.
- Both pull-request commands (`commit-push-pr.md` and `pr.md`) inline the locked five-section body
  template and a mandatory self-review step that sits above the `gh-axi pr create` call in the file, so
  the body cannot reach GitHub unreviewed. The body is passed with `--body-file`.
- Fixes `private_dot_claude/commands/pr-merge.md`, which described a squash merge and called the bare
  `gh` CLI. It now runs `npx -y gh-axi pr merge <number> --merge --delete-branch` with the subject
  `Merge pull request #N from webdavis/<branch> (#N)`.
- `clean-gone.md` and `sync-worktrees.md` defer to worktrunk instead of fighting it: a gone branch that
  owns a worktree is routed through `wt remove`, and `sync-worktrees` is a thin wrapper of `wt up`.
- Adds `test/unit/claude-commands-govern.sh`, 120 assertions over the eight prompts, each one
  mutation-verified against an unmutated control (table below).

## How it was verified

- `just l` (treefmt over the tree): traversed 603 files, emitted 374, **0 changed**.
- `shellcheck -x test/unit/claude-commands-govern.sh`: clean.
- `just test` (all four suites): exit 0, zero `not ok` and zero failing scripts, 328 bats assertions
  passing.
- `test/unit/claude-commands-govern.sh` standalone: `PASS: 120 assertions over 8 command prompts`.
- Each of the three commits passed the pre-commit gate on its own (unit suite plus a gitleaks scan
  reporting no leaks).

Every assertion was mutation-verified. Each row applies one mutation to a pristine snapshot, runs the
guard, records the first failure, and restores; the last row is the unmutated control.

| # | Mutation | Verdict | First failure reported |
| - | -------- | ------- | ---------------------- |
| M01 | swap `gh-axi` for `gh` in a create call | RED | `pr.md` invokes the bare gh CLI |
| M02 | stop naming gh-axi at all (`pr-merge.md`) | RED | never names gh-axi |
| M03 | allowlist `Bash(gh pr create:*)` in frontmatter | RED | allowlists the bare gh CLI |
| M04 | delete the `## Effect of merging` heading | RED | omits that template section |
| M05 | swap `## Summary` and `## How it was verified` | RED | template order is locked |
| M06 | delete the review step heading | RED | has no mandatory review step |
| M07 | delete the em-dash item from the checklist | RED | checklist no longer mentions it |
| M08 | move the create call above the review step | RED | body can be posted unreviewed |
| M09 | stop passing the body as a file | RED | does not pass the body with `--body-file` |
| M10 | pass the body inline instead | RED | passes the body inline |
| M11 | stop invoking the `conventional-commits` skill | RED | does not invoke the skill |
| M12 | delete the Co-Authored-By prohibition | RED | does not forbid the trailer |
| M13 | drop "per-invocation" from a confirmation | RED | does not demand per-invocation confirmation |
| M14 | delete the "does not carry over" clause | RED | an earlier yes would still count |
| M15 | insert an em-dash | RED | contains an em-dash |
| M16 | reintroduce the squash wording in `pr-merge.md` | RED | still mentions squashing |
| M17 | drop the `--merge` flag | RED | does not pass `--merge` |
| M18 | drop the merge subject convention | RED | does not spell out the subject |
| M19 | add an ungoverned `rogue.md` | RED | roster and directory disagree |
| M20 | delete a command file | RED | roster and directory disagree |
| M21 | empty a command file | RED | missing or empty |
| M22 | drop the frontmatter fence | RED | no `---` fence, so no metadata |
| M23 | drop the frontmatter `description` | RED | has no description |
| M24 | drop every `allowed-tools` entry | RED | allowlist is empty |
| M25 | drop the gh-axi allowlist entry | RED | create call is not permitted |
| M26 | CONTROL, no mutation | GREEN | `PASS: 120 assertions` |

M04 exposed a real weakness on the first pass. The heading-presence assertion used substring matching,
so deleting `## Effect of merging` from the template block still satisfied it: the prose bullet that
explains that section repeats the same words. The guard went red anyway, but through the ordering check
rather than the assertion that should have caught it. The heading assertions now match whole lines, and
M04 fails on the heading itself.

## Effect of merging

Merging changes nothing on a live machine. These are plain files, so they reach `~/.claude/commands/`
only at the next `chezmoi apply`, and no apply has been run (pre-cutover freeze). The commands are inert
until someone invokes one.

It does not re-enable the `commit-commands` plugin, and it does not touch the global CLAUDE.md rule that
routes pull request descriptions through the humanizer skill; that wording update belongs to the
separate global-rules refactor.

One property worth knowing: `treefmt.nix` excludes `private_dot_claude/commands/**` from mdformat, so
that YAML frontmatter survives (mdformat without the frontmatter plugin turns `---` into a horizontal
rule plus a heading and breaks command discovery). The 105-column wrap in these files is therefore held
by hand and by review; the guard checks content rules, not line width.

## Review guide

Read `private_dot_claude/commands/commit-push-pr.md` first. It is the longest prompt and every other
command is a subset of its rules. `pr.md` repeats the same body machinery without the commit and push
steps; that duplication is deliberate, since a slash command cannot include another one.

`test/unit/claude-commands-govern.sh` is the load-bearing file. The assertion worth the closest look is
the review-step ordering, which compares line numbers rather than presence: a prompt is read top to
bottom, so a review instruction below the create call is a review that never runs.

`pr-merge.md` is a small independent fix and sits in its own commit. Everything else in the diff is
prose.
