### PR TITLE
test(osquery): make ten CI-coupled osquery tests hermetic

### DIFF
--- a/test/e2e/osquery-alert-drainer.bats
+++ b/test/e2e/osquery-alert-drainer.bats
@@ -138,7 +138,12 @@ STUB
   # about fd inheritance and would pass for the wrong reason.
   local banner_pid=""
   local attempt
-  for ((attempt = 0; attempt < 40; attempt++)); do
+  # The loop breaks the moment the file appears, so a healthy run still costs
+  # milliseconds; the ceiling only decides how long a MISSING banner takes to be
+  # reported. Two seconds was not enough of it: this waits on a forked stub under
+  # `bats --jobs 4` on a shared runner, and a fork that is merely slow reported
+  # itself as a drainer that never fired the banner at all.
+  for ((attempt = 0; attempt < 200; attempt++)); do
     [[ -s $BANNER_PID_FILE ]] && break
     sleep 0.05
   done

--- a/test/e2e/osquery-alerter-hostile-columns.bats
+++ b/test/e2e/osquery-alerter-hostile-columns.bats
@@ -36,6 +36,36 @@ STUB
 {"label":"com.good","path":"~/Library/LaunchAgents/com.good.plist","program":"~/bin/good","sha256":""}
 EOF
 
+  # Bind the verdict to a SANDBOX manifest. Left unset, pipeline-verdict.sh falls
+  # back to its production default, /var/osquery/pipeline-known-good.sha256, and
+  # the run then reads a real machine path this test never wrote. That made the
+  # outcome a property of the host rather than of the code, in both directions:
+  # on a machine without that file nothing can ever vouch for the allowlist, so
+  # allowlist_verdict cannot suppress ANYTHING and each "the finding pages"
+  # assertion below passed without the suppression path existing at all; on a
+  # machine that has one, the same run also spends the 5-second settle loop per
+  # finding. Binding it here makes suppression genuinely reachable, which is what
+  # gives the injection pins something to defeat, and the HOSTILE-control test at
+  # the bottom of this file is what proves that reachability on every run.
+  export OSQUERY_PIPELINE_MANIFEST="$HOME/pipeline-known-good.sha256"
+  export OSQUERY_PIPELINE_SETTLE_SECONDS=0
+  printf 'FIXTURE PLIST\n' >"$HOME/Library/LaunchAgents/com.good.plist"
+  printf 'FIXTURE PROGRAM\n' >"$HOME/bin/good"
+  _bless_path() { # <path> -- append the path's current tuple to the sandbox manifest
+    local raw mode
+    raw=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1" 2>/dev/null) || return 1
+    mode="000$raw"
+    printf '%s %s %s %s\n' \
+      "$(shasum -a 256 "$1" | awk '{print $1}')" "${mode: -4}" "$(id -u)" "$1" \
+      >>"$OSQUERY_PIPELINE_MANIFEST"
+  }
+  : >"$OSQUERY_PIPELINE_MANIFEST"
+  # The allowlist FILE (the verdict's last gate) and the unpinned entry's plist
+  # (its per-entry authority) are the two paths the manifest has to account for.
+  chmod 600 "$HOME/.config/osquery/page-launchd-allowlist.txt"
+  _bless_path "$HOME/.config/osquery/page-launchd-allowlist.txt"
+  _bless_path "$HOME/Library/LaunchAgents/com.good.plist"
+
   export OSQUERY_RESULTS_LOG="$HOME/.local/log/osquery/osqueryd.results.log"
   export OSQUERY_RESULTS_OFFSET="$HOME/.local/state/osquery-results-offset"
   : >"$OSQUERY_RESULTS_LOG"
@@ -46,6 +76,14 @@ log_inode() { ls -i "$OSQUERY_RESULTS_LOG" | awk '{print $1}'; }
 seed_cursor() { printf '%s 0\n' "$(log_inode)" >"$OSQUERY_RESULTS_OFFSET"; }
 run_entry() { run bash "$ENTRY"; [ "$status" -eq 0 ]; }
 assert_paged() { grep -q 'severity=CRIT' "$SEND_ALERT_SPY"; }
