### PR TITLE
fix(chezmoi): let chezmoi run on a host without Homebrew

### DIFF
--- a/.install-password-manager.sh
+++ b/.install-password-manager.sh
@@ -1,18 +1,43 @@
 #!/bin/sh
 
+# chezmoi runs this as the `hooks.read-source-state.pre` command declared in
+# .chezmoi.toml.tmpl, so it runs before EVERY chezmoi command that reads the
+# source state, the read-only ones included (execute-template, managed, status,
+# diff), and its exit status becomes that command's exit status.
+#
+# That makes it best-effort by construction: it installs KeePassXC when it can
+# and reports why when it cannot. Failing instead takes the whole chezmoi CLI
+# down with it. On a host with no Homebrew, `brew` is not found, the hook exits
+# 127, and every template render fails for a reason that has nothing to do with
+# the template. A fresh Mac is in exactly that state until
+# .chezmoiscripts/run_once_before_00-install-homebrew.sh has run, and this hook
+# runs before any script does, so aborting here would deadlock the bootstrap the
+# hook exists to serve; the next `chezmoi apply` installs the cask through the
+# Homebrew the first one laid down.
+#
+# The tradeoff: a template that reads the vault now fails at its own call site,
+# naming itself, instead of every chezmoi command failing up front.
+
 # Exit immediately if password-manager-binary is already in $PATH.
-type keepassxc-cli >/dev/null 2>&1 && exit
+type keepassxc-cli >/dev/null 2>&1 && exit 0
 
 os="$(uname -s)"
 
 case "$os" in
   Darwin)
-    brew install --cask keepassxc
+    if type brew >/dev/null 2>&1; then
+      brew install --cask keepassxc ||
+        echo "Warning: 'brew install --cask keepassxc' failed. Install KeePassXC by hand before applying any template that reads the vault." >&2
+    else
+      echo "Warning: KeePassXC is missing and Homebrew is not on PATH, so it cannot be installed here. Templates that read the vault will fail until it is installed." >&2
+    fi
     ;;
   Linux)
     # commands to install password-manager-binary on Linux
     ;;
   *)
+    # No install branch exists for this platform, so there is no bootstrap to
+    # protect and the error is the only signal the operator gets.
     echo "Error: unsupported OS '$os'" >&2
     exit 1
     ;;

