### PR TITLE
fix(claude-settings): quarantine an unreadable settings.json before the apply reads it

### DIFF
--- a/.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh
+++ b/.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Move an unreadable ~/.claude/settings.json out of the way before the settings
+# modify-template reads it.
+#
+# WHY. private_dot_claude/modify_settings.json is a chezmoi modify-template: it
+# receives the live ~/.claude/settings.json on .chezmoi.stdin and hands it to
+# fromJson, which HARD ERRORS on input that is not JSON. A modify-template that
+# errors aborts the WHOLE apply rather than one target, so every later target and
+# every run_after_ script is skipped and the corrupt file is left in place, which
+# means permissions.deny is not restored either. No template can catch it:
+# chezmoi's three JSON readers all fail the template on bad input and Go's
+# text/template has no recover, so the repair has to run BEFORE the template.
+# test/unit/claude-enabled-plugins.sh pins that limit from the template's side.
+#
+# WHAT IT DOES. An unreadable file is MOVED (never deleted) into
+# ~/workspaces/backups and replaced with `{}`, so the same apply rebuilds every
+# stable field from source. A readable file is left byte-identical and an absent
+# one is left absent, so the common case is a no-op. Idempotent: what a
+# quarantine leaves behind is readable, so the next run does nothing.
+#
+# WHAT THE MOVE COSTS. Per-plugin state (the boolean `claude plugin disable`
+# writes, or a version pin) is READ from the live file rather than declared in
+# the template, so a quarantine loses it and every declared plugin comes back
+# enabled. The warning below says so. The alternative is an apply that cannot run
+# at all.
+#
+# Ordering: after 10-system-packages, which is where jq comes from.
+
+set -euo pipefail
+
+settings="$HOME/.claude/settings.json"
+backup_dir="$HOME/workspaces/backups"
+
+warn() { printf 'quarantine-claude-settings: WARNING -- %s\n' "$*" >&2; }
+
+[[ -f $settings ]] || exit 0
+
+# No parser, no verdict. A fresh machine reaches this before Homebrew has
+# installed jq, and a false positive would destroy a healthy settings file, so
+# "cannot tell" leaves the file alone.
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Readable means the file holds AT MOST ONE JSON value. `jq empty` alone is not
+# that test: it accepts a STREAM of values, so `{"a": 1}{"b": 2}` passes it while
+# Go's encoding/json rejects it (`invalid character '{' after top-level value`)
+# and the template dies on exactly the file jq called fine. Slurping and counting
+# is the single-value test. Zero values (an empty or whitespace-only file) count
+# as readable on purpose: the template trims its stdin and treats that shape as
+# an absent file. Every JSON value is accepted, an object or otherwise, because
+# the template survives a whole-file `null` and a whole-file array too.
+if jq -e -s 'length <= 1' <"$settings" >/dev/null 2>&1; then
+  exit 0
+fi
+
+# ISO 8601 with hyphens inside the timestamp: BSD date has no -Is, and a colon in
+# a filename is a poor idea on macOS anyway.
+backup="$backup_dir/$(date -u +"%Y-%m-%dT%H-%M-%S").claude-settings-quarantined.backup.json"
+
+if ! mkdir -p "$backup_dir" || ! mv "$settings" "$backup"; then
+  warn "$settings does not parse and could not be moved into $backup_dir."
+  warn "The apply will fail in modify_settings.json until that file is repaired by hand."
+  exit 0
+fi
+
+warn "$settings did not parse. It was MOVED to $backup and replaced with an empty object."
+warn "This apply rebuilds the managed fields. It does NOT restore per-plugin state: re-run 'claude plugin disable <id>' for anything that was disabled."
+printf '{}\n' >"$settings"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,17 @@ cleanest way to keep policy fields under chezmoi control while letting `/config`
 freely. See https://www.chezmoi.io/user-guide/manage-different-types-of-file/ for the `modify_` template
 \+ `setValueAtPath` reference.
 