+# A plain `! grep` cannot fail a bats test: set -e ignores the status of an
+# inverted command, so the refutation would be dead. Report and return 1.
+refute_paged() {
+  if grep -q 'severity=CRIT' "$SEND_ALERT_SPY"; then
+    echo "expected no CRIT page, got: $(cat "$SEND_ALERT_SPY")"
+    return 1
+  fi
+}
 
 # HEADLINE: a persistence_launchd finding whose crafted .cols.path embeds a 0x1F
 # tuple (path\x1flabel\x1fprogram) matching the allowlisted own-agent - under an
@@ -70,6 +108,20 @@ assert_paged() { grep -q 'severity=CRIT' "$SEND_ALERT_SPY"; }
     "$HOME" "$HOME" >>"$OSQUERY_RESULTS_LOG"
   run_entry
   assert_paged
+}
+
+# CONTROL for the three pins above: the GENUINE allowlisted own-agent, named with
+# no injected byte at all, is suppressed. Without it this file could pass while
+# allowlist_verdict was incapable of suppressing anything (its manifest missing,
+# its allowlist unreadable, the helper never sourced), leaving the three "it pages"
+# assertions vacuously true. This test fails the moment suppression stops working,
+# which is what makes their PAGE verdicts evidence rather than a default.
+@test "HOSTILE-control: the genuine allowlisted own-agent is suppressed, so the injection pins are not vacuous" {
+  seed_cursor
+  printf '{"name":"pack_intrusion-detection_persistence_launchd","action":"added","columns":{"label":"com.good","path":"%s/Library/LaunchAgents/com.good.plist","program":"%s/bin/good"}}\n' \
+    "$HOME" "$HOME" >>"$OSQUERY_RESULTS_LOG"
+  run_entry
+  refute_paged
 }
 
 # A tab embedded in .cols.program must stay an opaque value; the unknown agent pages.

--- a/test/integration/osquery-allowlist.bats
+++ b/test/integration/osquery-allowlist.bats
@@ -282,7 +282,12 @@ stub_launchd() {
   printf 'plist-bytes\n' >"$plist"
   stub_launchd "$plist" /opt/homebrew/opt/foo/bin/foo
 
-  export ALLOWLIST_OSQUERYI_LINGER=5
+  # The grandchild has to outlive a REAL `chezmoi apply` plus the manifest-runner
+  # spy that `-a` performs before this test looks at it, and it is detached, so a
+  # wide window costs the run nothing while a narrow one fails the pin on a
+  # contended runner for a reason that has nothing to do with fd hygiene. The
+  # already-exited branch below says "widen ALLOWLIST_OSQUERYI_LINGER"; this is that.
+  export ALLOWLIST_OSQUERYI_LINGER=60
   export ALLOWLIST_OSQUERYI_LINGER_PID_FILE="$ALLOWLIST_HOME/linger-pid"
   run run_allowlist -a com.foo.agent
   [ "$status" -eq 0 ] || {

--- a/test/integration/osquery-page-allowlist-seed.sh
+++ b/test/integration/osquery-page-allowlist-seed.sh
@@ -22,8 +22,10 @@ new_file="$REPO_ROOT/dot_config/osquery/private_page-launchd-allowlist.txt"
 old_file="$REPO_ROOT/dot_config/osquery/launch-allowlist.txt"
 
 if ! command -v jq >/dev/null 2>&1; then
-  printf 'SKIP: jq not found (run inside the nix dev shell)\n'
-  exit 0
+  # Hard stop, not a skip: every NDJSON assertion below runs through jq, so
+  # without it this file would report a green run that checked nothing.
+  printf 'FAIL: jq is not on PATH; it is this repo'"'"'s JSON tool everywhere, so this is a broken environment rather than a reason to skip\n' >&2
+  exit 1
 fi
 
 fails=0

--- a/test/integration/osquery-pipeline-manifest-agreement.sh
+++ b/test/integration/osquery-pipeline-manifest-agreement.sh
@@ -390,7 +390,14 @@ touch -t 200001010000 "$MF_MANIFEST"
 ) &
 settle_pid=$!
 got=0
-run_verdict "$settle_target" "$settle_hash" UPDATED 4 || got=$?
+# The settle budget here is a CEILING the happy path never spends, not a
+# measurement: the verdict re-checks once a second and returns the moment the
+# writer's tuple lands, so a passing run still costs about a second. It is wide
+# because the pass/fail must not turn on how promptly a contended runner
+# schedules that one-second writer subshell -- with a 4-second ceiling the writer
+# had roughly three seconds of slack, which a loaded macos-latest job can eat.
+# Only a verdict that never settles pays the full ceiling, and that run is red.
+run_verdict "$settle_target" "$settle_hash" UPDATED 30 || got=$?
 wait "$settle_pid"
 [[ $got -eq 1 ]] ||
   fail "a manifest that lands during the settle window must resolve to SILENT (got rc $got)"
@@ -403,7 +410,11 @@ got=0
 run_verdict "$settle_target" "$settle_hash" UPDATED 2 || got=$?
 elapsed=$(($(date +%s) - start))
 [[ $got -eq 0 ]] || fail "a tuple that never arrives must still PAGE (got rc $got)"
-((elapsed <= 6)) || fail "the settle wait is not bounded (${elapsed}s for a 2s window)"
+# The bug this catches is an UNBOUNDED wait, which never returns at all, so the
+# threshold only has to sit far below "forever" -- it never had the resolution to
+# tell a 2-second window from the 5-second default (5 passed at 6 too). Twenty
+# seconds still catches the unbounded wait and no longer turns on runner load.
+((elapsed <= 20)) || fail "the settle wait is not bounded (${elapsed}s for a 2s window)"
 
 # --- an ATTRIBUTE-only apply can settle too ----------------------------------
 # A chmod moves a file's inode CHANGE time, not its modification time. Keying the
@@ -430,7 +441,8 @@ touch -t 200001010000 "$MF_MANIFEST"
 ) &
 chmod_settle_pid=$!
 got=0
