### PR TITLE
fix(ssh-hardening): bound, trap and restore what install and reload could not

### DIFF
--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -55,12 +55,14 @@
 #                       reload for as long as it blocks -- the bound limits
 #                       how many times a probe runs, not how long one takes.
 #   SSH_HARDENING_VERIFY_DEADLINE
-#                       seconds the child verify may run before it is stopped
-#                       and reported as a FAILED verify (default 120; see
-#                       VERIFY_DEADLINE_SECONDS for why that bound is safe and
-#                       what an expiry costs). Anything but a positive whole
-#                       number is the default. The override exists for tests,
-#                       which cannot wait out the real bound.
+#                       seconds any ONE sshd call this script waits on may run
+#                       before it is stopped and its failure reported: the child
+#                       verify, and --reload's syntax check and port resolution
+#                       (default 120; see VERIFY_DEADLINE_SECONDS for why that
+#                       bound is safe and what an expiry costs). Anything but a
+#                       positive whole number, or more than one day, is the
+#                       default. The override exists for tests, which cannot
+#                       wait out the real bound.
 #   SSH_HARDENING_ALLOW_MISSING_SSHD
 #                       explicit test seam: when set to a TRUE-ish value AND
 #                       $SSHD_BIN cannot run, --verify skips (exit 0) WITHOUT a
@@ -364,9 +366,28 @@ VERIFY_FAILURES=()
 #
 # A value that is not a positive whole number of seconds is the DEFAULT, never
 # taken at face value: 0 would stop every verify at once, and a non-number would
-# make the arithmetic in run_verify_child a shell error.
+# make the arithmetic in run_bounded a shell error.
+#
+# So is a value past VERIFY_DEADLINE_MAX_SECONDS, and that bound is not
+# decoration. The wait is counted in TICKS, four per second, and bash arithmetic
+# is signed 64-bit: SSH_HARDENING_VERIFY_DEADLINE=2305843009213693952 multiplied
+# by four is exactly -9223372036854775808 (measured on bash 3.2.57), so the tick
+# budget comes out NEGATIVE, the poll loop never runs a single pass, and a
+# perfectly healthy verify is stopped the instant it starts and reported as
+# having timed out after 2.3e18 seconds -- which on the install path rolls a
+# valid install back. The digit-count in the pattern is what keeps the range
+# comparison itself out of overflow territory: a 30-digit value would wrap
+# before `-gt` ever saw it, so it is refused by shape before it is compared.
+#
+# One day is the maximum, and it is already absurd for the job: the measurements
+# above put a real verify at 0.22s and a deliberately oversized one at 5.1s.
+# What the ceiling exists for is arithmetic safety, not policy.
+VERIFY_DEADLINE_MAX_SECONDS=86400
 VERIFY_DEADLINE_SECONDS="${SSH_HARDENING_VERIFY_DEADLINE:-120}"
-[[ $VERIFY_DEADLINE_SECONDS =~ ^[1-9][0-9]*$ ]] || VERIFY_DEADLINE_SECONDS=120
+if [[ ! $VERIFY_DEADLINE_SECONDS =~ ^[1-9][0-9]{0,4}$ ]] ||
+  [[ $VERIFY_DEADLINE_SECONDS -gt $VERIFY_DEADLINE_MAX_SECONDS ]]; then
+  VERIFY_DEADLINE_SECONDS=120
+fi
 VERIFY_STOP_GRACE_SECONDS=2
 # The wait POLLS, because bash has no wait-with-timeout. A quarter second and
 # not a whole one: the check runs before the first sleep, so a whole-second
@@ -382,20 +403,113 @@ VERIFY_POLL_TICKS_PER_SECOND=4
 # watchdog's ticks into the seam log every other assertion diffs.
 VERIFY_POLL_SLEEP='/bin/sleep'
 
-# stop_verify_child <pid>: stop a verify that is past its deadline, and
-# everything it started. TERM to the whole PROCESS GROUP, then KILL to the same
-# group after the grace: the chain is this shell -> bash -> sshd, and sshd is
-# the process actually blocked, so signalling the group leader alone would leave
-# the real sshd holding the open forever. The group id IS the child's pid
-# (run_verify_child starts it under monitor mode for exactly this), and the child
-# is not reaped until after both kills, so its pid cannot be recycled underneath
+# stop_bounded_group <pid>: stop a bounded command that is past its deadline,
+# and everything it started. TERM to the whole PROCESS GROUP, then KILL to the
+# same group after the grace: the chain is this shell -> bash -> sshd, and sshd
+# is the process actually blocked, so signalling the group leader alone would
+# leave the real sshd holding the open forever. The group id IS the child's pid
+# (run_bounded starts it under monitor mode for exactly this), and the child is
+# not reaped until after both kills, so its pid cannot be recycled underneath
 # them. Never fails: a group that exited between the deadline check and here is
 # the same outcome as one that took the signal.
