### PR TITLE
fix(ssh-hardening): bound the child verify so a hang rolls the install back

### DIFF
--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -54,6 +54,13 @@
 #                       overridden KEYSCAN_BIN that never returns holds the
 #                       reload for as long as it blocks -- the bound limits
 #                       how many times a probe runs, not how long one takes.
+#   SSH_HARDENING_VERIFY_DEADLINE
+#                       seconds the child verify may run before it is stopped
+#                       and reported as a FAILED verify (default 120; see
+#                       VERIFY_DEADLINE_SECONDS for why that bound is safe and
+#                       what an expiry costs). Anything but a positive whole
+#                       number is the default. The override exists for tests,
+#                       which cannot wait out the real bound.
 #   SSH_HARDENING_ALLOW_MISSING_SSHD
 #                       explicit test seam: when set to a TRUE-ish value AND
 #                       $SSHD_BIN cannot run, --verify skips (exit 0) WITHOUT a
@@ -325,7 +332,73 @@ EOF
 
 VERIFY_FAILURES=()
 
-# run_verify_child: re-run this script's --verify in a CHILD shell. bash
+# How long the child verify may run before it is stopped and reported as a
+# FAILED verify, how long the stopped process group gets to unwind before it is
+# killed outright, and what the wait is made of.
+#
+# WHY A BOUND EXISTS. The install path is a transaction that rolls back when a
+# step RETURNS a failure, and a step that never returns is neither a success nor
+# a failure. The child verify can be one: measured 2026-08-01, a single named
+# pipe in the drop-in directory makes `sshd -G` block forever, because sshd
+# resolves its own Include globs with no type filter (see resolve_include_paths).
+# On such a tree the install stopped after publishing the drop-in, never reached
+# rollback_install, and left the tree half-applied with the run stuck. Bounding
+# the wait turns that into a failure, which is what puts the EXISTING rollback
+# back on that path; nothing else about the transaction changes.
+#
+# WHY 120 SECONDS IS SAFE. Measured against a sandbox tree with the real
+# /usr/sbin/sshd on macOS 26.2: a three-file tree verifies in 0.22s, and a
+# deliberately oversized one verifies in 5.1s. The oversized tree is a single
+# 1.0 MB file matched by the stock `Include <dir>/*`, which is the shape
+# MAX_CONFIG_TREE_BYTES was set against and roughly two hundred times the live
+# tree. The bound is 545 times the first measurement and 23 times the second.
+#
+# WHAT AN EXPIRY COSTS, said plainly because the comment this replaced refused a
+# bound on the grounds that "a verify killed for being slow would roll the
+# hardening back OFF a machine that was fine". It does not: rollback_install
+# restores what THIS run found, so a machine hardened before the run gets its own
+# drop-in and legacy file back byte for byte, and a machine with no hardening
+# before the run ends where it started. An expiry costs an install that did not
+# apply and says so, which is re-runnable. No bound costs a tree left
+# half-applied by a run that never returns.
+#
+# A value that is not a positive whole number of seconds is the DEFAULT, never
+# taken at face value: 0 would stop every verify at once, and a non-number would
+# make the arithmetic in run_verify_child a shell error.
+VERIFY_DEADLINE_SECONDS="${SSH_HARDENING_VERIFY_DEADLINE:-120}"
+[[ $VERIFY_DEADLINE_SECONDS =~ ^[1-9][0-9]*$ ]] || VERIFY_DEADLINE_SECONDS=120
+VERIFY_STOP_GRACE_SECONDS=2
+# The wait POLLS, because bash has no wait-with-timeout. A quarter second and
+# not a whole one: the check runs before the first sleep, so a whole-second
+# interval would charge every healthy verify up to a second it does not need,
+# and every install runs one. The deadline is counted in TICKS so the fractional
+# interval cannot drift away from the seconds the operator-facing message
+# quotes.
+VERIFY_POLL_INTERVAL='0.25'
+VERIFY_POLL_TICKS_PER_SECOND=4
+# The poll's delay tool. ABSOLUTE for the reason SLEEP_BIN is, and SEPARATE from
+# SLEEP_BIN because that seam is --reload's pacing knob: the suites point it at
+# an instant-return spy, which would turn this poll into a busy spin and put the
+# watchdog's ticks into the seam log every other assertion diffs.
+VERIFY_POLL_SLEEP='/bin/sleep'
+
+# stop_verify_child <pid>: stop a verify that is past its deadline, and
+# everything it started. TERM to the whole PROCESS GROUP, then KILL to the same
+# group after the grace: the chain is this shell -> bash -> sshd, and sshd is
+# the process actually blocked, so signalling the group leader alone would leave
+# the real sshd holding the open forever. The group id IS the child's pid
+# (run_verify_child starts it under monitor mode for exactly this), and the child
+# is not reaped until after both kills, so its pid cannot be recycled underneath
+# them. Never fails: a group that exited between the deadline check and here is
+# the same outcome as one that took the signal.
+stop_verify_child() {
+  local child_pid="$1"
+  kill -TERM -"$child_pid" 2>/dev/null || :
+  "$VERIFY_POLL_SLEEP" "$VERIFY_STOP_GRACE_SECONDS" || :
+  kill -KILL -"$child_pid" 2>/dev/null || :
+}
+
+# run_verify_child: re-run this script's --verify in a CHILD shell, bounded. bash
 # suppresses `set -e` for everything inside an `if !` or `||` test, and that
 # suppression reaches into called functions and even into subshells (confirmed
 # on bash 3.2), so a caller judging the tree from inside such a test would run