-run_verdict "$chmod_settle_target" "$chmod_settle_hash" ATTRIBUTES_MODIFIED 5 || got=$?
+# Same ceiling-not-measurement reasoning as the content-settle case above.
+run_verdict "$chmod_settle_target" "$chmod_settle_hash" ATTRIBUTES_MODIFIED 30 || got=$?
 wait "$chmod_settle_pid"
 [[ $got -eq 1 ]] ||
   fail "an attribute-only change whose manifest lands inside the settle window must resolve to SILENT (got rc $got)"
@@ -467,7 +479,11 @@ HOME="$MF_HOME" OSQUERY_PIPELINE_MANIFEST="$miss_manifest" \
     done
   ' _ "$VERDICT" "$misses" >/dev/null 2>&1
 elapsed=$(($(date +%s) - start))
-((elapsed <= 8)) ||
+# The bug is a PER-FINDING budget, which costs misses x 3 = 30 seconds here. The
+# threshold has to separate one budget from ten, so anything comfortably under 30
+# does the job; 8 left only five seconds of headroom over the expected ~3, which
+# a contended runner spends on ten rounds of shasum plus two stat calls each.
+((elapsed <= 20)) ||
   fail "$misses misses took ${elapsed}s: the settle budget is per finding, not per alerter run (a stall vector)"
 
 # --- THE ALLOWLIST BINDING SURVIVES THE SAME APPLY RACE ----------------------
@@ -546,7 +562,8 @@ touch -t 200001010000 "$MF_MANIFEST"
 ) &
 allowlist_settle_pid=$!
 got=0
-run_allowlist_verdict 4 || got=$?
+# Same ceiling-not-measurement reasoning as the content-settle case above.
+run_allowlist_verdict 30 || got=$?
 wait "$allowlist_settle_pid"
 [[ $got -eq 0 ]] ||
   fail "a legitimate apply must NOT false-page: the allowlist binding has to settle when the manifest lands (got rc $got)"
@@ -561,7 +578,9 @@ run_allowlist_verdict 2 || got=$?
 elapsed=$(($(date +%s) - start))
 [[ $got -eq 1 ]] ||
   fail "an allowlist the manifest never vouches for must not suppress (got rc $got)"