+**A corrupt live file cannot block the apply.** The template reads `~/.claude/settings.json` and hands it
+to `fromJson`, which hard errors on input that is not JSON, and a modify-template that errors aborts the
+whole apply rather than one target. No template can catch that, so the repair runs first:
+`.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh` moves an unreadable settings
+file into `~/workspaces/backups/<timestamp>.claude-settings-quarantined.backup.json` (moved, never
+deleted), warns loudly, and leaves `{}` for the template to rebuild from. A readable file is left
+byte-identical, including the shapes that are not JSON objects (empty, whitespace-only, a whole-file
+array), and an absent one stays absent. What the move costs is per-plugin state, which lives only in the
+live file: every declared plugin comes back enabled, so a disable has to be re-applied with
+`claude plugin disable <id>` after a quarantine.
+
 ### Git Hooks
 
 All four hooks live in the **user-wide** hooks dir (`core.hooksPath = ~/.config/git/hooks`, set in

--- a/private_dot_claude/modify_settings.json
+++ b/private_dot_claude/modify_settings.json
@@ -49,25 +49,28 @@
        holding one newline is what an editor leaves after saving an emptied
        buffer, so this is the cheapest shape to produce.
 
-       KNOWN LIMIT, deliberately not worked around here. Trimming only fixes
-       the shapes that are EMPTY once trimmed. A live file that is non-empty
-       and does not parse (a write truncated mid-object, a hand edit with a
-       stray character) still aborts the apply, and no template can catch it:
-       chezmoi's three JSON readers (fromJson, fromJsonc, fromYaml) all fail
-       the template on bad input, and Go's text/template has no recover, so
-       there is nothing to fall back FROM (measured 2026-08-02, and
+       KNOWN LIMIT, and it is repaired OUTSIDE this template. Trimming only
+       fixes the shapes that are EMPTY once trimmed. A live file that is
+       non-empty and does not parse (a write truncated mid-object, a hand edit
+       with a stray character) aborts the apply from here, and no template can
+       catch it: chezmoi's three JSON readers (fromJson, fromJsonc, fromYaml)
+       all fail the template on bad input, and Go's text/template has no
+       recover, so there is nothing to fall back FROM (measured 2026-08-02, and
        test/unit/claude-enabled-plugins.sh pins the boundary with a case per
-       shape). Repairing that needs something outside this template that runs
-       BEFORE it. Until then the apply's own error names this file. Repair
-       ~/.claude/settings.json if you can. DELETING it loses the one managed
-       thing this template cannot rebuild: plugin state is READ from the live
-       file rather than declared here, so with nothing to read every declared
-       plugin renders `true`, which re-enables every disabled plugin and drops
-       every version pin. Nothing reports that afterwards either (see the plugin
-       block below). Note the disabled set first and restore it with
-       `claude plugin disable <id>` per plugin. Everything else this template
-       manages does come back from here on the next apply, and free-drift keys
-       are lost as before. */ -}}
+       shape). So the repair runs BEFORE this template instead:
+       .chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh
+       moves an unreadable settings file into ~/workspaces/backups and leaves
+       `{}` in its place, which this template then rebuilds from.
+
+       The move is not free, and the script says so at the time. Plugin state is
+       the one managed thing this template cannot rebuild: it is READ from the
+       live file rather than declared here, so with nothing to read every
+       declared plugin renders `true`, which re-enables every disabled plugin
+       and drops every version pin. Nothing reports that afterwards either (see
+       the plugin block below), so restore it with `claude plugin disable <id>`
+       per plugin, reading the quarantined copy for the set that was disabled.
+       Everything else this template manages does come back from here on the
+       next apply, and free-drift keys are lost as before. */ -}}
 {{- $stdin := index .chezmoi "stdin" | default "" | trim -}}
 {{- $merged := dict -}}
 {{- if $stdin -}}

--- a/test/unit/claude-enabled-plugins.sh
+++ b/test/unit/claude-enabled-plugins.sh
@@ -50,13 +50,20 @@
 # can: chezmoi's three JSON readers (fromJson, fromJsonc, fromYaml) all fail the
 # template on bad input, and Go's text/template has no recover, so there is
 # nothing to fall back FROM (measured 2026-08-02 on chezmoi 2.62.3 and 2.71.1;
-# `try`, `catch` and every lenient-parse name probed are undefined). Repairing
-# that needs something outside this template that runs BEFORE it. So the shapes
-# that abort are not left unmentioned: UNPARSEABLE_LIVE_FILE_CASES applies each
-# one, requires the failure, requires the apply's error to NAME the template so
-# the operator is not left guessing, and requires the live file to come back
+# `try`, `catch` and every lenient-parse name probed are undefined). So the
+# shapes that abort are not left unmentioned: UNPARSEABLE_LIVE_FILE_CASES applies
+# each one, requires the failure, requires the apply's error to NAME the template
+# so the operator is not left guessing, and requires the live file to come back
 # byte-identical so the failure is inert rather than destructive. If someone
 # fixes the limitation, those cases fail and say where to move them.