@@ -334,13 +407,58 @@ VERIFY_FAILURES=()
 # `set -euo pipefail`, so every caller judges the tree by exactly the rules
 # --verify applies on its own. The seams are passed explicitly so the child
 # inspects the tree the caller just changed whether or not they were exported.
+#
+# Both callers read the result the same way they always did: nonzero is a failed
+# verify, and a verify stopped at its deadline returns nonzero like any other.
+# No `timeout(1)` is involved, stock macOS ships none; the bound is the poll
+# below.
 run_verify_child() {
+  local child_pid ticks=0 status=0
+  local deadline_ticks=$((VERIFY_DEADLINE_SECONDS * VERIFY_POLL_TICKS_PER_SECOND))
+  # Monitor mode across the launch and nothing else. It is what puts the child
+  # in a process group of its own, which is what lets stop_verify_child reach
+  # the sshd underneath it; without it the child shares this shell's group and
+  # the only safe signal target is the child alone.
+  #
+  # What the separate group COSTS, said rather than left to be found: Ctrl-C
+  # goes to the foreground group, so it no longer reaches this child. An
+  # operator who interrupts a hung install inside the deadline leaves that
+  # verify running, where before it died with this shell. What is left behind is
+  # a blocked reader that writes nothing, and the deadline it was interrupted
+  # before is what would otherwise have collected it.
+  #
+  # stdin from /dev/null: an UNmonitored background job gets that for free,
+  # a monitored one keeps the shell's stdin, and a child reading a terminal
+  # from its own process group is stopped by SIGTTIN, which is a hang of its
+  # own. Nothing in --verify reads stdin, and this keeps it that way.
+  set -m
   SSHD_CONFIG_D="$SSHD_CONFIG_D" \
     SSHD_MAIN_CONFIG="$SSHD_MAIN_CONFIG" \
     SSHD_BIN="$SSHD_BIN" \
     SSH_HARDENING_SUDO="$SSH_HARDENING_SUDO" \
     SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
-    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify
+    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify </dev/null &
+  child_pid=$!
+  set +m
+  while [[ $ticks -lt $deadline_ticks ]] && kill -0 "$child_pid" 2>/dev/null; do
+    "$VERIFY_POLL_SLEEP" "$VERIFY_POLL_INTERVAL"
+    ticks=$((ticks + 1))
+  done
+  if kill -0 "$child_pid" 2>/dev/null; then
+    printf '[ssh-hardening] verify TIMED OUT: the check was still running after %ss and is being stopped. A verify that never returns is treated as a FAILED verify, so exactly what a reported failure does happens now. One known cause: a named pipe reached through an Include glob, which blocks sshd forever on the open.\n' \
+      "$VERIFY_DEADLINE_SECONDS" >&2
+    # The reap, and the job-control notice it draws, go to /dev/null: the child
+    # was started under monitor mode, so bash announces the termination itself
+    # ("Terminated: 15") at the next command boundary, and that line reads as an
+    # internal error beside the message above.
+    {
+      stop_verify_child "$child_pid"
+      wait "$child_pid"
+    } 2>/dev/null || :
+    return 1
+  fi
+  { wait "$child_pid"; } 2>/dev/null || status=$?
+  return "$status"
 }
 
 # verify_skip_allowed: the SSH_HARDENING_ALLOW_MISSING_SSHD seam is ON only for