-((elapsed <= 6)) || fail "the allowlist binding wait is not bounded (${elapsed}s for a 2s window)"
+# Twenty for the same reason as the pipeline twin above: the bug is an unbounded
+# wait, and the old threshold had no resolution below that anyway.
+((elapsed <= 20)) || fail "the allowlist binding wait is not bounded (${elapsed}s for a 2s window)"
 
 if [[ $fails -gt 0 ]]; then
   printf '%d check(s) failed\n' "$fails" >&2

--- a/test/integration/osquery-queue-counts-wal.sh
+++ b/test/integration/osquery-queue-counts-wal.sh
@@ -77,8 +77,15 @@ trap cleanup EXIT
 # Block until the holder reports it applied the inserts: deterministic, no sleep.
 # By the time SYNC-DONE arrives the rows are committed into the WAL, and the
 # holder still owns the connection, so no checkpoint has folded them away.
+#
+# The read is bounded. A holder that DIED gives EOF and the loop ends on its own,
+# but a holder that is alive and simply never emits the marker (a sqlite3 build
+# that refuses WAL, or one still waiting on input) would block this read forever,
+# and an unattended CI job turns that into a six-hour timeout instead of a
+# failure. `read -t` returns nonzero on expiry exactly as it does on EOF, so both
+# shapes land on the same loud failure below.
 sync_seen=0
-while IFS= read -r line <&"${HOLDER[0]}"; do
+while IFS= read -r -t 60 line <&"${HOLDER[0]}"; do
   if [[ $line == *SYNC-DONE* ]]; then
     sync_seen=1
     break

--- a/test/integration/osquery-queue-counts-wal.sh
+++ b/test/integration/osquery-queue-counts-wal.sh
@@ -26,10 +26,8 @@ fail() {
   exit 1
 }
 