+#
+# WHAT KEEPS THOSE SHAPES AWAY FROM A REAL APPLY. The repair is a separate
+# script that runs BEFORE this template rather than a change to the template:
+# .chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh moves
+# an unreadable live file into ~/workspaces/backups and leaves `{}` behind.
+# test/unit/claude-settings-quarantine.sh pins that side, reusing these three
+# fixtures byte for byte. The cases here still describe what the template does
+# when a bad file reaches it, which is what the quarantine exists to prevent.
 #
 # WHY THE STABLE FIELDS ARE ASSERTED HERE AT ALL. The version of this file that
 # shipped before 2026-08-02 asserted only enabledPlugins, and measured green at

--- a/test/unit/claude-settings-quarantine.sh
+++ b/test/unit/claude-settings-quarantine.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# claude-settings-quarantine.sh, the run_before quarantine script must move an
+# unreadable ~/.claude/settings.json out of the way BEFORE the settings
+# modify-template reads it, and must leave every readable one alone.
+#
+# WHY IT EXISTS. private_dot_claude/modify_settings.json receives the live
+# settings file on .chezmoi.stdin and hands it to fromJson, which hard errors on
+# input that is not JSON. A modify-template that errors aborts the WHOLE apply,
+# so one corrupt byte in that file skips every other target and every run_after_
+# script in the run. test/unit/claude-enabled-plugins.sh pins that limit from the
+# template's side (UNPARSEABLE_LIVE_FILE_CASES); this test pins the repair.
+#
+# WHY THE READABLE CASES OUTNUMBER THE CORRUPT ONES. A quarantine that fires on
+# a file the template can read is worse than the bug it fixes: it moves a
+# healthy settings file away and drops the per-plugin state that only the live
+# file carries. So every shape the template survives is asserted byte-identical
+# afterwards, including the three that are not JSON OBJECTS (empty,
+# whitespace-only, a whole-file JSON array), which a stricter "must be an
+# object" predicate would quarantine wrongly.
+#
+# WHY A MULTI-ROOT CASE IS HERE. `jq empty` accepts a STREAM of JSON values, so
+# `{"a": 1}{"b": 2}` passes it while Go's encoding/json (what the template uses)
+# rejects it. That shape is the one an implementation reaching for the obvious
+# `jq empty` gets wrong, so it gets its own case.
+#
+# HOW IT STAYS HERMETIC. Every run gets its own throwaway HOME under one mktemp
+# directory. The operator's ~/.claude/settings.json and ~/workspaces/backups are
+# never read or written.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly SCRIPT="$REPO_ROOT/.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh"
+
+# The repo's backup naming convention: timestamp first, hyphens inside the
+# timestamp, a period before the name, `.backup` before the extension.
+readonly BACKUP_NAME_PATTERN='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\.claude-settings-quarantined\.backup\.json$'
+
+fail() {
+  printf 'claude-settings-quarantine: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "the quarantine script is missing: $SCRIPT"
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+
+# Set by the helpers below; read by every case. case_home carries the home
+# directory a case ran in, so no assertion has to live inside a command
+# substitution (fail's exit would only leave the subshell there).
+rc=0
+output=''
+case_home=''
+declare -a backups=()
+
+run_script() { # <home>
+  rc=0
+  output="$(HOME="$1" bash "$SCRIPT" 2>&1)" || rc=$?
+}
+
+collect_backups() { # <home>
+  local candidate
+  backups=()
+  shopt -s nullglob
+  for candidate in "$1"/workspaces/backups/*; do
+    backups+=("$candidate")
+  done
+  shopt -u nullglob
+}
+
+# A live file the template CANNOT read: moved to ~/workspaces/backups with its
+# bytes intact, replaced with `{}`, reported loudly, and the apply left alive.
+assert_quarantined() { # <name> <bytes>
+  local name=$1 bytes=$2 home original
+  home="$sandbox/$name"
+  mkdir -p "$home/.claude"
+  case_home="$home"
+  original="$sandbox/$name.original-bytes"
+  printf '%s' "$bytes" >"$home/.claude/settings.json"
+  printf '%s' "$bytes" >"$original"
+
+  run_script "$home"
+  [[ $rc -eq 0 ]] || fail "$name: exit $rc, want 0 (a quarantine must not block the apply)"
+
+  collect_backups "$home"
+  [[ ${#backups[@]} -eq 1 ]] || fail "$name: ${#backups[@]} files in ~/workspaces/backups, want exactly 1"
+  [[ $(basename "${backups[0]}") =~ $BACKUP_NAME_PATTERN ]] ||
+    fail "$name: backup name $(basename "${backups[0]}") does not match the repo naming convention"
+  cmp -s "$original" "${backups[0]}" || fail "$name: the backup does not hold the original bytes"
+
+  [[ -f $home/.claude/settings.json ]] || fail "$name: settings.json was left absent instead of reset"
+  [[ $(cat "$home/.claude/settings.json") == '{}' ]] ||
+    fail "$name: settings.json was not reset to {} (got $(cat "$home/.claude/settings.json"))"
+
+  grep -qF "${backups[0]}" <<<"$output" || fail "$name: the warning does not name the backup path"
+}
+
+# A live file the template CAN read: byte-identical afterwards, and no backup
+# directory brought into existence at all.
+assert_untouched() { # <name> <bytes>
+  local name=$1 bytes=$2 home original
+  home="$sandbox/$name"
+  mkdir -p "$home/.claude"
+  original="$sandbox/$name.original-bytes"
+  printf '%s' "$bytes" >"$home/.claude/settings.json"
+  printf '%s' "$bytes" >"$original"
+
+  run_script "$home"
+  [[ $rc -eq 0 ]] || fail "$name: exit $rc, want 0"
+  cmp -s "$original" "$home/.claude/settings.json" ||
+    fail "$name: a settings file the template can read was modified"
+  [[ ! -d $home/workspaces/backups ]] ||
+    fail "$name: a settings file the template can read was quarantined"
+}
+
+# --- the shapes that abort the apply today ---------------------------------
+# The first three are UNPARSEABLE_LIVE_FILE_CASES from
+# test/unit/claude-enabled-plugins.sh, byte for byte.
+assert_quarantined 'truncated-json' '{"voiceEnabled": true, "enabledPlugins": {'
+assert_quarantined 'trailing-garbage' '{"voiceEnabled": true}}}
+'
+assert_quarantined 'not-json' 'this file is not json
+'
+assert_quarantined 'multi-root-json' '{"a": 1}{"b": 2}'
+healed_home="$case_home"
+
+# Idempotent: the file a quarantine leaves behind is readable, so a second run
+# writes no second backup and changes nothing.
+run_script "$healed_home"
+[[ $rc -eq 0 ]] || fail "idempotence: exit $rc on the second run, want 0"
+collect_backups "$healed_home"
+[[ ${#backups[@]} -eq 1 ]] || fail "idempotence: a second run left ${#backups[@]} backups, want 1"
+[[ $(cat "$healed_home/.claude/settings.json") == '{}' ]] ||
+  fail "idempotence: a second run changed the healed settings.json"
+
+# --- the shapes the template already survives ------------------------------
+assert_untouched 'plain-object' '{
+  "voiceEnabled": true,
+  "enabledPlugins": { "codex@openai-codex": false }
+}
+'
+assert_untouched 'empty-json-object' '{}'
+assert_untouched 'empty-file' ''
+assert_untouched 'blank-file' '
+   '
+assert_untouched 'whole-file-json-array' '[1, 2]'
+
+# --- no live file ----------------------------------------------------------
+# Nothing to read, so nothing to write: the script must not conjure a settings
+# file, a .claude directory or a backup directory out of an absent one.
+absent_home="$sandbox/absent-settings-file"
+mkdir -p "$absent_home/.claude"
+run_script "$absent_home"
+[[ $rc -eq 0 ]] || fail "absent settings.json: exit $rc, want 0"
+[[ ! -e $absent_home/.claude/settings.json ]] || fail "absent settings.json: the script created one"
+[[ ! -d $absent_home/workspaces/backups ]] || fail "absent settings.json: the script created a backup directory"
+
+bare_home="$sandbox/absent-claude-directory"
+mkdir -p "$bare_home"
+run_script "$bare_home"
+[[ $rc -eq 0 ]] || fail "absent .claude: exit $rc, want 0"
+[[ ! -e $bare_home/.claude ]] || fail "absent .claude: the script created it"
+[[ ! -d $bare_home/workspaces/backups ]] || fail "absent .claude: the script created a backup directory"
+
+printf 'claude-settings-quarantine: OK\n'


### PR DESCRIPTION
## Context

This repository keeps `~/.claude/settings.json` under partial chezmoi control through a modify-template,
`private_dot_claude/modify_settings.json`. A modify-template reads the live target file, overlays the
fields this repo owns, and writes the merged result back. The read is the fragile part. The live bytes go
to `fromJson`, which fails hard on input that is not JSON, and the failure is never contained to one
target: a modify-template that errors aborts the whole `chezmoi apply`. One bad byte in that file skips
every later target and every `run_after_` script in the run, so `permissions.deny` is not restored
either.

No version of the template can catch that. chezmoi's JSON readers all fail the template on bad input and
Go's `text/template` has no recover, so the repair has to run before the template does. This branch adds
it (task #92).

## Summary

- New `.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh`: when the live
  `~/.claude/settings.json` does not parse, it moves the file to
  `~/workspaces/backups/<timestamp>.claude-settings-quarantined.backup.json` and leaves `{}` behind for
  the template to rebuild from. The file is moved, never deleted.
- A settings file the template can read is left byte-identical, an absent one stays absent, and a machine
  with no jq is left alone. A quarantine that fires on a healthy file would be worse than the bug being
  fixed, so those paths carry more test cases than the corrupt ones.
- The readability test is `jq -e -s 'length <= 1'` rather than `jq empty`, because `jq empty` accepts a
  stream of JSON values: `{"a": 1}{"b": 2}` passes it while Go's parser rejects it.
- The warning names the backup path and the one thing an apply cannot rebuild. Per-plugin state lives
  only in the live file, so `claude plugin disable <id>` has to be re-run by hand for anything that was
  disabled before a quarantine.
- New `test/unit/claude-settings-quarantine.sh` pins the behavior, reusing the three corrupt fixtures
  from `test/unit/claude-enabled-plugins.sh` byte for byte and adding the multi-root shape. CLAUDE.md and
  the two comments that said this repair did not exist yet now point at the script.

## How it was verified

- The test was written first and run red twice: with no script at all, then against a stub script that
  exits 0, which failed with `truncated-json: 0 files in ~/workspaces/backups, want exactly 1`. It went
  green once the real script existed.
- Five mutants of the script, each run against the unmutated test, each killed, with the control
  restored and re-run green between them:
  - `jq -e -s 'length <= 1'` weakened to `jq empty` gives
    `multi-root-json: 0 files in ~/workspaces/backups, want exactly 1`.
  - the predicate forced true (never quarantine) gives
    `truncated-json: 0 files in ~/workspaces/backups, want exactly 1`.
  - the predicate forced false (always quarantine) gives
    `plain-object: a settings file the template can read was modified`.
  - the `[[ -f $settings ]]` guard deleted gives
    `absent settings.json: the script created a backup directory`.
  - the timestamp format changed to `%Y%m%d%H%M%S` gives `backup name
    20260804051828.claude-settings-quarantined.backup.json does not match the repo naming convention`.
- `just l` clean, and all four suites green under `just test` in the flake's `run` shell, the pinned
  toolchain CI uses.
- No `chezmoi apply` was run in any form. The script is a plain `.sh`, so treefmt shellchecks and
  shfmt-formats it directly: confirmed by planting a syntax error in a throwaway `.chezmoiscripts/*.sh`
  and watching `just s` reject it by path.

## Effect of merging

Nothing changes on the live machine. The script runs at apply time, and nothing is applied before the D1
cutover. From then on it runs early in every apply and does nothing unless `~/.claude/settings.json` has
become unreadable, in which case that apply completes instead of aborting, with the unreadable file
preserved under `~/workspaces/backups/`.

## Review guide

Start with `.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh`. Its header explains
why the repair cannot live in the template. The load-bearing line is the `jq -e -s 'length <= 1'`
predicate; the two paths that must never fire are the absent-file guard above it and the `command -v jq`
guard beside it.

Then `test/unit/claude-settings-quarantine.sh` for what is pinned, in particular the readable shapes that
are not JSON objects (empty, whitespace-only, a whole-file array). The template already survives those,
so a stricter "must be an object" predicate would quarantine them wrongly.

The changes in `private_dot_claude/modify_settings.json`, `test/unit/claude-enabled-plugins.sh` and
CLAUDE.md are comments and prose. The template's rendered output is unchanged.