--- a/test/integration/render-without-package-manager.sh
+++ b/test/integration/render-without-package-manager.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# render-without-package-manager.sh -- rendering this repo's templates must not
+# require Homebrew.
+#
+# `chezmoi execute-template` reads the source state, and reading the source
+# state fires the `hooks.read-source-state.pre` command declared in
+# .chezmoi.toml.tmpl (.install-password-manager.sh). The hook's exit status is
+# the render's exit status, so when the hook shelled out to a `brew` that was
+# not on PATH, every one of this repo's render tests failed on a host without
+# Homebrew, for a reason none of them was testing.
+#
+# This test reproduces that path deliberately: a chezmoi config carrying the
+# same hook declaration the real config carries, a PATH with neither
+# keepassxc-cli nor brew, and a render that must still succeed.
+#
+# Two things keep it honest:
+#   - it asserts .chezmoi.toml.tmpl still routes the hook at
+#     .install-password-manager.sh, so the test cannot pass by testing a hook
+#     the real config stopped using;
+#   - it renders a second time through a hook that fails on purpose, proving the
+#     harness DOES observe the hook and would catch a regression, rather than
+#     passing because the hook never ran.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.install-password-manager.sh"
+CONFIG_TEMPLATE="$REPO_ROOT/.chezmoi.toml.tmpl"
+
+fail() {
+  printf 'render-without-package-manager: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x $HOOK ]] || fail "missing or non-executable hook: $HOOK"
+[[ -f $CONFIG_TEMPLATE ]] || fail "missing config template: $CONFIG_TEMPLATE"
+
+# Resolve chezmoi from the AMBIENT PATH before the stripped PATH is built: on
+# this host chezmoi itself is a Homebrew formula, and the point of the test is
+# that the RENDER does not need Homebrew, not that chezmoi is installed
+# somewhere else.
+CHEZMOI_BIN="$(command -v chezmoi)" ||
+  fail "chezmoi is not on PATH; this test renders with the host chezmoi"
+
+# The hook this repo actually declares, read out of the config template rather
+# than assumed. The template writes it as a Go-templated sourceDir path.
+grep -q 'hooks.read-source-state.pre' "$CONFIG_TEMPLATE" ||
+  fail "$CONFIG_TEMPLATE no longer declares hooks.read-source-state.pre; this test guards a mechanism that moved"
+grep -q '\.install-password-manager\.sh' "$CONFIG_TEMPLATE" ||
+  fail "$CONFIG_TEMPLATE no longer routes the read-source-state hook at .install-password-manager.sh"
+
+work="$(mktemp -d)"
+# `trash` is the operator's rule for interactive removals; a committed test has
+# to run on a bare CI runner, where only coreutils exist.
+trap 'rm -rf "$work"' EXIT
+
+# A PATH the render cannot smuggle a package manager in through. Asserted, not
+# assumed: a system-wide brew would turn this into a test of nothing.
+BASE_PATH="/usr/bin:/bin"
+for absent in brew keepassxc-cli; do
+  if PATH="$BASE_PATH" command -v "$absent" >/dev/null 2>&1; then
+    fail "$absent resolves under PATH=$BASE_PATH, so this test cannot show the render works without it"
+  fi
+done
+
+# write_config <path> <hook-command> -- the minimum config that reproduces the
+# real one's hook wiring. Nothing else from the authoring machine's config is
+# copied: the render must not depend on it either.
+write_config() {
+  cat >"$1" <<CONFIG
+[hooks.read-source-state.pre]
+  command = "$2"
+CONFIG
+}
+
+# render <config> <outfile> <errfile> -- render a template that needs no data of
+# its own, so the only thing under test is whether reading the source state
+# succeeded. Returns chezmoi's exit status.
+render() {
+  PATH="$BASE_PATH" HOME="$work/home" CI=1 "$CHEZMOI_BIN" \
+    --config "$1" --source "$REPO_ROOT" --destination "$work/home" \
+    execute-template --no-tty <<<'{{ .chezmoi.os }}' >"$2" 2>"$3"
+}
+
+mkdir -p "$work/home"
+
+# ---- the behavior: the real hook must not block a render ---------------------
+real_config="$work/real-hook.toml"
+write_config "$real_config" "$HOOK"
+
+status=0
+render "$real_config" "$work/real.out" "$work/real.err" || status=$?
+if [[ $status -ne 0 ]]; then
+  printf 'render-without-package-manager: FAIL -- rendering through %s failed (exit %d) on a PATH with no Homebrew; chezmoi said:\n' \
+    "$HOOK" "$status" >&2
+  cat "$work/real.err" >&2
+  exit 1
+fi
+[[ -s $work/real.out ]] ||
+  fail "the render exited 0 but produced nothing, so it did not actually render"
+
+# ---- the control: the harness must be able to SEE a failing hook -------------
+# Without this, a hook that never ran would look identical to a hook that ran
+# and behaved.
+failing_hook="$work/failing-hook.sh"
+printf '#!/bin/sh\necho "deliberate hook failure" >&2\nexit 1\n' >"$failing_hook"
+chmod +x "$failing_hook"
+
+control_config="$work/failing-hook.toml"
+write_config "$control_config" "$failing_hook"
+
+control_status=0
+render "$control_config" "$work/control.out" "$work/control.err" || control_status=$?
+[[ $control_status -ne 0 ]] ||
+  fail "a hook that exits 1 must fail the render; it did not, so this test is not observing the hook at all"
+grep -q 'deliberate hook failure' "$work/control.err" ||
+  fail "the control render failed without running the hook, so the failure proves nothing (stderr: $(cat "$work/control.err"))"
+
+printf 'render-without-package-manager: OK (renders through the real read-source-state hook with no brew and no keepassxc-cli on PATH; a failing hook still fails the render)\n'

--- a/test/unit/install-password-manager-hook.sh
+++ b/test/unit/install-password-manager-hook.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# install-password-manager-hook.sh -- .install-password-manager.sh is wired in
+# .chezmoi.toml.tmpl as chezmoi's `hooks.read-source-state.pre` command, so it
+# runs before EVERY chezmoi command that reads the source state, including the
+# read-only ones (`execute-template`, `managed`, `status`). Its exit status is
+# the whole command's exit status: a hook that fails aborts the chezmoi call
+# that triggered it.
+#
+# That makes the hook best-effort by construction. It may install KeePassXC when
+# it can, but a machine it cannot install on must still be able to RUN chezmoi.
+# The cases, all with the hook's own PATH under test control:
+#
+#   keepassxc-cli present            -> exit 0, no package manager touched
+#   absent, brew present             -> exit 0, `brew install --cask keepassxc`
+#   absent, brew install fails       -> exit 0, names the failure on stderr
+#   absent, brew absent              -> exit 0, names KeePassXC and Homebrew
+#   unsupported OS                   -> exit 1 (deliberately still fatal: no
+#                                       branch exists to install anything, and
+#                                       the message is the only signal)
+#
+# The brew-absent case is the one that coupled the whole render-test layer to
+# Homebrew: the hook exited 127 there, so every test that rendered a template
+# failed on a host without brew on PATH.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.install-password-manager.sh"
+
+fail() {
+  printf 'install-password-manager-hook: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x $HOOK ]] || fail "missing or non-executable hook: $HOOK"
+
+work="$(mktemp -d)"
+# `trash` is the operator's rule for interactive removals; a committed test has
+# to run on a bare CI runner, where only coreutils exist.
+trap 'rm -rf "$work"' EXIT
+
+# The hook needs `uname` and a shell, and must find NOTHING else unless this
+# test puts it there. /usr/bin:/bin carries neither brew nor keepassxc-cli on a
+# stock macOS or Linux host; assert that instead of assuming it, or a stray
+# system-wide install would silently turn a case into a different case.
+BASE_PATH="/usr/bin:/bin"
+for absent in brew keepassxc-cli; do
+  if PATH="$BASE_PATH" command -v "$absent" >/dev/null 2>&1; then
+    fail "$absent resolves under PATH=$BASE_PATH, so the cases below cannot control whether the hook sees it"
+  fi
+done
+
+failures=0
+report() { # <ok|bad> <message>
+  if [[ $1 == ok ]]; then
+    printf '  ok   %s\n' "$2"
+  else
+    printf '  FAIL %s\n' "$2"
+    failures=$((failures + 1))
+  fi
+}
+
+# run_case <name> <stub-spec...> -- build a stub bin dir from the specs, run the
+# hook with PATH = that dir plus the base path, and publish RC, ERR and the
+# recorded stub calls in CALLS.
+#
+# A stub spec is "<name>:<exit-status>[:<stdout>]". Every stub appends its own
+# argv to the case's call log, so a case can prove a command was NOT run, not
+# just that the hook exited a particular way.
+run_case() {
+  local name="$1"
+  shift
+  local dir="$work/$name"
+  mkdir -p "$dir/bin"
+  local calls="$dir/calls"
+  : >"$calls"
+
+  local spec stub_name stub_status stub_stdout
+  for spec in "$@"; do
+    IFS=: read -r stub_name stub_status stub_stdout <<<"$spec"
+    {
+      printf '#!/bin/sh\n'
+      printf 'printf "%%s %%s\\n" "%s" "$*" >>"%s"\n' "$stub_name" "$calls"
+      [[ -n $stub_stdout ]] && printf 'printf "%%s\\n" "%s"\n' "$stub_stdout"
+      printf 'exit %s\n' "$stub_status"
+    } >"$dir/bin/$stub_name"
+    chmod +x "$dir/bin/$stub_name"
+  done
+
+  # $(<file) and the pattern tests below are builtins: this is a unit test, and
+  # a fork per assertion is most of what it would otherwise cost.
+  RC=0
+  PATH="$dir/bin:$BASE_PATH" "$HOOK" >"$dir/out" 2>"$dir/err" || RC=$?
+  ERR="$(<"$dir/err")"
+  CALLS="$(<"$calls")"
+}
+
+assert_status() { # <case> <expected-status>
+  if [[ $RC -eq $2 ]]; then
+    report ok "$1: exits $2"
+  else
+    report bad "$1: expected exit $2, got $RC (stderr: $ERR)"
+  fi
+}
+
+assert_called() { # <case> <fragment>
+  if [[ $CALLS == *"$2"* ]]; then
+    report ok "$1: ran '$2'"
+  else
+    report bad "$1: expected a call matching '$2', recorded calls: ${CALLS:-<none>}"
+  fi
+}
+
+assert_not_called() { # <case> <fragment>
+  if [[ $CALLS == *"$2"* ]]; then
+    report bad "$1: must NOT run '$2', recorded calls: $CALLS"
+  else
+    report ok "$1: did not run '$2'"
+  fi
+}
+
+assert_stderr_mentions() { # <case> <fragment>
+  if [[ $ERR == *"$2"* ]]; then
+    report ok "$1: stderr names '$2'"
+  else
+    report bad "$1: stderr must name '$2' (stderr: ${ERR:-<empty>})"
+  fi
+}
+
+assert_stderr_silent() { # <case>
+  if [[ -z $ERR ]]; then
+    report ok "$1: silent"
+  else
+    report bad "$1: expected no stderr, got: $ERR"
+  fi
+}
+
+printf 'install-password-manager-hook cases:\n'
+
+# The password manager is already there: nothing to do, and nothing installed.
+run_case already-installed keepassxc-cli:0 brew:0
+assert_status already-installed 0
+assert_not_called already-installed brew
+assert_stderr_silent already-installed
+
+# The hook's real job on a fresh Mac that has Homebrew.
+run_case installs-with-brew brew:0
+assert_status installs-with-brew 0
+assert_called installs-with-brew 'brew install --cask keepassxc'
+
+# Homebrew is there but the install does not work (offline, a cask rename, a
+# broken tap). The hook reports it and still lets chezmoi run.
+run_case brew-install-fails brew:1
+assert_status brew-install-fails 0
+assert_called brew-install-fails 'brew install --cask keepassxc'
+assert_stderr_mentions brew-install-fails KeePassXC
+
+# Neither the password manager nor the package manager that would install it.
+# The hook has nothing it can do, so it says so and gets out of chezmoi's way.
+run_case no-package-manager
+assert_status no-package-manager 0
+assert_stderr_mentions no-package-manager KeePassXC
+assert_stderr_mentions no-package-manager Homebrew
+
+# An OS with no install branch at all stays fatal: there is no bootstrap to
+# protect on a platform this repo does not target, and the error is the signal.
+run_case unsupported-os uname:0:Plan9
+assert_status unsupported-os 1
+assert_stderr_mentions unsupported-os Plan9
+
+if [[ $failures -gt 0 ]]; then
+  printf 'install-password-manager-hook: %d assertion(s) FAILED\n' "$failures" >&2
+  exit 1
+fi
+printf 'install-password-manager-hook: OK (present, installable, install failed, no package manager, unsupported OS)\n'


### PR DESCRIPTION
## Context

This repository is a chezmoi dotfiles tree whose tests verify apply-time behavior by rendering the
real templates with `chezmoi execute-template` and asserting on the result. Dozens of tests across the
unit, integration and e2e suites do that.

Rendering a template reads the source state, and reading the source state fires the
`hooks.read-source-state.pre` command that `.chezmoi.toml.tmpl` declares: `.install-password-manager.sh`,
the bootstrap hook that installs KeePassXC. That hook called `brew` without checking whether Homebrew
existed, and a hook's exit status is the exit status of the chezmoi command that triggered it. On a host
with no Homebrew on PATH the hook exited 127 and took every render down with it, so a whole layer of
tests failed for a reason none of them was about.

## Summary

- `.install-password-manager.sh` now checks for `brew` before calling it, and reports on stderr instead
  of failing, both when Homebrew is missing and when the install itself fails.
- An unsupported operating system stays a hard error in `.install-password-manager.sh`, and the hook
  still installs the KeePassXC cask whenever Homebrew is present. Nothing else in it changed.
- `test/unit/install-password-manager-hook.sh` drives the hook's five outcomes against a PATH built from
  stubs: KeePassXC already installed, installable, install failed, no package manager, unsupported
  operating system.
- `test/integration/render-without-package-manager.sh` renders through the real hook with neither `brew`
  nor `keepassxc-cli` on PATH, then re-renders through a deliberately failing hook, so a run that never
  reached the hook cannot pass as a success.

## What changed

The hook's Darwin branch went from one unguarded `brew install --cask keepassxc` to a presence-checked
call with a message on each failure path. The two new tests are the only other files in the change.

The reasoning sits in a comment at the top of the hook. A read-source-state pre hook runs before every
chezmoi command that reads the source state, read-only ones included, so it is best-effort by
construction. It also runs before any `run_once_before_*` script, which is where this repository installs
Homebrew, so a fresh Mac with no Homebrew could not get past the hook to the script that would have fixed
it.

The tradeoff, written in the same comment: a template that reads the vault now fails at its own call site
and names itself, instead of every chezmoi command failing up front.

## How it was verified

**Run 1, the de-homebrewed environment.** A scratch `XDG_CONFIG_HOME` holding a chezmoi config wired the
way the live one is (`[hooks.read-source-state.pre] command = <hook>`), a PATH with every `/opt/homebrew`
entry removed, and `bash --noprofile --norc` so no login shell could put Homebrew back. The harness ran
each suite twice: once with the hook as it is at HEAD, once with the hook from this branch.

Harness header, identical in both runs apart from the hook path:

```
brew: (absent)
keepassxc-cli: (absent)
chezmoi: /nix/store/w8cp1c2ixw7zg8m8x5w5r2m4gqa5qxhh-chezmoi-2.62.3/bin/chezmoi
```

The 46 integration and e2e tests that drive chezmoi against the source state:

```
before  TOTALS pass=15 fail=31
after   TOTALS pass=43 fail=3
```

All three that still fail say the same thing, and none of it is about Homebrew:

```
FAIL test/integration/hermes-route-status.sh
     | hermes-route-status: FAIL -- yq is not on PATH; the script under test needs it
FAIL test/integration/macos-defaults-shape-agreement.sh
     | FAIL: yq is not on PATH; this suite renders a real template and cannot be meaningfully skipped
FAIL test/integration/macos-defaults-validate-before-write.sh
     | FAIL: yq is not on PATH; this suite renders a real template and streams real YAML, so it cannot be meaningfully skipped
```

The unit suite over the same two runs went from 26 failures to 7: 19 tests flipped from red to green, and
the 7 that remain are the six that need `yq` plus `test/unit/gitconfig-tool-and-url-hygiene.sh`, which
derives a target path from `XDG_CONFIG_HOME` and so cannot run under a harness that overrides it. Its
failure text is the tell. Before:

```
/…/install-password-manager.sh: line 10: brew: command not found
chezmoi: read-source-state: pre: /…/install-password-manager.sh: exit status 127
FAIL: chezmoi managed failed against source /…; invariant 4 cannot be decided
```

After, the render succeeds and only the harness's own path assertion is left:

```
Warning: KeePassXC is missing and Homebrew is not on PATH, so it cannot be installed here. Templates that read the vault will fail until it is installed.
FAIL: core.excludesfile is unset, so git falls back to …/brewproof/after/git/ignore …
```

**Run 2, the normal environment.** `just l` reports no drift (`formatted 375 files (0 changed)`), and
`just test` is green across all four suites.

**Mutation check.** Five mutations of `.install-password-manager.sh`, each run against both new tests,
with an unmutated control before and after:

```
control (unmutated)                  unit=GREEN integration=GREEN
M1 no brew-presence guard            unit=RED   integration=RED
M2 missing brew is fatal             unit=RED   integration=RED
M3 failed install propagates         unit=RED   integration=GREEN
M4 always exits early                unit=RED   integration=GREEN
M5 unsupported OS accepted           unit=RED   integration=GREEN
control (restored)                   unit=GREEN integration=GREEN
```

## Effect of merging

Test runs stop requiring Homebrew on PATH. No live-machine state changes: the hook is a source-tree file
that chezmoi invokes from its config, so the new behavior takes effect the next time chezmoi runs, and
the behavior it replaces is a failure path on a host that has no Homebrew.

The `yq` dependency the runs above expose is untouched and is a separate problem: seven tests fail
without `yq` on PATH, and `yq` reaches this machine as a Homebrew formula.

## Review guide

Confirm the coupling mechanism first, since the rest follows from it: `chezmoi execute-template` fires
`hooks.read-source-state.pre`. That is not obvious from the command name, and it is what makes a
password-manager installer a dependency of a template render. A three-line reproduction is a config with
that hook, a hook that exits 1, and any `execute-template` call.

`.install-password-manager.sh` is the load-bearing file. The question to press on is whether exiting 0 on
a missing package manager weakens the hook's real job. One case does narrow: on a machine with neither
KeePassXC nor Homebrew, a template that reads the vault now fails later, at that template, rather than
the chezmoi command failing sooner. On a machine that has Homebrew the hook still installs the cask.

The unsupported-OS branch was deliberately left fatal, and
`test/unit/install-password-manager-hook.sh` pins that asymmetry so it cannot be tidied away by
symmetry alone.