@@ -1265,26 +1383,28 @@ verify() {
 # exactly as it was found, because refusing to CLAIM success is not the same
 # as refusing to CAUSE harm and the previous version did only the first.
 #
-# WHERE THAT PROPERTY STOPS, because "if any step fails" reads wider than it
-# is. The rollback runs when a step RETURNS a failure. A step that never
-# returns is a different thing, and the child verify can be one: sshd blocks
+# WHERE THAT PROPERTY USED TO STOP, because "if any step fails" reads wider
+# than it is. The rollback runs when a step RETURNS a failure, and a step that
+# never returns is a different thing. The child verify was one: sshd blocks
 # forever on a named pipe reached through its Include glob (measured, see
-# resolve_include_paths). Measured 2026-08-01 on such a tree, the install stops
-# after printing "wrote <target>" and "removed legacy drop-in <legacy>",
-# rollback_install is never reached, and both the published drop-in and the
-# dot-prefixed .<legacy>.saved copy stay. Killing it does not recover either:
-# SIGINT and SIGTERM reach the whole process group, which is what Ctrl-C sends,
-# so they kill this shell before any trap could run, and SIGKILL cannot be
-# trapped at all.
+# resolve_include_paths). Measured 2026-08-01 on such a tree, the install
+# stopped after printing "wrote <target>" and "removed legacy drop-in <legacy>",
+# rollback_install was never reached, and both the published drop-in and the
+# dot-prefixed .<legacy>.saved copy stayed.
 #
-# That residue is deliberately left alone rather than defended against. What it
-# IS: the new policy published and the legacy file preserved under a name
-# sshd's Include glob does not match (verified: a dot-prefixed file holding an
-# invalid directive leaves `sshd -G` at exit 0, the same file undotted takes it
-# to 255), so the tree is hardened and the leftovers are inert. A wall clock
-# over the child verify is NOT the answer: stock macOS ships no `timeout`
-# binary, and a verify killed for being slow would roll the hardening back OFF
-# a machine that was fine, which is a worse outcome than an inert dot-file.
+# The child verify is now BOUNDED, and the argument for why that bound is safe
+# sits with it at VERIFY_DEADLINE_SECONDS: past the deadline the verify is
+# stopped, its process group with it, and reported as a failed verify, so the
+# rollback below runs on that path like on any other. What is NOT defended
+# against, still, is this shell
+# being killed from the terminal mid-install: SIGINT and SIGTERM reach the whole
+# process group, which is what Ctrl-C sends, so they kill this shell before any
+# trap could run, and SIGKILL cannot be trapped at all. The residue that leaves
+# is deliberately left alone. What it IS: the new policy published and the
+# legacy file preserved under a name sshd's Include glob does not match
+# (verified: a dot-prefixed file holding an invalid directive leaves `sshd -G`
+# at exit 0, the same file undotted takes it to 255), so the tree is hardened
+# and the leftovers are inert.
 #
 # The working files are DOT-PREFIXED deliberately: sshd's Include glob does not
 # match a leading dot (glob(3) semantics, verified), so a half-written staging

--- a/test/e2e/ssh-hardening-verify-watchdog.sh
+++ b/test/e2e/ssh-hardening-verify-watchdog.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# ssh-hardening-verify-watchdog.sh -- install is a transaction against a verify
+# that HANGS, not only against one that fails.
+#
+# THE DEFECT THIS PINS. The install path stages the drop-in, publishes it with
+# one rename, moves the legacy file aside, and only then verifies; a verify that
+# RETURNS a failure takes the rollback and the tree goes back exactly as it was
+# found. A verify that never returns took nothing: the run parked with the new
+# drop-in published and the legacy file gone, rollback_install unreached. That is
+# not hypothetical, it is measured (2026-08-01): one named pipe in the drop-in
+# directory blocks `sshd -G` forever, because sshd resolves its own Include globs
+# with no type filter, and the child verify runs sshd.
+#
+# HOW THE HANG IS BUILT. The reload library's SSH_TREE_MUTATION_HOOK seam runs an
+# executable INSIDE each controlled stub, before that stub does its own work, so
+# a hook that never returns is an `sshd -G` that never answers. That is the same
+# shape as the real defect (sshd blocked in an open) without needing a named pipe
+# or the real binary, and it wedges the FIRST sshd call the child verify makes
+# (check_global), which is after the drop-in is already published.
+#
+# WHY e2e. The case waits out a deliberate wall clock, which is what this camp is
+# for. The bound is shortened through SSH_HARDENING_VERIFY_DEADLINE; the harness
+# clock in run_ssh_reload is the outer net, so a regressed script that hangs
+# again fails this suite instead of parking it.
+#
+# Properties pinned:
+#   1. a wedged verify is stopped at the deadline, reported as a failed verify,
+#      and the tree it found is restored byte for byte with no working files left
+#   2. nothing the wedged verify started outlives the run: the sshd stub and the
+#      sleeper under it are both gone (a group kill, not a kill of the child
+#      shell alone, is what makes that true)
+#   3. a healthy verify is untouched by the bound: install still succeeds, and
+#      the seam calls are exactly the three resolutions the verify makes, so a
+#      watchdog built out of the SLEEP_BIN seam would be caught here
+#   4. a verify that genuinely FAILS still rolls back, and is reported as a
+#      failure rather than as a timeout
+set -euo pipefail
+
+# Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
+# suite can still inherit one from its caller.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE
+
+# shellcheck source=../fixtures/ssh-reload-lib.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib.bash"
+
+# Three seconds instead of the shipped 120: the case has to wait the deadline
+# out, and the property under test is that the bound FIRES, not what number it
+# holds. The shipped default is judged where it is defined, against measured
+# verify times.
+export SSH_HARDENING_VERIFY_DEADLINE=3
+# The stop grace the script allows after the deadline (VERIFY_STOP_GRACE_SECONDS)
+# plus room for a loaded CI machine. A run that needs longer than this has not
+# bounded the verify at all.
+WEDGED_RUN_LIMIT_SECONDS=20
+
+reload_sandbox_setup
+trap 'ssh_sandbox_teardown' EXIT
+
+dropin="$SSHD_CONFIG_D/$SSH_DROPIN_NAME"
+legacy="$SSHD_CONFIG_D/50-no-password-auth.conf"
+
+# Every process the wedge starts records its pid here: the sshd stub (as the
+# hook's parent) and the sleeper the hook becomes. Read back after the run to
+# prove the stop reached the whole group, and read by the cleanup below so a
+# FAILING case cannot leave a 15-minute sleeper behind.
+SSH_VERIFY_WEDGE_PID_FILE="$SSH_SANDBOX/wedge-pids"
+export SSH_VERIFY_WEDGE_PID_FILE
+: >"$SSH_VERIFY_WEDGE_PID_FILE"
+
+wedge_cleanup() {
+  local pid
+  [[ -s ${SSH_VERIFY_WEDGE_PID_FILE:-/dev/null} ]] || return 0
+  while IFS= read -r pid; do
+    kill -KILL "$pid" 2>/dev/null || :
+  done <"$SSH_VERIFY_WEDGE_PID_FILE"
+}
+
+# Extended only now that wedge_cleanup exists: a trap naming a function that has
+# not been defined yet would fire as a command-not-found on any early exit.
+trap 'wedge_cleanup; ssh_sandbox_teardown' EXIT
+
+WEDGE_HOOK="$SSH_SANDBOX/wedge-hook"
+cat >"$WEDGE_HOOK" <<'HOOK'
+#!/bin/bash
+# Runs inside every controlled stub. Only the sshd stub is wedged: the install
+# path drives `sudo` through the same hook, and wedging that would stop the run
+# before it ever published anything, which is a different case.
+set -euo pipefail
+[[ ${1:-} == 'sshd' ]] || exit 0
+# $PPID is the stub shell; $$ survives the exec below, so it is the sleeper's
+# pid. Both are the descendants a kill of the child shell alone would orphan.
+printf '%s\n%s\n' "$PPID" "$$" >>"${SSH_VERIFY_WEDGE_PID_FILE:?}"
+exec /bin/sleep 900
+HOOK
+chmod +x "$WEDGE_HOOK"
+
+file_fingerprint() { # <path> -> checksum and size, or the word absent
+  if [[ -e $1 ]]; then
+    cksum <"$1"
+  else
+    printf 'absent\n'
+  fi
+}
+
+# working_file_leftovers: any staging or rollback copy still in the drop-in
+# directory. Globs rather than `ls | grep`, so an unusual name still matches.
+working_file_leftovers() {
+  local candidate found=''
+  for candidate in "$SSHD_CONFIG_D"/*.staging "$SSHD_CONFIG_D"/*.saved \
+    "$SSHD_CONFIG_D"/.*.staging "$SSHD_CONFIG_D"/.*.saved; do
+    if [[ -e $candidate ]]; then
+      found="$found $candidate"
+    fi
+  done
+  printf '%s\n' "$found"
+}
+
+# build_tree_with_previous_policy: a drop-in that is NOT what install writes,
+# plus a legacy file. Both must come back byte for byte when the install fails,
+# and a drop-in identical to the one install publishes could not tell a restore
+# from a leftover.
+build_tree_with_previous_policy() {
+  rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+  printf '# a previous drop-in, not the one install writes\nPasswordAuthentication no\n' \
+    >"$dropin"
+  printf 'PasswordAuthentication no\n' >"$legacy"
+}
+
+# assert_pids_reaped <label>: every process the wedge started is gone. Polled,
+# not asserted once: a killed process is a zombie until its parent (or init,
+# after reparenting) reaps it, and `kill -0` answers 0 for a zombie.
+assert_pids_reaped() {
+  local label="$1" pid waited=0 alive
+  [[ -s $SSH_VERIFY_WEDGE_PID_FILE ]] ||
+    fail "$label: the wedge never recorded a pid, so it never fired and this case proves nothing about orphans"
+  while [[ $waited -lt 50 ]]; do
+    alive=''
+    while IFS= read -r pid; do
+      if kill -0 "$pid" 2>/dev/null; then
+        alive="$alive $pid"
+      fi
+    done <"$SSH_VERIFY_WEDGE_PID_FILE"
+    [[ -n $alive ]] || return 0
+    /bin/sleep 0.1
+    waited=$((waited + 1))
+  done
+  fail "$label: the wedged verify left processes behind:$alive (a kill of the child shell alone orphans the sshd under it; the stop must signal the process group)"
+}
+
+# --- 3: a healthy verify is untouched by the bound ----------------------------
+# First, because a bound that broke the normal path would make every case below
+# pass for the wrong reason.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+run_ssh_reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "3: install on a clean tree must still succeed under the bound (stderr: $SSH_RUN_ERR)"
+[[ -f $dropin ]] ||
+  fail '3: install must leave the drop-in in place'
+refute_contains "$SSH_RUN_ERR" 'TIMED OUT' \
+  '3: a verify that answered must never be reported as timed out'
+invoking_user="$(id -un)"
+# The exact seam calls, in order: the verify's global resolution and its two
+# per-connection resolutions, and NOTHING else. A watchdog built out of the
+# SLEEP_BIN seam would show up here as extra `sleep` lines, and a bound that
+# re-ran the verify would show up as a second set of resolutions.
+assert_seam_calls '3' \
+  "sshd -G -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -T -C user=root,host=localhost,addr=127.0.0.1 -f $SSHD_MAIN_CONFIG" \
+  "sshd -G -T -C user=$invoking_user,host=localhost,addr=127.0.0.1 -f $SSHD_MAIN_CONFIG"
+leftovers="$(working_file_leftovers)"
+[[ -z $leftovers ]] ||
+  fail "3: a successful install left working files behind:$leftovers"
+
+# --- 4: a verify that genuinely fails still rolls back ------------------------
+# The regression pin for the path that already worked. `sshd -G` exits nonzero
+# for every call in this run, which is a verify that ANSWERS with a failure.
+
+build_tree_with_previous_policy
+dropin_before="$(file_fingerprint "$dropin")"
+legacy_before="$(file_fingerprint "$legacy")"
+
+SSHD_STUB_RESOLVE_STATUSES='1' run_ssh_reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '4: an install whose verify failed must not report success'
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  '4: a failed verify must not claim the install completed'
+refute_contains "$SSH_RUN_ERR" 'TIMED OUT' \
+  '4: a verify that answered with a failure must be reported as a failure, not as a timeout'
+[[ "$(file_fingerprint "$dropin")" == "$dropin_before" ]] ||
+  fail '4: the drop-in that was in place must come back byte for byte'
+[[ "$(file_fingerprint "$legacy")" == "$legacy_before" ]] ||
+  fail '4: the legacy drop-in must come back byte for byte'
+leftovers="$(working_file_leftovers)"
+[[ -z $leftovers ]] ||
+  fail "4: a failed install left working files behind:$leftovers"
+
+# --- 1 and 2: a wedged verify is stopped, rolled back, and leaves nothing -----
+
+build_tree_with_previous_policy
+dropin_before="$(file_fingerprint "$dropin")"
+legacy_before="$(file_fingerprint "$legacy")"
+: >"$SSH_VERIFY_WEDGE_PID_FILE"
+
+wedged_started=$SECONDS
+SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload
+wedged_elapsed=$((SECONDS - wedged_started))
+
+[[ $wedged_elapsed -le $WEDGED_RUN_LIMIT_SECONDS ]] ||
+  fail "1: the wedged install took ${wedged_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s this bound allows (deadline ${SSH_HARDENING_VERIFY_DEADLINE}s plus the stop grace)"
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '1: an install whose verify never answered must not report success'
+grep -qF 'verify TIMED OUT' <<<"$SSH_RUN_ERR" ||
+  fail "1: the run must say which path fired, naming the timeout (stderr: $SSH_RUN_ERR)"
+grep -qF 'rolled back' <<<"$SSH_RUN_ERR" ||
+  fail "1: the run must report the rollback it performed (stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_OUT" 'install complete' \
+  '1: a wedged verify must not claim the install completed'
+[[ "$(file_fingerprint "$dropin")" == "$dropin_before" ]] ||
+  fail '1: the drop-in that was in place must come back byte for byte after a wedged verify'
+[[ "$(file_fingerprint "$legacy")" == "$legacy_before" ]] ||
+  fail '1: the legacy drop-in must come back byte for byte after a wedged verify'
+leftovers="$(working_file_leftovers)"
+[[ -z $leftovers ]] ||
+  fail "1: the wedged install left working files behind:$leftovers"
+assert_pids_reaped '2'
+
+printf 'ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in %ss, reported as a failed verify, rolled back to a byte-identical tree with no working files and no surviving processes; a healthy verify still installs with exactly its three seam calls; a verify that answers with a failure still rolls back and is not reported as a timeout)\n' \
+  "$wedged_elapsed"


### PR DESCRIPTION
## Context

This is the chezmoi source tree for the dotfiles. One of the scripts it manages,
`dot_local/bin/executable_ssh-hardening.sh`, installs a public-key-only sshd drop-in on macOS. Installing
is written as a transaction: stage the new policy file, publish it with one rename, move the legacy
drop-in aside, verify the configuration sshd actually resolves, and put the tree back exactly as it was
found if that verify reports a failure.

The transaction held only against a verify that RETURNS. A verify that hangs returns nothing to roll back
on, so the run parked with the new drop-in published and the legacy file gone, and the rollback was never
reached. That is measured rather than theoretical: a single named pipe in the drop-in directory blocks
`sshd -G` forever, because sshd resolves its own Include globs with no type filter, and the install's
verify runs sshd.

## Summary

- The child verify now runs under a deadline in `dot_local/bin/executable_ssh-hardening.sh`
  (`VERIFY_DEADLINE_SECONDS`, 120 seconds, with `SSH_HARDENING_VERIFY_DEADLINE` overriding it for tests).
  It is a poll around a background job, not `timeout(1)`, which stock macOS does not ship.
- An expiry returns nonzero, which is what both callers of `run_verify_child` already read as a failed
  verify: the install takes its existing rollback, and `--reload` refuses to restart. No rollback logic
  was added or changed, and a loud `verify TIMED OUT` line says which path fired.
- The stopped verify is signalled as a process group (TERM, a 2 second grace, then KILL), so the sshd
  blocked underneath the child shell is stopped with it instead of orphaned.
- `test/e2e/ssh-hardening-verify-watchdog.sh` pins three outcomes: a wedged verify, a healthy verify, and
  a verify that fails by answering. The hang is built with the ssh fixtures' existing
  `SSH_TREE_MUTATION_HOOK` seam, which runs inside the sshd stub.
- The install-section comment that argued against a wall clock is replaced by the measurements and the
  cost argument that answer it: a rollback restores what the run found, so an expiry costs an install
  that did not apply, not the hardening of a machine that was fine.

## How it was verified

Red for the right reason. The new e2e file, run with `SSH_HARDENING_SCRIPT` pointed at the pre-fix script
from `HEAD`, fails on the harness clock rather than hanging the suite:

```
FAIL: run_ssh_reload  exceeded its 30s wall clock; a reload that can hang is itself a regression
```

The same file with the wedged case cut off passes against that same pre-fix script, so the
healthy-verify and answered-failure cases are regression pins rather than restatements of the new
behavior:

```
pins-only (cases 3 and 4) PASSED
```

Green with the fix, in 5 seconds (a 3 second test deadline plus the 2 second stop grace):

```
ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in 5s,
reported as a failed verify, rolled back to a byte-identical tree with no working files and no
surviving processes; a healthy verify still installs with exactly its three seam calls; a verify
that answers with a failure still rolls back and is not reported as a timeout)
```

No orphans. The wedge records the sshd stub's pid and the pid of the sleeper it becomes, and the test
polls both after the run and fails naming whichever is still alive (polled, because a killed process is a
zombie until it is reaped and `kill -0` answers 0 for a zombie). The mechanism was checked on its own
against bash 3.2 first: `set -m` puts the background job in its own process group, and a group TERM
reaps a grandchild that a kill of the child alone leaves running.

The bound is set from measurement, taken against a sandbox tree driven by the real `/usr/sbin/sshd`
through the fixtures' seams: a three-file tree verifies in 0.22s, and a 1.0 MB tree, the shape
`MAX_CONFIG_TREE_BYTES` was set against, verifies in 5.1s.

Every existing ssh-hardening suite passes (the unit and integration files both), then `just l` reported
0 changed and the full `just test` was green.

## Effect of merging

Merging changes the source tree and nothing on this machine. The script reaches
`~/.local/bin/ssh-hardening.sh` at the next `chezmoi apply`, and no apply runs before the D1 cutover, so
the live `/etc/ssh` tree and the running sshd are untouched by this. For an operator running the script
after that apply, behavior is identical except when a verify does not answer inside 120 seconds, where an
install that used to park now rolls back and says so.

## Review guide

- The watchdog block, `run_verify_child` and `stop_verify_child`. What carries weight there: the group
  kill works only because the job is launched under `set -m`, the child is reaped after both kills so its
  pid cannot be recycled underneath them, and the poll's delay tool is deliberately not the `SLEEP_BIN`
  seam, which the suites stub with an instant-return spy.
- The rollback junction, `install_dropin`'s `run_verify_child || verify_status=$?`, which this change
  leaves alone. The question worth asking is whether an expiry can reach any path other than that one.
- The bound itself. It is safe if no tree that would eventually verify can cross 120 seconds; the
  measurements above are the argument, and a counterexample is the useful kind of pushback.
- The narrowing recorded in `run_verify_child`: a child in its own process group no longer dies with a
  Ctrl-C aimed at this shell, so interrupting a hung install inside the deadline leaves that verify
  running where it used to be killed with the shell.