-stop_verify_child() {
+#
+# The KILL is not belt-and-braces. sshd blocked in an open on a named pipe does
+# take the TERM, but nothing makes that true of every process a bounded command
+# can be waiting on: one that traps or ignores TERM survives the first signal
+# and the group has to be killed outright, which is the case
+# test/e2e/ssh-hardening-verify-watchdog.sh drives with a TERM-ignoring wedge.
+stop_bounded_group() {
   local child_pid="$1"
   kill -TERM -"$child_pid" 2>/dev/null || :
   "$VERIFY_POLL_SLEEP" "$VERIFY_STOP_GRACE_SECONDS" || :
   kill -KILL -"$child_pid" 2>/dev/null || :
+}
+
+# The status run_bounded returns when it stopped a command at its deadline,
+# rather than the status the command itself exited with. 124 is the value
+# timeout(1) reports the same event with; nothing here shells out to timeout
+# (stock macOS ships none) and the number is only ever compared against this
+# name.
+BOUNDED_TIMEOUT_STATUS=124
+
+# The pid (and process group id) of the bounded command running right now, empty
+# when none is. Global because the install path's interrupt handler has to reach
+# the same group stop_bounded_group reaches, from a trap that fires while
+# run_bounded is mid-poll.
+BOUNDED_CHILD_PID=''
+
+# run_bounded <deadline-seconds> <command...>: run one command in a process
+# group of its own, bounded by a wall clock. Returns the command's own exit
+# status, or BOUNDED_TIMEOUT_STATUS if the deadline fired first, in which case
+# the whole group has been stopped before this returns.
+#
+# ONE mechanism, three call sites: the child verify, the reload's syntax check,
+# and the reload's port resolution. Every one of them runs sshd over the
+# configuration tree, and sshd blocks forever on a named pipe reached through
+# its own Include glob (measured 2026-08-01; sshd applies no type filter), so
+# each is a step that can fail to return rather than return a failure. A second
+# watchdog mechanism for the later two would be a second set of edge cases to
+# get right, and the deadline knob would stop meaning one thing.
+#
+# No timeout(1) is involved, stock macOS ships none; the bound is the poll.
+#
+# Monitor mode across the launch and nothing else. It is what puts the child in
+# a process group of its own, which is what lets stop_bounded_group reach the
+# sshd underneath it; without it the child shares this shell's group and the
+# only safe signal target is the child alone.
+#
+# What the separate group COSTS, said rather than left to be found: Ctrl-C goes
+# to the foreground group, so it no longer reaches this child. The install path
+# answers that with a trap (see handle_install_interrupt); a --reload
+# interrupted mid-preflight leaves the bounded command running until its own
+# deadline collects it, and nothing has been disturbed at that point.
+#
+# stdin from /dev/null: an UNmonitored background job gets that for free, a
+# monitored one keeps the shell's stdin, and a child reading a terminal from its
+# own process group is stopped by SIGTTIN, which is a hang of its own.
+#
+# SIGTTOU and SIGTTIN are IGNORED for the whole group, and that is the fix for a
+# defect, not a precaution. Under `stty tostop` (not the default, but a setting
+# operators do use) a process in a background group is STOPPED the moment it
+# writes to the terminal. The verify writes: its very first line is the PASS or
+# the failure list. Measured through a pty: without this, a healthy verify stops
+# on its first write, `kill -0` keeps answering 0 for a stopped process, the
+# poll runs to the deadline, and a VALID install is reported as timed out and
+# rolled back. An ignored disposition survives both fork and exec, so the bash
+# under this subshell and the sshd under that inherit it, and a background write
+# then completes instead of stopping.
+run_bounded() {
+  local deadline_seconds="$1"
+  shift
+  local ticks=0 status=0
+  local deadline_ticks=$((deadline_seconds * VERIFY_POLL_TICKS_PER_SECOND))
+  set -m
+  (
+    trap '' TTOU TTIN
+    "$@"
+  ) </dev/null &
+  BOUNDED_CHILD_PID=$!
+  set +m
+  while [[ $ticks -lt $deadline_ticks ]] &&
+    kill -0 "$BOUNDED_CHILD_PID" 2>/dev/null; do
+    "$VERIFY_POLL_SLEEP" "$VERIFY_POLL_INTERVAL"
+    ticks=$((ticks + 1))
+  done
+  if kill -0 "$BOUNDED_CHILD_PID" 2>/dev/null; then
+    # The reap, and the job-control notice it draws, go to /dev/null: the child
+    # was started under monitor mode, so bash announces the termination itself
+    # ("Terminated: 15") at the next command boundary, and that line reads as an
+    # internal error beside the message the caller prints.
+    {
+      stop_bounded_group "$BOUNDED_CHILD_PID"
+      wait "$BOUNDED_CHILD_PID"
+    } 2>/dev/null || :
+    BOUNDED_CHILD_PID=''
+    return "$BOUNDED_TIMEOUT_STATUS"
+  fi
+  { wait "$BOUNDED_CHILD_PID"; } 2>/dev/null || status=$?
+  BOUNDED_CHILD_PID=''
+  return "$status"
 }
 
 # run_verify_child: re-run this script's --verify in a CHILD shell, bounded. bash
@@ -410,54 +524,27 @@ stop_verify_child() {
 #
 # Both callers read the result the same way they always did: nonzero is a failed
 # verify, and a verify stopped at its deadline returns nonzero like any other.
-# No `timeout(1)` is involved, stock macOS ships none; the bound is the poll
-# below.
-run_verify_child() {
-  local child_pid ticks=0 status=0
-  local deadline_ticks=$((VERIFY_DEADLINE_SECONDS * VERIFY_POLL_TICKS_PER_SECOND))
-  # Monitor mode across the launch and nothing else. It is what puts the child
-  # in a process group of its own, which is what lets stop_verify_child reach
-  # the sshd underneath it; without it the child shares this shell's group and
-  # the only safe signal target is the child alone.
-  #
-  # What the separate group COSTS, said rather than left to be found: Ctrl-C
-  # goes to the foreground group, so it no longer reaches this child. An
-  # operator who interrupts a hung install inside the deadline leaves that
-  # verify running, where before it died with this shell. What is left behind is
-  # a blocked reader that writes nothing, and the deadline it was interrupted
-  # before is what would otherwise have collected it.
-  #
-  # stdin from /dev/null: an UNmonitored background job gets that for free,
-  # a monitored one keeps the shell's stdin, and a child reading a terminal
-  # from its own process group is stopped by SIGTTIN, which is a hang of its
-  # own. Nothing in --verify reads stdin, and this keeps it that way.
-  set -m
+#
+# The seams are passed explicitly, in a function rather than inline, because
+# run_bounded takes a COMMAND: an environment-prefixed assignment is shell
+# syntax, not an argument vector, so it cannot be handed over as one.
+verify_child_command() {
   SSHD_CONFIG_D="$SSHD_CONFIG_D" \
     SSHD_MAIN_CONFIG="$SSHD_MAIN_CONFIG" \
     SSHD_BIN="$SSHD_BIN" \
     SSH_HARDENING_SUDO="$SSH_HARDENING_SUDO" \
     SSH_HARDENING_ALLOW_MISSING_SSHD="${SSH_HARDENING_ALLOW_MISSING_SSHD:-}" \
-    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify </dev/null &
-  child_pid=$!
-  set +m
-  while [[ $ticks -lt $deadline_ticks ]] && kill -0 "$child_pid" 2>/dev/null; do
-    "$VERIFY_POLL_SLEEP" "$VERIFY_POLL_INTERVAL"
-    ticks=$((ticks + 1))
-  done
-  if kill -0 "$child_pid" 2>/dev/null; then
-    printf '[ssh-hardening] verify TIMED OUT: the check was still running after %ss and is being stopped. A verify that never returns is treated as a FAILED verify, so exactly what a reported failure does happens now. One known cause: a named pipe reached through an Include glob, which blocks sshd forever on the open.\n' \
+    "${BASH:-/bin/bash}" "$SSH_HARDENING_SELF" --verify
+}
+
+run_verify_child() {
+  local status=0
+  run_bounded "$VERIFY_DEADLINE_SECONDS" verify_child_command || status=$?
+  if [[ $status -eq $BOUNDED_TIMEOUT_STATUS ]]; then
+    printf '[ssh-hardening] verify TIMED OUT: the check was still running after %ss and was stopped, its whole process group with it. A verify that never returns is treated as a FAILED verify, so exactly what a reported failure does happens now. One known cause: a named pipe reached through an Include glob, which blocks sshd forever on the open.\n' \
       "$VERIFY_DEADLINE_SECONDS" >&2
-    # The reap, and the job-control notice it draws, go to /dev/null: the child
-    # was started under monitor mode, so bash announces the termination itself
-    # ("Terminated: 15") at the next command boundary, and that line reads as an
-    # internal error beside the message above.
-    {
-      stop_verify_child "$child_pid"
-      wait "$child_pid"
-    } 2>/dev/null || :
     return 1
   fi
-  { wait "$child_pid"; } 2>/dev/null || status=$?
   return "$status"
 }
 
@@ -1395,16 +1482,24 @@ verify() {
 # The child verify is now BOUNDED, and the argument for why that bound is safe
 # sits with it at VERIFY_DEADLINE_SECONDS: past the deadline the verify is
 # stopped, its process group with it, and reported as a failed verify, so the
-# rollback below runs on that path like on any other. What is NOT defended
-# against, still, is this shell
-# being killed from the terminal mid-install: SIGINT and SIGTERM reach the whole
-# process group, which is what Ctrl-C sends, so they kill this shell before any
-# trap could run, and SIGKILL cannot be trapped at all. The residue that leaves
-# is deliberately left alone. What it IS: the new policy published and the
-# legacy file preserved under a name sshd's Include glob does not match
-# (verified: a dot-prefixed file holding an invalid directive leaves `sshd -G`
-# at exit 0, the same file undotted takes it to 255), so the tree is hardened
-# and the leftovers are inert.
+# rollback below runs on that path like on any other.
+#
+# An INTERRUPT takes the same rollback, and the comment that used to sit here
+# said the opposite: it claimed SIGINT and SIGTERM "kill this shell before any
+# trap could run". They do not. Bash runs a trap at the next command boundary,
+# and mid-install this shell is either between two filesystem commands or
+# waiting out a poll interval, so the handler runs in either case
+# (handle_install_interrupt, armed before the first write). Believing otherwise
+# left the worse half of the story unwritten: the verify is in a process group
+# of its own, so Ctrl-C does NOT reach it, and what an interrupt used to leave
+# behind was not an inert residue but a PUBLISHED drop-in with the run gone and
+# the verify still holding the tree open.
+#
+# What remains genuinely undefended is SIGKILL, which cannot be trapped at all.
+# What that leaves is the new policy published and the legacy file preserved
+# under a name sshd's Include glob does not match (verified: a dot-prefixed file
+# holding an invalid directive leaves `sshd -G` at exit 0, the same file undotted
+# takes it to 255), so the tree is hardened and the leftovers are inert.
 #
 # The working files are DOT-PREFIXED deliberately: sshd's Include glob does not
 # match a leading dot (glob(3) semantics, verified), so a half-written staging
@@ -1421,11 +1516,23 @@ INSTALL_STAGING=''
 INSTALL_SAVED_TARGET=''
 INSTALL_SAVED_LEGACY=''
 INSTALL_PUBLISHED=0
+INSTALL_ROLLED_BACK=0
 
 # rollback_install: undo everything install did, and nothing it did not. Every
 # step reports on its own rather than aborting the rollback, because a rollback
 # that stops half way leaves exactly the state it exists to prevent.
+#
+# It runs AT MOST ONCE, and that guard is load-bearing now that a signal can
+# reach it. A second pass over a tree the first pass already restored reads the
+# absence of the saved copy as "no drop-in existed before this run" and DELETES
+# the file it just put back. The two callers can now overlap for real: a failing
+# step takes the rollback and dies, while the interrupt that killed that step
+# runs its handler at the next command boundary.
 rollback_install() {
+  if [[ $INSTALL_ROLLED_BACK -eq 1 ]]; then
+    return 0
+  fi
+  INSTALL_ROLLED_BACK=1
   if [[ -e $INSTALL_STAGING || -L $INSTALL_STAGING ]]; then
     run_privileged rm -f -- "$INSTALL_STAGING" ||
       warn "rollback could not remove the staging file '$INSTALL_STAGING'"
@@ -1448,6 +1555,47 @@ rollback_install() {
   fi
 }
 
+# handle_install_interrupt <signal>: an interrupt is a failed install, not an
+# abandoned one.
+#
+# The verify runs in a process group of its own (that is what lets the whole
+# group be stopped at the deadline), and the price is that Ctrl-C no longer
+# reaches it. Without this handler the parent died on the signal while the
+# verify kept running, the drop-in it had already PUBLISHED stayed published,
+# the legacy file stayed moved aside, and rollback_install was never reached --
+# which is the same half-applied tree the deadline exists to prevent, reached by
+# a shorter route, because an operator watching an install hang is exactly the
+# operator who reaches for Ctrl-C before the deadline expires.
+#
+# It stops the bounded group first and rolls back second: rolling back while a
+# verify still holds the tree open would race the thing it is undoing.
+#
+# Then it RE-RAISES rather than exiting. A shell that exits 130 is not the same
+# as a shell that died of SIGINT: the caller's own `wait` reports the signal,
+# and an interactive shell above prints its own notice. Resetting the trap first
+# is what makes the re-raise terminal instead of recursive.
+handle_install_interrupt() {
+  local signal="$1"
+  trap - INT TERM HUP
+  if [[ -n $BOUNDED_CHILD_PID ]]; then
+    # Reaped here, and the job-control notice it draws sent to /dev/null, for
+    # the reason run_bounded gives: the child runs under monitor mode, so bash
+    # announces "Terminated: 15" itself at the next command boundary, which
+    # lands in the middle of this handler's own message and reads as an
+    # internal error. Waiting also means the rollback below starts after the
+    # verify has let go of the tree rather than beside it.
+    {
+      stop_bounded_group "$BOUNDED_CHILD_PID"
+      wait "$BOUNDED_CHILD_PID"
+    } 2>/dev/null || :
+    BOUNDED_CHILD_PID=''
+  fi
+  rollback_install
+  printf '[ssh-hardening] INTERRUPTED (SIG%s): the tree was rolled back to the state this install found it in, nothing the verify started is still running, and no success is claimed.\n' \
+    "$signal" >&2
+  kill -"$signal" "$$"
+}
+
 install_dropin() {
   local target legacy staging saved_target saved_legacy
   target="$(dropin_path)"
@@ -1461,6 +1609,14 @@ install_dropin() {
   INSTALL_SAVED_TARGET="$saved_target"
   INSTALL_SAVED_LEGACY="$saved_legacy"
   INSTALL_PUBLISHED=0
+  INSTALL_ROLLED_BACK=0
+
+  # Armed BEFORE the first write and disarmed once the transaction is complete,
+  # so a signal is only ever answered with a rollback while there is something
+  # to roll back.
+  trap 'handle_install_interrupt INT' INT
+  trap 'handle_install_interrupt TERM' TERM
+  trap 'handle_install_interrupt HUP' HUP
 
   [[ -d $SSHD_CONFIG_D ]] ||
     die "drop-in directory '$SSHD_CONFIG_D' does not exist"
@@ -1488,8 +1644,18 @@ install_dropin() {
   fi
   # Copy the existing drop-in aside BEFORE replacing it, so the target itself
   # is never absent: the copy is the backup, and the rename below is atomic.
+  #
+  # `-R`, and not for directories. Without it `cp` FOLLOWS what it is given, and
+  # a drop-in that is not a plain regular file is not restored as what it was:
+  # a symlink comes back as a regular file holding a copy of its target's bytes
+  # (so a rollback silently detaches a managed file from whatever it pointed
+  # at), a dangling symlink fails the copy outright and refuses an install that
+  # had nothing to lose, and a NAMED PIPE blocks the copy forever -- an
+  # unbounded privileged call on the install path, measured, sitting one step
+  # before the bounded verify. With -R each of those is recreated as itself and
+  # the copy returns.
   if [[ -e $target || -L $target ]]; then
-    if ! run_privileged cp -p -- "$target" "$saved_target"; then
+    if ! run_privileged cp -Rp -- "$target" "$saved_target"; then
       rollback_install
       die "could not copy the existing '$target' aside; refusing to replace a file that could not then be restored"
     fi
@@ -1523,6 +1689,11 @@ install_dropin() {
     rollback_install
     die "the effective configuration did NOT verify as fully hardened; the tree was rolled back to the state this install found it in, and no success is claimed"
   fi
+  # Disarmed here and not at the end of the function: the new drop-in is
+  # published and verified, so from this line on an interrupt must leave the
+  # hardening in place. What follows only removes the rollback copies, which are
+  # dot-prefixed and inert whether or not they are cleaned up.
+  trap - INT TERM HUP
   if ! run_privileged rm -f -- "$saved_target" "$saved_legacy"; then
     warn "could not remove the rollback copies under '$SSHD_CONFIG_D'; they are dot-prefixed and inert, but should be cleaned up"
   fi
@@ -2130,10 +2301,32 @@ validate_readiness_knobs() {
 # daemon. Each value is checked as a canonical integer and range-bounded on
 # BOTH sides (1-65535) before it reaches arithmetic or a probe argv.
 PROBE_PORTS=()
+# The file the bounded port resolution writes to, and the command that writes
+# it. A command substitution reads its child through a pipe and waits for the
+# pipe to close, which is exactly the unbounded wait this call had; run_bounded
+# hands over an argument vector and cannot carry a redirection, so the
+# redirection lives in the command it runs.
+PORT_RESOLUTION_OUTPUT=''
+resolve_ports_command() {
+  "$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" >"$PORT_RESOLUTION_OUTPUT" 2>&1
+}
+
 resolve_probe_ports() {
   local status=0 output listing port existing duplicate
   PROBE_PORTS=()
-  output="$("$SSHD_BIN" -G -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  PORT_RESOLUTION_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ssh-hardening-ports.XXXXXX")" ||
+    die "could not create a temporary file to resolve the effective sshd port into; failing closed before the disruptive step. sshd was not touched."
+  # BOUNDED for the reason the syntax check above is: this is the third and last
+  # reader of the configuration tree before the restart, it is the same `sshd
+  # -G` that blocks forever on a named pipe reached through an Include glob, and
+  # a tree that grew one between the verify and this call would otherwise park
+  # the reload here with nothing printed.
+  run_bounded "$VERIFY_DEADLINE_SECONDS" resolve_ports_command || status=$?
+  output="$(cat "$PORT_RESOLUTION_OUTPUT" 2>/dev/null || :)"
+  rm -f "$PORT_RESOLUTION_OUTPUT"
+  if [[ $status -eq $BOUNDED_TIMEOUT_STATUS ]]; then
+    die "resolving the effective sshd port ('$SSHD_BIN -G') was still running after ${VERIFY_DEADLINE_SECONDS}s and was stopped, so there is no port to probe readiness on; refusing to restart blind. sshd was not touched. One known cause: a named pipe reached through an Include glob, which blocks sshd forever on the open."
+  fi
   if [[ $status -ne 0 ]]; then
     die "could not resolve the effective sshd port ('$SSHD_BIN -G' exited $status); refusing to restart a daemon whose readiness could not then be probed. sshd was not touched. Output: $output"
   fi
@@ -2269,10 +2462,28 @@ reload_sshd() {
 
   # 4. Syntax: never restart onto a configuration sshd cannot parse.
   # Privileged, because -t reads the root-owned host keys.
+  #
+  # BOUNDED by the same watchdog the verify below uses, because this call is the
+  # same shape of risk and reaches sshd FIRST. `sshd -t` opens every file in its
+  # own Include graph with no type filter, so one named pipe under the drop-in
+  # glob blocks it forever (measured 2026-08-01 against OpenSSH 10.0p2: -t and
+  # -G both hit a 10s probe timeout where the same tree without the pipe exits
+  # 0). This script's own walk skips a non-regular entry and reports nothing
+  # wrong, so an unbounded call here parked --reload before it reached the
+  # verify's deadline, before the kickstart, and before anything printed.
+  #
+  # Its output is NOT captured any more. Capturing it means a pipe or a
+  # temporary file, and a pipe is what makes the read unbounded again; sshd's
+  # own message goes straight to this run's stderr instead, one step earlier
+  # than it used to appear.
   status=0
-  output="$(run_privileged "$SSHD_BIN" -t -f "$SSHD_MAIN_CONFIG" 2>&1)" || status=$?
+  run_bounded "$VERIFY_DEADLINE_SECONDS" \
+    run_privileged "$SSHD_BIN" -t -f "$SSHD_MAIN_CONFIG" || status=$?
+  if [[ $status -eq $BOUNDED_TIMEOUT_STATUS ]]; then
+    die "the configuration's syntax check ('$SSHD_BIN -t') was still running after ${VERIFY_DEADLINE_SECONDS}s and was stopped, so whether sshd can parse this tree is unknown; refusing to restart onto it. sshd was not touched. One known cause: a named pipe reached through an Include glob, which blocks sshd forever on the open."
+  fi
   if [[ $status -ne 0 ]]; then
-    die "the configuration failed sshd's syntax check ('$SSHD_BIN -t' exited $status); refusing to restart onto it. sshd was not touched. Output: $output"
+    die "the configuration failed sshd's syntax check ('$SSHD_BIN -t' exited $status); refusing to restart onto it. sshd was not touched. Its own message is above."
   fi
 
   # 5. The full three-way verify: never restart onto a configuration that

--- a/dot_local/bin/executable_ssh-hardening.sh
+++ b/dot_local/bin/executable_ssh-hardening.sh
@@ -2639,7 +2639,30 @@ PASSWORD_CHANNEL_ERROR=2
 # neither yes nor no) is the ERROR outcome, never a quiet pass, and every
 # command's status is captured explicitly so the answer does not depend on
 # errexit, which callers judging a status have switched off.
+# The file the bounded recovery resolutions write to, the spec the next one
+# asks about, and the command that runs it. Same shape as the port resolution
+# above and for the same reason: run_bounded takes an argument vector and
+# cannot carry a redirection, so the redirection lives in the command.
+PASSWORD_CHANNEL_OUTPUT=''
+PASSWORD_CHANNEL_SPEC=''
+password_channel_command() {
+  "$SSHD_BIN" -G -T -C "$PASSWORD_CHANNEL_SPEC" -f "$SSHD_MAIN_CONFIG" \
+    >"$PASSWORD_CHANNEL_OUTPUT" 2>&1
+}
+
+# check_password_channel: owns the temporary file resolve_password_channel
+# writes through, so the many ways that function can answer early do not each
+# have to remember to clean up. The status is passed through untouched.
 check_password_channel() {
+  local status=0
+  PASSWORD_CHANNEL_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ssh-hardening-recovery.XXXXXX")" ||
+    return "$PASSWORD_CHANNEL_ERROR"
+  resolve_password_channel || status=$?
+  rm -f "$PASSWORD_CHANNEL_OUTPUT"
+  return "$status"
+}
+
+resolve_password_channel() {
   local invoking_user status=0 output spec key value channel_open
   invoking_user="$(id -un)" || status=$?
   if [[ $status -ne 0 || -z $invoking_user ]]; then
@@ -2649,8 +2672,13 @@ check_password_channel() {
     "user=$invoking_user,host=localhost,addr=127.0.0.1" \
     "user=$invoking_user,host=recovery.invalid,addr=198.51.100.23"; do
     status=0
-    output="$("$SSHD_BIN" -G -T -C "$spec" -f "$SSHD_MAIN_CONFIG" 2>&1)" ||
-      status=$?
+    # BOUNDED like every other sshd call this script waits on. This one runs
+    # AFTER the drop-in has been removed, so a hang here parks the mode with
+    # the removal done and the proof missing: the way back in is open and the
+    # operator watching for the sentence that says so never gets one.
+    PASSWORD_CHANNEL_SPEC="$spec"
+    run_bounded "$VERIFY_DEADLINE_SECONDS" password_channel_command || status=$?
+    output="$(cat "$PASSWORD_CHANNEL_OUTPUT" 2>/dev/null || :)"
     if [[ $status -ne 0 ]]; then
       return "$PASSWORD_CHANNEL_ERROR"
     fi
@@ -2703,7 +2731,7 @@ confirm_password_access_restored() {
       die "'$target' is absent, but the interactive password channels (PasswordAuthentication and KbdInteractiveAuthentication) still resolve OFF for a sampled connection, so something else under '$SSHD_CONFIG_D' (or the main config) is still enforcing the policy and password access is NOT restored. Inspect the remaining files there."
       ;;
     *)
-      die "could not verify that password access is restored: the recovery check errored (sshd resolution or its parsing failed) instead of answering; refusing to guess either way"
+      die "could not verify that password access is restored: the recovery check errored instead of answering (an sshd resolution failed, was stopped at its ${VERIFY_DEADLINE_SECONDS}s bound, or could not be parsed); refusing to guess either way. The removal itself already happened, so re-run --rollback once the tree can be resolved to get the answer."
       ;;
   esac
 }

--- a/test/e2e/ssh-hardening-verify-watchdog.sh
+++ b/test/e2e/ssh-hardening-verify-watchdog.sh
@@ -439,8 +439,13 @@ syntax_elapsed=$((SECONDS - syntax_started))
   fail "8: the wedged syntax check took ${syntax_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s the bound allows"
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '8: a reload whose syntax check never answered must not report success'
+# Both halves, because either alone is satisfied by the wrong thing: `sshd -t`
+# also fails this reload when it EXITS nonzero, and every other bounded step
+# reports being stopped in the same words.
 grep -qi 'syntax check' <<<"$SSH_RUN_ERR" ||
   fail "8: the failure must name the step that was stopped (stderr: $SSH_RUN_ERR)"
+grep -qi 'was still running after' <<<"$SSH_RUN_ERR" ||
+  fail "8: the syntax check must be reported as STOPPED at its bound, not as a configuration that failed to parse (stderr: $SSH_RUN_ERR)"
 grep -qi 'sshd was not touched' <<<"$SSH_RUN_ERR" ||
   fail "8: nothing was restarted, and the refusal must say so (stderr: $SSH_RUN_ERR)"
 assert_no_kickstart '8'
@@ -464,8 +469,13 @@ port_elapsed=$((SECONDS - port_started))
   fail "9: the wedged port resolution took ${port_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s the bound allows"
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '9: a reload whose port resolution never answered must not report success'
-grep -qi 'port' <<<"$SSH_RUN_ERR" ||
+# The full phrase, not the word "port": the readiness failure, the
+# no-port-at-all refusal and the out-of-range refusal all carry that word, and
+# any of them passing here would let the case go green on the wrong branch.
+grep -qi 'resolving the effective sshd port' <<<"$SSH_RUN_ERR" ||
   fail "9: the failure must name the step that was stopped (stderr: $SSH_RUN_ERR)"
+grep -qi 'was still running after' <<<"$SSH_RUN_ERR" ||
+  fail "9: the port resolution must be reported as STOPPED at its bound (stderr: $SSH_RUN_ERR)"
 assert_no_kickstart '9'
 assert_pids_reaped '9 (wedged port resolution)'
 

--- a/test/e2e/ssh-hardening-verify-watchdog.sh
+++ b/test/e2e/ssh-hardening-verify-watchdog.sh
@@ -41,11 +41,17 @@
 #   7. what comes back is the file that was there, not just its bytes: a
 #      symlinked drop-in is restored as a symlink to the same target
 #   8. --reload's syntax check and port resolution are bounded too, so the two
-#      sshd calls that bracket the verify cannot park the reload
+#      sshd calls that bracket the verify cannot park the reload, and so is
+#      --rollback's recovery proof, which runs after the removal
 #   9. a deadline so large that its tick arithmetic overflows is refused rather
 #      than believed
 #  10. a healthy verify survives `stty tostop`, which stops a background process
 #      group on its first write to the terminal
+#
+# A case's label is a stable identifier, not an index into that list and not the
+# order the cases run in: 3 and 4 run first on purpose (a bound that broke the
+# normal path would make everything below pass for the wrong reason), and 8, 9
+# and 12 all pin property 8, one bounded call each.
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -479,6 +485,37 @@ grep -qi 'was still running after' <<<"$SSH_RUN_ERR" ||
 assert_no_kickstart '9'
 assert_pids_reaped '9 (wedged port resolution)'
 
+# --- 12: --rollback's recovery proof is bounded too ---------------------------
+# The last sshd call in the file that this script waits on, and the one whose
+# hang is easiest to talk yourself out of: it runs AFTER the drop-in has been
+# removed, so the way back in is already open and only the sentence saying so is
+# missing. That is precisely the moment the sentence matters. The operator ran
+# --rollback because they are locked out, and a mode that goes silent there
+# leaves them unable to tell "password access is restored" from "the removal
+# never happened".
+#
+# The wedge matches the first `-T` call, which is the recovery gate's own
+# resolution; nothing earlier on this path makes one.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+write_hardened_dropin
+reset_wedge
+
+rollback_started=$SECONDS
+WEDGE_MATCH='* -T *' SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload --rollback
+rollback_elapsed=$((SECONDS - rollback_started))
+[[ $rollback_elapsed -le $WEDGED_RUN_LIMIT_SECONDS ]] ||
+  fail "12: the wedged recovery proof took ${rollback_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s the bound allows"
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '12: a rollback whose recovery proof never answered must not claim password access is restored'
+refute_contains "$SSH_RUN_OUT" 'rollback complete' \
+  '12: an unproven recovery must not claim the rollback completed'
+grep -qi 'stopped at its' <<<"$SSH_RUN_ERR" ||
+  fail "12: the failure must say the proof was stopped at its bound, not merely that it errored (stderr: $SSH_RUN_ERR)"
+[[ ! -e $dropin ]] ||
+  fail '12: the removal happens before the proof, and a stopped proof must not put the hardening back'
+assert_pids_reaped '12 (wedged recovery proof)'
+
 # --- 10: a deadline whose tick arithmetic overflows is refused ----------------
 # The wait is counted in ticks, four per second, and bash arithmetic is signed
 # 64-bit. 2305843009213693952 * 4 is exactly -9223372036854775808, so the budget
@@ -534,5 +571,5 @@ grep -qF 'install complete' <<<"$tostop_output" ||
   fail "11: the install must complete under 'stty tostop' (transcript: $tostop_output)"
 assert_no_escalation '11 (stty tostop)'
 
-printf 'ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in %ss and rolled back, TERM-ignoring wedges included; an interrupt rolls back the same way and reaps the verify group; a symlinked drop-in comes back as a symlink; --reload bounds its syntax check and its port resolution; an overflowing deadline falls back to the default; and a healthy verify still installs, under a tostop terminal too)\n' \
+printf 'ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in %ss and rolled back, TERM-ignoring wedges included; an interrupt rolls back the same way and reaps the verify group; a symlinked drop-in comes back as a symlink; --reload bounds its syntax check and its port resolution and --rollback bounds its recovery proof; an overflowing deadline falls back to the default; and a healthy verify still installs, under a tostop terminal too)\n' \
   "$wedged_elapsed"

--- a/test/e2e/ssh-hardening-verify-watchdog.sh
+++ b/test/e2e/ssh-hardening-verify-watchdog.sh
@@ -25,7 +25,7 @@
 #
 # Properties pinned:
 #   1. a wedged verify is stopped at the deadline, reported as a failed verify,
-#      and the tree it found is restored byte for byte with no working files left
+#      and the tree it found is restored as it was, with no working files left
 #   2. nothing the wedged verify started outlives the run: the sshd stub and the
 #      sleeper under it are both gone (a group kill, not a kill of the child
 #      shell alone, is what makes that true)
@@ -34,6 +34,18 @@
 #      watchdog built out of the SLEEP_BIN seam would be caught here
 #   4. a verify that genuinely FAILS still rolls back, and is reported as a
 #      failure rather than as a timeout
+#   5. a wedge that IGNORES SIGTERM is still reaped, so the KILL after the grace
+#      is exercised rather than assumed
+#   6. an INTERRUPT mid-install rolls back and takes the verify group with it,
+#      instead of leaving a published drop-in behind a shell that is gone
+#   7. what comes back is the file that was there, not just its bytes: a
+#      symlinked drop-in is restored as a symlink to the same target
+#   8. --reload's syntax check and port resolution are bounded too, so the two
+#      sshd calls that bracket the verify cannot park the reload
+#   9. a deadline so large that its tick arithmetic overflows is refused rather
+#      than believed
+#  10. a healthy verify survives `stty tostop`, which stops a background process
+#      group on its first write to the terminal
 set -euo pipefail
 
 # Scrubbed at SCRIPT scope. Git exports GIT_DIR to every hook it runs and this
@@ -48,10 +60,24 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)/ssh-reload-lib
 # holds. The shipped default is judged where it is defined, against measured
 # verify times.
 export SSH_HARDENING_VERIFY_DEADLINE=3
-# The stop grace the script allows after the deadline (VERIFY_STOP_GRACE_SECONDS)
-# plus room for a loaded CI machine. A run that needs longer than this has not
-# bounded the verify at all.
-WEDGED_RUN_LIMIT_SECONDS=20
+# The window a wedged run must land in: not before the deadline, and not much
+# after the deadline plus the script's stop grace (VERIFY_STOP_GRACE_SECONDS,
+# 2s). Measured on this machine, a wedged run takes 5s to 6s, and $SECONDS
+# counts in whole seconds so a 5.4s run reads as either.
+#
+# The ceiling is what makes the POLL INTERVAL a pinned quantity rather than a
+# comment. The wait is counted in ticks, four per second, so the deadline is
+# only three seconds if a tick really is a quarter of one: change
+# VERIFY_POLL_INTERVAL to 1 and the same twelve ticks take 12s, which lands at
+# 14s with the grace. The 20s ceiling this replaces accepted that silently, so a
+# whole-second poll passed every case in this file.
+#
+# The floor pins the other direction, where a bound that fires EARLY looks
+# exactly like a bound that works: a healthy install rolled back at once, the
+# operator told it waited the whole deadline. That is what an overflowed tick
+# budget does (see case 9), and a ceiling alone cannot see it.
+WEDGED_RUN_LIMIT_SECONDS=9
+WEDGED_RUN_FLOOR_SECONDS="$SSH_HARDENING_VERIFY_DEADLINE"
 
 reload_sandbox_setup
 trap 'ssh_sandbox_teardown' EXIT
@@ -85,18 +111,68 @@ cat >"$WEDGE_HOOK" <<'HOOK'
 # Runs inside every controlled stub. Only the sshd stub is wedged: the install
 # path drives `sudo` through the same hook, and wedging that would stop the run
 # before it ever published anything, which is a different case.
-set -euo pipefail
+#
+# Which sshd call is wedged is the caller's choice, because the calls are not
+# interchangeable -- the install path's first one is the child verify, and
+# --reload makes two more that bracket it:
+#   WEDGE_MATCH        a case pattern against " <argv> " (default *: any call)
+#   WEDGE_SKIP_MATCHES how many MATCHING calls to let through first (default 0)
+#   WEDGE_IGNORE_TERM  nonempty: the sleeper ignores SIGTERM, so only the KILL
+#                      after the stop grace can reap it
+set -uo pipefail
 [[ ${1:-} == 'sshd' ]] || exit 0
+shift
+# shellcheck disable=SC2254  # WEDGE_MATCH is a PATTERN by design, not a literal
+case " $* " in
+  ${WEDGE_MATCH:-*}) ;;
+  *) exit 0 ;;
+esac
+count_file="${SSH_VERIFY_WEDGE_PID_FILE:?}.matches"
+count="$(cat "$count_file" 2>/dev/null || printf '0')"
+count=$((count + 1))
+printf '%s' "$count" >"$count_file"
+[[ $count -gt ${WEDGE_SKIP_MATCHES:-0} ]] || exit 0
 # $PPID is the stub shell; $$ survives the exec below, so it is the sleeper's
 # pid. Both are the descendants a kill of the child shell alone would orphan.
-printf '%s\n%s\n' "$PPID" "$$" >>"${SSH_VERIFY_WEDGE_PID_FILE:?}"
+printf '%s\n%s\n' "$PPID" "$$" >>"$SSH_VERIFY_WEDGE_PID_FILE"
+if [[ -n ${WEDGE_IGNORE_TERM:-} ]]; then
+  # No exec: the trap has to belong to a process that stays alive, and an
+  # ignored disposition would survive into /bin/sleep and never come back.
+  trap '' TERM
+  while :; do
+    /bin/sleep 1
+  done
+fi
 exec /bin/sleep 900
 HOOK
 chmod +x "$WEDGE_HOOK"
 
-file_fingerprint() { # <path> -> checksum and size, or the word absent
-  if [[ -e $1 ]]; then
-    cksum <"$1"
+# reset_wedge: forget the pids and the match count of the previous case, so one
+# case's wedge can never satisfy the next case's assertions.
+reset_wedge() {
+  : >"$SSH_VERIFY_WEDGE_PID_FILE"
+  rm -f "$SSH_VERIFY_WEDGE_PID_FILE.matches"
+}
+
+# file_fingerprint <path> -> what the file IS as well as what it holds.
+#
+# Bytes alone are not the restore this suite claims to check. A managed drop-in
+# an operator had symlinked elsewhere, replaced by a regular file holding a copy
+# of the same bytes, passed a checksum comparison while the link was gone -- and
+# `cp -p` (no -R) does exactly that replacement, so the assertion was blind to a
+# live defect. Type first, then the link target for a symlink and the checksum
+# for a regular file.
+file_fingerprint() {
+  if [[ -L $1 ]]; then
+    printf 'symlink -> %s\n' "$(readlink "$1")"
+  elif [[ -p $1 ]]; then
+    printf 'named pipe\n'
+  elif [[ -d $1 ]]; then
+    printf 'directory\n'
+  elif [[ -f $1 ]]; then
+    printf 'regular file %s\n' "$(cksum <"$1")"
+  elif [[ -e $1 ]]; then
+    printf 'other file type\n'
   else
     printf 'absent\n'
   fi
@@ -200,14 +276,16 @@ leftovers="$(working_file_leftovers)"
 build_tree_with_previous_policy
 dropin_before="$(file_fingerprint "$dropin")"
 legacy_before="$(file_fingerprint "$legacy")"
-: >"$SSH_VERIFY_WEDGE_PID_FILE"
+reset_wedge
 
 wedged_started=$SECONDS
 SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload
 wedged_elapsed=$((SECONDS - wedged_started))
 
 [[ $wedged_elapsed -le $WEDGED_RUN_LIMIT_SECONDS ]] ||
-  fail "1: the wedged install took ${wedged_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s this bound allows (deadline ${SSH_HARDENING_VERIFY_DEADLINE}s plus the stop grace)"
+  fail "1: the wedged install took ${wedged_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s this bound allows (deadline ${SSH_HARDENING_VERIFY_DEADLINE}s plus the stop grace; a poll interval of a whole second instead of a quarter lands here)"
+[[ $wedged_elapsed -ge $WEDGED_RUN_FLOOR_SECONDS ]] ||
+  fail "1: the wedged install gave up after ${wedged_elapsed}s, before the ${WEDGED_RUN_FLOOR_SECONDS}s deadline it reports having waited; a bound that fires early rolls back installs that were fine"
 [[ $SSH_RUN_STATUS -ne 0 ]] ||
   fail '1: an install whose verify never answered must not report success'
 grep -qF 'verify TIMED OUT' <<<"$SSH_RUN_ERR" ||
@@ -225,5 +303,226 @@ leftovers="$(working_file_leftovers)"
   fail "1: the wedged install left working files behind:$leftovers"
 assert_pids_reaped '2'
 
-printf 'ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in %ss, reported as a failed verify, rolled back to a byte-identical tree with no working files and no surviving processes; a healthy verify still installs with exactly its three seam calls; a verify that answers with a failure still rolls back and is not reported as a timeout)\n' \
+# --- 5: the KILL after the grace is what reaps a wedge that ignores TERM ------
+# The wedge above is a plain /bin/sleep, which dies of the first TERM, so the
+# KILL that follows the grace was never the thing that reaped anything: measured
+# before this case existed, deleting the `kill -KILL` line left the whole file
+# green. A wedge that IGNORES TERM is what makes the second signal load-bearing,
+# and it is not a contrived shape -- a process blocked in an uninterruptible
+# state, or one with its own TERM handler, is the ordinary reason a group
+# survives the first signal.
+
+build_tree_with_previous_policy
+dropin_before="$(file_fingerprint "$dropin")"
+legacy_before="$(file_fingerprint "$legacy")"
+reset_wedge
+
+WEDGE_IGNORE_TERM=1 SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '5: an install whose verify never answered must not report success'
+grep -qF 'verify TIMED OUT' <<<"$SSH_RUN_ERR" ||
+  fail "5: the run must still report the timeout (stderr: $SSH_RUN_ERR)"
+[[ "$(file_fingerprint "$dropin")" == "$dropin_before" ]] ||
+  fail '5: the drop-in that was in place must come back after a TERM-ignoring wedge'
+assert_pids_reaped '5 (TERM-ignoring wedge)'
+
+# --- 6: an interrupt mid-install rolls back, and takes the verify with it -----
+# The verify runs in a process group of its own, so Ctrl-C reaches the script
+# and NOT the verify. Measured before the handler existed: the script died at
+# once, the drop-in it had already published stayed published, the legacy file
+# stayed moved aside, and both recorded descendants were still running -- a
+# half-applied tree reached in a fifth of a second, where the deadline the
+# operator interrupted was the only thing that would have collected it.
+#
+# The launch runs under MONITOR MODE, and that is a correctness requirement of
+# the case rather than a detail. Bash gives an asynchronous command SIGINT and
+# SIGQUIT ignored when job control is not in effect, and a signal ignored at
+# entry cannot be trapped at all -- so a plain `script &` here would run with
+# the handler disabled and prove nothing about the handler (measured: the run
+# slept through the signal and hit the deadline instead). Monitor mode restores
+# the default disposition and gives the run a process group of its own, so the
+# signal below reaches the script and its foreground children exactly as Ctrl-C
+# would, and reaches neither the test shell nor the verify (which is in a group
+# of its own by construction).
+
+build_tree_with_previous_policy
+dropin_before="$(file_fingerprint "$dropin")"
+legacy_before="$(file_fingerprint "$legacy")"
+reset_wedge
+
+INTERRUPT_STATUS=0
+INTERRUPT_ERR=''
+run_install_and_interrupt() { # <signal>
+  local signal="$1" waited=0 child
+  local out_file="$SSH_SANDBOX/interrupt.out" err_file="$SSH_SANDBOX/interrupt.err"
+  INTERRUPT_STATUS=0
+  set -m
+  SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" \
+    /bin/bash "$SSH_HARDENING_SCRIPT" >"$out_file" 2>"$err_file" &
+  child=$!
+  set +m
+  # The wedge fires on the verify's first sshd call, which is strictly after the
+  # drop-in has been published and the legacy file moved aside. Waiting for it
+  # is what makes this an interrupt of a half-applied tree rather than a race
+  # with the staging step.
+  while [[ ! -s $SSH_VERIFY_WEDGE_PID_FILE ]]; do
+    [[ $waited -lt 100 ]] ||
+      fail '6: the wedge never fired, so the install was never interrupted mid-transaction'
+    /bin/sleep 0.1
+    waited=$((waited + 1))
+  done
+  # To the GROUP, which is what a terminal sends: the script and whatever it has
+  # in the foreground (the poll's own sleep), and nothing else.
+  kill -"$signal" -"$child"
+  wait "$child" 2>/dev/null || INTERRUPT_STATUS=$?
+  INTERRUPT_ERR="$(cat "$err_file")"
+  assert_no_escalation "run_install_and_interrupt $signal"
+}
+
+run_install_and_interrupt INT
+[[ $INTERRUPT_STATUS -ne 0 ]] ||
+  fail '6: an interrupted install must not report success'
+grep -qF 'INTERRUPTED' <<<"$INTERRUPT_ERR" ||
+  fail "6: the run must say it was interrupted, which is what distinguishes the handler from the deadline firing later (stderr: $INTERRUPT_ERR)"
+[[ "$(file_fingerprint "$dropin")" == "$dropin_before" ]] ||
+  fail "6: the drop-in that was in place must come back after an interrupt (before: $dropin_before, after: $(file_fingerprint "$dropin"))"
+[[ "$(file_fingerprint "$legacy")" == "$legacy_before" ]] ||
+  fail '6: the legacy drop-in must come back after an interrupt'
+leftovers="$(working_file_leftovers)"
+[[ -z $leftovers ]] ||
+  fail "6: an interrupted install left working files behind:$leftovers"
+assert_pids_reaped '6 (interrupt)'
+
+# --- 7: a symlinked drop-in comes back as a symlink ---------------------------
+# "Byte for byte" was the whole claim and it was the wrong measure. An operator
+# who symlinks the managed drop-in at some other file gets it back as a REGULAR
+# file holding a copy of that file's bytes, because `cp -p` without -R follows
+# what it is given. Every checksum comparison in this file passed that, so the
+# suite could not see the link disappear.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+symlink_source="$SSH_SANDBOX/previous-policy.conf"
+printf '# a previous drop-in reached through a symlink\nPasswordAuthentication no\n' \
+  >"$symlink_source"
+ln -s "$symlink_source" "$dropin"
+printf 'PasswordAuthentication no\n' >"$legacy"
+dropin_before="$(file_fingerprint "$dropin")"
+[[ $dropin_before == "symlink -> $symlink_source" ]] ||
+  fail "7: the fixture must start as a symlink, got '$dropin_before'"
+reset_wedge
+
+SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '7: an install whose verify never answered must not report success'
+[[ "$(file_fingerprint "$dropin")" == "$dropin_before" ]] ||
+  fail "7: a symlinked drop-in must come back as the same symlink (before: $dropin_before, after: $(file_fingerprint "$dropin"))"
+[[ "$(cat "$symlink_source")" == "$(printf '# a previous drop-in reached through a symlink\nPasswordAuthentication no\n')" ]] ||
+  fail '7: the file the symlink pointed at must be untouched'
+assert_pids_reaped '7 (symlink)'
+
+# --- 8: --reload's syntax check is bounded too --------------------------------
+# The verify is not the only sshd call on a disruptive path. `sshd -t` runs
+# BEFORE it, over the same tree, opening the same Include graph with the same
+# absence of a type filter, and it was unbounded: a named pipe under the drop-in
+# glob parked --reload there, before the verify's deadline could apply, with
+# nothing printed and no kickstart to show for it. This script's own walk skips
+# the pipe and reports the tree healthy, so nothing else would have caught it.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+write_hardened_dropin
+reset_wedge
+
+syntax_started=$SECONDS
+WEDGE_MATCH='* -t *' SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload --reload
+syntax_elapsed=$((SECONDS - syntax_started))
+[[ $syntax_elapsed -le $WEDGED_RUN_LIMIT_SECONDS ]] ||
+  fail "8: the wedged syntax check took ${syntax_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s the bound allows"
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '8: a reload whose syntax check never answered must not report success'
+grep -qi 'syntax check' <<<"$SSH_RUN_ERR" ||
+  fail "8: the failure must name the step that was stopped (stderr: $SSH_RUN_ERR)"
+grep -qi 'sshd was not touched' <<<"$SSH_RUN_ERR" ||
+  fail "8: nothing was restarted, and the refusal must say so (stderr: $SSH_RUN_ERR)"
+assert_no_kickstart '8'
+assert_pids_reaped '8 (wedged syntax check)'
+
+# --- 9: --reload's port resolution is bounded too -----------------------------
+# The third and last sshd call before the restart, and the one a tree that grew
+# a named pipe DURING the preflight reaches: the syntax check and the verify are
+# already past. It is the same `sshd -G`, and it used to be read through a
+# command substitution, which waits for the pipe to close and so waits forever.
+#
+# The wedge skips the first plain `-G -f` call, which is the child verify's
+# global resolution; the two per-connection calls carry `-T` and do not match.
+
+reset_wedge
+port_started=$SECONDS
+WEDGE_MATCH='* -G -f *' WEDGE_SKIP_MATCHES=1 \
+  SSH_TREE_MUTATION_HOOK="$WEDGE_HOOK" run_ssh_reload --reload
+port_elapsed=$((SECONDS - port_started))
+[[ $port_elapsed -le $WEDGED_RUN_LIMIT_SECONDS ]] ||
+  fail "9: the wedged port resolution took ${port_elapsed}s, past the ${WEDGED_RUN_LIMIT_SECONDS}s the bound allows"
+[[ $SSH_RUN_STATUS -ne 0 ]] ||
+  fail '9: a reload whose port resolution never answered must not report success'
+grep -qi 'port' <<<"$SSH_RUN_ERR" ||
+  fail "9: the failure must name the step that was stopped (stderr: $SSH_RUN_ERR)"
+assert_no_kickstart '9'
+assert_pids_reaped '9 (wedged port resolution)'
+
+# --- 10: a deadline whose tick arithmetic overflows is refused ----------------
+# The wait is counted in ticks, four per second, and bash arithmetic is signed
+# 64-bit. 2305843009213693952 * 4 is exactly -9223372036854775808, so the budget
+# goes negative, the poll runs zero passes, and a HEALTHY verify is stopped the
+# instant it starts -- a valid install rolled back, reported as a timeout that
+# waited 2.3e18 seconds. The value is not a fixture curiosity: it is one
+# keystroke off a plausible "make the bound effectively infinite".
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+SSH_HARDENING_VERIFY_DEADLINE=2305843009213693952 run_ssh_reload
+[[ $SSH_RUN_STATUS -eq 0 ]] ||
+  fail "10: an absurd deadline must fall back to the default, not stop a healthy verify at once (status $SSH_RUN_STATUS, stderr: $SSH_RUN_ERR)"
+refute_contains "$SSH_RUN_ERR" 'TIMED OUT' \
+  '10: a verify that answered must never be reported as timed out'
+[[ -f $dropin ]] ||
+  fail '10: install must leave the drop-in in place'
+
+# --- 11: a healthy verify survives `stty tostop` ------------------------------
+# The verify runs in a process group of its own, and under `stty tostop` a
+# background group is STOPPED by SIGTTOU the moment it writes to the terminal.
+# The verify's first act is to write: PASS or the failure list. Measured through
+# a pty: the child stopped on that write, `kill -0` kept answering 0 for it
+# (a stopped process is still a process), the poll ran out, and a VALID install
+# was reported as TIMED OUT and rolled back -- the watchdog firing on a machine
+# whose only unusual property is a terminal setting.
+#
+# The case needs a real controlling terminal, which is what `script` provides.
+# The transcript is the assertion surface, because the script's stdout has to BE
+# the terminal here; a redirection into a file is the one thing that would make
+# the defect unreachable.
+
+rm -f "$SSHD_CONFIG_D"/* "$SSHD_CONFIG_D"/.[!.]* 2>/dev/null || :
+tostop_transcript="$SSH_SANDBOX/tostop-transcript"
+TOSTOP_STATUS_FILE="$SSH_SANDBOX/tostop-status"
+export SSH_HARDENING_SCRIPT TOSTOP_STATUS_FILE
+: >"$TOSTOP_STATUS_FILE"
+# shellcheck disable=SC2016  # the inner shell expands these, not this one
+script -q "$tostop_transcript" /bin/bash -c '
+  stty tostop
+  status=0
+  /bin/bash "$SSH_HARDENING_SCRIPT" || status=$?
+  printf "%s\n" "$status" >"$TOSTOP_STATUS_FILE"
+' >/dev/null 2>&1 || :
+tostop_status="$(cat "$TOSTOP_STATUS_FILE")"
+tostop_output="$(cat "$tostop_transcript")"
+[[ -n $tostop_status ]] ||
+  fail "11: the pty run never recorded a status; transcript: $tostop_output"
+[[ $tostop_status -eq 0 ]] ||
+  fail "11: a healthy install under 'stty tostop' must still succeed (status $tostop_status, transcript: $tostop_output)"
+refute_contains "$tostop_output" 'TIMED OUT' \
+  "11: a verify stopped by SIGTTOU is not a verify that timed out (transcript: $tostop_output)"
+grep -qF 'install complete' <<<"$tostop_output" ||
+  fail "11: the install must complete under 'stty tostop' (transcript: $tostop_output)"
+assert_no_escalation '11 (stty tostop)'
+
+printf 'ssh-hardening-verify-watchdog: OK (a verify wedged inside sshd is stopped at its deadline in %ss and rolled back, TERM-ignoring wedges included; an interrupt rolls back the same way and reaps the verify group; a symlinked drop-in comes back as a symlink; --reload bounds its syntax check and its port resolution; an overflowing deadline falls back to the default; and a healthy verify still installs, under a tostop terminal too)\n' \
   "$wedged_elapsed"

--- a/test/integration/ssh-hardening-reload-tree-drift.sh
+++ b/test/integration/ssh-hardening-reload-tree-drift.sh
@@ -690,12 +690,13 @@ write_hardened_dropin
 # stub, and the stub never opens the configuration tree. The real sshd does,
 # and it applies no type filter of its own: measured 2026-08-01 against OpenSSH
 # 10.0p2 on macOS 26.2, this exact tree makes `sshd -G` and `sshd -t` each hit
-# a 10s timeout where the same tree without the pipe exits 0. A production
-# --reload over it therefore hangs at its syntax check, and a production
-# --verify hangs with an empty stdout AND an empty stderr. That is sshd's
-# behaviour, it predates this branch, and no filter in the script reaches it.
-# What this case judges is only the narrower property the script does own: its
-# own walk neither opens the pipe nor stops on it.
+# a 10s timeout where the same tree without the pipe exits 0. That is sshd's
+# behaviour and no filter in the script reaches it. What the script owns is what
+# it does about it, and that is now two separate things: its own walk neither
+# opens the pipe nor stops on it (this case), and every call it makes to sshd is
+# bounded, so a production --reload over this tree fails at its syntax check
+# instead of parking there (test/e2e/ssh-hardening-verify-watchdog.sh, cases 8
+# and 9, which is where the wall clock that would prove it belongs).
 
 fifo_path="$SSHD_CONFIG_D/040-fifo.conf"
 mkfifo "$fifo_path"


### PR DESCRIPTION
## Context

`dot_local/bin/executable_ssh-hardening.sh` writes a public-key-only sshd drop-in, verifies the
effective configuration, and puts the tree back the way it found it if that verify fails. PR #142 added
a watchdog to it, because a verify that HANGS is neither a success nor a failure and the transaction
only knew how to answer the second: sshd blocks forever on a named pipe reached through its own Include
glob, so on such a tree the install parked with the drop-in already published and the rollback never
reached.

A review of that merged work found five defects and two places where its new tests pinned nothing.
This branch fixes all seven against current main.

## Summary

- `run_bounded <deadline> <command...>` replaces the verify-only poll, and `--reload`'s syntax check
  (`sshd -t`) and port resolution (`sshd -G`) now run through it. Both were unbounded, and the syntax
  check runs before the verify, so a tree that hangs sshd parked the whole reload before the verify's
  deadline could apply to anything. `dot_local/bin/executable_ssh-hardening.sh`.
- `--rollback`'s recovery proof goes through the same watchdog. It was the fourth unbounded sshd call,
  found while auditing, and it runs after the drop-in has been removed: a hang there leaves the way back
  in open and the operator with no sentence saying so, which is the one moment that sentence matters.
- SIGINT, SIGTERM and SIGHUP during an install now stop the verify's process group, take the same
  rollback a failed verify takes, and re-raise. Measured against main, an interrupt left the new
  drop-in published, the legacy file moved aside, and both verify descendants running.
- The bounded group ignores SIGTTOU and SIGTTIN. Under `stty tostop` a background group is stopped on
  its first write to the terminal, and a stopped process answers `kill -0` exactly like a running one,
  so a healthy install was rolled back and reported as a timeout.
- `cp -Rp` replaces `cp -p` where an existing drop-in is copied aside: a symlinked drop-in is restored
  as a symlink, a dangling one no longer fails the copy outright, and a named pipe no longer blocks it
  forever.
- `SSH_HARDENING_VERIFY_DEADLINE` is capped at 86400 seconds. Past that the tick multiplication
  overflows to a negative budget, the poll runs zero passes, and a healthy verify is stopped at once
  and reported as having waited 2.3e18 seconds.
- `test/e2e/ssh-hardening-verify-watchdog.sh` gains eight cases and two sharper assertions: a floor and
  a 9s ceiling on the wedged run, which is what pins the quarter-second poll interval, and a
  TERM-ignoring wedge, which is what makes the KILL after the stop grace load-bearing.

## How it was verified

Every case is RED without its fix. The e2e suite stops at the first failure, so per-finding evidence
comes from mutations applied to the fixed tree, each reverting exactly one fix. The control (no
mutation) is all 12 cases green, and the whole new suite run against `origin/main`'s script through the
`SSH_HARDENING_SCRIPT` seam fails at case 6, the first case main cannot satisfy.

| Mutation, applied to the fixed tree              | Case that went RED                                                     |
| ------------------------------------------------ | ---------------------------------------------------------------------- |
| M1 syntax check back to an unbounded substitution | 8, through the harness wall clock: "a reload that can hang is itself a regression" |
| M2 install interrupt traps removed                | 6, no INTERRUPTED message and an empty stderr                          |
| M3 `trap '' TTOU TTIN` removed                    | 11, the install under `stty tostop` exited 1                           |
| M4 `cp -Rp` back to `cp -p`                       | 7, the symlink came back as a regular file                             |
| M5 deadline ceiling removed                       | 10, a healthy install rolled back at once                              |
| M6 port resolution back to an unbounded call      | 9, through the harness wall clock                                      |
| M7 `kill -KILL` removed from the group stop       | 5, a pid survived; cases 1 to 4 stayed green                           |
| M8 poll interval 0.25 to 1                        | 1, the wedged run took 15s against the 9s ceiling                      |
| M9 timeout branch worded as a plain parse failure  | 8, which the first version of that assertion did not notice            |
| M10 recovery proof back to an unbounded call       | 12, through the harness wall clock                                     |
| control, unmutated                                | all 12 green, wedged run 5s                                            |

The two coverage gaps needed the opposite demonstration, that the OLD assertion could not see the
defect it was meant to catch. Each of these runs pairs the old assertion with the live defect, and both
are green:

| Old form plus the defect it should have caught       | Result                                      |
| ---------------------------------------------------- | ------------------------------------------- |
| byte-only `file_fingerprint` plus `cp -p`             | green, the symlink was silently lost        |
| old 20s ceiling with no floor plus a 1s poll interval | green, the wedged run took 14s              |

M7 shows the same thing for the KILL: with it deleted, cases 1 to 4 all passed, because the old wedge
was a plain `/bin/sleep` that dies of the first TERM.

Gates: `just l` reports no drift, `just test` exits 0 across all four suites, and CI's lint job passed
on the first commit of this branch.

Two measurements behind the fixes, both on this machine, bash 3.2.57 and macOS 26.2:
`$((2305843009213693952 * 4))` is `-9223372036854775808`; and under a pty with `stty tostop` a child in
its own process group sits in state `T` after writing, while the same child with SIGTTOU ignored sits
in state `S` and its write lands.

### Unbounded call audit

Every external call on the install and reload paths, and what bounds it.

Install:

- `rm -f`, `chmod`, and the three `mv -f` calls: unlink, chmod and rename never open the file, so none
  of them can block on its content.
- `print_config | tee -- <staging>`: opens the staging path for writing, which blocks on a named pipe.
  The same path is removed immediately before. Left as is: recreating it inside that window needs write
  access to the root-owned drop-in directory, which is the trust boundary the whole script assumes.
- the copy of the existing drop-in aside: was unbounded, measured blocking forever on a named pipe.
  Fixed by `cp -Rp`, which recreates a special file instead of reading it.
- the child verify: bounded, and was already.

Reload:

- `sudo -v`: can wait on a password prompt. Deliberate, it is the operator's own prompt, and it runs
  before anything is disturbed.
- the tree observation (`stat`, `cksum`, and the walk's own reads): each open is guarded by a
  regular-file test immediately before it. Residual: a writer swapping a pipe in between the test and
  the open, which again needs write access to the root-owned directory.
- `sshd -t`: bounded here.
- the child verify: bounded.
- `sshd -G` for the probe ports: bounded here.
- `launchctl print`: not a reader of the configuration tree, and no hang has been measured. A wedged
  launchd is a machine-level fault this mode cannot remediate. Left unbounded deliberately.
- `launchctl kickstart -k`: the disruptive step itself. Stopping it midway would leave the service
  somewhere between untouched and stopped, and the readiness prover is what bounds that outcome.
- `ssh-keyscan -T <timeout>`: bounded per attempt by its own flag, and overall by the attempt count.
- `sleep <interval>`: bounded by its argument.

Outside the two paths, found while auditing and fixed here rather than deferred: `--rollback` proves a
password channel is open with two `sshd -G -T -C` calls, and neither was bounded. `check_password_channel`
now owns the temporary file and `resolve_password_channel` asks each question through `run_bounded`, so
the mode reports a stopped proof instead of going quiet. The removal still happens first, and the
failure text now says so, because a re-run is what gets the operator the answer.

## Effect of merging

Nothing on any machine changes when this merges. The script is a chezmoi source file, no `chezmoi
apply` was run, and no test touches `~/.ssh` or the live daemon: every case drives a scratch tree
through the `SSHD_CONFIG_D` and `SSH_HARDENING_SUDO` seams, against stubs.

What changes at the next apply, in operator-visible terms: a `--reload` over a tree that hangs sshd
fails inside the deadline instead of parking, an interrupted install rolls back and says so, an
existing drop-in that is a symlink survives a failed install as a symlink, and a
`SSH_HARDENING_VERIFY_DEADLINE` above 86400 reads as the default 120 rather than as itself.

## Review guide

- The mechanism is `run_bounded`, next to `stop_bounded_group`. Its four call sites are
  `run_verify_child`, step 4 of `reload_sshd`, `resolve_probe_ports`, and `resolve_password_channel`.
  The last two need the command's output, which is why they write to a temporary file: a command
  substitution reads through a pipe and waits for the pipe to close, which is the unbounded wait being
  removed.
- `handle_install_interrupt` and the `INSTALL_ROLLED_BACK` guard belong together. The guard is not
  defensive: a failing step and the interrupt that killed it can both reach the rollback, and a second
  pass over a restored tree reads the absent backup as "nothing was here before" and deletes the file
  the first pass just put back.
- A case label in the e2e file is a stable identifier, not an index into the property list in its
  header and not the running order. Cases 8, 9 and 12 all pin the same property, one bounded call each.
- One thing in the suite is a harness property rather than a script property, and case 6 would prove
  nothing without it: bash gives an asynchronous command SIGINT ignored when job control is off, and a
  signal ignored at entry cannot be trapped, so that case launches under monitor mode. Measured both
  ways before it was written that way.
