### PR TITLE
feat(packages): declare the thaw menu bar manager cask

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -214,6 +214,7 @@ packages:
         - retroarch-metal
         - signal
         - slack
+        - thaw
         - todoist-app
         - torguard
         - upterm


### PR DESCRIPTION
## Context

This is a chezmoi dotfiles repository. Every Homebrew package the machine is meant to have is declared in
`.chezmoidata/system_packages_autoinstall.yaml`, and an apply-time script turns that data into a Brewfile
and runs `brew bundle --cleanup`. A package that is installed but not declared gets removed on the next
run; one that is declared but missing gets installed on a fresh machine.

Thaw is a menu bar manager for macOS. It was wanted on this machine but had never been installed or
declared, so it sat outside that contract.

## Summary

- Adds `thaw` to the `casks` list in `.chezmoidata/system_packages_autoinstall.yaml`, in alphabetical
  position between `slack` and `todoist-app`.
- Declares the stable cask, not `thaw@beta` (2.0.0-rc.1, which also requires macOS 26).
- No `trusted_taps` entry is added: `thaw` ships from the official `Homebrew/homebrew-cask` tap, so the
  `HOMEBREW_REQUIRE_TAP_TRUST` gate that third-party taps trip does not apply to it.
- The app is installed live by this change, so the declaration records a state the machine is already in.

## How it was verified

- `brew info --cask thaw` names `Homebrew/homebrew-cask` as the source and 1.2.0 as the version;
  `brew info --cask thaw@beta` is 2.0.0-rc.1 and requires macOS >= 26, which is why the plain name was
  taken.
- `brew install --cask thaw` succeeded with no trust prompt. `brew list --cask thaw` shows the 1.2.0
  Caskroom entry and `/Applications/Thaw.app` exists.
- `just l` reports 380 files traversed and 0 changed, so there is no format drift.
- `just test-unit` exits 0.

## Effect of merging

Thaw is already installed here, so merging changes nothing about this machine today. What it changes is
convergence: the next apply and any fresh machine install it, and `brew bundle --cleanup` stops seeing it
as an undeclared package to remove. Merging does not run an apply and does not touch the live Homebrew
state on its own.

## Review guide

The diff is one line of YAML. Worth checking: the alphabetical position within `casks`, and that the
stable cask name was chosen over `thaw@beta`.
