### PR TITLE
fix(test): wait for the regenerated cache, not the brew stub counter

### DIFF
--- a/test/e2e/bashrc-brew-cache-self-heal.sh
+++ b/test/e2e/bashrc-brew-cache-self-heal.sh
@@ -203,12 +203,28 @@ wait_for_invocations() {
   return 1
 }
 
+# Wait for the CONTENT a regeneration leaves behind, which is what the assertions
+# that follow actually read. Waiting on the invocation counter instead is a race:
+# the stub records its invocation on its FIRST line, before it prints the payload,
+# and the writer then still has to capture that output into a temp file and
+# rename it over the cache, so a wait on the counter resumes while the cache file
+# is absent or still holds the old bytes. The counter wait remains right for the
+# cases that assert a regeneration was LAUNCHED and cannot wait on a result,
+# because their whole point is that the repair does not converge.
+wait_for_file_content() {
+  local file="$1" wanted="$2" deadline=$((SECONDS + REGENERATION_TIMEOUT_SECONDS))
+  while ((SECONDS < deadline)); do
+    if grep -qF "$wanted" "$file" 2>/dev/null; then return 0; fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+  return 1
+}
+
 assert_regenerated() {
   local host="$1" label="$2"
-  wait_for_invocations "$host" 1 ||
-    fail "$label: the guard never regenerated the cache (brew was never invoked)"
-  grep -qF "$STUB_PAYLOAD" "$host/home/$CACHE_RELATIVE" ||
-    fail "$label: the cache does not carry the regenerated output"
+  wait_for_file_content "$host/home/$CACHE_RELATIVE" "$STUB_PAYLOAD" ||
+    fail "$label: the cache did not carry the regenerated output within" \
+      "${REGENERATION_TIMEOUT_SECONDS}s (brew invocations: $(invocation_count "$host"))"
   local litter
   litter="$(find "$host/home/${CACHE_RELATIVE%/*}" -maxdepth 1 -name "${CACHE_RELATIVE##*/}.*" -print)"
   [[ -z $litter ]] || fail "$label: a temp file was left behind: $litter"
@@ -248,7 +264,9 @@ start_shell "$host"
 assert_shell_was_silent "$host" 'fresh host'
 assert_regenerated "$host" 'fresh host'
 [[ -f $host/home/$LOG_RELATIVE ]] || fail 'fresh host: no log file was created'
-grep -qF 'Regenerated' "$host/home/$LOG_RELATIVE" ||
+# Bounded rather than immediate for the same reason: the writer prints its report
+# AFTER the rename, so the log line trails the cache content the assert waited on.
+wait_for_file_content "$host/home/$LOG_RELATIVE" 'Regenerated' ||
   fail "fresh host: the writer's report did not land in the log"
 [[ -s $host/home/$STAMP_RELATIVE ]] ||
   fail 'fresh host: the repair attempt was not recorded, so nothing bounds the retries'


### PR DESCRIPTION
## Context

This is a chezmoi dotfiles repository. `~/.bashrc` carries a self-heal guard for the cached
`brew shellenv` output: when that cache is missing, unusable or stale, the guard launches a detached
writer that regenerates it. `test/e2e/bashrc-brew-cache-self-heal.sh` drives the real rendered block
against a fixture Homebrew prefix, with a stub `brew` that records every invocation and prints a
recognizable payload.

The test flaked twice under load on 2026-08-04. Its regeneration assertion waited on the stub's
invocation counter, and that counter moves well before the regenerated cache file exists.

## Summary

- Adds `wait_for_file_content` to `test/e2e/bashrc-brew-cache-self-heal.sh`, a bounded poll for a fixed
  string in a file that reuses the file's existing 10 second timeout and 50 ms poll interval.
- `assert_regenerated` now waits for the regenerated payload to land in the cache file rather than for
  the brew stub's invocation counter to move. Its timeout message carries the invocation count, so
  "brew never ran" stays distinguishable from "brew ran and the cache never landed".
- The fresh-host case waits for the writer's `Regenerated` line to reach the log instead of reading the
  log the instant the cache appears. The writer prints that line after the rename, so it trails the
  content the assertion waited on.
- `wait_for_invocations` stays, and stays in use at the three sites whose whole point is that a repair
  was launched and cannot converge (unreadable cache, unreadable paths file, repeated shell starts).
- Nothing was removed or relaxed: the same payload check, temp-file litter check and log check run, on a
  bounded wait instead of an immediate read.

## How it was verified

- Root cause, read out of the two files involved: the stub appends to its invocation file on its first
  line and prints the payload afterwards, and the writer
  (`dot_local/bin/executable_brew-shellenv-cache-refresh.sh`) then captures that output into
  `mktemp "${cache_file}.XXXXXX"` and renames it over the cache. A wait on the counter returns in the
  middle of that window, so the `grep` that followed read a file that did not exist yet.
- Mutation against an unmutated control: with `sleep 0.2` injected into the brew stub before its payload
  line, the version of this test on `main` fails with
  `grep: .../brew-shellenv.sh: No such file or directory` followed by
  `FAIL -- fresh host: the cache does not carry the regenerated output`, which is the flake signature.
  The same delay against this version passes.
- 60 runs of the fixed test with zero failures, run as three concurrent loops of 20, so every run had two
  other copies of the same test competing with it for CPU. One run takes about 10.7 seconds by itself.
- `just l` reports no format drift, `just test-unit` and `just test-e2e` both exit 0.

## Effect of merging

Test-only. No template, script or data file changes, so no machine state moves and no apply behavior
changes. Merging buys a suite that stops failing on a timing window unrelated to the behavior under
test, which matters because CI is the only gate that runs the e2e suite.

## Review guide

- The judgement call is whether waiting on content weakens the assertion. Compare `assert_regenerated`
  before and after: the old first wait proved only that brew ran, the new one proves brew ran and
  produced the cache, so it is strictly stronger, and the invocation count moved into the timeout
  message to preserve the old diagnostic.
- Worth a second look: whether `wait_for_invocations` is still the right call at each of its three
  remaining sites. Those cases assert that a repair which cannot converge was nevertheless launched, so
  there is no result to wait for.
