### PR TITLE
fix(osquery): seven review findings against the file-integrity page triage

### DIFF
--- a/dot_local/bin/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/bin/executable_homebrew-weekly-upgrade.sh
@@ -81,6 +81,16 @@ if [[ -n $UNATTENDED_LOG_AVAILABLE ]]; then
   LOG_ENTRY_HEADER="$(unattended_log_entry_header "$LOG_SUCCESS_MARKER")"
 fi
 
+# The upgrade record's timestamp, read ONCE here and used by both the record this
+# run publishes before it starts and the one it finalizes after (see
+# write_upgrade_record). It dates the moment the run BEGAN, which is what makes
+# the record cover the window it describes: the epoch is what the consumer does
+# arithmetic on and the ISO string is what it renders, and two `date` calls could
+# disagree about which run they belong to.
+UPGRADE_RECORD_EPOCH=""
+UPGRADE_RECORD_ISO=""
+read -r UPGRADE_RECORD_EPOCH UPGRADE_RECORD_ISO < <(date -u '+%s %Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || true
+
 # The relay script by ABSOLUTE path. The LaunchAgent's PATH is
 # /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin, with no
 # ~/.local/bin in it, so a bare `relay.sh` would never be found under launchd and
@@ -165,8 +175,26 @@ __homebrew_package_snapshot() {
   esac
 }
 
-# write_upgrade_record -- persist what this run moved, so something days later
-# can ask whether an upgrade plausibly explains a file that changed.
+# write_upgrade_record <started|completed> -- persist what this run moved, so
+# something days later can ask whether an upgrade plausibly explains a file that
+# changed.
+#
+# PUBLISHED TWICE, ONE RUN. `started` writes the run line alone before the first
+# brew step; `completed` rewrites it with the package rows once the after
+# snapshot is taken. Both carry the SAME timestamp, so the two are one record at
+# two levels of detail rather than two runs. It was written only at the end
+# before, and that left the whole upgrade window uncovered: a watched file
+# rewritten in the first seconds of a run pages while the newest record on disk
+# is still the previous week's, so the correlation answers "no recorded upgrade
+# in the last 3 days" about a file an upgrade is moving right then.
+#
+# THE LIMIT, since this is a lead and its limits are what keep it honest: a page
+# fired mid-run reads a record that dates the run and names NOTHING, because
+# nothing has been compared yet. That renders as the no-match line, which states
+# what the run recorded rather than claiming a mapping; it is the same sentence a
+# genuinely empty week produces. Naming the packages mid-run would mean diffing
+# the Cellar on every page, which is the fork-brew-from-the-alert-path this
+# deliberately does not do.
 #
 # WHO READS IT. The osquery file-integrity page fires when a watched file leaves
 # its known-good manifest, and a vendor update and a tamper used to render the
@@ -193,20 +221,30 @@ __homebrew_package_snapshot() {
 # previous record whole rather than a torn one. Best effort throughout: upgrading
 # matters more than bookkeeping, and every failure is stated rather than silent.
 write_upgrade_record() {
-  local epoch="" iso=""
+  local phase="$1"
+  case "$phase" in
+    started | completed) ;;
+    *)
+      printf 'homebrew-weekly-upgrade: WARNING unknown upgrade-record phase: %s; no record was written\n' "$phase" >&2
+      return 0
+      ;;
+  esac
   [[ -n $brew_snapshot_ok ]] || {
-    printf 'homebrew-weekly-upgrade: the package listing could not be read, so the upgrade record was left at its previous contents; a stale record simply falls out of the correlation window\n' >&2
+    printf 'homebrew-weekly-upgrade: the package listing could not be read, so this run adds no package rows to the upgrade record; the correlation line will name nothing\n' >&2
     return 0
   }
-  read -r epoch iso < <(date -u '+%s %Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || true
-  if [[ ! $epoch =~ ^[0-9]+$ || -z $iso ]]; then
+  if [[ ! $UPGRADE_RECORD_EPOCH =~ ^[0-9]+$ || -z $UPGRADE_RECORD_ISO ]]; then
     printf 'homebrew-weekly-upgrade: WARNING this clock could not be read, so no upgrade record was written for this run\n' >&2
     return 0
   fi
   mkdir -p "$STATE_DIR" 2>/dev/null || true
   if ! {
-    printf '%s\t%s\n' "$epoch" "$iso"
-    unattended_log_change_tuples "$snapshot_dir/brew.before" "$snapshot_dir/brew.after"
+    printf '%s\t%s\n' "$UPGRADE_RECORD_EPOCH" "$UPGRADE_RECORD_ISO"
+    # An `if`, not a `&&` list: the group's status is what the caller tests, and
+    # a false test as the last statement would report a written record as failed.
+    if [[ $phase == completed ]]; then
+      unattended_log_change_tuples "$snapshot_dir/brew.before" "$snapshot_dir/brew.after"
+    fi
   } >"$UPGRADE_RECORD.tmp" 2>/dev/null; then
     printf 'homebrew-weekly-upgrade: WARNING could not write the upgrade record at %s; the file-integrity page will report no recorded upgrade\n' \
       "$UPGRADE_RECORD" >&2
@@ -332,6 +370,9 @@ if [[ -n $UNATTENDED_LOG_AVAILABLE ]]; then
     trap 'rm -rf "$snapshot_dir"' EXIT
     __homebrew_package_snapshot brew >"$snapshot_dir/brew.before" || brew_snapshot_ok=""
     __homebrew_package_snapshot mas >"$snapshot_dir/mas.before" || mas_snapshot_ok=""
+    # Published BEFORE the first brew step, so the record covers the window it
+    # describes rather than appearing only once the window has closed.
+    write_upgrade_record started
   else
     snapshot_dir=""
     brew_snapshot_ok=""
@@ -365,7 +406,7 @@ if [[ -n $UNATTENDED_LOG_AVAILABLE ]]; then
   if [[ -n $snapshot_dir ]]; then
     __homebrew_package_snapshot brew >"$snapshot_dir/brew.after" || brew_snapshot_ok=""
     __homebrew_package_snapshot mas >"$snapshot_dir/mas.after" || mas_snapshot_ok=""
-    write_upgrade_record
+    write_upgrade_record completed
   fi
   weekly_record completed "$(printf '%s\n%s\nfailed steps: %d' \
     "$(unattended_log_change_section "$brew_snapshot_ok" \

--- a/dot_local/bin/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/bin/executable_homebrew-weekly-upgrade.sh
@@ -213,9 +213,11 @@ __homebrew_package_snapshot() {
 # manifest covers and no file-integrity watch reads, so a mas transition could
 # never explain one of these pages and listing it would only pad the line.
 #
-# ONE CLOCK READING for both timestamp fields (the house idiom from
-# unattended_log_entry_header): the epoch is what the reader does arithmetic on
-# and the ISO string is what it renders, and two `date` calls could disagree.
+# ONE CLOCK READING for both timestamp fields AND for both phases (the house
+# idiom from unattended_log_entry_header), taken once near the top of this script
+# into UPGRADE_RECORD_EPOCH / UPGRADE_RECORD_ISO: the epoch is what the reader
+# does arithmetic on and the ISO string is what it renders, and separate `date`
+# calls could disagree, which here would also make one run look like two.
 #
 # Written to a temp file and moved into place, so a reader mid-write sees the
 # previous record whole rather than a torn one. Best effort throughout: upgrading

--- a/dot_local/libexec/osquery/executable_results-alerter.sh
+++ b/dot_local/libexec/osquery/executable_results-alerter.sh
@@ -25,9 +25,11 @@ set -euo pipefail
 LOG="${OSQUERY_RESULTS_LOG:-$HOME/.local/log/osquery/osqueryd.results.log}"
 STATE="${OSQUERY_RESULTS_OFFSET:-$HOME/.local/state/osquery-results-offset}"
 
-# The dispatch library and the seven pipeline helpers, from the libexec home (the
-# same deployed path the other consumers source; literal so the relocation guard
-# can assert it).
+# The dispatch library and the six REQUIRED pipeline helpers, from the libexec
+# home (the same deployed path the other consumers source; literal so the
+# relocation guard can assert it). These sources are deliberately UNGUARDED:
+# without any one of them there is no detection, no routing and no delivery, so
+# an absent file must abort under errexit rather than page a half-run pipeline.
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/alert-dispatch.sh"
 # shellcheck source=/dev/null
@@ -39,11 +41,29 @@ source "$HOME/.local/libexec/osquery/results-alerter/allowlist-verdict.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 # shellcheck source=/dev/null
-source "$HOME/.local/libexec/osquery/results-alerter/file-integrity-triage.sh"
-# shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/digest-store.sh"
 # shellcheck source=/dev/null
 source "$HOME/.local/libexec/osquery/results-alerter/render-page.sh"
+
+# The one OPTIONAL helper, sourced CONDITIONALLY and never fatally. It adds
+# display-only triage facts to a file-integrity page, and route.sh already calls
+# it behind a `declare -F file_integrity_triage` guard, so a page without it
+# costs two LINES. Sourced beside the required libraries above it cost far more:
+# this entry runs under `set -euo pipefail`, so a file that had not been deployed
+# yet aborted the run BEFORE any routing, delivery or checkpointing, and every
+# page on the machine was blocked until the file came back. That is strictly
+# worse than the missing-line case the router's fallback was written to tolerate,
+# so the guard below is what makes that fallback reachable at all. LOUD when
+# absent: this stderr is the alerter's launchd log, and a partial deploy that
+# quietly drops facts off every page is exactly the state that stays invisible.
+OSQUERY_TRIAGE_HELPER="$HOME/.local/libexec/osquery/results-alerter/file-integrity-triage.sh"
+if [[ -r $OSQUERY_TRIAGE_HELPER ]]; then
+  # shellcheck source=/dev/null
+  source "$OSQUERY_TRIAGE_HELPER"
+else
+  printf 'results-alerter: WARNING the file-integrity triage helper is missing at %s; pages still fire, without their recorded/on-disk hashes and upgrade correlation (run chezmoi apply)\n' \
+    "$OSQUERY_TRIAGE_HELPER" >&2
+fi
 
 # The single-instance lock file sits beside the cursor it guards, so every alerter
 # invocation contends on one lock no matter what launched it (a WatchPaths burst can

--- a/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
+++ b/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
@@ -206,7 +206,7 @@ _file_integrity_upgrade_line() {
   local target="$1" record="$OSQUERY_UPGRADE_RECORD"
   local basename_of_target="${target##*/}"
   local epoch iso now age window rows=0
-  local name state version_before version_after
+  local row rest name state version_before version_after
   local matched="" matched_before="" matched_after=""
   local -a changed_names=()
 
@@ -235,9 +235,25 @@ _file_integrity_upgrade_line() {
     return 0
   fi
 
-  while IFS=$'\t' read -r name state version_before version_after || [[ -n $name ]]; do
+  while IFS= read -r row || [[ -n $row ]]; do
     rows=$((rows + 1))
     ((rows == 1)) && continue # the run timestamp, already read above
+    # FIELD DECODING BY EXPANSION, NOT BY `read`. A tab is one of the three IFS
+    # WHITESPACE characters, so `IFS=$'\t' read -r name state before after`
+    # treats a RUN of tabs as a single delimiter and drops the empty column the
+    # producer writes for the absent side of an add or a remove. An `added` row
+    # (name, added, EMPTY, version) decoded as (name, added, version, EMPTY) and
+    # rendered backwards: a package that had just appeared read as one that had
+    # just been removed. Splitting on each delimiter in turn keeps an empty
+    # column exactly where the producer put it. A row with too few columns lands
+    # a copy of the tail in `state`, which the recognised-state check below
+    # refuses along with every other row shape this cannot describe.
+    name="${row%%$'\t'*}"
+    rest="${row#*$'\t'}"
+    state="${rest%%$'\t'*}"
+    rest="${rest#*$'\t'}"
+    version_before="${rest%%$'\t'*}"
+    version_after="${rest#*$'\t'}"
     [[ -n $name ]] || continue
     if ((rows > OSQUERY_UPGRADE_RECORD_MAX_ROWS)); then
       printf 'osquery file-integrity triage: the upgrade record at %s lists more than %s rows; this page carries no correlation\n' \

--- a/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
+++ b/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
@@ -335,7 +335,13 @@ _file_integrity_upgrade_line() {
     return 0
   fi
   if [[ ${#changed_names[@]} -eq 0 ]]; then
-    printf 'no recorded upgrade names this file; the run at %s changed nothing' "$iso"
+    # "recorded no package change", not "changed nothing". The producer publishes
+    # the run line before its first brew step and fills in the rows afterwards,
+    # so this shape is read by two different runs: a week that genuinely moved
+    # nothing, and a run still in flight that has not compared anything yet. The
+    # first wording is true of both; the second would claim a completed run about
+    # one that is still going.
+    printf 'no recorded upgrade names this file; the run at %s recorded no package change' "$iso"
     return 0
   fi
   # Names only, no versions: the whole sentence shares a 240-character cap with

--- a/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
+++ b/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
@@ -100,6 +100,14 @@ OSQUERY_UPGRADE_RECORD_WINDOW_DAYS=3
 # file anyone can append to would be a way to stall paging.
 OSQUERY_UPGRADE_RECORD_MAX_ROWS=500
 
+# The most bytes that may be read, and the size past which the record is refused
+# whole. The row cap above bounds how many LINES are walked; it does not bound
+# the read itself, because a single line with no newline in it can be as large as
+# the disk allows and would be read in full before the first row was counted. At
+# 500 rows this leaves over 500 bytes per row, and the real file averages well
+# under a hundred.
+OSQUERY_UPGRADE_RECORD_MAX_BYTES=262144
+
 # How many package names an unmatched line lists before it counts the rest. The
 # whole sentence is capped at 240 characters by the renderer, so a long list
 # would be truncated mid-name and take the timestamp with it.
@@ -205,18 +213,58 @@ _file_integrity_disk_hash() {
 _file_integrity_upgrade_line() {
   local target="$1" record="$OSQUERY_UPGRADE_RECORD"
   local basename_of_target="${target##*/}"
-  local epoch iso now age window rows=0
+  local epoch iso now age window rows=0 bytes snapshot=""
   local row rest name state version_before version_after
   local matched="" matched_before="" matched_after=""
   local -a changed_names=()
 
-  if [[ ! -r $record ]]; then
+  if [[ ! -e $record ]]; then
     printf 'no upgrade record on this machine'
     return 0
   fi
-  # The first line dates the record. Read on its own open rather than inside the
-  # row loop, so the row loop needs no line counter and the two shapes never mix.
-  read -r epoch iso <"$record" 2>/dev/null || true
+  # WHAT MAY BE READ AT ALL. The record path is not a trust input: it lives in
+  # the operator-writable state dir, so anything can be standing there. A
+  # readable FIFO with no writer is the shape that matters, because `read` on it
+  # blocks FOREVER, and it blocks while the alerter holds its single-instance
+  # lock, so the page is never sent and the cursor never advances: every page on
+  # the machine stops behind one named pipe. A character device does the same by
+  # never yielding a newline. A regular file is the only shape that cannot, so it
+  # is the only shape accepted. SYMLINKS ARE FOLLOWED, deliberately: `-f` judges
+  # the final target, so a link to a regular file is read (a normal way to place
+  # state) and a link to a pipe or a device is refused exactly like the bare one.
+  if [[ ! -f $record || ! -r $record ]]; then
+    printf 'osquery file-integrity triage: the upgrade record at %s is not a readable regular file; this page carries no correlation\n' \
+      "$record" >&2
+    printf 'the upgrade record could not be read'
+    return 0
+  fi
+  # ONE OPEN, ONE SNAPSHOT, BOUNDED. Both shapes (the run line and the package
+  # rows) are parsed from these same bytes. Two opens could straddle the atomic
+  # rename the producer publishes with, and would then pair one generation's
+  # timestamp with the other generation's transitions: a correlation that no run
+  # ever produced, rendered as if it had. The read is capped because this is the
+  # alert path. The type check above already refuses the shapes that block
+  # forever, so what is left to bound is size, and a byte cap bounds that
+  # directly; a watchdog child (the shape ssh-hardening --verify uses to bound a
+  # blocking `sshd -G`) would buy nothing here, since there is no external
+  # process to signal, only this shell reading a local file. A record over the
+  # cap is refused WHOLE rather than parsed from its first bytes, for the same
+  # reason an unrecognised row refuses the whole record: a partial reading
+  # rendered as a complete one is the failure this correlation exists to avoid.
+  snapshot="$(head -c "$((OSQUERY_UPGRADE_RECORD_MAX_BYTES + 1))" -- "$record" 2>/dev/null)" || snapshot=""
+  bytes="$(printf '%s' "$snapshot" | LC_ALL=C wc -c)" || bytes=""
+  bytes="${bytes//[[:space:]]/}"
+  if [[ ! $bytes =~ ^[0-9]+$ ]] || ((bytes > OSQUERY_UPGRADE_RECORD_MAX_BYTES)); then
+    printf 'osquery file-integrity triage: the upgrade record at %s could not be read within %s bytes; this page carries no correlation\n' \
+      "$record" "$OSQUERY_UPGRADE_RECORD_MAX_BYTES" >&2
+    printf 'the upgrade record could not be read'
+    return 0
+  fi
+  # The first line dates the record, taken from the snapshot rather than from a
+  # second open of the file.
+  row="${snapshot%%$'\n'*}"
+  epoch="${row%%$'\t'*}"
+  iso="${row#*$'\t'}"
   if [[ ! $epoch =~ ^[0-9]{1,11}$ ]] ||
     [[ ! $iso =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
     printf 'osquery file-integrity triage: the upgrade record at %s does not start with a run timestamp; this page carries no correlation\n' \
@@ -235,7 +283,7 @@ _file_integrity_upgrade_line() {
     return 0
   fi
 
-  while IFS= read -r row || [[ -n $row ]]; do
+  while IFS= read -r row; do
     rows=$((rows + 1))
     ((rows == 1)) && continue # the run timestamp, already read above
     # FIELD DECODING BY EXPANSION, NOT BY `read`. A tab is one of the three IFS
@@ -279,7 +327,7 @@ _file_integrity_upgrade_line() {
       matched_before="${version_before:-none}"
       matched_after="${version_after:-none}"
     fi
-  done <"$record"
+  done <<<"$snapshot"
 
   if [[ -n $matched ]]; then
     printf 'recorded upgrade: %s %s -> %s at %s (the name matches this file, which is not proof)' \

--- a/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
+++ b/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh
@@ -62,8 +62,13 @@
 # render-page.sh, whose jq program is bash SINGLE-QUOTED; an apostrophe in a
 # rendered string ends that quoting and breaks the renderer.
 
-# The upgrade record, written by ~/.local/bin/homebrew-weekly-upgrade.sh at the
-# end of every run whose package listing could be read. Keep this literal in sync
+# The upgrade record, written by ~/.local/bin/homebrew-weekly-upgrade.sh TWICE per
+# run whose package listing could be read: the run line alone before the first
+# brew step, then the whole thing again with the package rows once the run is
+# done. Both carry the same timestamp, so the two are one record at two levels of
+# detail; the pre-upgrade publish is what makes the record cover the window it
+# describes, since a watched file rewritten in the first seconds of a run would
+# otherwise be correlated against the PREVIOUS week. Keep this literal in sync
 # with the producer; test/unit/osquery-file-integrity-triage.sh pins them equal,
 # because a rename in one alone leaves this answering no-record forever, which
 # reads exactly like a quiet month of upgrades.
@@ -76,9 +81,11 @@
 #
 #   <name>	<added|removed|changed>	<before-version>	<after-version>
 #
-# The absent side of an add or a remove is the empty string. A run that changed
-# nothing writes line 1 alone, which is a fact worth having: it dates the last
-# time anything upgraded at all.
+# The absent side of an add or a remove is the empty string. LINE 1 ALONE has two
+# readings, which is why the sentence rendered for it states what the run
+# recorded rather than what it did: a run still in flight has compared nothing
+# yet, and a finished run that moved nothing dates the last time anything
+# upgraded at all.
 OSQUERY_UPGRADE_RECORD="${OSQUERY_UPGRADE_RECORD:-$HOME/.local/state/homebrew-weekly-upgrade/last-upgrade-changes.tsv}"
 
 # How recent a recorded upgrade must be to be offered as an explanation.

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -309,14 +309,32 @@ route_findings() {
             # holds the standing rule that a correlation never says safe.
             #
             # GUARDED AT EVERY STEP so a page cannot be lost to a fact that is
-            # merely nice to have: an absent helper, a helper that fails, and
-            # output that is not JSON each leave the finding exactly as the
-            # verdict produced it. Both conditions are `if` tests, which is what
-            # keeps `set -e` from ending the pass on any of them.
+            # merely nice to have: an absent helper, a helper that fails, output
+            # that is not JSON, and output whose SHAPE the renderer cannot print
+            # each leave the finding exactly as the verdict produced it. Both
+            # conditions are `if` tests, which is what keeps `set -e` from ending
+            # the pass on any of them.
+            #
+            # THE SHAPE IS CHECKED HERE, not merely the syntax. render-page.sh
+            # prints all three members as strings, and an object or a number
+            # cannot be rendered as one: jq exits non-zero, the whole render dies,
+            # and the page the verdict had ALREADY confirmed is never written.
+            # The entry checkpoints only after delivery, so every retry then
+            # wedged on the same batch. A half-deployed or hostile helper
+            # answering {"recorded":"abc","ondisk":{},"upgrade":"lead"} is valid
+            # JSON, which is why parseability was never the property that
+            # mattered. The check is jq-side (one pass, no second fork) and the
+            # `and` short-circuits, so a triage value that is not an object at all
+            # is refused before anything indexes it.
             if declare -F file_integrity_triage >/dev/null 2>&1; then
               triage=$(file_integrity_triage "$target" 2>/dev/null) || triage=""
               if [[ -n $triage ]] &&
-                enriched=$(jq -c --argjson t "$triage" '.triage = $t' <<<"$obj" 2>/dev/null); then
+                enriched=$(jq -c --argjson t "$triage" '
+                  if ($t | type) == "object"
+                     and (["recorded", "ondisk", "upgrade"] | all(($t[.] | type) == "string"))
+                  then .triage = $t
+                  else .
+                  end' <<<"$obj" 2>/dev/null); then
                 obj="$enriched"
               fi
             fi

--- a/dot_local/libexec/osquery/results-alerter/route.sh
+++ b/dot_local/libexec/osquery/results-alerter/route.sh
@@ -326,8 +326,16 @@ route_findings() {
             # mattered. The check is jq-side (one pass, no second fork) and the
             # `and` short-circuits, so a triage value that is not an object at all
             # is refused before anything indexes it.
+            #
+            # ITS STDERR IS LEFT ALONE, which is the point of writing those
+            # diagnostics at all: the helper says on stderr WHICH path it could
+            # not read and why, this stage's stderr is the alerter's stderr, and
+            # that is the launchd log. Redirecting it to /dev/null left a page
+            # saying the record could not be read and a log that never said which
+            # record or what was wrong with it, and it protected nothing, since
+            # the call below is already guarded against a helper that fails.
             if declare -F file_integrity_triage >/dev/null 2>&1; then
-              triage=$(file_integrity_triage "$target" 2>/dev/null) || triage=""
+              triage=$(file_integrity_triage "$target") || triage=""
               if [[ -n $triage ]] &&
                 enriched=$(jq -c --argjson t "$triage" '
                   if ($t | type) == "object"

--- a/test/e2e/homebrew-weekly-record.sh
+++ b/test/e2e/homebrew-weekly-record.sh
@@ -277,6 +277,66 @@ refute '^yq' "$(cat "$record_path")" "the record lists a formula that did not mo
 refute 'Xcode' "$(cat "$record_path")" "the record carries App Store apps, which no file-integrity page can be about"
 unset MAS_AFTER
 
+# ── 4c. THE RECORD COVERS THE UPGRADE IT DESCRIBES. It used to be written only
+#       after every brew step had finished, so a watched file rewritten early in
+#       the upgrade paged while the newest record on disk was still last week's:
+#       the correlation answered "no recorded upgrade in the last 3 days" about a
+#       file that an upgrade was moving at that very moment, which is the exact
+#       false reading the line exists to prevent. The run now publishes its
+#       timestamp before the first brew step and fills in what moved afterwards,
+#       both by atomic rename. The brew stub below copies the record at the
+#       instant `brew upgrade` runs, which is what a page fired then would read.
+rm -rf "$HOME/.local/state"
+MID_RUN_RECORD="$tmp/record-mid-upgrade.tsv"
+cat >"$tmp/brew" <<'MOCK'
+#!/usr/bin/env bash
+if [[ ${1:-} == "list" ]]; then
+  if [[ -e "$UPGRADE_MARKER" ]]; then printf '%s\n' "$BREW_AFTER"; else printf '%s\n' "$BREW_BEFORE"; fi
+  exit 0
+fi
+if [[ ${1:-} == "upgrade" ]]; then
+  # Mid-run: whatever the file-integrity page would read if a watched file
+  # changed right now.
+  [[ -f $RECORD_PATH ]] && cp "$RECORD_PATH" "$MID_RUN_RECORD"
+  : >"$UPGRADE_MARKER"
+fi
+echo "mock brew $*"
+exit 0
+MOCK
+chmod +x "$tmp/brew"
+rm -f "$UPGRADE_MARKER" "$MID_RUN_RECORD"
+RUN_OUTPUT="$(HOMEBREW_WEEKLY_BREW="$tmp/brew" HOMEBREW_WEEKLY_MAS="$tmp/mas" \
+  HOMEBREW_WEEKLY_TAILSCALED="/nonexistent" HOMEBREW_WEEKLY_LOCKFILE="$tmp/lock.midrun" \
+  MAS_VERSIONS="$MAS_VERSIONS" RECORD_PATH="$record_path" MID_RUN_RECORD="$MID_RUN_RECORD" \
+  bash "$HELPER" --scheduled 2>&1)"
+[[ -f $MID_RUN_RECORD ]] ||
+  fail "no upgrade record existed while the upgrade was running, so a page fired then correlates against last week: $RUN_OUTPUT"
+read -r mid_epoch mid_iso <"$MID_RUN_RECORD"
+[[ $mid_epoch =~ ^[0-9]+$ ]] ||
+  fail "the mid-run record does not open with an epoch: $(cat "$MID_RUN_RECORD")"
+[[ $mid_iso =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+  fail "the mid-run record does not open with an ISO 8601 UTC stamp: $(cat "$MID_RUN_RECORD")"
+# The page reads it through the real consumer, not through a restatement of what
+# the consumer is assumed to do.
+mid_upgrade_line="$(OSQUERY_UPGRADE_RECORD="$MID_RUN_RECORD" bash -c '
+  set -euo pipefail
+  source "$1"
+  file_integrity_triage "$2"
+' _ "$TRIAGE_HELPER" "$HOME/.local/bin/ripgrep" 2>/dev/null | jq -r '.upgrade')"
+refute 'no upgrade record' "$mid_upgrade_line" \
+  "a file changed during the upgrade correlates against no record at all"
+refute 'no recorded upgrade in the last' "$mid_upgrade_line" \
+  "a file changed during the upgrade correlates as having no recent upgrade"
+grep -qF "the run at $mid_iso" <<<"$mid_upgrade_line" ||
+  fail "the mid-run correlation does not date the run that was in flight: $mid_upgrade_line"
+# The finalized record is the SAME run, not a second one: one clock reading dates
+# both, so a page before the run finished and a page after it agree on when.
+read -r final_epoch _ <"$record_path"
+[[ $final_epoch == "$mid_epoch" ]] ||
+  fail "the finalized record dates a different moment than the one the run published ($final_epoch vs $mid_epoch)"
+grep -qF "$(printf 'ripgrep\tadded\t\t14.1.1')" "$record_path" ||
+  fail "the finalized record does not carry what the run moved: $(cat "$record_path")"
+
 # ── 5. FAILURES go to the EXISTING alert route, and the record still goes out
 #      saying how many steps failed. A failing weekly upgrade that tells nobody
 #      is the gap this closes. ─────────────────────────────────────────────────

--- a/test/e2e/osquery-alerter-entry.bats
+++ b/test/e2e/osquery-alerter-entry.bats
@@ -220,3 +220,23 @@ run_entry() { run bash "$ENTRY"; }
   [ "$(crit_page_count)" -eq 1 ]
   [ "$(cursor_offset)" -eq "$(log_size)" ]
 }
+
+# (k) The OPTIONAL triage helper is absent. It adds display-only facts to a
+#     file-integrity page and route.sh already guards its call with
+#     `declare -F`, so a partial deploy must cost a page two LINES and nothing
+#     else. Sourced beside the required libraries it did far worse: the entry
+#     runs under `set -euo pipefail`, so a missing file aborted the run BEFORE
+#     any routing, delivery or checkpoint, and every page on the machine was
+#     blocked until the file came back. The absence is also said out loud,
+#     because this stderr is the alerter's launchd log and a silently degraded
+#     page is how a partial deploy stays invisible.
+@test "T-ENTRY-optional-triage: an absent triage helper still pages, loudly" {
+  rm -f "$HOME/.local/libexec/osquery/results-alerter/file-integrity-triage.sh"
+  seed_cursor 0
+  append_row "$ADMIN_ROW"
+  run_entry
+  [ "$status" -eq 0 ]
+  [ "$(crit_page_count)" -eq 1 ]               # the page still went out
+  [ "$(cursor_offset)" -eq "$(log_size)" ]     # and the batch was checkpointed
+  grep -qi 'triage' <<<"$output"               # the run said the helper is gone
+}

--- a/test/unit/osquery-file-integrity-triage.sh
+++ b/test/unit/osquery-file-integrity-triage.sh
@@ -331,8 +331,8 @@ out="$(PATH="$shim_bin:$PATH" HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest"
   OSQUERY_UPGRADE_RECORD="$record" \
   bash -c '
     set -euo pipefail
-    # Without this the clock read below is answered from bash own variable and
-    # the shim, which is the hook that drives the swap, never runs.
+    # Without this, bash answers the helper clock read from its own
+    # EPOCHSECONDS, and the shim that drives the swap never runs.
     unset EPOCHSECONDS
     source "$1"
     source "$2"

--- a/test/unit/osquery-file-integrity-triage.sh
+++ b/test/unit/osquery-file-integrity-triage.sh
@@ -233,4 +233,116 @@ assert_json "$out" "changed row"
 grep -qF 'recorded upgrade: jq 1.7.1 -> 1.8.0' <<<"$(jq -r '.upgrade' <<<"$out")" ||
   fail "a CHANGED package did not render its version transition -- $(jq -r '.upgrade' <<<"$out")"
 
+# triage_bounded <target> -- run the helper with a WATCHDOG, so a record shape
+# that blocks fails this suite instead of wedging it. A plain triage() call is a
+# command substitution, which waits forever; the cases below are exactly the
+# shapes that never return, so the call has to be bounded from the outside.
+#
+# The bound is a killer subshell rather than a poll loop, so the passing path
+# sleeps for NOTHING: `wait` returns the instant the helper exits and the killer
+# is torn down unused. The killer detaches its own stdin and stdout so a lingering
+# sleep can never hold the suite runner's pipe open.
+triage_bounded_out=""
+triage_bounded() {
+  local target="$1" child killer status=0
+  : >"$triage_stderr"
+  HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" \
+    OSQUERY_MANAGED_BIN_MANIFEST="$work/no-bin-manifest.sha256" \
+    OSQUERY_UPGRADE_RECORD="$record" \
+    bash -c '
+      set -euo pipefail
+      source "$1"
+      source "$2"
+      file_integrity_triage "$3"
+    ' _ "$PIPELINE_HELPER" "$HELPER" "$target" >"$work/bounded.out" 2>"$triage_stderr" &
+  child=$!
+  {
+    sleep 10
+    kill -KILL "$child" 2>/dev/null || true
+  } </dev/null >/dev/null 2>&1 &
+  killer=$!
+  wait "$child" || status=$?
+  kill "$killer" 2>/dev/null || true
+  triage_bounded_out="$(cat "$work/bounded.out")"
+  return "$status"
+}
+
+# ---- 9. A record path that is NOT A REGULAR FILE is refused rather than read.
+#      The record lives in the operator-writable state dir, so its path is not a
+#      trust input: a readable FIFO with no writer standing there makes `read`
+#      block FOREVER, and it blocks while the alerter holds its single-instance
+#      lock, so the page is never sent and the cursor never advances. Every page
+#      on the machine stops behind one named pipe. A character device does the
+#      same thing by never yielding a newline. ----
+fifo_record="$work/record.fifo"
+rm -f "$fifo_record"
+mkfifo "$fifo_record"
+record="$fifo_record"
+rc=0
+triage_bounded "$target" || rc=$?
+[[ $rc -eq 0 ]] ||
+  fail "a FIFO upgrade record blocked or failed the helper (exit $rc); every page waits behind it"
+assert_json "$triage_bounded_out" "fifo record"
+grep -qF 'could not be read' <<<"$(jq -r '.upgrade' <<<"$triage_bounded_out")" ||
+  fail "a FIFO record did not degrade to a stated could-not-read line -- $triage_bounded_out"
+[[ -s $triage_stderr ]] || fail "a FIFO record degraded SILENTLY; it must say so on stderr"
+
+record="/dev/zero"
+rc=0
+triage_bounded "$target" || rc=$?
+[[ $rc -eq 0 ]] ||
+  fail "a character-device upgrade record blocked or failed the helper (exit $rc)"
+assert_json "$triage_bounded_out" "device record"
+grep -qF 'could not be read' <<<"$(jq -r '.upgrade' <<<"$triage_bounded_out")" ||
+  fail "a character-device record did not degrade to a stated could-not-read line -- $triage_bounded_out"
+record="$work/last-upgrade-changes.tsv"
+
+# ---- 10. The record is read ONCE. It is published by an atomic rename, so two
+#      opens can straddle a replacement and pair one generation's timestamp with
+#      the other generation's package rows, which is a rendered correlation that
+#      never existed. The interleaving is driven deterministically rather than
+#      raced: the helper reads its clock between the two opens it used to do, so
+#      a `date` shim on PATH is a hook that fires exactly there, and it swaps the
+#      record for a second generation. The shim leaves a MARKER and the marker is
+#      asserted, so this can never pass by quietly failing to drive the swap.
+#      EPOCHSECONDS is unset for the same reason: with it set, bash answers the
+#      clock read from its own variable and never forks the shim. ----
+shim_bin="$work/shim-bin"
+mkdir -p "$shim_bin"
+gen_b_record="$work/generation-b.tsv"
+{
+  printf '%s\t%s\n' "$recent_epoch" "$recent_iso"
+  printf 'ripgrep\tchanged\t14.1.0\t14.1.1\n'
+} >"$gen_b_record"
+cat >"$shim_bin/date" <<SHIM
+#!/usr/bin/env bash
+# Publish generation B over the record, the way the weekly job does.
+: >"$work/date-shim-fired"
+cp "$gen_b_record" "$record.next"
+mv -f "$record.next" "$record"
+exec /bin/date "\$@"
+SHIM
+chmod +x "$shim_bin/date"
+# Generation A: the SAME timestamp, a DIFFERENT transition for the same package.
+write_record "$recent_epoch" "$recent_iso" "$(printf 'ripgrep\tchanged\t13.0.0\t14.0.0')"
+rm -f "$work/date-shim-fired"
+out="$(PATH="$shim_bin:$PATH" HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" \
+  OSQUERY_MANAGED_BIN_MANIFEST="$work/no-bin-manifest.sha256" \
+  OSQUERY_UPGRADE_RECORD="$record" \
+  bash -c '
+    set -euo pipefail
+    # Without this the clock read below is answered from bash own variable and
+    # the shim, which is the hook that drives the swap, never runs.
+    unset EPOCHSECONDS
+    source "$1"
+    source "$2"
+    file_integrity_triage "$3"
+  ' _ "$PIPELINE_HELPER" "$HELPER" "$home/.local/bin/ripgrep" 2>"$triage_stderr")"
+[[ -e $work/date-shim-fired ]] ||
+  fail "the record-swap hook never fired, so this case proved nothing about how often the record is opened"
+assert_json "$out" "single read"
+upgrade="$(jq -r '.upgrade' <<<"$out")"
+grep -qF 'recorded upgrade: ripgrep 13.0.0 -> 14.0.0' <<<"$upgrade" ||
+  fail "the helper re-opened the record and rendered a generation it did not date -- $upgrade"
+
 printf 'osquery-file-integrity-triage: OK (short recorded/on-disk hashes; a name-matching record renders the transition and says it is not proof; added, removed and changed rows each render in the direction the run moved; an unmatched, stale, absent or malformed record each degrade to a stated line, loudly and without losing the page)\n'

--- a/test/unit/osquery-file-integrity-triage.sh
+++ b/test/unit/osquery-file-integrity-triage.sh
@@ -202,4 +202,35 @@ assert_json "$out" "vanished target"
 [[ "$(jq -r '.recorded' <<<"$out")" == "not in the manifest" ]] ||
   fail "an unmanifested target did not say the manifest has no tuple for it -- $out"
 
-printf 'osquery-file-integrity-triage: OK (short recorded/on-disk hashes; a name-matching record renders the transition and says it is not proof; an unmatched, stale, absent or malformed record each degrade to a stated line, loudly and without losing the page)\n'
+# ---- 8. ALL THREE ROW KINDS render the transition in the direction the run
+#      actually moved. The producer writes the absent side of an add or a remove
+#      as an EMPTY column, and a tab is an IFS WHITESPACE character, so decoding
+#      a row with `IFS=$'\t' read -r name state before after` collapsed the two
+#      tabs of an `added` row into one delimiter and shifted the version into the
+#      BEFORE field: a package that had just appeared rendered as "14.1.1 ->
+#      none", i.e. as a package that had just been REMOVED. Only `changed` rows
+#      were covered before, which is the one shape that survives the collapse. --
+added_target="$home/.local/bin/ripgrep"
+removed_target="$home/.local/bin/oldpkg"
+changed_target="$home/.local/bin/jq"
+write_record "$recent_epoch" "$recent_iso" \
+  "$(printf 'ripgrep\tadded\t\t14.1.1')" \
+  "$(printf 'oldpkg\tremoved\t9.9\t')" \
+  "$(printf 'jq\tchanged\t1.7.1\t1.8.0')"
+
+out="$(triage "$added_target")"
+assert_json "$out" "added row"
+grep -qF 'recorded upgrade: ripgrep none -> 14.1.1' <<<"$(jq -r '.upgrade' <<<"$out")" ||
+  fail "an ADDED package did not render as none -> version -- $(jq -r '.upgrade' <<<"$out")"
+
+out="$(triage "$removed_target")"
+assert_json "$out" "removed row"
+grep -qF 'recorded upgrade: oldpkg 9.9 -> none' <<<"$(jq -r '.upgrade' <<<"$out")" ||
+  fail "a REMOVED package did not render as version -> none -- $(jq -r '.upgrade' <<<"$out")"
+
+out="$(triage "$changed_target")"
+assert_json "$out" "changed row"
+grep -qF 'recorded upgrade: jq 1.7.1 -> 1.8.0' <<<"$(jq -r '.upgrade' <<<"$out")" ||
+  fail "a CHANGED package did not render its version transition -- $(jq -r '.upgrade' <<<"$out")"
+
+printf 'osquery-file-integrity-triage: OK (short recorded/on-disk hashes; a name-matching record renders the transition and says it is not proof; added, removed and changed rows each render in the direction the run moved; an unmatched, stale, absent or malformed record each degrade to a stated line, loudly and without losing the page)\n'

--- a/test/unit/osquery-route-pipeline.sh
+++ b/test/unit/osquery-route-pipeline.sh
@@ -270,6 +270,31 @@ page_f="$(UPGRADE_RECORD="$UPGRADE_RECORD" run_gate_render "$triage_manifest" "$
 assert_paged "$(jq -r '.pbody' <<<"$page_f")" "Recorded:" \
   "a well-formed triage object was dropped, so the page lost the facts it exists to carry"
 
+# ---- Pass F: the triage helper's DIAGNOSTICS reach the alerter log. Every way
+#      the correlation can degrade is written to stderr on purpose (an unreadable
+#      record, a record that is not a regular file, a record with a row it cannot
+#      describe), and the alerter's stderr is its launchd log, which is the only
+#      place those states are ever visible. The gate called the helper with
+#      2>/dev/null, so the page said the record could not be read and the log
+#      never said which path or why. Silencing it also cost nothing it protected:
+#      the call is already guarded, so a noisy helper could never fail the page. --
+noisy_triage="$work/noisy-triage.sh"
+cat >"$noisy_triage" <<'NOISY'
+# shellcheck shell=bash
+file_integrity_triage() {
+  printf 'osquery file-integrity triage: the upgrade record at /nowhere/record.tsv is not a readable regular file\n' >&2
+  printf '{"recorded":"?","ondisk":"?","upgrade":"the upgrade record could not be read"}\n'
+  return 0
+}
+NOISY
+gate_stderr="$work/gate-stderr"
+: >"$gate_stderr"
+page_g="$(TRIAGE_OVERRIDE="$noisy_triage" run_gate "$triage_manifest" "$absent_bin_manifest" \
+  "$(fe pipeline_integrity "$tampered" "$event_hash" UPDATED)" 2>"$gate_stderr")"
+assert_paged "$page_g" TAG11 "a helper that warns must still page"
+grep -qF '/nowhere/record.tsv' "$gate_stderr" ||
+  fail "the triage helper's diagnostic never reached the alerter log: $(cat "$gate_stderr")"
+
 # Every paged line is a CRIT finding.
 for out in "$page_a" "$page_b" "$page_c" "$page_d"; do
   [[ -z $out ]] && continue

--- a/test/unit/osquery-route-pipeline.sh
+++ b/test/unit/osquery-route-pipeline.sh
@@ -26,13 +26,14 @@ ROUTE="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/route.sh"
 PIPELINE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/pipeline-verdict.sh"
 ALLOWLIST_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/allowlist-verdict.sh"
 TRIAGE_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh"
+RENDER_HELPER="$REPO_ROOT/dot_local/libexec/osquery/results-alerter/render-page.sh"
 
 fail() {
   printf 'osquery-route-pipeline: FAIL -- %s\n' "$*" >&2
   exit 1
 }
 
-for h in "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "$TRIAGE_HELPER"; do
+for h in "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "$TRIAGE_HELPER" "$RENDER_HELPER"; do
   [[ -f $h ]] || fail "missing helper: $h"
 done
 
@@ -76,6 +77,30 @@ run_gate() {
         digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
         route_findings
       ' _ "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "${TRIAGE_OVERRIDE:-$TRIAGE_HELPER}"
+}
+
+# run_gate_render <manifest> <bin-manifest> <finding...> -> the {pcount, pbody}
+# object the entry delivers. Same gate, with the RENDERER on the end, because the
+# facts the gate attaches are not consumed until rendering: a finding the gate
+# accepted and the renderer cannot print is a page that was confirmed and then
+# lost, and only running both stages can tell the two apart.
+run_gate_render() {
+  local manifest="$1" bin_manifest="$2"
+  shift 2
+  printf '%s\n' "$@" |
+    HOME="$home" OSQUERY_PIPELINE_MANIFEST="$manifest" \
+      OSQUERY_MANAGED_BIN_MANIFEST="$bin_manifest" OSQUERY_PIPELINE_REHASH_DELAY=0 \
+      OSQUERY_LAUNCHD_ALLOWLIST="$work/no-allowlist.txt" DIGEST_SPY="$spy" \
+      OSQUERY_UPGRADE_RECORD="${UPGRADE_RECORD:-$work/no-upgrade-record.tsv}" bash -c '
+        set -euo pipefail
+        source "$1"
+        source "$2"
+        source "$3"
+        source "$4"
+        source "$5"
+        digest_append() { printf "%s\n" "$1" >>"$DIGEST_SPY"; }
+        route_findings | render_page
+      ' _ "$ROUTE" "$PIPELINE_HELPER" "$ALLOWLIST_HELPER" "${TRIAGE_OVERRIDE:-$TRIAGE_HELPER}" "$RENDER_HELPER"
 }
 
 # assert_paged / refute_paged <pages> <tag> <message>. The negative form is a plain
@@ -205,6 +230,45 @@ page_d="$(TRIAGE_OVERRIDE="$broken_triage" run_gate "$triage_manifest" "$absent_
 [[ $broken_rc -eq 0 ]] ||
   fail "a triage helper that FAILS aborted the gate itself (exit $broken_rc), so the page was lost"
 assert_paged "$page_d" TAG11 "a triage helper that FAILS must not take the page down with it"
+
+# ---- Pass E: a triage object whose SYNTAX is right and whose member TYPES are
+#      wrong. The gate used to check that the helper returned parseable JSON and
+#      nothing else, so a half-deployed helper answering
+#      {"recorded":"abc","ondisk":{},"upgrade":"lead"} was attached whole. The
+#      renderer prints those members as strings, an object cannot be rendered as
+#      one, and jq exits non-zero: the page the verdict had already confirmed was
+#      never written, and because the entry checkpoints only after delivery, every
+#      retry wedged on the same batch. The shape is checked where it is attached,
+#      and a mismatch costs the page its two triage LINES and nothing else. ----
+wrongtype_triage="$work/wrongtype-triage.sh"
+cat >"$wrongtype_triage" <<'WRONGTYPE'
+# shellcheck shell=bash
+file_integrity_triage() {
+  printf '{"recorded":"abc","ondisk":{},"upgrade":"lead"}\n'
+  return 0
+}
+WRONGTYPE
+render_rc=0
+page_e="$(TRIAGE_OVERRIDE="$wrongtype_triage" run_gate_render "$triage_manifest" "$absent_bin_manifest" \
+  "$(fe pipeline_integrity "$tampered" "$event_hash" UPDATED)")" || render_rc=$?
+[[ $render_rc -eq 0 ]] ||
+  fail "a triage object with wrong member types killed the render (exit $render_rc), so a confirmed page was lost"
+[[ "$(jq -r '.pcount' <<<"$page_e")" == 1 ]] ||
+  fail "a triage object with wrong member types cost the page itself -- $page_e"
+page_e_body="$(jq -r '.pbody' <<<"$page_e")"
+assert_paged "$page_e_body" "tamperedTAG11.sh" \
+  "the page no longer names the file whose bytes left the manifest"
+refute_paged "$page_e_body" "Recorded:" \
+  "a triage object the renderer cannot print was still attached to the finding"
+refute_paged "$page_e_body" "Upgrade record:" \
+  "a triage object the renderer cannot print was still attached to the finding"
+
+# The same renderer prints the triage lines when the helper answers the shape it
+# promises, so the check above rejects a broken object rather than every object.
+page_f="$(UPGRADE_RECORD="$UPGRADE_RECORD" run_gate_render "$triage_manifest" "$absent_bin_manifest" \
+  "$(fe pipeline_integrity "$tampered" "$event_hash" UPDATED)")"
+assert_paged "$(jq -r '.pbody' <<<"$page_f")" "Recorded:" \
+  "a well-formed triage object was dropped, so the page lost the facts it exists to carry"
 
 # Every paged line is a CRIT finding.
 for out in "$page_a" "$page_b" "$page_c" "$page_d"; do


### PR DESCRIPTION
## Context

The osquery alerter watches this machine and pages when a watched file leaves its root-owned
known-good manifest. PR #146 added file-integrity triage to those pages: three facts (the hash the
manifest records, the hash the file carries now, and whether a recorded Homebrew upgrade plausibly
explains the change) so that a routine vendor update and a tamper stop rendering as the same body.
That work is already merged into `main`.

A review of the merged code by sol (gpt-5.6-sol) came back with seven findings, three rated HIGH.
This branch fixes all seven. Nothing here is new functionality: every change is a defect fix against
code that is on `main` today, and the triage feature keeps the shape it shipped with.

## Summary

- The alerter entry (`dot_local/libexec/osquery/executable_results-alerter.sh`) sourced the optional
  triage helper next to the required libraries, so a helper that had not been deployed yet aborted
  the run under `set -euo pipefail` before any routing, delivery or checkpointing. Every page on the
  machine was blocked until the file came back. That source is now conditional and warns loudly; the
  required libraries stay unguarded and fatal.
- `results-alerter/file-integrity-triage.sh` read the upgrade record with `read -r epoch iso
  <"$record"`, which blocks forever when a readable FIFO stands at that operator-writable path. It
  now refuses anything that is not a readable regular file, and bounds the read at 256 KiB.
- The same helper opened the record twice, once for the run timestamp and once for the package rows.
  The producer publishes by atomic rename, so the two opens could pair one generation's timestamp
  with another generation's transitions. Both shapes now come from one snapshot.
- The same helper decoded rows with `IFS=$'\t' read`, and a tab is an IFS whitespace character, so
  the empty column of an `added` row collapsed and the transition rendered backwards: "14.1.1 ->
  none" for a package that had just appeared.
- `results-alerter/route.sh` validated only that the triage helper returned parseable JSON, so an
  object with wrong member types was attached and then killed the renderer, losing a page the verdict
  had already confirmed. The shape is checked where it is attached now. Separately, that call sent
  the helper's stderr to `/dev/null`, so the launchd log never saw which record could not be read.
- `dot_local/bin/executable_homebrew-weekly-upgrade.sh` wrote the upgrade record only after every
  brew step finished, so a file rewritten early in a run correlated against last week's record. The
  run now publishes its timestamp before the first brew step and fills in the package rows
  afterwards.

## What changed

Six commits, one per logical fix, plus one that corrects the comments describing the record contract
on both sides of it.

| Commit | Finding | File |
| --- | --- | --- |
| `bcf27bb9` | HIGH 1, absent optional helper blocks every page | `executable_results-alerter.sh` |
| `29bff617` | MEDIUM 5, added-row transition reversed | `file-integrity-triage.sh` |
| `a05b08da` | HIGH 2 and MEDIUM 6, blocking record read, two opens | `file-integrity-triage.sh` |
| `10d125eb` | HIGH 3, triage shape not validated | `route.sh` |
| `9875b9f5` | LOW 7, helper diagnostics discarded | `route.sh` |
| `466656a9` | MEDIUM 4, record does not cover its own window | `executable_homebrew-weekly-upgrade.sh` |
| `937a3665` | contract comments, both sides of the record | both of the above |

Three decisions are worth naming, since each closes a finding in a way the review left open.

**The read bound is a byte cap, not a watchdog child.** What blocks forever is a FIFO or a device,
and the regular-file check refuses both at the door; what is left to bound is size, which `head -c`
bounds directly. A watchdog child buys nothing when there is no external process to signal, only this
shell reading a local file. A record over the cap is refused whole rather than parsed from its first
bytes, matching the rule the file already applies to an unrecognised row.

**Fields are decoded by parameter expansion.** `IFS=$'\t' read` cannot express an empty column,
because tab is one of the three IFS whitespace characters and a run of them collapses to a single
delimiter. Splitting on each delimiter in turn keeps the empty column where the producer put it. A
row with too few columns lands a copy of the tail in the state field, which the existing
recognised-state check refuses along with every other shape it cannot describe.

**The homebrew record is published twice per run, both times with the same timestamp.** A `started`
record carrying the run line alone goes out before the first brew step; a `completed` record with the
package rows replaces it after the after-snapshot. The limit is stated in the code: a page fired
mid-run reads a record that dates the run and names nothing, which renders as the existing no-match
line. That line's wording moved from "changed nothing" to "recorded no package change", because the
old wording claims a completed run about one that is still in flight.

## How it was verified

Every fix got a test written first, run RED against unfixed code, then GREEN. Every fix was then
mutation-verified: the fix alone was reverted in an otherwise-fixed tree, the test re-run to confirm
it fails for the right reason, and the fix restored to confirm GREEN.

| Finding | Test | RED without the fix | GREEN with it |
| --- | --- | --- | --- |
| HIGH 1, optional helper | `test/e2e/osquery-alerter-entry.bats` T-ENTRY-optional-triage | entry exits non-zero, no page, cursor never advances | page delivered, cursor advanced, warning on stderr |
| HIGH 2, blocking record | `test/unit/osquery-file-integrity-triage.sh` case 9 | watchdog kills the helper at 10s (exit 137) on a FIFO record | a FIFO and `/dev/zero` both degrade promptly to the could-not-read line |
| HIGH 3, triage shape | `test/unit/osquery-route-pipeline.sh` pass E | `jq: error ... object ({}) cannot be matched`, render exits 5, page lost | page rendered without triage lines, and a well-formed triage object still renders |
| MEDIUM 4, record window | `test/e2e/homebrew-weekly-record.sh` case 4c | no record exists while `brew upgrade` runs | the mid-run record dates the run, at the same epoch as the finalized one |
| MEDIUM 5, added row | `test/unit/osquery-file-integrity-triage.sh` case 8 | `recorded upgrade: ripgrep 14.1.1 -> none` | added, removed and changed each render in the direction the run moved |
| MEDIUM 6, two opens | `test/unit/osquery-file-integrity-triage.sh` case 10 | generation A timestamp paired with generation B transition | the generation the record dates is the one it renders |
| LOW 7, discarded stderr | `test/unit/osquery-route-pipeline.sh` pass F | gate stderr empty | the helper's path and reason reach the alerter log |

Two of those tests need a note on how they are driven, because neither condition arrives by waiting.

The blocking-record case runs the helper under a watchdog, since a plain call would wedge the suite
rather than fail it. The bound is a killer subshell, not a poll loop, so the passing path sleeps for
nothing: `wait` returns the instant the helper exits and the killer is torn down unused.

The two-opens case drives the interleaving deterministically rather than racing it. The helper reads
its clock between the two opens it used to do, so a `date` shim on PATH is a hook that fires exactly
there, and it publishes a second generation over the record. The shim leaves a marker and the test
asserts that marker, so the case cannot pass by quietly failing to drive the swap.

`main` advanced during the work (a cask declaration and a brew-cache test race fix, neither touching
these files), so it is merged into the branch and the gates were re-run on the merged tree. `just l`
reports no drift. `just test` exits 0 across all four suites with zero `not ok` lines.

## Effect of merging

Nothing changes on this machine when this merges. Every source file here is chezmoi source state, and
none of it reaches `$HOME` until an apply, which is held for the D1 cutover. The live alerter keeps
running the code deployed today, including the blocking read and the unguarded source, until then.

After that cutover the behavior differences are: a page fires even when the triage helper is missing;
a record that is not a readable regular file costs a page its correlation line instead of costing the
page; a triage object the renderer cannot print is dropped rather than taking the page with it; the
helper's degradation reasons appear in the alerter's launchd log; an `added` package renders its
transition in the right direction; and a file changed during the weekly Homebrew run correlates
against that run rather than against the previous week's.

## Review guide

Start with `dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh`, which carries four
of the seven findings. The region to read is the top of `_file_integrity_upgrade_line`: the type
check, the bounded snapshot, and the row decoding are three separate fixes, and each states in a
comment what it refuses and why.

Then `dot_local/libexec/osquery/results-alerter/route.sh` at the triage attachment point, where the
shape check and the stderr change are adjacent but independent.

The producer change in `dot_local/bin/executable_homebrew-weekly-upgrade.sh` reads best against its
consumer: `write_upgrade_record` takes a phase, the two call sites bracket the brew work, and
`UPGRADE_RECORD_EPOCH` is read once near the top so both records date the same moment.

For the tests, `test/unit/osquery-file-integrity-triage.sh` cases 8 through 10 are the new ones, and
case 10 is the one whose mechanism is worth understanding before trusting it.