-command -v sqlite3 >/dev/null 2>&1 || {
-  printf 'SKIP: sqlite3 not on PATH; cannot exercise the WAL counters\n'
-  exit 0
-}
+command -v sqlite3 >/dev/null 2>&1 ||
+  fail "sqlite3 is not on PATH; the alert store IS SQLite, so this is a broken environment rather than a reason to skip"
 [[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
 
 work="$(mktemp -d)"

--- a/test/unit/osquery-local-notify-durable.sh
+++ b/test/unit/osquery-local-notify-durable.sh
@@ -23,10 +23,8 @@ fail() {
   exit 1
 }
 
-command -v sqlite3 >/dev/null 2>&1 || {
-  printf 'SKIP: sqlite3 not on PATH; cannot exercise the local-notification store\n'
-  exit 0
-}
+command -v sqlite3 >/dev/null 2>&1 ||
+  fail "sqlite3 is not on PATH; the local-notification store IS SQLite, so this is a broken environment rather than a reason to skip"
 [[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
 
 work="$(mktemp -d)"

--- a/test/unit/osquery-loud-local-status.sh
+++ b/test/unit/osquery-loud-local-status.sh
@@ -84,10 +84,8 @@ run_loud_local 0 "osascript fallback succeeds"
 # (d) Errexit safety of the existing one-CRIT caller: a drain pass that
 # dead-letters a record fires _loud_local; with a FAILING notifier the drain
 # must complete and exit 0 under set -euo pipefail, never abort mid-sweep.
-command -v sqlite3 >/dev/null 2>&1 || {
-  printf 'osquery-loud-local-status: OK (a, a2, b, b2, c; d skipped: no sqlite3)\n'
-  exit 0
-}
+command -v sqlite3 >/dev/null 2>&1 ||
+  fail "sqlite3 is not on PATH; the drain's store IS SQLite, so this is a broken environment rather than a reason to skip case (d)"
 rm -f "$work/bin/osascript"
 printf '#!/usr/bin/env bash\nexit 64\n' >"$work/bin/alerter" # notifier always fails
 chmod +x "$work/bin/alerter"

--- a/test/unit/osquery-queue-counts.sh
+++ b/test/unit/osquery-queue-counts.sh
@@ -20,10 +20,8 @@ fail() {
   exit 1
 }
 
-command -v sqlite3 >/dev/null 2>&1 || {
-  printf 'SKIP: sqlite3 not on PATH; cannot exercise the counters\n'
-  exit 0
-}
+command -v sqlite3 >/dev/null 2>&1 ||
+  fail "sqlite3 is not on PATH; the alert store IS SQLite, so this is a broken environment rather than a reason to skip"
 [[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
 
 work="$(mktemp -d)"

--- a/test/unit/osquery-store-quote-safety.sh
+++ b/test/unit/osquery-store-quote-safety.sh
@@ -27,10 +27,8 @@ fail() {
   exit 1
 }
 
-command -v sqlite3 >/dev/null 2>&1 || {
-  printf 'SKIP: sqlite3 not on PATH; cannot exercise the store helpers\n'
-  exit 0
-}
+command -v sqlite3 >/dev/null 2>&1 ||
+  fail "sqlite3 is not on PATH; the alert store IS SQLite, so this is a broken environment rather than a reason to skip"
 [[ -f $DISPATCH ]] || fail "missing dispatch library: $DISPATCH"
 
 # The strict interpreter: macOS system bash 3.2 when present, else plain bash.


### PR DESCRIPTION
## Context

This is a chezmoi dotfiles repository whose tests run in four camps (unit, integration, e2e,
test-system). Continuous integration is the only gate that runs all four: the commit hook runs the unit
camp alone, and the pre-push hook runs lint only, so a GitHub Actions job on `macos-latest` is the single
place the whole suite executes. CI's verdict is therefore the one signal worth trusting, and anything
that lets it turn on the runner instead of on the code corrupts it.

The osquery security pipeline (a local osquery installation whose findings are routed to pages, digests,
or log-only records) owns roughly sixty test files, the largest concentration in the repository. This
branch audits those files for couplings to the machine and removes the ones that can flip the verdict.

## Summary

- Six suites treated a missing tool as a reason to exit 0. `test/unit/osquery-queue-counts.sh`,
  `test/unit/osquery-store-quote-safety.sh`, `test/unit/osquery-local-notify-durable.sh`,
  `test/unit/osquery-loud-local-status.sh`, and `test/integration/osquery-queue-counts-wal.sh` skipped
  themselves without `sqlite3`; `test/integration/osquery-page-allowlist-seed.sh` skipped without `jq`.
  Each is a hard failure now. Neither tool is a `flake.nix` buildInput, so CI resolves `jq` from the
  runner image and `sqlite3` from `/usr/bin`, and an image change would have turned all six silently
  green.
- `test/e2e/osquery-alerter-hostile-columns.bats` never set `OSQUERY_PIPELINE_MANIFEST`, so its verdict
  fell back to `/var/osquery/pipeline-known-good.sha256`, a real machine path the suite never wrote. It
  now binds a manifest inside its sandbox home, and a new control test asserts that the genuine
  allowlisted agent is suppressed.
- `test/integration/osquery-pipeline-manifest-agreement.sh` raced a backgrounded one-second writer
  against a four-second settle ceiling, and its elapsed-time assertions left five seconds of headroom.
  Each ceiling there is a bound the passing path returns well inside, so all six are wide enough now that
  runner load cannot decide the result.
- Three more waits were too tight for a shared runner: `test/integration/osquery-queue-counts-wal.sh`
  blocked forever on a `read` from a WAL holder that stayed alive without confirming, and it is bounded
  now; `test/e2e/osquery-alert-drainer.bats` gave a forked stub two seconds to write its pid file; and
  `test/integration/osquery-allowlist.bats` gave a lingering grandchild five seconds to outlive a real
  `chezmoi apply`.
- The task named seven tests and ten are changed here, across four coupling classes. Every one is
  reproduced by a mutation in the table below, so none is padding. Three further findings were
  investigated and left alone, with the reasons under the review guide.

## How it was verified

Every reworked test keeps a demonstrated RED path. Each row below was produced by mutating the named
source, running the test, and restoring the source. The control (unmutated) run of each test is green.

| Test | Mutation applied | Result |
| --- | --- | --- |
| `test/unit/osquery-queue-counts.sh` | `sqlite3` removed from PATH | RED, names the missing prerequisite |
| `test/unit/osquery-queue-counts.sh` | corrupt-store branch reports a false zero | RED, `a false zero hides a real backlog` |
| `test/unit/osquery-store-quote-safety.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-store-quote-safety.sh` | URL quote doubling dropped from the store helper | RED, `URL did not round-trip intact` |
| `test/unit/osquery-local-notify-durable.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-local-notify-durable.sh` | confirmed banner no longer deletes its row | RED, `expected 0 row(s) once the watcher settled, still 1` |
| `test/unit/osquery-loud-local-status.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-loud-local-status.sh` | `_loud_local` always returns 0 | RED, `expected a NONZERO status, got 0` |
| `test/integration/osquery-queue-counts-wal.sh` | `sqlite3` removed from PATH | RED |
| `test/integration/osquery-queue-counts-wal.sh` | counters opened `immutable=1`, skipping the WAL | RED, `expected '3', got '0'` |
| `test/integration/osquery-queue-counts-wal.sh` | holder never emits its marker | RED at 5s with the bound; without it, still blocked when an external kill landed at 10s |
| `test/integration/osquery-page-allowlist-seed.sh` | `jq` removed from PATH | RED |
| `test/integration/osquery-page-allowlist-seed.sh` | digest agent's allowlist tuple deleted | RED, names the agent that would self-page |
| `test/e2e/osquery-alerter-hostile-columns.bats` | manifest vouching disabled (the pre-change world) | control RED while the three injection pins stayed GREEN, which is the evidence they were vacuous before |
| `test/e2e/osquery-alerter-hostile-columns.bats` | in-band 0x1F re-split reintroduced into the verdict | `HOSTILE-0x1F` RED |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle window never waits | RED, `must resolve to SILENT` |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle budget becomes per-finding | RED, `10 misses took 35s` against the 20s ceiling |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle wait multiplied 30x (the unbounded shape) | RED, `60s for a 2s window` |
| `test/e2e/osquery-alert-drainer.bats` | banner child inherits the drain lock fd | `T-DRAIN-lock-fd-leak` RED |
| `test/integration/osquery-allowlist.bats` | osqueryi capture inherits the writer lock fd | `the writer's lock never leaks to a child` RED |

The PATH mutations run each test on a mirror of the real PATH with one tool removed, so the guard under
test is the only thing that changes.

The full gate is green. `just l` reformatted nothing, and `just test` exited 0 across all four camps: 201
executable `.sh` tests plus 329 bats tests (264 integration, 46 e2e, 19 test-system), with zero `not ok`
lines.

## Effect of merging

CI going red starts meaning the code is broken again for these ten files. Nothing about the live machine
changes: every file touched is under `test/`, which `.chezmoiignore` keeps out of the target state, so no
`chezmoi apply` behaves differently and no osquery agent, plist, or library is modified. Production
sources were temporarily mutated to produce the table above, and every one was restored from git.

## Review guide

Read in this order.

`test/e2e/osquery-alerter-hostile-columns.bats` carried the worst coupling, and it is the only file whose
assertions changed instead of its plumbing. Its three injection pins were passing while the suppression
path they exist to defeat could not run at all, because nothing in the sandbox could vouch for the
allowlist. The setup block and the new `HOSTILE-control` test are what make the other three mean
something, and this file's two mutation rows are the argument for that.

`test/integration/osquery-pipeline-manifest-agreement.sh` next: six wall-clock sites, with the reasoning
for each widened number in the comment beside it. Check whether a widened ceiling still separates the bug
it pins from a healthy run. For the ten-miss case the bug costs thirty seconds against a twenty-second
ceiling, and the mutation row measuring thirty-five seconds is that check.

The six skip-to-fail conversions are mechanical and read together. The remaining three files are one
changed number or one added flag each.

Three findings were deliberately left alone. The `chezmoi` skip guards in the launch-agent and config
suites cannot fire in CI, because `chezmoi` is a `flake.nix` buildInput and resolves from the nix store;
that is the distinction which put `jq` and `sqlite3` in scope and left these out. The `lockf` skips
assert a darwin-only kernel guarantee, and asserting the host is the shape
`test/unit/no-empty-render-skip-on-darwin.sh` already blesses, as against inferring it.
`test/integration/osquery-feature-set-location.sh` reads through `git grep`, which searches the working
tree and not the index (checked against an unstaged probe line), and it fails closed on any git error.
