### PR TITLE
fix(update-skills): close the review findings against the merged idle-gate work

### DIFF
--- a/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.update-skills.plist.tmpl
@@ -22,11 +22,15 @@
   <key>RunAtLoad</key>
   <false/>
   <!-- 24 hourly Monday retry slots (00:00..23:00), generated programmatically.
-       A slot that finds a harness with recent activity defers and leaves no
-       weekly success stamp, so the next slot retries; once a slot succeeds, the
-       rest no-op on the stamp. The 23:00 slot is the LAST (a deferral there
-       alerts loudly). Keep the last hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR
-       in update-skills.sh. -->
+       A slot writes the weekly success stamp only when it fully succeeds, so a
+       required-phase failure, or a deferral because another run holds the
+       serialize lock, leaves the week unstamped and the next slot retries; once
+       a slot succeeds, the rest no-op on the stamp. (There is no harness-activity
+       gate any more: a run under a live session is safe, and the gate deferred
+       every slot on a machine in daily use.) The 23:00 slot is the LAST, where
+       both a failure and lock contention alert loudly, having nothing behind
+       them. Keep the last hour in sync with UPDATE_SKILLS_LAST_SLOT_HOUR in
+       update-skills.sh. -->
   <key>StartCalendarInterval</key>
   <array>
 {{- range $hour := until 24 }}

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -876,7 +876,8 @@ __gen_roster_schema_ok() {
       and ((.clawhubTracked // {}) | to_entries
         | all((.value | type == "object")
           and nonempty_string(.value.slug) and nonempty_string(.value.registry)))
-      and ((.claudeDelivery // {}) | to_entries | all(.value == "none")))
+      and ((.claudeDelivery // {}) | to_entries | all(.value == "none"))
+      and ((.claudeDelivery // {}) | keys | all(test("[[:cntrl:]]") | not)))
   ' "$1" >/dev/null 2>&1
 }
 
@@ -2370,6 +2371,13 @@ converge_dir() {
 # other direction is unthinkable here: a jq that failed would otherwise mark
 # every roster skill undelivered and step 2 of converge_dir would reap the
 # ENTIRE Claude fan-out on one bad read.
+#
+# ONE NAME PER LINE is this reader's whole contract, which is why the two
+# validators refuse a key holding a control character. A key spelled
+# "gh-axi\nhumanizer" is one exemption to the schema and TWO names here, and the
+# second one costs a link: converge_dir removes every updater-owned link outside
+# the desired set, so one forged name reaps a delivery nobody de-delivered. No
+# store name contains a control character, so nothing legitimate is refused.
 __update_skills_claude_undelivered() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   jq -r '.claudeDelivery // {} | to_entries[] | select(.value == "none") | .key' \
@@ -2396,7 +2404,8 @@ __update_skills_claude_delivery_malformed() {
   jq -e -s 'length == 1 and (.[0] |
       (has("claudeDelivery") | not)
       or ((.claudeDelivery | type == "object")
-        and (.claudeDelivery | to_entries | all(.value == "none"))))' \
+        and (.claudeDelivery | to_entries | all(.value == "none"))
+        and (.claudeDelivery | keys | all(test("[[:cntrl:]]") | not))))' \
     "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 && return 1
   return 0
 }

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -848,21 +848,35 @@ GEN_ROSTER_HASH=""          # sha256 of the snapshot at run start
 # a present-but-non-object table and any value other than the string "none"
 # (absent means the default, delivered), so a malformed delivery table refuses the
 # run loudly instead of silently restoring a de-delivered skill.
+#
+# The gate reads the lock SLURPED, and the -s is the load-bearing part.
+# `jq -e '<filter>' file` reads a STREAM of values and evaluates the filter once
+# per document, so its exit status is the LAST document's verdict while every
+# extractor downstream still reads them ALL. A roster with a second top-level
+# `{}` appended therefore passed every check here on the trailing empty object
+# (an absent table is legal) and the run went on to read the real tables out of
+# the first document: with claudeDelivery emptied in that first document, the
+# undelivered-name reader returned nothing and convergence RECREATED a
+# deliberately absent Claude link before stamping the week a success. Slurping
+# and requiring exactly one value is the single-value test; the same shape
+# guards ~/.claude/settings.json in run_before_12-quarantine-unparseable-claude-settings.sh
+# and the forks table in __gen_fork_lock_single_document below.
 __gen_roster_schema_ok() {
-  jq -e '
+  jq -e -s '
     def object_or_absent($k): (has($k) | not) or (.[$k] | type == "object");
     def nonempty_string($v): ($v | type) == "string" and ($v | length) > 0;
-    (type == "object")
-    and object_or_absent("npxTracked")
-    and object_or_absent("clawhubTracked")
-    and object_or_absent("tiers")
-    and object_or_absent("claudeDelivery")
-    and ((.npxTracked // {}) | to_entries
-      | all((.value | type == "object") and nonempty_string(.value.repo)))
-    and ((.clawhubTracked // {}) | to_entries
-      | all((.value | type == "object")
-        and nonempty_string(.value.slug) and nonempty_string(.value.registry)))
-    and ((.claudeDelivery // {}) | to_entries | all(.value == "none"))
+    length == 1 and (.[0] |
+      (type == "object")
+      and object_or_absent("npxTracked")
+      and object_or_absent("clawhubTracked")
+      and object_or_absent("tiers")
+      and object_or_absent("claudeDelivery")
+      and ((.npxTracked // {}) | to_entries
+        | all((.value | type == "object") and nonempty_string(.value.repo)))
+      and ((.clawhubTracked // {}) | to_entries
+        | all((.value | type == "object")
+          and nonempty_string(.value.slug) and nonempty_string(.value.registry)))
+      and ((.claudeDelivery // {}) | to_entries | all(.value == "none")))
   ' "$1" >/dev/null 2>&1
 }
 
@@ -1521,12 +1535,17 @@ __gen_reconcile_candidate_npx_lock() {
   local candidate_lock="$AGENTS/.skill-lock.json"
   local cli_lock="${XDG_STATE_HOME:-$HOME/.local/state}/skills/.skill-lock.json"
   local base cli reconciled
+  # Each input must be EXACTLY ONE JSON value, not the stream `jq -e .` accepts:
+  # both are handed to --argjson below, which refuses a stream outright, so an
+  # unreadable-for-our-purpose lock has to reach the '{}' fallback here instead
+  # of failing the whole reconcile. `length == 1` (not `<= 1`) keeps the empty
+  # file on the fallback path too, where the old `jq -e .` already put it.
   base="$(cat "$candidate_lock" 2>/dev/null || printf '{}')"
-  jq -e . <<<"$base" >/dev/null 2>&1 || base='{}'
+  jq -e -s 'length == 1' <<<"$base" >/dev/null 2>&1 || base='{}'
   cli='{}'
   if [[ -f $cli_lock ]]; then
     cli="$(cat "$cli_lock" 2>/dev/null || printf '{}')"
-    jq -e . <<<"$cli" >/dev/null 2>&1 || cli='{}'
+    jq -e -s 'length == 1' <<<"$cli" >/dev/null 2>&1 || cli='{}'
   fi
   if ! reconciled="$(jq -n \
     --argjson base "$base" \
@@ -1640,9 +1659,12 @@ __gen_validate_candidate() {
     log "validate: candidate has no ready marker"
     return 1
   }
-  # npx lock must be valid JSON.
-  jq -e . "$agents/.skill-lock.json" >/dev/null 2>&1 || {
-    log "validate: candidate .skill-lock.json is not valid JSON"
+  # npx lock must be ONE JSON value. Slurped, because `jq -e .` accepts a STREAM
+  # and every later reader of this file answers from the LAST document alone
+  # (`.skills | has($n)` in the drift report and the health check), so a
+  # two-document lock could publish while claiming a skill it does not hold.
+  jq -e -s 'length == 1' "$agents/.skill-lock.json" >/dev/null 2>&1 || {
+    log "validate: candidate .skill-lock.json is not one JSON value"
     return 1
   }
   # A FULL candidate's npx lock must hold EXACTLY the npxTracked key set
@@ -1889,7 +1911,11 @@ __gen_update_failure_streaks() {
   week="$(date +%G-%V)"
   mkdir -p "$STATE_DIR" 2>/dev/null || return 0
   streaks="$(cat "$STREAK_FILE" 2>/dev/null || true)"
-  jq -e . <<<"$streaks" >/dev/null 2>&1 || streaks='{}'
+  # ONE JSON OBJECT or start over. `jq -e .` accepted a stream (whose per-name
+  # reads below then yield one line per document, so no week ever compares equal
+  # and every slot re-increments) and accepted a bare scalar (whose `.[$n]` read
+  # is a jq error, fatal under errexit inside the command substitution).
+  jq -e -s 'length == 1 and (.[0] | type == "object")' <<<"$streaks" >/dev/null 2>&1 || streaks='{}'
   local -a escalated=()
   local -a seen=()
   local dup
@@ -2359,10 +2385,18 @@ __update_skills_claude_undelivered() {
 # the fan-out validates the table at the point of use and refuses (no fan-out, no
 # reap) rather than fail open, in every mode. Absent or a valid "none" object is
 # NOT malformed.
+#
+# Slurped, for the reason __gen_roster_schema_ok is: an unslurped `jq -e` reads a
+# STREAM and answers for the LAST document only, so a lock with a second
+# top-level `{}` appended looked table-less (and therefore fine) here while the
+# reader above still read the first document's table. A multi-document lock is
+# malformed for this purpose whatever its documents say.
 __update_skills_claude_delivery_malformed() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 1
-  jq -e '(has("claudeDelivery") | not)
-    or ((.claudeDelivery | type == "object") and (.claudeDelivery | to_entries | all(.value == "none")))' \
+  jq -e -s 'length == 1 and (.[0] |
+      (has("claudeDelivery") | not)
+      or ((.claudeDelivery | type == "object")
+        and (.claudeDelivery | to_entries | all(.value == "none"))))' \
     "$CUSTOM_SKILL_LOCK" >/dev/null 2>&1 && return 1
   return 0
 }

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -2730,7 +2730,26 @@ else
   __update_skills_acquire_lock || __update_skills_lock_rc=$?
   if [[ $__update_skills_lock_rc -eq 75 ]]; then
     log "another run holds the lock; deferring (retryable, exit 75)"
-    __update_skills_record deferred "nothing was attempted: another update-skills run already holds the serialize lock, so this slot deferred (exit 75). A later slot retries."
+    # SEMANTICS OF A CONTENDED LAST SLOT. Contention stays a deferral in every
+    # mode: nothing was attempted, so it is not a required failure and the exit
+    # stays the retryable 75. What changes on the LAST scheduled slot is that
+    # there is no later slot behind it. The holder (an --install-only run from a
+    # chezmoi apply, say) writes no weekly stamp, so the week ends with the full
+    # update never run, no stamp, and, before this, nothing said: the same
+    # silence a week that simply worked produces. So the last slot ALERTS, on the
+    # same route a required-phase failure uses at exhaustion, and the run is
+    # recovered by hand with one update-skills.sh.
+    #
+    # It does not WAIT for the lock instead. A holder can run for many minutes,
+    # and blocking the last slot on it trades a visible miss for an invisible
+    # stall inside a launchd job nobody is watching.
+    __update_skills_contention_detail="another update-skills run already holds the serialize lock, so this slot deferred (exit 75). A later slot retries."
+    if __update_skills_scheduled_budget_exhausted; then
+      __update_skills_contention_detail="another update-skills run held the serialize lock on the LAST scheduled slot this week, so this week's update never ran. No later slot remains: re-run ~/.local/bin/update-skills.sh by hand."
+      log "EXHAUSTED: lock contention on the last scheduled slot this week; no later slot remains, so this week's update did not run"
+      __update_skills_alert "Weekly skills update deferred over lock contention on the LAST scheduled slot this week; no later slot remains, so it did not run. Re-run ~/.local/bin/update-skills.sh."
+    fi
+    __update_skills_record deferred "nothing was attempted: $__update_skills_contention_detail"
     exit 75
   elif [[ $__update_skills_lock_rc -ne 0 ]]; then
     record_required_failure "could not acquire the serialize lock (rc $__update_skills_lock_rc; e.g. ~/.agents is not writable); no build, no publish, no stamp"

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -465,7 +465,17 @@ __gen_hash_file() {
 # lock (what skills the repo wants + how) and this updater script (how they are
 # built). A change in either must invalidate the weekly stamp and force a rebuild.
 __gen_custom_lock_hash() { __gen_hash_file "$CUSTOM_SKILL_LOCK"; }
-__gen_updater_hash() { __gen_hash_file "${BASH_SOURCE[0]}"; }
+# The updater hash is THIS PROCESS'S identity, so it is read ONCE, here, from the
+# bytes on disk at start-up, and every later record uses the captured value.
+# Reading the path again at write time recorded whatever was there THEN: a
+# chezmoi apply landing mid-run made an old parent stamp the NEW updater's hash
+# into generation.json and the weekly stamp, and the new updater then matched
+# that stamp and early-exited every remaining slot, so the code recorded as
+# having run never ran. Captured, the mismatch survives and a later slot
+# rebuilds. (The apply also replaces the file by rename, so this process keeps
+# executing the inode it opened; the hash and the bytes stay the same answer.)
+GEN_UPDATER_HASH="$(__gen_hash_file "${BASH_SOURCE[0]}")"
+__gen_updater_hash() { printf '%s' "$GEN_UPDATER_HASH"; }
 
 # The weekly success stamp value: the ISO year-week PLUS the custom-lock hash and
 # the updater hash. A roster change (custom-lock) or an updater change after a

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -3552,10 +3552,10 @@ if [[ $DRYRUN == "--dry-run" ]]; then
   converge_claude_skills
   converge_hermes_skills
   report_unrostered_live_content # names delist leftovers; removes nothing
-  refresh_app_owned_cua_pack    # its dry branch logs the would-run line only
-  assert_superpowers_routing    # --dry-run probe of the routing script (read-only)
-  update_hermes_registry_skills # its dry branch logs would-update lines only
-  run_fork_drift_watch          # its dry branch logs would-drift-check lines only
+  refresh_app_owned_cua_pack     # its dry branch logs the would-run line only
+  assert_superpowers_routing     # --dry-run probe of the routing script (read-only)
+  update_hermes_registry_skills  # its dry branch logs would-update lines only
+  run_fork_drift_watch           # its dry branch logs would-drift-check lines only
   log "done (dry-run)"
   # A preview that REFUSED part of its work is not a preview of the run: the
   # fan-out refuses outright on a malformed claudeDelivery table, and the routing

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -2459,6 +2459,57 @@ converge_claude_skills() {
   fi
 }
 
+# Live content the roster no longer declares. WARN ONLY, and that is the ruling,
+# not an oversight: nothing in this vertical removes what the lock stopped
+# naming. Delisting a skill (deleting its rows from the lock) leaves its store
+# directory where it is and leaves its ~/.claude/settings.json skillOverrides
+# entry where it is, and until now nothing said so, so the leftovers were found
+# by reading files by hand. A run that names them is the operator's cue to
+# remove them by hand, which stays the only way they go.
+#
+# The roster is the lock's tiers table, which covers exactly the roster
+# (test/unit/skills-roster-fanout.sh fails the build otherwise), so vendored and
+# app-owned store entries are rostered and stay quiet. Only a name the lock no
+# longer carries is reported.
+#
+# The override half is reported only for a name the STORE also carries, which is
+# the delist shape. A skillOverrides key with no store entry is not evidence of
+# anything: Claude Code takes overrides for skills from sources this vertical
+# does not deliver, and naming those would be a weekly false positive.
+report_unrostered_live_content() {
+  [[ -d $STORE ]] || return 0
+  local -a rostered=()
+  local name entry rostered_name found overrides="" settings="$HOME/.claude/settings.json"
+  while IFS= read -r name; do
+    [[ -n $name ]] && rostered+=("$name")
+  done < <(jq -r '.tiers // {} | keys[]?' "$CUSTOM_SKILL_LOCK" 2>/dev/null)
+  # No roster to compare against (absent lock, empty or unreadable tiers) is not
+  # evidence that every store entry is a leftover. Say nothing rather than name
+  # the whole store.
+  [[ ${#rostered[@]} -gt 0 ]] || return 0
+  if [[ -f $settings ]]; then
+    overrides="$(jq -r -s 'if length == 1 then (.[0].skillOverrides // {} | keys[]?) else empty end' \
+      "$settings" 2>/dev/null || true)"
+  fi
+  for entry in "$STORE"/*; do
+    [[ -e $entry || -L $entry ]] || continue
+    name="${entry##*/}"
+    found=""
+    for rostered_name in "${rostered[@]}"; do
+      [[ $rostered_name == "$name" ]] && {
+        found=1
+        break
+      }
+    done
+    [[ -n $found ]] && continue
+    if printf '%s\n' "$overrides" | grep -qxF -- "$name"; then
+      log "UNROSTERED: $STORE/$name is not in the roster, and $settings still carries a skillOverrides entry for it. Nothing here removes either; remove both by hand if this is a delist leftover."
+    else
+      log "UNROSTERED: $STORE/$name is not in the roster. Nothing here removes it; remove it by hand if this is a delist leftover."
+    fi
+  done
+}
+
 # Hermes fan-out is profile-driven by the lock's hermesProfiles map. "default" is
 # ~/.hermes/skills (Bob), any other name is ~/.hermes/profiles/<name>/skills
 # (created here when absent, so a mapping can land before its profile exists on
@@ -3500,6 +3551,7 @@ if [[ $DRYRUN == "--dry-run" ]]; then
   __gen_dryrun_drift_report
   converge_claude_skills
   converge_hermes_skills
+  report_unrostered_live_content # names delist leftovers; removes nothing
   refresh_app_owned_cua_pack    # its dry branch logs the would-run line only
   assert_superpowers_routing    # --dry-run probe of the routing script (read-only)
   update_hermes_registry_skills # its dry branch logs would-update lines only
@@ -3609,6 +3661,10 @@ refresh_app_owned_cua_pack
 # exactly the hermes profile skills dirs its hermesProfiles mapping names.
 converge_claude_skills
 converge_hermes_skills
+
+# NAME the live content the roster no longer declares (delist leftovers). This
+# removes nothing; it is the only thing that says the leftovers are there.
+report_unrostered_live_content
 
 # VERIFY the Codex overlays through the store links (asserted in the candidate;
 # a missing one here is a required failure, never an in-place write); vendored

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -3476,6 +3476,15 @@ if [[ $DRYRUN == "--dry-run" ]]; then
   update_hermes_registry_skills # its dry branch logs would-update lines only
   run_fork_drift_watch          # its dry branch logs would-drift-check lines only
   log "done (dry-run)"
+  # A preview that REFUSED part of its work is not a preview of the run: the
+  # fan-out refuses outright on a malformed claudeDelivery table, and the routing
+  # probe records a missing prerequisite, so a caller reading exit 0 accepted an
+  # incomplete picture as the whole one. Same signal the install-only path gives,
+  # and it costs nothing on a healthy machine, where a dry run records nothing.
+  if [[ $REQUIRED_FAILURES -gt 0 ]]; then
+    log "dry-run finished with $REQUIRED_FAILURES refusal(s)/required-phase failure(s); this preview is INCOMPLETE"
+    exit 1
+  fi
   exit 0
 fi
 

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -60,6 +60,48 @@
       "norm_label": "refresh_manifest()"
     },
     {
+      "label": "run_before_12-quarantine-unparseable-claude-settings.sh",
+      "file_type": "code",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings",
+      "community": 459,
+      "norm_label": "run_before_12-quarantine-unparseable-claude-settings.sh"
+    },
+    {
+      "label": "run_before_12-quarantine-unparseable-claude-settings.sh script",
+      "file_type": "code",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_sh__entry",
+      "community": 459,
+      "norm_label": "run_before_12-quarantine-unparseable-claude-settings.sh script"
+    },
+    {
+      "label": "warn()",
+      "file_type": "code",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L34",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_warn",
+      "community": 459,
+      "norm_label": "warn()"
+    },
+    {
       "label": ".install-password-manager.sh",
       "file_type": "code",
       "source_file": ".install-password-manager.sh",
@@ -1207,7 +1249,7 @@
       "label": "weekly_alert()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L85",
+      "source_location": "L93",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1221,7 +1263,7 @@
       "label": "weekly_record()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L99",
+      "source_location": "L107",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1235,7 +1277,7 @@
       "label": "__homebrew_package_snapshot()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L135",
+      "source_location": "L143",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1246,10 +1288,24 @@
       "norm_label": "__homebrew_package_snapshot()"
     },
     {
+      "label": "write_upgrade_record()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
+      "source_location": "L195",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_homebrew_weekly_upgrade_write_upgrade_record",
+      "community": 419,
+      "norm_label": "write_upgrade_record()"
+    },
+    {
       "label": "acquire_lock()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L170",
+      "source_location": "L232",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1263,7 +1319,7 @@
       "label": "run()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L186",
+      "source_location": "L248",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1277,7 +1333,7 @@
       "label": "refresh_tailscaled()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L208",
+      "source_location": "L270",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1596,6 +1652,118 @@
       "norm_label": "is_relay_flag()"
     },
     {
+      "label": "executable_report-plugin-updates.sh",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates",
+      "community": 419,
+      "norm_label": "executable_report-plugin-updates.sh"
+    },
+    {
+      "label": "executable_report-plugin-updates.sh script",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_sh__entry",
+      "community": 419,
+      "norm_label": "executable_report-plugin-updates.sh script"
+    },
+    {
+      "label": "RECORD_CAVEAT",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L100",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_record_caveat",
+      "community": 419,
+      "norm_label": "record_caveat"
+    },
+    {
+      "label": "RECORD_LABEL",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L102",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_record_label",
+      "community": 419,
+      "norm_label": "record_label"
+    },
+    {
+      "label": "RECORD_SOURCE_DESCRIPTION",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L103",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_record_source_description",
+      "community": 419,
+      "norm_label": "record_source_description"
+    },
+    {
+      "label": "alert()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L108",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_alert",
+      "community": 419,
+      "norm_label": "alert()"
+    },
+    {
+      "label": "record_entry()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L129",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_record_entry",
+      "community": 419,
+      "norm_label": "record_entry()"
+    },
+    {
+      "label": "plugin_snapshot()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L177",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_report_plugin_updates_plugin_snapshot",
+      "community": 419,
+      "norm_label": "plugin_snapshot()"
+    },
+    {
       "label": "executable_rotate-logs.sh",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_rotate-logs.sh",
@@ -1865,7 +2033,7 @@
       "label": "die()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L237",
+      "source_location": "L244",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1879,7 +2047,7 @@
       "label": "warn()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L242",
+      "source_location": "L249",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1893,7 +2061,7 @@
       "label": "run_privileged()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L246",
+      "source_location": "L253",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1907,7 +2075,7 @@
       "label": "dropin_path()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L254",
+      "source_location": "L261",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1921,7 +2089,7 @@
       "label": "print_config()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L258",
+      "source_location": "L265",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1932,10 +2100,24 @@
       "norm_label": "print_config()"
     },
     {
+      "label": "stop_verify_child()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L394",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_ssh_hardening_stop_verify_child",
+      "community": 263,
+      "norm_label": "stop_verify_child()"
+    },
+    {
       "label": "run_verify_child()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L337",
+      "source_location": "L415",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1949,7 +2131,7 @@
       "label": "verify_skip_allowed()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L351",
+      "source_location": "L469",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1963,7 +2145,7 @@
       "label": "add_failure()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L362",
+      "source_location": "L480",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1977,7 +2159,7 @@
       "label": "canonical_key()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L389",
+      "source_location": "L507",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -1991,7 +2173,7 @@
       "label": "required_value()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L400",
+      "source_location": "L518",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2005,7 +2187,7 @@
       "label": "assert_output_hardened()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L416",
+      "source_location": "L534",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2019,7 +2201,7 @@
       "label": "check_global()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L434",
+      "source_location": "L552",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2033,7 +2215,7 @@
       "label": "trim_trailing_line_whitespace()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L528",
+      "source_location": "L646",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2047,7 +2229,7 @@
       "label": "skip_keyword_separators()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L539",
+      "source_location": "L657",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2061,7 +2243,7 @@
       "label": "consume_keyword_separator()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L555",
+      "source_location": "L673",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2075,7 +2257,7 @@
       "label": "read_keyword_token()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L567",
+      "source_location": "L685",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2089,7 +2271,7 @@
       "label": "skip_argument_separators()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L608",
+      "source_location": "L726",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2103,7 +2285,7 @@
       "label": "read_argument_token()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L620",
+      "source_location": "L738",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2117,7 +2299,7 @@
       "label": "read_token_with_progress_guard()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L696",
+      "source_location": "L814",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2131,7 +2313,7 @@
       "label": "next_keyword_token()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L705",
+      "source_location": "L823",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2145,7 +2327,7 @@
       "label": "next_argument_token()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L709",
+      "source_location": "L827",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2159,7 +2341,7 @@
       "label": "parse_config_line()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L718",
+      "source_location": "L836",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2173,7 +2355,7 @@
       "label": "include_bracket_opens_a_set()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L794",
+      "source_location": "L912",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2187,7 +2369,7 @@
       "label": "unescape_include_pattern()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L844",
+      "source_location": "L962",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2201,7 +2383,7 @@
       "label": "resolve_include_paths()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L930",
+      "source_location": "L1048",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2215,7 +2397,7 @@
       "label": "path_is_a_regular_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1045",
+      "source_location": "L1163",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2229,7 +2411,7 @@
       "label": "scan_included_files()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1049",
+      "source_location": "L1167",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2243,7 +2425,7 @@
       "label": "scan_config_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1071",
+      "source_location": "L1189",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2257,7 +2439,7 @@
       "label": "config_tree_roots()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1155",
+      "source_location": "L1273",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2271,7 +2453,7 @@
       "label": "check_match_scan()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1192",
+      "source_location": "L1310",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2285,7 +2467,7 @@
       "label": "check_connection_specs()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1208",
+      "source_location": "L1326",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2299,7 +2481,7 @@
       "label": "verify()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1237",
+      "source_location": "L1355",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2313,7 +2495,7 @@
       "label": "rollback_install()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1308",
+      "source_location": "L1428",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2327,7 +2509,7 @@
       "label": "install_dropin()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1331",
+      "source_location": "L1451",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2341,7 +2523,7 @@
       "label": "config_tree_would_exceed_width()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1498",
+      "source_location": "L1618",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2355,7 +2537,7 @@
       "label": "collect_config_tree_from_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1516",
+      "source_location": "L1636",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2369,7 +2551,7 @@
       "label": "collect_config_tree_files()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1597",
+      "source_location": "L1717",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2383,7 +2565,7 @@
       "label": "config_tree_path_is_recordable()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1641",
+      "source_location": "L1761",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2397,7 +2579,7 @@
       "label": "observe_config_tree()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1657",
+      "source_location": "L1777",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2411,7 +2593,7 @@
       "label": "config_tree_record_fields()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1738",
+      "source_location": "L1858",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2425,7 +2607,7 @@
       "label": "config_tree_find_record()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1761",
+      "source_location": "L1881",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2439,7 +2621,7 @@
       "label": "config_tree_is_unchanged()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1785",
+      "source_location": "L1905",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2453,7 +2635,7 @@
       "label": "report_absent_service_outcome()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1898",
+      "source_location": "L2018",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2467,7 +2649,7 @@
       "label": "recovery_instructions()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1916",
+      "source_location": "L2036",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2481,7 +2663,7 @@
       "label": "probe_sshd_service()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1935",
+      "source_location": "L2055",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2495,7 +2677,7 @@
       "label": "validate_readiness_knobs()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1965",
+      "source_location": "L2085",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2509,7 +2691,7 @@
       "label": "resolve_probe_ports()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2013",
+      "source_location": "L2133",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2523,7 +2705,7 @@
       "label": "banner_output_names_host_key()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2067",
+      "source_location": "L2187",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2537,7 +2719,7 @@
       "label": "wait_for_ssh_banner()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2082",
+      "source_location": "L2202",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2551,7 +2733,7 @@
       "label": "reload_sshd()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2108",
+      "source_location": "L2228",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2565,7 +2747,7 @@
       "label": "check_password_channel()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2311",
+      "source_location": "L2431",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2579,7 +2761,7 @@
       "label": "confirm_password_access_restored()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2353",
+      "source_location": "L2473",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2593,7 +2775,7 @@
       "label": "rollback_dropin()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2392",
+      "source_location": "L2512",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2607,7 +2789,7 @@
       "label": "usage()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2410",
+      "source_location": "L2530",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2621,7 +2803,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2433",
+      "source_location": "L2553",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2663,7 +2845,7 @@
       "label": "UPDATE_SKILLS_LAST_SLOT_HOUR",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L184",
+      "source_location": "L167",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -2677,7 +2859,7 @@
       "label": "CODEX_POLICY",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L188",
+      "source_location": "L171",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -2691,7 +2873,7 @@
       "label": "log()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L219",
+      "source_location": "L202",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2705,7 +2887,7 @@
       "label": "__update_skills_record()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L259",
+      "source_location": "L242",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2719,7 +2901,7 @@
       "label": "__update_skills_change_snapshot()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L309",
+      "source_location": "L292",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2733,7 +2915,7 @@
       "label": "__update_skills_take_snapshot()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L383",
+      "source_location": "L366",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2747,7 +2929,7 @@
       "label": "record_required_failure()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L402",
+      "source_location": "L385",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2761,7 +2943,7 @@
       "label": "__update_skills_no_scheduled_slot_remains()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L415",
+      "source_location": "L398",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2775,7 +2957,7 @@
       "label": "__update_skills_scheduled_budget_exhausted()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L432",
+      "source_location": "L415",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2789,7 +2971,7 @@
       "label": "__update_skills_note_scheduled_attempt()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L439",
+      "source_location": "L422",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2803,7 +2985,7 @@
       "label": "__update_skills_alert()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L448",
+      "source_location": "L431",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2817,7 +2999,7 @@
       "label": "__gen_hash_file()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L472",
+      "source_location": "L455",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2831,7 +3013,7 @@
       "label": "__gen_custom_lock_hash()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L484",
+      "source_location": "L467",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2845,7 +3027,7 @@
       "label": "__gen_updater_hash()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L485",
+      "source_location": "L478",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2859,7 +3041,7 @@
       "label": "__update_skills_stamp_value()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L492",
+      "source_location": "L485",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2873,7 +3055,7 @@
       "label": "__gen_new_id()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L498",
+      "source_location": "L491",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2887,7 +3069,7 @@
       "label": "__gen_same_device()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L507",
+      "source_location": "L500",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2901,7 +3083,7 @@
       "label": "__gen_exchange_tool_capable()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L523",
+      "source_location": "L516",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2915,7 +3097,7 @@
       "label": "__gen_resolve_exchange_tool()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L546",
+      "source_location": "L539",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2929,7 +3111,7 @@
       "label": "__gen_exchange()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L563",
+      "source_location": "L556",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2943,7 +3125,7 @@
       "label": "__gen_write_meta()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L580",
+      "source_location": "L573",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2957,7 +3139,7 @@
       "label": "__gen_meta_field()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L594",
+      "source_location": "L587",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2971,7 +3153,7 @@
       "label": "__gen_is_complete()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L602",
+      "source_location": "L595",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2985,7 +3167,7 @@
       "label": "__gen_meta_matches_desired()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L611",
+      "source_location": "L604",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -2999,7 +3181,7 @@
       "label": "__gen_garbage_destroy()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L621",
+      "source_location": "L614",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3013,7 +3195,7 @@
       "label": "__gen_sweep_garbage()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L633",
+      "source_location": "L626",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3027,7 +3209,7 @@
       "label": "__gen_plant_store_link()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L645",
+      "source_location": "L638",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3041,7 +3223,7 @@
       "label": "__gen_absorb_store_link()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L663",
+      "source_location": "L656",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3055,7 +3237,7 @@
       "label": "__gen_plant_lock_link()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L674",
+      "source_location": "L667",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3069,7 +3251,7 @@
       "label": "__gen_publish()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L691",
+      "source_location": "L684",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3083,7 +3265,7 @@
       "label": "__gen_prune_generations()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L791",
+      "source_location": "L784",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3097,7 +3279,7 @@
       "label": "__gen_tracked_names()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L810",
+      "source_location": "L803",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3111,7 +3293,7 @@
       "label": "__gen_roster_schema_ok()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L858",
+      "source_location": "L874",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3125,7 +3307,7 @@
       "label": "__gen_snapshot_roster()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L880",
+      "source_location": "L900",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3139,7 +3321,7 @@
       "label": "__gen_roster_unchanged()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L914",
+      "source_location": "L934",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3153,7 +3335,7 @@
       "label": "__gen_name_is_tracked()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L923",
+      "source_location": "L943",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3167,7 +3349,7 @@
       "label": "__gen_name_was_generation_owned()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L934",
+      "source_location": "L954",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3181,7 +3363,7 @@
       "label": "__gen_store_link_correct()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L943",
+      "source_location": "L963",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3195,7 +3377,7 @@
       "label": "__gen_recover_exchange_marker()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L982",
+      "source_location": "L1001",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3209,7 +3391,7 @@
       "label": "__gen_recover()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1021",
+      "source_location": "L1040",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3223,7 +3405,7 @@
       "label": "__gen_migration_needed()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1129",
+      "source_location": "L1148",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3237,7 +3419,7 @@
       "label": "__gen_migrate()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1134",
+      "source_location": "L1153",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3251,7 +3433,7 @@
       "label": "__gen_build_candidate()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1257",
+      "source_location": "L1267",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3265,7 +3447,7 @@
       "label": "record_failed_skill()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1319",
+      "source_location": "L1329",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3279,7 +3461,7 @@
       "label": "__gen_lane_force_reinstall()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1328",
+      "source_location": "L1338",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3293,7 +3475,7 @@
       "label": "__gen_lane_npx()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1347",
+      "source_location": "L1357",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3307,7 +3489,7 @@
       "label": "__gen_lane_clawhub()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1386",
+      "source_location": "L1396",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3321,7 +3503,7 @@
       "label": "__gen_strip_codex_policy()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1462",
+      "source_location": "L1472",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3335,7 +3517,7 @@
       "label": "__gen_assert_overlays()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1494",
+      "source_location": "L1504",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3349,7 +3531,7 @@
       "label": "__gen_reconcile_candidate_npx_lock()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1534",
+      "source_location": "L1544",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3363,7 +3545,7 @@
       "label": "__gen_do_build_lanes()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1576",
+      "source_location": "L1591",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3377,7 +3559,7 @@
       "label": "__gen_run_lanes()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1615",
+      "source_location": "L1630",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3391,7 +3573,7 @@
       "label": "__gen_validate_candidate()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1647",
+      "source_location": "L1662",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3405,7 +3587,7 @@
       "label": "__gen_reconcile_store_links()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1729",
+      "source_location": "L1747",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3419,7 +3601,7 @@
       "label": "__gen_prune_delisted_store_links()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1776",
+      "source_location": "L1794",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3433,7 +3615,7 @@
       "label": "__gen_verify_live_overlays()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1812",
+      "source_location": "L1830",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3447,7 +3629,7 @@
       "label": "record_failed_skill_parent()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1855",
+      "source_location": "L1873",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3461,7 +3643,7 @@
       "label": "__gen_merge_lane_failures()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1856",
+      "source_location": "L1874",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3475,7 +3657,7 @@
       "label": "__gen_dryrun_drift_report()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1869",
+      "source_location": "L1887",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3489,7 +3671,7 @@
       "label": "__gen_update_failure_streaks()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1901",
+      "source_location": "L1919",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3503,7 +3685,7 @@
       "label": "__gen_reset_failure_streaks()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1940",
+      "source_location": "L1962",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3514,24 +3696,10 @@
       "norm_label": "__gen_reset_failure_streaks()"
     },
     {
-      "label": "__gen_exchange_would_defer()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1953",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_gen_exchange_would_defer",
-      "community": 0,
-      "norm_label": "__gen_exchange_would_defer()"
-    },
-    {
       "label": "__gen_weekly_attempt()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1964",
+      "source_location": "L1973",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3545,7 +3713,7 @@
       "label": "__gen_roster_skill_health()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2073",
+      "source_location": "L2070",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3559,7 +3727,7 @@
       "label": "__gen_install_only_attempt()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2145",
+      "source_location": "L2138",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3573,7 +3741,7 @@
       "label": "__update_skills_acquire_lock()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2253",
+      "source_location": "L2223",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3584,94 +3752,10 @@
       "norm_label": "__update_skills_acquire_lock()"
     },
     {
-      "label": "__update_skills_effective_program()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2326",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_effective_program",
-      "community": 0,
-      "norm_label": "__update_skills_effective_program()"
-    },
-    {
-      "label": "__update_skills_is_interactive_harness()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2391",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_is_interactive_harness",
-      "community": 0,
-      "norm_label": "__update_skills_is_interactive_harness()"
-    },
-    {
-      "label": "__update_skills_harness_active()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2405",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_harness_active",
-      "community": 0,
-      "norm_label": "__update_skills_harness_active()"
-    },
-    {
-      "label": "__update_skills_activity_state()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2442",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_activity_state",
-      "community": 0,
-      "norm_label": "__update_skills_activity_state()"
-    },
-    {
-      "label": "__update_skills_make_cutoff_sentinel()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2455",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_make_cutoff_sentinel",
-      "community": 0,
-      "norm_label": "__update_skills_make_cutoff_sentinel()"
-    },
-    {
-      "label": "__update_skills_should_defer()",
-      "file_type": "code",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2481",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "dot_local_bin_executable_update_skills_update_skills_should_defer",
-      "community": 0,
-      "norm_label": "__update_skills_should_defer()"
-    },
-    {
       "label": "__update_skills_is_owned_link()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2515",
+      "source_location": "L2271",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3685,7 +3769,7 @@
       "label": "converge_dir()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2547",
+      "source_location": "L2302",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3696,10 +3780,38 @@
       "norm_label": "converge_dir()"
     },
     {
+      "label": "__update_skills_claude_undelivered()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2391",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_update_skills_update_skills_claude_undelivered",
+      "community": 0,
+      "norm_label": "__update_skills_claude_undelivered()"
+    },
+    {
+      "label": "__update_skills_claude_delivery_malformed()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2412",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_update_skills_update_skills_claude_delivery_malformed",
+      "community": 0,
+      "norm_label": "__update_skills_claude_delivery_malformed()"
+    },
+    {
       "label": "converge_claude_skills()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2623",
+      "source_location": "L2430",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3710,10 +3822,24 @@
       "norm_label": "converge_claude_skills()"
     },
     {
+      "label": "report_unrostered_live_content()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2479",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_executable_update_skills_report_unrostered_live_content",
+      "community": 0,
+      "norm_label": "report_unrostered_live_content()"
+    },
+    {
       "label": "is_hermes_collision_name()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2652",
+      "source_location": "L2527",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3727,7 +3853,7 @@
       "label": "__update_skills_hermes_profile_universe()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2661",
+      "source_location": "L2536",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3741,7 +3867,7 @@
       "label": "__update_skills_hermes_dir_safe()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2680",
+      "source_location": "L2555",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3755,7 +3881,7 @@
       "label": "converge_hermes_skills()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2697",
+      "source_location": "L2572",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3769,7 +3895,7 @@
       "label": "assert_superpowers_routing()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2739",
+      "source_location": "L2614",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3783,7 +3909,7 @@
       "label": "update_hermes_registry_skills()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2794",
+      "source_location": "L2667",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3797,7 +3923,7 @@
       "label": "refresh_app_owned_cua_pack()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2868",
+      "source_location": "L2741",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3811,7 +3937,7 @@
       "label": "relay_fork_advisory()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3181",
+      "source_location": "L3059",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3825,7 +3951,7 @@
       "label": "notify_fork_drift()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3192",
+      "source_location": "L3070",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3839,7 +3965,7 @@
       "label": "notify_fork_path_missing()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3205",
+      "source_location": "L3083",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3853,7 +3979,7 @@
       "label": "notify_fork_upstream_unreachable()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3221",
+      "source_location": "L3099",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3867,7 +3993,7 @@
       "label": "notify_fork_upstream_headless()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3239",
+      "source_location": "L3117",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3881,7 +4007,7 @@
       "label": "notify_fork_clone_timeout()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3252",
+      "source_location": "L3130",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3895,7 +4021,7 @@
       "label": "notify_fork_clone_unstageable()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3263",
+      "source_location": "L3141",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3909,7 +4035,7 @@
       "label": "notify_fork_lock_missing()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3276",
+      "source_location": "L3154",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3923,7 +4049,7 @@
       "label": "notify_fork_walk_incomplete()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3289",
+      "source_location": "L3167",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3937,7 +4063,7 @@
       "label": "lock_is_readable_json_object()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3309",
+      "source_location": "L3187",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3951,7 +4077,7 @@
       "label": "fork_table_is_present()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3324",
+      "source_location": "L3202",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3965,7 +4091,7 @@
       "label": "fork_table_is_object()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3338",
+      "source_location": "L3216",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3979,7 +4105,7 @@
       "label": "fork_entry_is_object()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3349",
+      "source_location": "L3227",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -3993,7 +4119,7 @@
       "label": "fork_entry_unusable_fields()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3379",
+      "source_location": "L3257",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4007,7 +4133,7 @@
       "label": "notify_fork_entry_malformed()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3397",
+      "source_location": "L3275",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4021,7 +4147,7 @@
       "label": "stop_fork_clone()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3408",
+      "source_location": "L3286",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4035,7 +4161,7 @@
       "label": "clone_fork_upstream()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3452",
+      "source_location": "L3330",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4049,7 +4175,7 @@
       "label": "discard_fork_clone()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3477",
+      "source_location": "L3355",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4063,7 +4189,7 @@
       "label": "fork_clone_head_resolves()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3494",
+      "source_location": "L3372",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4077,7 +4203,7 @@
       "label": "resolve_fork_upstream_hash()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3499",
+      "source_location": "L3377",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4091,7 +4217,7 @@
       "label": "check_fork_drift()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3509",
+      "source_location": "L3387",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4105,7 +4231,7 @@
       "label": "run_fork_drift_watch()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3652",
+      "source_location": "L3530",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4119,7 +4245,7 @@
       "label": "__update_skills_cleanup()",
       "file_type": "code",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3753",
+      "source_location": "L3631",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4942,10 +5068,24 @@
       "norm_label": "__unattended_log_code()"
     },
     {
+      "label": "unattended_log_change_tuples()",
+      "file_type": "code",
+      "source_file": "dot_local/bin/unattended-log-lib.sh",
+      "source_location": "L326",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_bin_unattended_log_lib_unattended_log_change_tuples",
+      "community": 419,
+      "norm_label": "unattended_log_change_tuples()"
+    },
+    {
       "label": "unattended_log_change_line()",
       "file_type": "code",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L329",
+      "source_location": "L371",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4959,7 +5099,7 @@
       "label": "unattended_log_change_section()",
       "file_type": "code",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L376",
+      "source_location": "L423",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4973,7 +5113,7 @@
       "label": "unattended_log_post()",
       "file_type": "code",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L419",
+      "source_location": "L466",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -4987,7 +5127,7 @@
       "label": "unattended_log_alert_delivery_failure()",
       "file_type": "code",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L458",
+      "source_location": "L505",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6527,7 +6667,7 @@
       "label": "_take_single_instance_lock()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L60",
+      "source_location": "L62",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6541,7 +6681,7 @@
       "label": "_checkpoint()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L73",
+      "source_location": "L75",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6555,7 +6695,7 @@
       "label": "main()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L75",
+      "source_location": "L77",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -6846,6 +6986,104 @@
       "norm_label": "digest_append()"
     },
     {
+      "label": "file-integrity-triage.sh",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "community": 447,
+      "norm_label": "file-integrity-triage.sh"
+    },
+    {
+      "label": "file-integrity-triage.sh script",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_sh__entry",
+      "community": 447,
+      "norm_label": "file-integrity-triage.sh script"
+    },
+    {
+      "label": "_file_integrity_short()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L113",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_short",
+      "community": 447,
+      "norm_label": "_file_integrity_short()"
+    },
+    {
+      "label": "_file_integrity_recorded_hash()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L128",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_recorded_hash",
+      "community": 447,
+      "norm_label": "_file_integrity_recorded_hash()"
+    },
+    {
+      "label": "_file_integrity_disk_hash()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L163",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_disk_hash",
+      "community": 447,
+      "norm_label": "_file_integrity_disk_hash()"
+    },
+    {
+      "label": "_file_integrity_upgrade_line()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L205",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_upgrade_line",
+      "community": 447,
+      "norm_label": "_file_integrity_upgrade_line()"
+    },
+    {
+      "label": "file_integrity_triage()",
+      "file_type": "code",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L297",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_triage",
+      "community": 447,
+      "norm_label": "file_integrity_triage()"
+    },
+    {
       "label": "normalize.sh",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/normalize.sh",
@@ -7129,7 +7367,7 @@
       "label": "render_page()",
       "file_type": "code",
       "source_file": "dot_local/libexec/osquery/results-alerter/render-page.sh",
-      "source_location": "L22",
+      "source_location": "L29",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8800,10 +9038,24 @@
       "norm_label": "wait_for_invocations()"
     },
     {
+      "label": "wait_for_file_content()",
+      "file_type": "code",
+      "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
+      "source_location": "L214",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_bashrc_brew_cache_self_heal_wait_for_file_content",
+      "community": 411,
+      "norm_label": "wait_for_file_content()"
+    },
+    {
       "label": "assert_regenerated()",
       "file_type": "code",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L206",
+      "source_location": "L223",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -8817,7 +9069,7 @@
       "label": "assert_did_not_regenerate()",
       "file_type": "code",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L217",
+      "source_location": "L233",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9066,6 +9318,20 @@
       "norm_label": "fail()"
     },
     {
+      "label": "HOMEBREW_WEEKLY_STATE_DIR",
+      "file_type": "code",
+      "source_file": "test/e2e/homebrew-weekly-lock.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_homebrew_weekly_lock_homebrew_weekly_state_dir",
+      "community": 274,
+      "norm_label": "homebrew_weekly_state_dir"
+    },
+    {
       "label": "homebrew-weekly-record.sh",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
@@ -9097,7 +9363,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L27",
+      "source_location": "L31",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9111,7 +9377,7 @@
       "label": "refute()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L32",
+      "source_location": "L36",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9125,7 +9391,7 @@
       "label": "UNATTENDED_LOG_HERMES_URL",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L66",
+      "source_location": "L70",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9139,7 +9405,7 @@
       "label": "run_helper()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L124",
+      "source_location": "L128",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9153,7 +9419,7 @@
       "label": "log_entries()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L137",
+      "source_location": "L141",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9167,7 +9433,7 @@
       "label": "alert_entries()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L138",
+      "source_location": "L142",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9181,7 +9447,7 @@
       "label": "log_entry_count()",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L139",
+      "source_location": "L143",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -9195,7 +9461,7 @@
       "label": "BREW_FAIL",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L141",
+      "source_location": "L145",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9209,7 +9475,7 @@
       "label": "BREW_VERSIONS",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L142",
+      "source_location": "L146",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9223,7 +9489,7 @@
       "label": "MAS_VERSIONS",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L144",
+      "source_location": "L148",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9237,7 +9503,7 @@
       "label": "UPGRADE_MARKER",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L212",
+      "source_location": "L216",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9251,7 +9517,7 @@
       "label": "BREW_BEFORE",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L218",
+      "source_location": "L222",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9265,7 +9531,7 @@
       "label": "BREW_AFTER",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L221",
+      "source_location": "L225",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9279,7 +9545,7 @@
       "label": "MAS_AFTER",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L225",
+      "source_location": "L229",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9293,7 +9559,7 @@
       "label": "RELAY_STUB_OUTCOME",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L352",
+      "source_location": "L383",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9307,7 +9573,7 @@
       "label": "CLOCK_TICKS",
       "file_type": "code",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L379",
+      "source_location": "L410",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9416,312 +9682,242 @@
       "norm_label": "relay_idle_secs"
     },
     {
-      "label": "update-skills-defer.sh",
+      "label": "report-plugin-updates-record.sh",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
       "source_location": "L1",
       "metadata": {
         "language": "bash",
         "kind": "file"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer",
-      "community": 26,
-      "norm_label": "update-skills-defer.sh"
+      "id": "test_e2e_report_plugin_updates_record",
+      "community": 444,
+      "norm_label": "report-plugin-updates-record.sh"
     },
     {
-      "label": "update-skills-defer.sh script",
+      "label": "report-plugin-updates-record.sh script",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
       "source_location": "L1",
       "metadata": {
         "language": "bash",
         "kind": "bash_entrypoint"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_sh__entry",
-      "community": 26,
-      "norm_label": "update-skills-defer.sh script"
+      "id": "test_e2e_report_plugin_updates_record_sh__entry",
+      "community": 444,
+      "norm_label": "report-plugin-updates-record.sh script"
     },
     {
       "label": "fail()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L36",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L20",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_fail",
-      "community": 26,
+      "id": "test_e2e_report_plugin_updates_record_fail",
+      "community": 444,
       "norm_label": "fail()"
     },
     {
-      "label": "cleanup()",
+      "label": "refute()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L42",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L25",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_cleanup",
-      "community": 26,
-      "norm_label": "cleanup()"
+      "id": "test_e2e_report_plugin_updates_record_refute",
+      "community": 444,
+      "norm_label": "refute()"
     },
     {
-      "label": "PATH",
+      "label": "UNATTENDED_LOG_HERMES_URL",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L117",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L62",
       "metadata": {
         "language": "bash",
         "kind": "code"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_path",
-      "community": 26,
-      "norm_label": "path"
+      "id": "test_e2e_report_plugin_updates_record_unattended_log_hermes_url",
+      "community": 444,
+      "norm_label": "unattended_log_hermes_url"
     },
     {
-      "label": "FAKE_WEEK",
+      "label": "write_plugin_state()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L118",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L75",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_report_plugin_updates_record_write_plugin_state",
+      "community": 444,
+      "norm_label": "write_plugin_state()"
+    },
+    {
+      "label": "run_helper()",
+      "file_type": "code",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L113",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_report_plugin_updates_record_run_helper",
+      "community": 444,
+      "norm_label": "run_helper()"
+    },
+    {
+      "label": "log_entries()",
+      "file_type": "code",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L123",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_report_plugin_updates_record_log_entries",
+      "community": 444,
+      "norm_label": "log_entries()"
+    },
+    {
+      "label": "alert_entries()",
+      "file_type": "code",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L124",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_report_plugin_updates_record_alert_entries",
+      "community": 444,
+      "norm_label": "alert_entries()"
+    },
+    {
+      "label": "ssh-hardening-verify-watchdog.sh",
+      "file_type": "code",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_ssh_hardening_verify_watchdog",
+      "community": 445,
+      "norm_label": "ssh-hardening-verify-watchdog.sh"
+    },
+    {
+      "label": "ssh-hardening-verify-watchdog.sh script",
+      "file_type": "code",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_ssh_hardening_verify_watchdog_sh__entry",
+      "community": 445,
+      "norm_label": "ssh-hardening-verify-watchdog.sh script"
+    },
+    {
+      "label": "SSH_HARDENING_VERIFY_DEADLINE",
+      "file_type": "code",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L50",
       "metadata": {
         "language": "bash",
         "kind": "code"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_fake_week",
-      "community": 26,
-      "norm_label": "fake_week"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_ssh_hardening_verify_deadline",
+      "community": 445,
+      "norm_label": "ssh_hardening_verify_deadline"
     },
     {
-      "label": "UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR",
+      "label": "wedge_cleanup()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L127",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_update_skills_claude_activity_dir",
-      "community": 26,
-      "norm_label": "update_skills_claude_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_CODEX_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L128",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_update_skills_codex_activity_dir",
-      "community": 26,
-      "norm_label": "update_skills_codex_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_HERMES_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L129",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_update_skills_hermes_activity_dir",
-      "community": 26,
-      "norm_label": "update_skills_hermes_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_IDLE_THRESHOLD",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L130",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_update_skills_idle_threshold",
-      "community": 26,
-      "norm_label": "update_skills_idle_threshold"
-    },
-    {
-      "label": "reset_activity()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L133",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L70",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_reset_activity",
-      "community": 26,
-      "norm_label": "reset_activity()"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_wedge_cleanup",
+      "community": 445,
+      "norm_label": "wedge_cleanup()"
     },
     {
-      "label": "harness_absent()",
+      "label": "file_fingerprint()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L137",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L97",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_harness_absent",
-      "community": 26,
-      "norm_label": "harness_absent()"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_file_fingerprint",
+      "community": 445,
+      "norm_label": "file_fingerprint()"
     },
     {
-      "label": "harness_active()",
+      "label": "working_file_leftovers()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L138",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L107",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_harness_active",
-      "community": 26,
-      "norm_label": "harness_active()"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_working_file_leftovers",
+      "community": 445,
+      "norm_label": "working_file_leftovers()"
     },
     {
-      "label": "harness_stale()",
+      "label": "build_tree_with_previous_policy()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L142",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L122",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_harness_stale",
-      "community": 26,
-      "norm_label": "harness_stale()"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_build_tree_with_previous_policy",
+      "community": 445,
+      "norm_label": "build_tree_with_previous_policy()"
     },
     {
-      "label": "harness_unreadable()",
+      "label": "assert_pids_reaped()",
       "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L149",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L132",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_harness_unreadable",
-      "community": 26,
-      "norm_label": "harness_unreadable()"
-    },
-    {
-      "label": "harness_file_aged()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L155",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_harness_file_aged",
-      "community": 26,
-      "norm_label": "harness_file_aged()"
-    },
-    {
-      "label": "run_gate()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L169",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_run_gate",
-      "community": 26,
-      "norm_label": "run_gate()"
-    },
-    {
-      "label": "run_gate_sched()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L178",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_run_gate_sched",
-      "community": 26,
-      "norm_label": "run_gate_sched()"
-    },
-    {
-      "label": "proceeded()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L180",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_proceeded",
-      "community": 26,
-      "norm_label": "proceeded()"
-    },
-    {
-      "label": "deferred()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L181",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_deferred",
-      "community": 26,
-      "norm_label": "deferred()"
-    },
-    {
-      "label": "early_exited()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L182",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_early_exited",
-      "community": 26,
-      "norm_label": "early_exited()"
-    },
-    {
-      "label": "alerted()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L183",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_defer_alerted",
-      "community": 26,
-      "norm_label": "alerted()"
+      "id": "test_e2e_ssh_hardening_verify_watchdog_assert_pids_reaped",
+      "community": 445,
+      "norm_label": "assert_pids_reaped()"
     },
     {
       "label": "update-skills-exchange-publish.sh",
@@ -9979,7 +10175,7 @@
       "label": "PATH",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-lock-contention.sh",
-      "source_location": "L93",
+      "source_location": "L99",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -9988,6 +10184,20 @@
       "id": "test_e2e_update_skills_lock_contention_path",
       "community": 120,
       "norm_label": "path"
+    },
+    {
+      "label": "run_contended()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-lock-contention.sh",
+      "source_location": "L167",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_lock_contention_run_contended",
+      "community": 120,
+      "norm_label": "run_contended()"
     },
     {
       "label": "update-skills-lock-fd-leak.sh",
@@ -10130,6 +10340,174 @@
       "norm_label": "path"
     },
     {
+      "label": "update-skills-unattended.sh",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended",
+      "community": 65,
+      "norm_label": "update-skills-unattended.sh"
+    },
+    {
+      "label": "update-skills-unattended.sh script",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_sh__entry",
+      "community": 65,
+      "norm_label": "update-skills-unattended.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_fail",
+      "community": 65,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L43",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_refute",
+      "community": 65,
+      "norm_label": "refute()"
+    },
+    {
+      "label": "cleanup()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L52",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_cleanup",
+      "community": 65,
+      "norm_label": "cleanup()"
+    },
+    {
+      "label": "PATH",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L122",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_path",
+      "community": 65,
+      "norm_label": "path"
+    },
+    {
+      "label": "FAKE_WEEK",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L123",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_fake_week",
+      "community": 65,
+      "norm_label": "fake_week"
+    },
+    {
+      "label": "stage_live_agent_activity()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L133",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_stage_live_agent_activity",
+      "community": 65,
+      "norm_label": "stage_live_agent_activity()"
+    },
+    {
+      "label": "clear_agent_activity()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L140",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_clear_agent_activity",
+      "community": 65,
+      "norm_label": "clear_agent_activity()"
+    },
+    {
+      "label": "run_updater()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L146",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_run_updater",
+      "community": 65,
+      "norm_label": "run_updater()"
+    },
+    {
+      "label": "proceeded()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L156",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_proceeded",
+      "community": 65,
+      "norm_label": "proceeded()"
+    },
+    {
+      "label": "early_exited()",
+      "file_type": "code",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L157",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_e2e_update_skills_unattended_early_exited",
+      "community": 65,
+      "norm_label": "early_exited()"
+    },
+    {
       "label": "update-skills-weekly-record.sh",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
@@ -10161,7 +10539,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L40",
+      "source_location": "L41",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10175,7 +10553,7 @@
       "label": "refute()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L46",
+      "source_location": "L47",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10189,7 +10567,7 @@
       "label": "cleanup()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L57",
+      "source_location": "L58",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10203,7 +10581,7 @@
       "label": "restage_lock()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L70",
+      "source_location": "L71",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10217,7 +10595,7 @@
       "label": "restage_lock_with_routing()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L87",
+      "source_location": "L88",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10231,7 +10609,7 @@
       "label": "clawhub_version()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L101",
+      "source_location": "L102",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10245,7 +10623,7 @@
       "label": "PATH",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L215",
+      "source_location": "L197",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -10259,7 +10637,7 @@
       "label": "FAKE_WEEK",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L216",
+      "source_location": "L198",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -10273,7 +10651,7 @@
       "label": "UNATTENDED_LOG_HERMES_URL",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L217",
+      "source_location": "L199",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -10284,94 +10662,24 @@
       "norm_label": "unattended_log_hermes_url"
     },
     {
-      "label": "UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR",
+      "label": "stage_refused_roster()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L219",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_update_skills_claude_activity_dir",
-      "community": 437,
-      "norm_label": "update_skills_claude_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_CODEX_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L220",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_update_skills_codex_activity_dir",
-      "community": 437,
-      "norm_label": "update_skills_codex_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_HERMES_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L221",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_update_skills_hermes_activity_dir",
-      "community": 437,
-      "norm_label": "update_skills_hermes_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_IDLE_THRESHOLD",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L222",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_update_skills_idle_threshold",
-      "community": 437,
-      "norm_label": "update_skills_idle_threshold"
-    },
-    {
-      "label": "harness_active()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L227",
+      "source_location": "L206",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_harness_active",
+      "id": "test_e2e_update_skills_weekly_record_stage_refused_roster",
       "community": 437,
-      "norm_label": "harness_active()"
-    },
-    {
-      "label": "harness_absent()",
-      "file_type": "code",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L231",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_e2e_update_skills_weekly_record_harness_absent",
-      "community": 437,
-      "norm_label": "harness_absent()"
+      "norm_label": "stage_refused_roster()"
     },
     {
       "label": "run_updater()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L236",
+      "source_location": "L211",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10385,7 +10693,7 @@
       "label": "log_entries()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L244",
+      "source_location": "L219",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10399,7 +10707,7 @@
       "label": "alert_entries()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L246",
+      "source_location": "L221",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10413,7 +10721,7 @@
       "label": "log_entry_count()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L247",
+      "source_location": "L222",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -10427,7 +10735,7 @@
       "label": "reset_state()",
       "file_type": "code",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L252",
+      "source_location": "L227",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14120,10 +14428,24 @@
       "norm_label": "fail()"
     },
     {
+      "label": "HOMEBREW_WEEKLY_STATE_DIR",
+      "file_type": "code",
+      "source_file": "test/integration/homebrew-weekly-upgrade.sh",
+      "source_location": "L34",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_homebrew_weekly_upgrade_homebrew_weekly_state_dir",
+      "community": 268,
+      "norm_label": "homebrew_weekly_state_dir"
+    },
+    {
       "label": "assert_all_sections()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L37",
+      "source_location": "L44",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -14137,7 +14459,7 @@
       "label": "make_brew()",
       "file_type": "code",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L49",
+      "source_location": "L56",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16419,7 +16741,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/osquery-page-allowlist-seed.sh",
-      "source_location": "L30",
+      "source_location": "L32",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16615,7 +16937,7 @@
       "label": "run_allowlist_verdict()",
       "file_type": "code",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L496",
+      "source_location": "L512",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16755,7 +17077,7 @@
       "label": "OSQUERY_UNDELIVERED_ALERTS_DB",
       "file_type": "code",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L36",
+      "source_location": "L34",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -16769,7 +17091,7 @@
       "label": "assert_eq()",
       "file_type": "code",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L41",
+      "source_location": "L39",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16783,7 +17105,7 @@
       "label": "cleanup()",
       "file_type": "code",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L60",
+      "source_location": "L58",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -16932,6 +17254,76 @@
       "id": "test_integration_relay_agent_relay_codex_home",
       "community": 278,
       "norm_label": "relay_codex_home"
+    },
+    {
+      "label": "render-without-package-manager.sh",
+      "file_type": "code",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_render_without_package_manager",
+      "community": 451,
+      "norm_label": "render-without-package-manager.sh"
+    },
+    {
+      "label": "render-without-package-manager.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_render_without_package_manager_sh__entry",
+      "community": 451,
+      "norm_label": "render-without-package-manager.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L29",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_render_without_package_manager_fail",
+      "community": 451,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "write_config()",
+      "file_type": "code",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L68",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_render_without_package_manager_write_config",
+      "community": 451,
+      "norm_label": "write_config()"
+    },
+    {
+      "label": "render()",
+      "file_type": "code",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L78",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_render_without_package_manager_render",
+      "community": 451,
+      "norm_label": "render()"
     },
     {
       "label": "rendered-template-coverage.sh",
@@ -18687,7 +19079,7 @@
       "label": "PATH",
       "file_type": "code",
       "source_file": "test/integration/update-skills-converge.sh",
-      "source_location": "L143",
+      "source_location": "L157",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -18701,7 +19093,7 @@
       "label": "run()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-converge.sh",
-      "source_location": "L147",
+      "source_location": "L161",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19230,146 +19622,6 @@
       "norm_label": "assert_refused()"
     },
     {
-      "label": "update-skills-exchange-reprobe.sh",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L1",
-      "metadata": {
-        "language": "bash",
-        "kind": "file"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe",
-      "community": 74,
-      "norm_label": "update-skills-exchange-reprobe.sh"
-    },
-    {
-      "label": "update-skills-exchange-reprobe.sh script",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L1",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_entrypoint"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_sh__entry",
-      "community": 74,
-      "norm_label": "update-skills-exchange-reprobe.sh script"
-    },
-    {
-      "label": "fail()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L19",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_fail",
-      "community": 74,
-      "norm_label": "fail()"
-    },
-    {
-      "label": "UPDATE_SKILLS_GMV",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L34",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_update_skills_gmv",
-      "community": 74,
-      "norm_label": "update_skills_gmv"
-    },
-    {
-      "label": "write_lock()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L40",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_write_lock",
-      "community": 74,
-      "norm_label": "write_lock()"
-    },
-    {
-      "label": "UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L60",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_update_skills_claude_activity_dir",
-      "community": 74,
-      "norm_label": "update_skills_claude_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_CODEX_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L61",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_update_skills_codex_activity_dir",
-      "community": 74,
-      "norm_label": "update_skills_codex_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_HERMES_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L62",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_update_skills_hermes_activity_dir",
-      "community": 74,
-      "norm_label": "update_skills_hermes_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_IDLE_THRESHOLD",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L63",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_update_skills_idle_threshold",
-      "community": 74,
-      "norm_label": "update_skills_idle_threshold"
-    },
-    {
-      "label": "PATH",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L94",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_exchange_reprobe_path",
-      "community": 74,
-      "norm_label": "path"
-    },
-    {
       "label": "update-skills-exchange-tool.sh",
       "file_type": "code",
       "source_file": "test/integration/update-skills-exchange-tool.sh",
@@ -19513,7 +19765,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L26",
+      "source_location": "L23",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19527,7 +19779,7 @@
       "label": "render_fixture()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L49",
+      "source_location": "L46",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -19541,7 +19793,7 @@
       "label": "PATH",
       "file_type": "code",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L125",
+      "source_location": "L122",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -20000,160 +20252,6 @@
       "norm_label": "path"
     },
     {
-      "label": "update-skills-install-defer-retry.sh",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L1",
-      "metadata": {
-        "language": "bash",
-        "kind": "file"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry",
-      "community": 65,
-      "norm_label": "update-skills-install-defer-retry.sh"
-    },
-    {
-      "label": "update-skills-install-defer-retry.sh script",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L1",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_entrypoint"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_sh__entry",
-      "community": 65,
-      "norm_label": "update-skills-install-defer-retry.sh script"
-    },
-    {
-      "label": "fail()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L22",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_fail",
-      "community": 65,
-      "norm_label": "fail()"
-    },
-    {
-      "label": "UPDATE_SKILLS_GMV",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L38",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_update_skills_gmv",
-      "community": 65,
-      "norm_label": "update_skills_gmv"
-    },
-    {
-      "label": "write_lock()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L44",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_write_lock",
-      "community": 65,
-      "norm_label": "write_lock()"
-    },
-    {
-      "label": "PATH",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L83",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_path",
-      "community": 65,
-      "norm_label": "path"
-    },
-    {
-      "label": "UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L86",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_update_skills_claude_activity_dir",
-      "community": 65,
-      "norm_label": "update_skills_claude_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_CODEX_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L87",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_update_skills_codex_activity_dir",
-      "community": 65,
-      "norm_label": "update_skills_codex_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_HERMES_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L88",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_update_skills_hermes_activity_dir",
-      "community": 65,
-      "norm_label": "update_skills_hermes_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_IDLE_THRESHOLD",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L89",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_update_skills_idle_threshold",
-      "community": 65,
-      "norm_label": "update_skills_idle_threshold"
-    },
-    {
-      "label": "render()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L141",
-      "metadata": {
-        "language": "bash",
-        "kind": "bash_function"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_defer_retry_render",
-      "community": 65,
-      "norm_label": "render()"
-    },
-    {
       "label": "update-skills-install-only-gate.sh",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
@@ -20185,7 +20283,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L19",
+      "source_location": "L18",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -20199,7 +20297,7 @@
       "label": "UPDATE_SKILLS_GMV",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L34",
+      "source_location": "L33",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -20213,7 +20311,7 @@
       "label": "write_lock()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L40",
+      "source_location": "L39",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -20238,80 +20336,24 @@
       "norm_label": "path"
     },
     {
-      "label": "UPDATE_SKILLS_CLAUDE_ACTIVITY_DIR",
+      "label": "stage_live_agent_activity()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
       "source_location": "L88",
       "metadata": {
         "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_only_gate_update_skills_claude_activity_dir",
-      "community": 53,
-      "norm_label": "update_skills_claude_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_CODEX_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L89",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_only_gate_update_skills_codex_activity_dir",
-      "community": 53,
-      "norm_label": "update_skills_codex_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_HERMES_ACTIVITY_DIR",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L90",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_only_gate_update_skills_hermes_activity_dir",
-      "community": 53,
-      "norm_label": "update_skills_hermes_activity_dir"
-    },
-    {
-      "label": "UPDATE_SKILLS_IDLE_THRESHOLD",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L91",
-      "metadata": {
-        "language": "bash",
-        "kind": "code"
-      },
-      "_origin": "ast",
-      "id": "test_integration_update_skills_install_only_gate_update_skills_idle_threshold",
-      "community": 53,
-      "norm_label": "update_skills_idle_threshold"
-    },
-    {
-      "label": "harness_active()",
-      "file_type": "code",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L92",
-      "metadata": {
-        "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
-      "id": "test_integration_update_skills_install_only_gate_harness_active",
+      "id": "test_integration_update_skills_install_only_gate_stage_live_agent_activity",
       "community": 53,
-      "norm_label": "harness_active()"
+      "norm_label": "stage_live_agent_activity()"
     },
     {
       "label": "gen_id()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L97",
+      "source_location": "L92",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -20418,6 +20460,104 @@
       "id": "test_integration_update_skills_install_only_health_gen_id",
       "community": 125,
       "norm_label": "gen_id()"
+    },
+    {
+      "label": "update-skills-install-retry-marker.sh",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker",
+      "community": 450,
+      "norm_label": "update-skills-install-retry-marker.sh"
+    },
+    {
+      "label": "update-skills-install-retry-marker.sh script",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_sh__entry",
+      "community": 450,
+      "norm_label": "update-skills-install-retry-marker.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L24",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_fail",
+      "community": 450,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "UPDATE_SKILLS_GMV",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L40",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_update_skills_gmv",
+      "community": 450,
+      "norm_label": "update_skills_gmv"
+    },
+    {
+      "label": "write_lock()",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L46",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_write_lock",
+      "community": 450,
+      "norm_label": "write_lock()"
+    },
+    {
+      "label": "PATH",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L81",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_path",
+      "community": 450,
+      "norm_label": "path"
+    },
+    {
+      "label": "render()",
+      "file_type": "code",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L154",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_integration_update_skills_install_retry_marker_render",
+      "community": 450,
+      "norm_label": "render()"
     },
     {
       "label": "update-skills-install.sh",
@@ -21501,7 +21641,7 @@
       "label": "assert_lock_level_advisory_names_deployed_lock()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L243",
+      "source_location": "L323",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -21515,7 +21655,7 @@
       "label": "assert_advisory_not_refusal()",
       "file_type": "code",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L252",
+      "source_location": "L332",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25054,6 +25194,370 @@
       "norm_label": "rendered_branch"
     },
     {
+      "label": "claude-commands-govern.sh",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern",
+      "community": 26,
+      "norm_label": "claude-commands-govern.sh"
+    },
+    {
+      "label": "claude-commands-govern.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_sh__entry",
+      "community": 26,
+      "norm_label": "claude-commands-govern.sh script"
+    },
+    {
+      "label": "COMMANDS_DIR",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L55",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_commands_dir",
+      "community": 26,
+      "norm_label": "commands_dir"
+    },
+    {
+      "label": "ALL_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L60",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_all_commands",
+      "community": 26,
+      "norm_label": "all_commands"
+    },
+    {
+      "label": "FRONTMATTER_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L74",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_frontmatter_commands",
+      "community": 26,
+      "norm_label": "frontmatter_commands"
+    },
+    {
+      "label": "GITHUB_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L85",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_github_commands",
+      "community": 26,
+      "norm_label": "github_commands"
+    },
+    {
+      "label": "PR_CREATING_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L93",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_pr_creating_commands",
+      "community": 26,
+      "norm_label": "pr_creating_commands"
+    },
+    {
+      "label": "COMMIT_MESSAGE_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L99",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_commit_message_commands",
+      "community": 26,
+      "norm_label": "commit_message_commands"
+    },
+    {
+      "label": "DESTRUCTIVE_COMMANDS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L108",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_destructive_commands",
+      "community": 26,
+      "norm_label": "destructive_commands"
+    },
+    {
+      "label": "TEMPLATE_HEADINGS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L116",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_template_headings",
+      "community": 26,
+      "norm_label": "template_headings"
+    },
+    {
+      "label": "REVIEW_STEP_HEADING",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L125",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_review_step_heading",
+      "community": 26,
+      "norm_label": "review_step_heading"
+    },
+    {
+      "label": "PR_CREATE_CALL",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L126",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_pr_create_call",
+      "community": 26,
+      "norm_label": "pr_create_call"
+    },
+    {
+      "label": "REVIEW_CHECKLIST_ITEMS",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L130",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_review_checklist_items",
+      "community": 26,
+      "norm_label": "review_checklist_items"
+    },
+    {
+      "label": "BARE_GH_CALL_PATTERN",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L142",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_bare_gh_call_pattern",
+      "community": 26,
+      "norm_label": "bare_gh_call_pattern"
+    },
+    {
+      "label": "BARE_GH_ALLOWLIST_PATTERN",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L146",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_bare_gh_allowlist_pattern",
+      "community": 26,
+      "norm_label": "bare_gh_allowlist_pattern"
+    },
+    {
+      "label": "INLINE_BODY_FLAG_PATTERN",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L150",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_inline_body_flag_pattern",
+      "community": 26,
+      "norm_label": "inline_body_flag_pattern"
+    },
+    {
+      "label": "MERGE_SUBJECT_PATTERN",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L154",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_merge_subject_pattern",
+      "community": 26,
+      "norm_label": "merge_subject_pattern"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L164",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_fail",
+      "community": 26,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "command_path()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L169",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_command_path",
+      "community": 26,
+      "norm_label": "command_path()"
+    },
+    {
+      "label": "require_pattern()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L174",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_require_pattern",
+      "community": 26,
+      "norm_label": "require_pattern()"
+    },
+    {
+      "label": "require_literal()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L181",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_require_literal",
+      "community": 26,
+      "norm_label": "require_literal()"
+    },
+    {
+      "label": "refuse_pattern()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L188",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_refuse_pattern",
+      "community": 26,
+      "norm_label": "refuse_pattern()"
+    },
+    {
+      "label": "refuse_literal()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L196",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_refuse_literal",
+      "community": 26,
+      "norm_label": "refuse_literal()"
+    },
+    {
+      "label": "require_heading()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L209",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_require_heading",
+      "community": 26,
+      "norm_label": "require_heading()"
+    },
+    {
+      "label": "literal_line_number()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L217",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_literal_line_number",
+      "community": 26,
+      "norm_label": "literal_line_number()"
+    },
+    {
+      "label": "heading_line_number()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L224",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_commands_govern_heading_line_number",
+      "community": 26,
+      "norm_label": "heading_line_number()"
+    },
+    {
       "label": "claude-enabled-plugins.sh",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
@@ -25085,7 +25589,7 @@
       "label": "SETTINGS_TARGET_RELATIVE_PATH",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L153",
+      "source_location": "L160",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25099,7 +25603,7 @@
       "label": "SANDBOX_SOURCE_FILES",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L160",
+      "source_location": "L167",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25113,7 +25617,7 @@
       "label": "TARGET_OPERATING_SYSTEMS",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L168",
+      "source_location": "L175",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25127,7 +25631,7 @@
       "label": "PASSTHROUGH_SETTING_KEY",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L177",
+      "source_location": "L184",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25141,7 +25645,7 @@
       "label": "LIVE_UNDECLARED_ENABLED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L184",
+      "source_location": "L191",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25155,7 +25659,7 @@
       "label": "LIVE_UNDECLARED_DISABLED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L185",
+      "source_location": "L192",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25169,7 +25673,7 @@
       "label": "DECLARED_PLUGINS",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L192",
+      "source_location": "L199",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25180,10 +25684,66 @@
       "norm_label": "declared_plugins"
     },
     {
+      "label": "OPERATOR_ADDED_MARKETPLACE",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L219",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_operator_added_marketplace",
+      "community": 424,
+      "norm_label": "operator_added_marketplace"
+    },
+    {
+      "label": "OPERATOR_ADDED_MARKETPLACE_REPO",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L220",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_operator_added_marketplace_repo",
+      "community": 424,
+      "norm_label": "operator_added_marketplace_repo"
+    },
+    {
+      "label": "LIVE_AUTOUPDATE_DISABLED_MARKETPLACE",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L229",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_live_autoupdate_disabled_marketplace",
+      "community": 424,
+      "norm_label": "live_autoupdate_disabled_marketplace"
+    },
+    {
+      "label": "LIVE_AUTOUPDATE_DISABLED_MARKETPLACE_REPO",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L230",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_live_autoupdate_disabled_marketplace_repo",
+      "community": 424,
+      "norm_label": "live_autoupdate_disabled_marketplace_repo"
+    },
+    {
       "label": "DISABLED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L208",
+      "source_location": "L236",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25197,7 +25757,7 @@
       "label": "ENABLED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L209",
+      "source_location": "L237",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25211,7 +25771,7 @@
       "label": "ARRAY_VALUED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L210",
+      "source_location": "L238",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25225,7 +25785,7 @@
       "label": "STRING_VALUED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L211",
+      "source_location": "L239",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25239,7 +25799,7 @@
       "label": "NUMBER_VALUED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L212",
+      "source_location": "L240",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25253,7 +25813,7 @@
       "label": "NULL_VALUED_DECLARED_PLUGIN",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L213",
+      "source_location": "L241",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25267,7 +25827,7 @@
       "label": "LIVE_FILE_CASES",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L247",
+      "source_location": "L281",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25281,7 +25841,7 @@
       "label": "UNPARSEABLE_LIVE_FILE_CASES",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L274",
+      "source_location": "L309",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25295,7 +25855,7 @@
       "label": "UNPARSEABLE_APPLY_ERROR_FRAGMENT",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L284",
+      "source_location": "L319",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25309,7 +25869,7 @@
       "label": "REPORT_FIELD_DELIMITER",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L296",
+      "source_location": "L331",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25323,7 +25883,7 @@
       "label": "PLUGIN_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L297",
+      "source_location": "L332",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25337,7 +25897,7 @@
       "label": "PLUGIN_CONTAINER_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L298",
+      "source_location": "L333",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25351,7 +25911,7 @@
       "label": "PASSTHROUGH_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L299",
+      "source_location": "L334",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25365,7 +25925,7 @@
       "label": "STABLE_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L300",
+      "source_location": "L335",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25379,7 +25939,7 @@
       "label": "DENY_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L301",
+      "source_location": "L336",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25393,7 +25953,7 @@
       "label": "HOOK_COMMAND_RECORD",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L302",
+      "source_location": "L337",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25407,7 +25967,7 @@
       "label": "JSON_BOOLEAN_KIND",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L312",
+      "source_location": "L347",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25421,7 +25981,7 @@
       "label": "JSON_TRUE_VALUE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L313",
+      "source_location": "L348",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25435,7 +25995,7 @@
       "label": "JSON_FALSE_VALUE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L314",
+      "source_location": "L349",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25449,7 +26009,7 @@
       "label": "JSON_ARRAY_KIND",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L325",
+      "source_location": "L360",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25463,7 +26023,7 @@
       "label": "LIVE_VERSION_CONSTRAINT_ENTRY",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L326",
+      "source_location": "L361",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25477,7 +26037,7 @@
       "label": "LIVE_VERSION_CONSTRAINT_RENDERED",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L327",
+      "source_location": "L362",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25491,7 +26051,7 @@
       "label": "STABLE_FIELD_KINDS",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L345",
+      "source_location": "L388",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25505,7 +26065,7 @@
       "label": "STABLE_CONTAINER_FIELDS",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L366",
+      "source_location": "L417",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25519,7 +26079,7 @@
       "label": "STABLE_FIELD_VALUES",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L380",
+      "source_location": "L431",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25533,7 +26093,7 @@
       "label": "STATUS_LINE_COMMAND_PATH",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L392",
+      "source_location": "L451",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25547,7 +26107,7 @@
       "label": "STATUS_LINE_COMMAND_SUFFIX",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L393",
+      "source_location": "L452",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25561,7 +26121,7 @@
       "label": "REQUIRED_DENY_ENTRIES",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L398",
+      "source_location": "L457",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25575,7 +26135,7 @@
       "label": "REQUIRED_HOOK_COMMAND_FRAGMENTS",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L411",
+      "source_location": "L470",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25589,7 +26149,7 @@
       "label": "FIXTURE_NULL_ENABLED_PLUGINS_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L427",
+      "source_location": "L486",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25603,7 +26163,7 @@
       "label": "FIXTURE_ARRAY_ENABLED_PLUGINS_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L434",
+      "source_location": "L493",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25617,7 +26177,7 @@
       "label": "FIXTURE_UNDECLARED_PLUGINS_ONLY_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L441",
+      "source_location": "L500",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25631,7 +26191,7 @@
       "label": "FIXTURE_DECLARED_PLUGIN_DISABLED_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L450",
+      "source_location": "L509",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25645,7 +26205,7 @@
       "label": "FIXTURE_NON_BOOLEAN_PLUGIN_VALUES_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L460",
+      "source_location": "L519",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25656,10 +26216,24 @@
       "norm_label": "fixture_non_boolean_plugin_values_template"
     },
     {
+      "label": "FIXTURE_OPERATOR_ADDED_MARKETPLACE_TEMPLATE",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L530",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_fixture_operator_added_marketplace_template",
+      "community": 424,
+      "norm_label": "fixture_operator_added_marketplace_template"
+    },
+    {
       "label": "SANDBOX_CONFIG_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L476",
+      "source_location": "L547",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25673,7 +26247,7 @@
       "label": "SETTINGS_REPORT_TEMPLATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L500",
+      "source_location": "L571",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25687,7 +26261,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L582",
+      "source_location": "L653",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25701,7 +26275,7 @@
       "label": "finish()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L587",
+      "source_location": "L658",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25715,7 +26289,7 @@
       "label": "SANDBOX_SOURCE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L618",
+      "source_location": "L689",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25729,7 +26303,7 @@
       "label": "SANDBOX_PERSISTENT_STATE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L619",
+      "source_location": "L690",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25743,7 +26317,7 @@
       "label": "SANDBOX_CACHE",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L620",
+      "source_location": "L691",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25757,7 +26331,7 @@
       "label": "BOOTSTRAP_CONFIG",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L626",
+      "source_location": "L697",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -25771,7 +26345,7 @@
       "label": "case_config_path()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L629",
+      "source_location": "L700",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25785,7 +26359,7 @@
       "label": "case_destination_directory()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L633",
+      "source_location": "L704",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25799,7 +26373,7 @@
       "label": "case_settings_path()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L637",
+      "source_location": "L708",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25813,7 +26387,7 @@
       "label": "case_apply_stderr_path()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L641",
+      "source_location": "L712",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25827,7 +26401,7 @@
       "label": "chezmoi_isolated()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L664",
+      "source_location": "L735",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25841,7 +26415,7 @@
       "label": "render_template()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L679",
+      "source_location": "L750",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25855,21 +26429,21 @@
       "label": "render_fixture_template()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L685",
+      "source_location": "L756",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
       "id": "test_unit_claude_enabled_plugins_render_fixture_template",
-      "community": 433,
+      "community": 432,
       "norm_label": "render_fixture_template()"
     },
     {
       "label": "populate_sandbox_source()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L703",
+      "source_location": "L778",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25883,7 +26457,7 @@
       "label": "write_sandbox_config()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L717",
+      "source_location": "L792",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25897,7 +26471,7 @@
       "label": "case_literal_fixture()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L728",
+      "source_location": "L803",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25911,7 +26485,7 @@
       "label": "case_fixture_template()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L747",
+      "source_location": "L822",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25925,7 +26499,7 @@
       "label": "case_expected_fixture_plugin_container_kind()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L763",
+      "source_location": "L839",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25939,7 +26513,7 @@
       "label": "case_expected_fixture_plugin_records()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L776",
+      "source_location": "L856",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25953,7 +26527,7 @@
       "label": "case_expected_rendered_plugin_records()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L815",
+      "source_location": "L895",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25967,7 +26541,7 @@
       "label": "write_case_fixture()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L837",
+      "source_location": "L917",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25981,7 +26555,7 @@
       "label": "stable_field_paths()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L858",
+      "source_location": "L938",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -25995,7 +26569,7 @@
       "label": "settings_report()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L870",
+      "source_location": "L950",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26009,7 +26583,7 @@
       "label": "parse_settings_report()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L898",
+      "source_location": "L978",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26023,7 +26597,7 @@
       "label": "stable_field_record()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L942",
+      "source_location": "L1022",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26037,7 +26611,7 @@
       "label": "stable_field_detail()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L956",
+      "source_location": "L1036",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26051,7 +26625,7 @@
       "label": "sorted_lines()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L966",
+      "source_location": "L1046",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26065,7 +26639,7 @@
       "label": "assert_test_constants()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L974",
+      "source_location": "L1054",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26079,7 +26653,7 @@
       "label": "assert_passthrough_field()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L996",
+      "source_location": "L1090",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26093,7 +26667,7 @@
       "label": "case_carries_passthrough()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1010",
+      "source_location": "L1104",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26107,7 +26681,7 @@
       "label": "assert_fixture_precondition()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1019",
+      "source_location": "L1113",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26121,21 +26695,21 @@
       "label": "apply_settings_target()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1075",
+      "source_location": "L1169",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
       },
       "_origin": "ast",
       "id": "test_unit_claude_enabled_plugins_apply_settings_target",
-      "community": 432,
+      "community": 433,
       "norm_label": "apply_settings_target()"
     },
     {
       "label": "assert_rendered_enabled_plugins()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1086",
+      "source_location": "L1180",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26149,7 +26723,7 @@
       "label": "assert_stable_fields_survived()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1136",
+      "source_location": "L1230",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26160,10 +26734,24 @@
       "norm_label": "assert_stable_fields_survived()"
     },
     {
+      "label": "assert_operator_marketplace_survived()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L1309",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_enabled_plugins_assert_operator_marketplace_survived",
+      "community": 432,
+      "norm_label": "assert_operator_marketplace_survived()"
+    },
+    {
       "label": "assert_stable_block_is_invariant()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1212",
+      "source_location": "L1324",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26177,7 +26765,7 @@
       "label": "verify_case()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1230",
+      "source_location": "L1342",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26191,7 +26779,7 @@
       "label": "file_bytes()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1268",
+      "source_location": "L1383",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26205,7 +26793,7 @@
       "label": "verify_unparseable_case()",
       "file_type": "code",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1278",
+      "source_location": "L1393",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26270,6 +26858,146 @@
       "id": "test_unit_claude_retirement_ordering_after_number",
       "community": 235,
       "norm_label": "after_number()"
+    },
+    {
+      "label": "claude-settings-quarantine.sh",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine",
+      "community": 442,
+      "norm_label": "claude-settings-quarantine.sh"
+    },
+    {
+      "label": "claude-settings-quarantine.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_sh__entry",
+      "community": 442,
+      "norm_label": "claude-settings-quarantine.sh script"
+    },
+    {
+      "label": "SCRIPT",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L33",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_script",
+      "community": 442,
+      "norm_label": "script"
+    },
+    {
+      "label": "BACKUP_NAME_PATTERN",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_backup_name_pattern",
+      "community": 442,
+      "norm_label": "backup_name_pattern"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L39",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_fail",
+      "community": 442,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "backups",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L55",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_backups",
+      "community": 442,
+      "norm_label": "backups"
+    },
+    {
+      "label": "run_script()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L57",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_run_script",
+      "community": 442,
+      "norm_label": "run_script()"
+    },
+    {
+      "label": "collect_backups()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_collect_backups",
+      "community": 442,
+      "norm_label": "collect_backups()"
+    },
+    {
+      "label": "assert_quarantined()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L74",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "community": 442,
+      "norm_label": "assert_quarantined()"
+    },
+    {
+      "label": "assert_untouched()",
+      "file_type": "code",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L101",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_claude_settings_quarantine_assert_untouched",
+      "community": 442,
+      "norm_label": "assert_untouched()"
     },
     {
       "label": "espanso-trigger-reachability.sh",
@@ -26566,6 +27294,174 @@
       "norm_label": "loaded_file"
     },
     {
+      "label": "gitconfig-homebrew-prefix-derivation.sh",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "community": 74,
+      "norm_label": "gitconfig-homebrew-prefix-derivation.sh"
+    },
+    {
+      "label": "gitconfig-homebrew-prefix-derivation.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_sh__entry",
+      "community": 74,
+      "norm_label": "gitconfig-homebrew-prefix-derivation.sh script"
+    },
+    {
+      "label": "EXPECTED_PREFIX_BY_PLATFORM",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L62",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_expected_prefix_by_platform",
+      "community": 74,
+      "norm_label": "expected_prefix_by_platform"
+    },
+    {
+      "label": "EXPECTED_BINARY_BY_CONFIG_KEY",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L84",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_expected_binary_by_config_key",
+      "community": 74,
+      "norm_label": "expected_binary_by_config_key"
+    },
+    {
+      "label": "GIT_CONFIG_NOSYSTEM",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_git_config_nosystem",
+      "community": 74,
+      "norm_label": "git_config_nosystem"
+    },
+    {
+      "label": "GIT_PAGER",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_git_pager",
+      "community": 74,
+      "norm_label": "git_pager"
+    },
+    {
+      "label": "PAGER",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_pager",
+      "community": 74,
+      "norm_label": "pager"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L101",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_fail",
+      "community": 74,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "line_numbers_containing()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L108",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_line_numbers_containing",
+      "community": 74,
+      "norm_label": "line_numbers_containing()"
+    },
+    {
+      "label": "count_lines_containing()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L113",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_count_lines_containing",
+      "community": 74,
+      "norm_label": "count_lines_containing()"
+    },
+    {
+      "label": "render_template()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L120",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_render_template",
+      "community": 74,
+      "norm_label": "render_template()"
+    },
+    {
+      "label": "site_binary_path()",
+      "file_type": "code",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L131",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_gitconfig_homebrew_prefix_derivation_site_binary_path",
+      "community": 74,
+      "norm_label": "site_binary_path()"
+    },
+    {
       "label": "gitconfig-tool-and-url-hygiene.sh",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
@@ -26597,7 +27493,7 @@
       "label": "GIT_CONFIG_NOSYSTEM",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -26611,7 +27507,7 @@
       "label": "GIT_PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -26625,7 +27521,7 @@
       "label": "PAGER",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -26639,7 +27535,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L99",
+      "source_location": "L109",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26653,7 +27549,7 @@
       "label": "list_chezmoi_delivered_target_paths()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L109",
+      "source_location": "L119",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26667,7 +27563,7 @@
       "label": "listing_contains_target_path()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L119",
+      "source_location": "L129",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26681,7 +27577,7 @@
       "label": "classify_path_resolution()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L130",
+      "source_location": "L140",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26695,7 +27591,7 @@
       "label": "classify_delivered_target_path()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L152",
+      "source_location": "L162",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26709,7 +27605,7 @@
       "label": "explain_rejected_delivery()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L168",
+      "source_location": "L178",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26723,7 +27619,7 @@
       "label": "require_delivered_readable_file()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L198",
+      "source_location": "L208",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26737,7 +27633,7 @@
       "label": "is_tool_binary_path_key()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L208",
+      "source_location": "L218",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26751,7 +27647,7 @@
       "label": "classify_core_excludesfile()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L216",
+      "source_location": "L226",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26765,7 +27661,7 @@
       "label": "git_resolves_tool_name()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L231",
+      "source_location": "L241",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26779,7 +27675,7 @@
       "label": "assert_path_resolution()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L301",
+      "source_location": "L318",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26793,7 +27689,7 @@
       "label": "assert_delivered_classification()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L318",
+      "source_location": "L335",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -26807,7 +27703,7 @@
       "label": "assert_guard_verdict()",
       "file_type": "code",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L337",
+      "source_location": "L354",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -27194,6 +28090,146 @@
       "id": "test_unit_homebrew_weekly_plist_assert_kv",
       "community": 273,
       "norm_label": "assert_kv()"
+    },
+    {
+      "label": "install-password-manager-hook.sh",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook",
+      "community": 443,
+      "norm_label": "install-password-manager-hook.sh"
+    },
+    {
+      "label": "install-password-manager-hook.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_sh__entry",
+      "community": 443,
+      "norm_label": "install-password-manager-hook.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L29",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_fail",
+      "community": 443,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "report()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L53",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_report",
+      "community": 443,
+      "norm_label": "report()"
+    },
+    {
+      "label": "run_case()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L69",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_run_case",
+      "community": 443,
+      "norm_label": "run_case()"
+    },
+    {
+      "label": "assert_status()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L97",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_assert_status",
+      "community": 443,
+      "norm_label": "assert_status()"
+    },
+    {
+      "label": "assert_called()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L105",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_assert_called",
+      "community": 443,
+      "norm_label": "assert_called()"
+    },
+    {
+      "label": "assert_not_called()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L113",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_assert_not_called",
+      "community": 443,
+      "norm_label": "assert_not_called()"
+    },
+    {
+      "label": "assert_stderr_mentions()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L121",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_assert_stderr_mentions",
+      "community": 443,
+      "norm_label": "assert_stderr_mentions()"
+    },
+    {
+      "label": "assert_stderr_silent()",
+      "file_type": "code",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L129",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_install_password_manager_hook_assert_stderr_silent",
+      "community": 443,
+      "norm_label": "assert_stderr_silent()"
     },
     {
       "label": "lulu-rule-existence-reader.sh",
@@ -29086,6 +30122,118 @@
       "norm_label": "perms_of()"
     },
     {
+      "label": "osquery-file-integrity-triage.sh",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage",
+      "community": 446,
+      "norm_label": "osquery-file-integrity-triage.sh"
+    },
+    {
+      "label": "osquery-file-integrity-triage.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "community": 446,
+      "norm_label": "osquery-file-integrity-triage.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L32",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_fail",
+      "community": 446,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "refute()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L37",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_refute",
+      "community": 446,
+      "norm_label": "refute()"
+    },
+    {
+      "label": "triage()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L69",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_triage",
+      "community": 446,
+      "norm_label": "triage()"
+    },
+    {
+      "label": "assert_json()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L90",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_assert_json",
+      "community": 446,
+      "norm_label": "assert_json()"
+    },
+    {
+      "label": "iso_at()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L96",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_iso_at",
+      "community": 446,
+      "norm_label": "iso_at()"
+    },
+    {
+      "label": "write_record()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L107",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_file_integrity_triage_write_record",
+      "community": 446,
+      "norm_label": "write_record()"
+    },
+    {
       "label": "osquery-firewall-gatekeeper-monitor-launchagent.sh",
       "file_type": "code",
       "source_file": "test/unit/osquery-firewall-gatekeeper-monitor-launchagent.sh",
@@ -29243,7 +30391,7 @@
       "label": "set_alerter_stub()",
       "file_type": "code",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L37",
+      "source_location": "L35",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -29257,7 +30405,7 @@
       "label": "run_durable()",
       "file_type": "code",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L44",
+      "source_location": "L42",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -29271,7 +30419,7 @@
       "label": "query()",
       "file_type": "code",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L52",
+      "source_location": "L50",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -29285,7 +30433,7 @@
       "label": "row_count()",
       "file_type": "code",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L56",
+      "source_location": "L54",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -29299,7 +30447,7 @@
       "label": "wait_for_row_count()",
       "file_type": "code",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L60",
+      "source_location": "L58",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -29369,7 +30517,7 @@
       "label": "OSQUERY_UNDELIVERED_ALERTS_DB",
       "file_type": "code",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L94",
+      "source_location": "L92",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -29383,7 +30531,7 @@
       "label": "OSQUERY_DELIVERY_LOG",
       "file_type": "code",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L95",
+      "source_location": "L93",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -29397,7 +30545,7 @@
       "label": "OSQUERY_WEBHOOK_SECRET",
       "file_type": "code",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L96",
+      "source_location": "L94",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -29411,7 +30559,7 @@
       "label": "OSQUERY_DRAIN_MAX_ATTEMPTS",
       "file_type": "code",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L97",
+      "source_location": "L95",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -29789,7 +30937,7 @@
       "label": "OSQUERY_UNDELIVERED_ALERTS_DB",
       "file_type": "code",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L31",
+      "source_location": "L29",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -29803,7 +30951,7 @@
       "label": "assert_eq()",
       "file_type": "code",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L36",
+      "source_location": "L34",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30078,6 +31226,34 @@
       "id": "test_unit_osquery_render_page_page_cap_hard_limits_length",
       "community": 301,
       "norm_label": "page_cap_hard_limits_length()"
+    },
+    {
+      "label": "triage_lines_render_when_present()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L118",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_render_page_triage_lines_render_when_present",
+      "community": 301,
+      "norm_label": "triage_lines_render_when_present()"
+    },
+    {
+      "label": "triage_absent_renders_the_old_block()",
+      "file_type": "code",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L139",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_osquery_render_page_triage_absent_renders_the_old_block",
+      "community": 301,
+      "norm_label": "triage_absent_renders_the_old_block()"
     },
     {
       "label": "osquery-route-emit-failure.sh",
@@ -30419,7 +31595,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L29",
+      "source_location": "L30",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30433,7 +31609,7 @@
       "label": "fe()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L48",
+      "source_location": "L49",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30447,7 +31623,7 @@
       "label": "run_gate()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L55",
+      "source_location": "L60",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30461,7 +31637,7 @@
       "label": "assert_paged()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L74",
+      "source_location": "L85",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30475,7 +31651,7 @@
       "label": "refute_paged()",
       "file_type": "code",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L77",
+      "source_location": "L88",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -30671,7 +31847,7 @@
       "label": "OSQUERY_UNDELIVERED_ALERTS_DB",
       "file_type": "code",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L42",
+      "source_location": "L40",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -30685,7 +31861,7 @@
       "label": "OSQUERY_DELIVERY_LOG",
       "file_type": "code",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L43",
+      "source_location": "L41",
       "metadata": {
         "language": "bash",
         "kind": "code"
@@ -30699,7 +31875,7 @@
       "label": "query()",
       "file_type": "code",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L45",
+      "source_location": "L43",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -31002,6 +32178,62 @@
       "id": "test_unit_rendered_template_shellcheck_wrapper_stub_shellcheck_exit",
       "community": 200,
       "norm_label": "stub_shellcheck_exit"
+    },
+    {
+      "label": "report-plugin-updates-plist.sh",
+      "file_type": "code",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_report_plugin_updates_plist",
+      "community": 458,
+      "norm_label": "report-plugin-updates-plist.sh"
+    },
+    {
+      "label": "report-plugin-updates-plist.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_report_plugin_updates_plist_sh__entry",
+      "community": 458,
+      "norm_label": "report-plugin-updates-plist.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L23",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_report_plugin_updates_plist_fail",
+      "community": 458,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "render()",
+      "file_type": "code",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L41",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_report_plugin_updates_plist_render",
+      "community": 458,
+      "norm_label": "render()"
     },
     {
       "label": "restore-age-key-secret-free.sh",
@@ -32281,7 +33513,7 @@
       "label": "fail()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L64",
+      "source_location": "L70",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32295,7 +33527,7 @@
       "label": "target_name()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L74",
+      "source_location": "L80",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32309,7 +33541,7 @@
       "label": "vendored_dirs()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L82",
+      "source_location": "L88",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32323,7 +33555,7 @@
       "label": "roster()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L89",
+      "source_location": "L95",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32337,7 +33569,7 @@
       "label": "claude_declarations()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L99",
+      "source_location": "L105",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32351,7 +33583,7 @@
       "label": "hermes_declaration_dirs()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L260",
+      "source_location": "L325",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32365,7 +33597,7 @@
       "label": "vendored_content_dirs()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L334",
+      "source_location": "L399",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32379,7 +33611,7 @@
       "label": "documented_count_is()",
       "file_type": "code",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L453",
+      "source_location": "L518",
       "metadata": {
         "language": "bash",
         "kind": "bash_function"
@@ -32964,6 +34196,20 @@
       "norm_label": "write_snapshot()"
     },
     {
+      "label": "tuples()",
+      "file_type": "code",
+      "source_file": "test/unit/unattended-log-lib.sh",
+      "source_location": "L701",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_unattended_log_lib_tuples",
+      "community": 436,
+      "norm_label": "tuples()"
+    },
+    {
       "label": "update-skills-change-report.sh",
       "file_type": "code",
       "source_file": "test/unit/update-skills-change-report.sh",
@@ -33046,6 +34292,76 @@
       "id": "test_unit_update_skills_change_report_row",
       "community": 438,
       "norm_label": "row()"
+    },
+    {
+      "label": "update-skills-json-stream-reads.sh",
+      "file_type": "code",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "test_unit_update_skills_json_stream_reads",
+      "community": 452,
+      "norm_label": "update-skills-json-stream-reads.sh"
+    },
+    {
+      "label": "update-skills-json-stream-reads.sh script",
+      "file_type": "code",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "test_unit_update_skills_json_stream_reads_sh__entry",
+      "community": 452,
+      "norm_label": "update-skills-json-stream-reads.sh script"
+    },
+    {
+      "label": "fail()",
+      "file_type": "code",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L30",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "test_unit_update_skills_json_stream_reads_fail",
+      "community": 452,
+      "norm_label": "fail()"
+    },
+    {
+      "label": "UPDATE_SKILLS_LIB_ONLY",
+      "file_type": "code",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L44",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_update_skills_json_stream_reads_update_skills_lib_only",
+      "community": 452,
+      "norm_label": "update_skills_lib_only"
+    },
+    {
+      "label": "XDG_STATE_HOME",
+      "file_type": "code",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L67",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "test_unit_update_skills_json_stream_reads_xdg_state_home",
+      "community": 452,
+      "norm_label": "xdg_state_home"
     },
     {
       "label": "update-skills-lock-symlink.sh",
@@ -33455,7 +34771,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L7",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
       "community": 431,
       "norm_label": "claude.md"
     },
@@ -33465,7 +34781,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L11",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_what_this_is",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_what_this_is",
       "community": 431,
       "norm_label": "what this is"
     },
@@ -33475,7 +34791,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L18",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
       "community": 431,
       "norm_label": "key commands"
     },
@@ -33485,7 +34801,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L20",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_linting_formatting",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_linting_formatting",
       "community": 431,
       "norm_label": "linting & formatting"
     },
@@ -33495,7 +34811,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L46",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_testing",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_testing",
       "community": 431,
       "norm_label": "testing"
     },
@@ -33505,7 +34821,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L86",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_chezmoi_operations",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_chezmoi_operations",
       "community": 431,
       "norm_label": "chezmoi operations"
     },
@@ -33515,7 +34831,7 @@
       "source_file": "AGENTS.md",
       "source_location": "L114",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_code_settings",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_code_settings",
       "community": 431,
       "norm_label": "claude code settings"
     },
@@ -33523,9 +34839,9 @@
       "label": "Git Hooks",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L215",
+      "source_location": "L233",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_hooks",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_hooks",
       "community": 431,
       "norm_label": "git hooks"
     },
@@ -33533,9 +34849,9 @@
       "label": "Architecture",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L282",
+      "source_location": "L300",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
       "community": 431,
       "norm_label": "architecture"
     },
@@ -33543,9 +34859,9 @@
       "label": "Source-Only Files",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L284",
+      "source_location": "L302",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_source_only_files",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_source_only_files",
       "community": 431,
       "norm_label": "source-only files"
     },
@@ -33553,9 +34869,9 @@
       "label": "Minimum Chezmoi Version",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L292",
+      "source_location": "L310",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_minimum_chezmoi_version",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_minimum_chezmoi_version",
       "community": 431,
       "norm_label": "minimum chezmoi version"
     },
@@ -33563,9 +34879,9 @@
       "label": "Secrets Management",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L296",
+      "source_location": "L314",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_secrets_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_secrets_management",
       "community": 431,
       "norm_label": "secrets management"
     },
@@ -33573,9 +34889,9 @@
       "label": "System Package Management",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L303",
+      "source_location": "L321",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_system_package_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_system_package_management",
       "community": 431,
       "norm_label": "system package management"
     },
@@ -33583,9 +34899,9 @@
       "label": "macOS Defaults Management",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L328",
+      "source_location": "L346",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_macos_defaults_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_macos_defaults_management",
       "community": 431,
       "norm_label": "macos defaults management"
     },
@@ -33593,9 +34909,9 @@
       "label": "Template Files",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L373",
+      "source_location": "L391",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_template_files",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_template_files",
       "community": 431,
       "norm_label": "template files"
     },
@@ -33603,9 +34919,9 @@
       "label": "Template Shellcheck Workaround",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L379",
+      "source_location": "L397",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_template_shellcheck_workaround",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_template_shellcheck_workaround",
       "community": 431,
       "norm_label": "template shellcheck workaround"
     },
@@ -33613,9 +34929,9 @@
       "label": "OS Targeting",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L400",
+      "source_location": "L418",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_os_targeting",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_os_targeting",
       "community": 431,
       "norm_label": "os targeting"
     },
@@ -33623,9 +34939,9 @@
       "label": "Dev Environment (Nix Flake)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L405",
+      "source_location": "L423",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_dev_environment_nix_flake",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_dev_environment_nix_flake",
       "community": 431,
       "norm_label": "dev environment (nix flake)"
     },
@@ -33633,9 +34949,9 @@
       "label": "CI",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L416",
+      "source_location": "L434",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_ci",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_ci",
       "community": 431,
       "norm_label": "ci"
     },
@@ -33643,9 +34959,9 @@
       "label": "Agent Skills (cross-harness store)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L426",
+      "source_location": "L444",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_agent_skills_cross_harness_store",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_agent_skills_cross_harness_store",
       "community": 431,
       "norm_label": "agent skills (cross-harness store)"
     },
@@ -33653,9 +34969,9 @@
       "label": "Herdr Workspace Management",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L645",
+      "source_location": "L679",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_herdr_workspace_management",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_herdr_workspace_management",
       "community": 431,
       "norm_label": "herdr workspace management"
     },
@@ -33663,9 +34979,9 @@
       "label": "Git Worktrees (Worktrunk)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L665",
+      "source_location": "L699",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_worktrees_worktrunk",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_worktrees_worktrunk",
       "community": 431,
       "norm_label": "git worktrees (worktrunk)"
     },
@@ -33673,9 +34989,9 @@
       "label": "Bashrc Init Ordering",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L672",
+      "source_location": "L706",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_bashrc_init_ordering",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_bashrc_init_ordering",
       "community": 431,
       "norm_label": "bashrc init ordering"
     },
@@ -33683,19 +34999,29 @@
       "label": "Shell History (Atuin)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L680",
+      "source_location": "L714",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_shell_history_atuin",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_shell_history_atuin",
       "community": 431,
       "norm_label": "shell history (atuin)"
+    },
+    {
+      "label": "Plugin Update Record",
+      "file_type": "document",
+      "source_file": "AGENTS.md",
+      "source_location": "L743",
+      "_origin": "ast",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_plugin_update_record",
+      "community": 431,
+      "norm_label": "plugin update record"
     },
     {
       "label": "Happy Daemon (Remote Agent Control)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L709",
+      "source_location": "L773",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_happy_daemon_remote_agent_control",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_happy_daemon_remote_agent_control",
       "community": 431,
       "norm_label": "happy daemon (remote agent control)"
     },
@@ -33703,9 +35029,9 @@
       "label": "Tailscale (headless daemon)",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L736",
+      "source_location": "L800",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_tailscale_headless_daemon",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_tailscale_headless_daemon",
       "community": 431,
       "norm_label": "tailscale (headless daemon)"
     },
@@ -33713,9 +35039,9 @@
       "label": "AI Commit Messages",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L773",
+      "source_location": "L837",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_ai_commit_messages",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_ai_commit_messages",
       "community": 431,
       "norm_label": "ai commit messages"
     },
@@ -33723,9 +35049,9 @@
       "label": "Long-running Command Notifier",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L786",
+      "source_location": "L850",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_long_running_command_notifier",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_long_running_command_notifier",
       "community": 431,
       "norm_label": "long-running command notifier"
     },
@@ -33733,9 +35059,9 @@
       "label": "Herdr Native Status",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L792",
+      "source_location": "L856",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_herdr_native_status",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_herdr_native_status",
       "community": 431,
       "norm_label": "herdr native status"
     },
@@ -33743,9 +35069,9 @@
       "label": "Code Style",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L798",
+      "source_location": "L862",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_code_style",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_code_style",
       "community": 431,
       "norm_label": "code style"
     },
@@ -33753,9 +35079,9 @@
       "label": "Git Commits",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L824",
+      "source_location": "L888",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_commits",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_commits",
       "community": 431,
       "norm_label": "git commits"
     },
@@ -33763,9 +35089,9 @@
       "label": "Security",
       "file_type": "document",
       "source_file": "AGENTS.md",
-      "source_location": "L831",
+      "source_location": "L895",
       "_origin": "ast",
-      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_security",
+      "id": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_security",
       "community": 431,
       "norm_label": "security"
     },
@@ -33853,7 +35179,7 @@
       "label": "Git Hooks",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L215",
+      "source_location": "L233",
       "_origin": "ast",
       "id": "claude_git_hooks",
       "community": 441,
@@ -33863,7 +35189,7 @@
       "label": "Architecture",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L282",
+      "source_location": "L300",
       "_origin": "ast",
       "id": "claude_architecture",
       "community": 441,
@@ -33873,7 +35199,7 @@
       "label": "Source-Only Files",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L284",
+      "source_location": "L302",
       "_origin": "ast",
       "id": "claude_source_only_files",
       "community": 441,
@@ -33883,7 +35209,7 @@
       "label": "Minimum Chezmoi Version",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L292",
+      "source_location": "L310",
       "_origin": "ast",
       "id": "claude_minimum_chezmoi_version",
       "community": 441,
@@ -33893,7 +35219,7 @@
       "label": "Secrets Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L296",
+      "source_location": "L314",
       "_origin": "ast",
       "id": "claude_secrets_management",
       "community": 441,
@@ -33903,7 +35229,7 @@
       "label": "System Package Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L303",
+      "source_location": "L321",
       "_origin": "ast",
       "id": "claude_system_package_management",
       "community": 441,
@@ -33913,7 +35239,7 @@
       "label": "macOS Defaults Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L328",
+      "source_location": "L346",
       "_origin": "ast",
       "id": "claude_macos_defaults_management",
       "community": 441,
@@ -33923,7 +35249,7 @@
       "label": "Template Files",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L373",
+      "source_location": "L391",
       "_origin": "ast",
       "id": "claude_template_files",
       "community": 441,
@@ -33933,7 +35259,7 @@
       "label": "Template Shellcheck Workaround",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L379",
+      "source_location": "L397",
       "_origin": "ast",
       "id": "claude_template_shellcheck_workaround",
       "community": 441,
@@ -33943,7 +35269,7 @@
       "label": "OS Targeting",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L400",
+      "source_location": "L418",
       "_origin": "ast",
       "id": "claude_os_targeting",
       "community": 441,
@@ -33953,7 +35279,7 @@
       "label": "Dev Environment (Nix Flake)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L405",
+      "source_location": "L423",
       "_origin": "ast",
       "id": "claude_dev_environment_nix_flake",
       "community": 441,
@@ -33963,7 +35289,7 @@
       "label": "CI",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L416",
+      "source_location": "L434",
       "_origin": "ast",
       "id": "claude_ci",
       "community": 441,
@@ -33973,7 +35299,7 @@
       "label": "Agent Skills (cross-harness store)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L426",
+      "source_location": "L444",
       "_origin": "ast",
       "id": "claude_agent_skills_cross_harness_store",
       "community": 441,
@@ -33983,7 +35309,7 @@
       "label": "Herdr Workspace Management",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L645",
+      "source_location": "L679",
       "_origin": "ast",
       "id": "claude_herdr_workspace_management",
       "community": 441,
@@ -33993,7 +35319,7 @@
       "label": "Git Worktrees (Worktrunk)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L665",
+      "source_location": "L699",
       "_origin": "ast",
       "id": "claude_git_worktrees_worktrunk",
       "community": 441,
@@ -34003,7 +35329,7 @@
       "label": "Bashrc Init Ordering",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L672",
+      "source_location": "L706",
       "_origin": "ast",
       "id": "claude_bashrc_init_ordering",
       "community": 441,
@@ -34013,17 +35339,27 @@
       "label": "Shell History (Atuin)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L680",
+      "source_location": "L714",
       "_origin": "ast",
       "id": "claude_shell_history_atuin",
       "community": 441,
       "norm_label": "shell history (atuin)"
     },
     {
+      "label": "Plugin Update Record",
+      "file_type": "document",
+      "source_file": "CLAUDE.md",
+      "source_location": "L743",
+      "_origin": "ast",
+      "id": "claude_plugin_update_record",
+      "community": 441,
+      "norm_label": "plugin update record"
+    },
+    {
       "label": "Happy Daemon (Remote Agent Control)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L709",
+      "source_location": "L773",
       "_origin": "ast",
       "id": "claude_happy_daemon_remote_agent_control",
       "community": 441,
@@ -34033,7 +35369,7 @@
       "label": "Tailscale (headless daemon)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L736",
+      "source_location": "L800",
       "_origin": "ast",
       "id": "claude_tailscale_headless_daemon",
       "community": 441,
@@ -34043,7 +35379,7 @@
       "label": "AI Commit Messages",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L773",
+      "source_location": "L837",
       "_origin": "ast",
       "id": "claude_ai_commit_messages",
       "community": 441,
@@ -34053,7 +35389,7 @@
       "label": "Long-running Command Notifier",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L786",
+      "source_location": "L850",
       "_origin": "ast",
       "id": "claude_long_running_command_notifier",
       "community": 441,
@@ -34063,7 +35399,7 @@
       "label": "Herdr Native Status",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L792",
+      "source_location": "L856",
       "_origin": "ast",
       "id": "claude_herdr_native_status",
       "community": 441,
@@ -34073,7 +35409,7 @@
       "label": "Code Style",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L798",
+      "source_location": "L862",
       "_origin": "ast",
       "id": "claude_code_style",
       "community": 441,
@@ -34083,7 +35419,7 @@
       "label": "Git Commits",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L824",
+      "source_location": "L888",
       "_origin": "ast",
       "id": "claude_git_commits",
       "community": 441,
@@ -34093,7 +35429,7 @@
       "label": "Security",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L831",
+      "source_location": "L895",
       "_origin": "ast",
       "id": "claude_security",
       "community": 441,
@@ -52950,6 +54286,196 @@
       "norm_label": "error handling"
     },
     {
+      "label": "amend.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_amend",
+      "community": 453,
+      "norm_label": "amend.md"
+    },
+    {
+      "label": "Amend",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L16",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_amend_amend",
+      "community": 453,
+      "norm_label": "amend"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_amend_steps",
+      "community": 453,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_amend_safeguards",
+      "community": 453,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "clean-gone.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_clean_gone",
+      "community": 454,
+      "norm_label": "clean-gone.md"
+    },
+    {
+      "label": "Clean Gone Branches",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_clean_gone_clean_gone_branches",
+      "community": 454,
+      "norm_label": "clean gone branches"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_clean_gone_steps",
+      "community": 454,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_clean_gone_safeguards",
+      "community": 454,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "commit-push-pr.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr",
+      "community": 448,
+      "norm_label": "commit-push-pr.md"
+    },
+    {
+      "label": "Commit, Push, PR",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "community": 448,
+      "norm_label": "commit, push, pr"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_steps",
+      "community": 448,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Pull request body template",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_pull_request_body_template",
+      "community": 448,
+      "norm_label": "pull request body template"
+    },
+    {
+      "label": "Review the draft before posting",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_review_the_draft_before_posting",
+      "community": 448,
+      "norm_label": "review the draft before posting"
+    },
+    {
+      "label": "Post the pull request",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L87",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_post_the_pull_request",
+      "community": 448,
+      "norm_label": "post the pull request"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L98",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_push_pr_safeguards",
+      "community": 448,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "commit.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit",
+      "community": 455,
+      "norm_label": "commit.md"
+    },
+    {
+      "label": "Commit",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_commit",
+      "community": 455,
+      "norm_label": "commit"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L18",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_steps",
+      "community": 455,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L31",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_commit_safeguards",
+      "community": 455,
+      "norm_label": "safeguards"
+    },
+    {
       "label": "pr-merge.md",
       "file_type": "document",
       "source_file": "private_dot_claude/commands/pr-merge.md",
@@ -52973,7 +54499,7 @@
       "label": "Steps",
       "file_type": "document",
       "source_file": "private_dot_claude/commands/pr-merge.md",
-      "source_location": "L5",
+      "source_location": "L7",
       "_origin": "ast",
       "id": "private_dot_claude_commands_pr_merge_steps",
       "community": 226,
@@ -52983,10 +54509,160 @@
       "label": "Safeguards",
       "file_type": "document",
       "source_file": "private_dot_claude/commands/pr-merge.md",
-      "source_location": "L12",
+      "source_location": "L22",
       "_origin": "ast",
       "id": "private_dot_claude_commands_pr_merge_safeguards",
       "community": 226,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "pr.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr",
+      "community": 449,
+      "norm_label": "pr.md"
+    },
+    {
+      "label": "PR",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_pr",
+      "community": 449,
+      "norm_label": "pr"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_steps",
+      "community": 449,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Pull request body template",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_pull_request_body_template",
+      "community": 449,
+      "norm_label": "pull request body template"
+    },
+    {
+      "label": "Review the draft before posting",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L60",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_review_the_draft_before_posting",
+      "community": 449,
+      "norm_label": "review the draft before posting"
+    },
+    {
+      "label": "Post the pull request",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_post_the_pull_request",
+      "community": 449,
+      "norm_label": "post the pull request"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L92",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_pr_safeguards",
+      "community": 449,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "sync-worktrees.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_sync_worktrees",
+      "community": 456,
+      "norm_label": "sync-worktrees.md"
+    },
+    {
+      "label": "Sync Worktrees",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_sync_worktrees_sync_worktrees",
+      "community": 456,
+      "norm_label": "sync worktrees"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_sync_worktrees_steps",
+      "community": 456,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_sync_worktrees_safeguards",
+      "community": 456,
+      "norm_label": "safeguards"
+    },
+    {
+      "label": "uncommit.md",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_uncommit",
+      "community": 457,
+      "norm_label": "uncommit.md"
+    },
+    {
+      "label": "Uncommit",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_uncommit_uncommit",
+      "community": 457,
+      "norm_label": "uncommit"
+    },
+    {
+      "label": "Steps",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_uncommit_steps",
+      "community": 457,
+      "norm_label": "steps"
+    },
+    {
+      "label": "Safeguards",
+      "file_type": "document",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "private_dot_claude_commands_uncommit_safeguards",
+      "community": 457,
       "norm_label": "safeguards"
     }
   ],
@@ -53030,6 +54706,37 @@
       "context": "call",
       "source": "chezmoiscripts_run_after_05_osquery_known_good_manifests_sh__entry",
       "target": "chezmoiscripts_run_after_05_osquery_known_good_manifests_refresh_manifest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings",
+      "target": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings",
+      "target": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_warn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": ".chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "context": "call",
+      "source": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_sh__entry",
+      "target": "chezmoiscripts_run_before_12_quarantine_unparseable_claude_settings_warn",
       "confidence_score": 1.0
     },
     {
@@ -54284,7 +55991,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L170",
+      "source_location": "L232",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_acquire_lock",
@@ -54294,7 +56001,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L135",
+      "source_location": "L143",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_homebrew_package_snapshot",
@@ -54304,7 +56011,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L208",
+      "source_location": "L270",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_refresh_tailscaled",
@@ -54314,7 +56021,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L186",
+      "source_location": "L248",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_run",
@@ -54334,7 +56041,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L85",
+      "source_location": "L93",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_weekly_alert",
@@ -54344,17 +56051,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L99",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_weekly_record",
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
+      "source_location": "L195",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
+      "target": "dot_local_bin_executable_homebrew_weekly_upgrade_write_upgrade_record",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L60",
+      "source_location": "L68",
       "weight": 1.0,
       "context": "import",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade",
@@ -54365,7 +56082,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L221",
+      "source_location": "L283",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
@@ -54376,7 +56093,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L271",
+      "source_location": "L333",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
@@ -54387,7 +56104,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L283",
+      "source_location": "L345",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
@@ -54398,7 +56115,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L232",
+      "source_location": "L294",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
@@ -54409,11 +56126,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
-      "source_location": "L227",
+      "source_location": "L289",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
       "target": "dot_local_bin_executable_homebrew_weekly_upgrade_weekly_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_homebrew-weekly-upgrade.sh",
+      "source_location": "L368",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_homebrew_weekly_upgrade_sh__entry",
+      "target": "dot_local_bin_executable_homebrew_weekly_upgrade_write_upgrade_record",
       "confidence_score": 1.0
     },
     {
@@ -54598,6 +56326,120 @@
       "context": "call",
       "source": "dot_local_bin_executable_relay_sh__entry",
       "target": "dot_local_bin_executable_relay_is_relay_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_alert",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L177",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_plugin_snapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_record_caveat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_record_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L102",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_record_label",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_record_source_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_executable_report_plugin_updates_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "context": "import",
+      "source": "dot_local_bin_executable_report_plugin_updates",
+      "target": "dot_local_bin_unattended_log_lib",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L203",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_report_plugin_updates_sh__entry",
+      "target": "dot_local_bin_executable_report_plugin_updates_alert",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L245",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_report_plugin_updates_sh__entry",
+      "target": "dot_local_bin_executable_report_plugin_updates_plugin_snapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_report-plugin-updates.sh",
+      "source_location": "L281",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_report_plugin_updates_sh__entry",
+      "target": "dot_local_bin_executable_report_plugin_updates_record_entry",
       "confidence_score": 1.0
     },
     {
@@ -55006,7 +56848,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L362",
+      "source_location": "L480",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_add_failure",
@@ -55016,7 +56858,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L416",
+      "source_location": "L534",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
@@ -55026,7 +56868,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2067",
+      "source_location": "L2187",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_banner_output_names_host_key",
@@ -55036,7 +56878,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L389",
+      "source_location": "L507",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_canonical_key",
@@ -55046,7 +56888,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1208",
+      "source_location": "L1326",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
@@ -55056,7 +56898,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L434",
+      "source_location": "L552",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_check_global",
@@ -55066,7 +56908,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1192",
+      "source_location": "L1310",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_check_match_scan",
@@ -55076,7 +56918,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2311",
+      "source_location": "L2431",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_check_password_channel",
@@ -55086,7 +56928,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1597",
+      "source_location": "L1717",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_collect_config_tree_files",
@@ -55096,7 +56938,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1516",
+      "source_location": "L1636",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_collect_config_tree_from_file",
@@ -55106,7 +56948,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1761",
+      "source_location": "L1881",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_find_record",
@@ -55116,7 +56958,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1785",
+      "source_location": "L1905",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_is_unchanged",
@@ -55126,7 +56968,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1641",
+      "source_location": "L1761",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_path_is_recordable",
@@ -55136,7 +56978,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1738",
+      "source_location": "L1858",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_record_fields",
@@ -55146,7 +56988,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1155",
+      "source_location": "L1273",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_roots",
@@ -55156,7 +56998,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1498",
+      "source_location": "L1618",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_config_tree_would_exceed_width",
@@ -55166,7 +57008,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2353",
+      "source_location": "L2473",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
@@ -55176,7 +57018,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L555",
+      "source_location": "L673",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
@@ -55186,7 +57028,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L237",
+      "source_location": "L244",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_die",
@@ -55196,7 +57038,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L254",
+      "source_location": "L261",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_dropin_path",
@@ -55206,7 +57048,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L794",
+      "source_location": "L912",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_include_bracket_opens_a_set",
@@ -55216,7 +57058,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1331",
+      "source_location": "L1451",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55226,7 +57068,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2433",
+      "source_location": "L2553",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_main",
@@ -55236,7 +57078,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L709",
+      "source_location": "L827",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_next_argument_token",
@@ -55246,7 +57088,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L705",
+      "source_location": "L823",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
@@ -55256,7 +57098,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1657",
+      "source_location": "L1777",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_observe_config_tree",
@@ -55266,7 +57108,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L718",
+      "source_location": "L836",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_parse_config_line",
@@ -55276,7 +57118,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1045",
+      "source_location": "L1163",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_path_is_a_regular_file",
@@ -55286,7 +57128,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L258",
+      "source_location": "L265",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_print_config",
@@ -55296,7 +57138,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1935",
+      "source_location": "L2055",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_probe_sshd_service",
@@ -55306,7 +57148,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L620",
+      "source_location": "L738",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_read_argument_token",
@@ -55316,7 +57158,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L567",
+      "source_location": "L685",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
@@ -55326,7 +57168,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L696",
+      "source_location": "L814",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_read_token_with_progress_guard",
@@ -55336,7 +57178,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1916",
+      "source_location": "L2036",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_recovery_instructions",
@@ -55346,7 +57188,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2108",
+      "source_location": "L2228",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -55356,7 +57198,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1898",
+      "source_location": "L2018",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_report_absent_service_outcome",
@@ -55366,7 +57208,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L400",
+      "source_location": "L518",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_required_value",
@@ -55376,7 +57218,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L930",
+      "source_location": "L1048",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_resolve_include_paths",
@@ -55386,7 +57228,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2013",
+      "source_location": "L2133",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
@@ -55396,7 +57238,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2392",
+      "source_location": "L2512",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
@@ -55406,7 +57248,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1308",
+      "source_location": "L1428",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_rollback_install",
@@ -55416,7 +57258,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L246",
+      "source_location": "L253",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_run_privileged",
@@ -55426,7 +57268,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L337",
+      "source_location": "L415",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_run_verify_child",
@@ -55436,7 +57278,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1071",
+      "source_location": "L1189",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -55446,7 +57288,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1049",
+      "source_location": "L1167",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_scan_included_files",
@@ -55466,7 +57308,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L608",
+      "source_location": "L726",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_skip_argument_separators",
@@ -55476,7 +57318,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L539",
+      "source_location": "L657",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_skip_keyword_separators",
@@ -55486,7 +57328,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L528",
+      "source_location": "L394",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_ssh_hardening",
+      "target": "dot_local_bin_executable_ssh_hardening_stop_verify_child",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L646",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_trim_trailing_line_whitespace",
@@ -55496,7 +57348,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L844",
+      "source_location": "L962",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
@@ -55506,7 +57358,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2410",
+      "source_location": "L2530",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_usage",
@@ -55516,7 +57368,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1965",
+      "source_location": "L2085",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
@@ -55526,7 +57378,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1237",
+      "source_location": "L1355",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_verify",
@@ -55536,7 +57388,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L351",
+      "source_location": "L469",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_verify_skip_allowed",
@@ -55546,7 +57398,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2082",
+      "source_location": "L2202",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
@@ -55556,7 +57408,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L242",
+      "source_location": "L249",
       "weight": 1.0,
       "source": "dot_local_bin_executable_ssh_hardening",
       "target": "dot_local_bin_executable_ssh_hardening_warn",
@@ -55566,7 +57418,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2467",
+      "source_location": "L2587",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_sh__entry",
@@ -55577,7 +57429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2360",
+      "source_location": "L2480",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
@@ -55588,7 +57440,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1346",
+      "source_location": "L1466",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55599,7 +57451,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2124",
+      "source_location": "L2244",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -55610,7 +57462,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1902",
+      "source_location": "L2022",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_report_absent_service_outcome",
@@ -55621,7 +57473,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2018",
+      "source_location": "L2138",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_resolve_probe_ports",
@@ -55632,7 +57484,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2401",
+      "source_location": "L2521",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
@@ -55643,7 +57495,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1968",
+      "source_location": "L2088",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_validate_readiness_knobs",
@@ -55654,7 +57506,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2100",
+      "source_location": "L2220",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
@@ -55665,7 +57517,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1407",
+      "source_location": "L1527",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55676,7 +57528,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1906",
+      "source_location": "L2026",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_report_absent_service_outcome",
@@ -55687,7 +57539,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1311",
+      "source_location": "L1431",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_rollback_install",
@@ -55698,7 +57550,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1347",
+      "source_location": "L1467",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55709,7 +57561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2400",
+      "source_location": "L2520",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
@@ -55720,7 +57572,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1310",
+      "source_location": "L1430",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_rollback_install",
@@ -55731,7 +57583,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2454",
+      "source_location": "L2574",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -55742,7 +57594,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1355",
+      "source_location": "L1475",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55753,7 +57605,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2453",
+      "source_location": "L2573",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -55764,7 +57616,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1401",
+      "source_location": "L455",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_ssh_hardening_run_verify_child",
+      "target": "dot_local_bin_executable_ssh_hardening_stop_verify_child",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_ssh-hardening.sh",
+      "source_location": "L1521",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55775,7 +57638,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2160",
+      "source_location": "L2280",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -55786,7 +57649,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2356",
+      "source_location": "L2476",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
@@ -55797,7 +57660,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1412",
+      "source_location": "L1532",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -55808,7 +57671,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1240",
+      "source_location": "L1358",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_verify",
@@ -55819,7 +57682,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L425",
+      "source_location": "L543",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_assert_output_hardened",
@@ -55830,7 +57693,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1214",
+      "source_location": "L1332",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
@@ -55841,7 +57704,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L440",
+      "source_location": "L558",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_global",
@@ -55852,7 +57715,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1196",
+      "source_location": "L1314",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_match_scan",
@@ -55863,7 +57726,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1075",
+      "source_location": "L1193",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -55874,7 +57737,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1054",
+      "source_location": "L1172",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_included_files",
@@ -55885,7 +57748,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1124",
+      "source_location": "L1242",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -55896,7 +57759,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1125",
+      "source_location": "L1243",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -55907,7 +57770,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1233",
+      "source_location": "L1351",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_connection_specs",
@@ -55918,7 +57781,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L443",
+      "source_location": "L561",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_global",
@@ -55929,7 +57792,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1247",
+      "source_location": "L1365",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_verify",
@@ -55940,7 +57803,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L720",
+      "source_location": "L838",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
@@ -55951,7 +57814,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L556",
+      "source_location": "L674",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_consume_keyword_separator",
@@ -55962,7 +57825,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L569",
+      "source_location": "L687",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
@@ -55973,7 +57836,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L578",
+      "source_location": "L696",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_read_keyword_token",
@@ -55984,7 +57847,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L622",
+      "source_location": "L740",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_read_argument_token",
@@ -55995,7 +57858,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L710",
+      "source_location": "L828",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_next_argument_token",
@@ -56006,7 +57869,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L706",
+      "source_location": "L824",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_next_keyword_token",
@@ -56017,7 +57880,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L723",
+      "source_location": "L841",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
@@ -56028,7 +57891,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L743",
+      "source_location": "L861",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_parse_config_line",
@@ -56039,7 +57902,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1564",
+      "source_location": "L1684",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_from_file",
@@ -56050,7 +57913,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1104",
+      "source_location": "L1222",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -56061,7 +57924,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L867",
+      "source_location": "L985",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_unescape_include_pattern",
@@ -56072,7 +57935,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L952",
+      "source_location": "L1070",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_resolve_include_paths",
@@ -56083,7 +57946,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1570",
+      "source_location": "L1690",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_from_file",
@@ -56094,7 +57957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1053",
+      "source_location": "L1171",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_included_files",
@@ -56105,7 +57968,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1541",
+      "source_location": "L1661",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_from_file",
@@ -56116,7 +57979,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1092",
+      "source_location": "L1210",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -56127,7 +57990,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1113",
+      "source_location": "L1231",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_scan_config_file",
@@ -56138,7 +58001,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1204",
+      "source_location": "L1322",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_match_scan",
@@ -56149,7 +58012,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1195",
+      "source_location": "L1313",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_check_match_scan",
@@ -56160,7 +58023,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1603",
+      "source_location": "L1723",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_files",
@@ -56171,7 +58034,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1248",
+      "source_location": "L1366",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_verify",
@@ -56182,7 +58045,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1249",
+      "source_location": "L1367",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_verify",
@@ -56193,7 +58056,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2455",
+      "source_location": "L2575",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -56204,7 +58067,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1356",
+      "source_location": "L1476",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_install_dropin",
@@ -56215,7 +58078,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2458",
+      "source_location": "L2578",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -56226,7 +58089,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1612",
+      "source_location": "L1732",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_files",
@@ -56237,7 +58100,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1520",
+      "source_location": "L1640",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_from_file",
@@ -56248,7 +58111,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1616",
+      "source_location": "L1736",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_collect_config_tree_files",
@@ -56259,7 +58122,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1661",
+      "source_location": "L1781",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_observe_config_tree",
@@ -56270,7 +58133,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1674",
+      "source_location": "L1794",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_observe_config_tree",
@@ -56281,7 +58144,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2145",
+      "source_location": "L2265",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56292,7 +58155,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1901",
+      "source_location": "L2021",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_report_absent_service_outcome",
@@ -56303,7 +58166,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1767",
+      "source_location": "L1887",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_config_tree_find_record",
@@ -56314,7 +58177,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1807",
+      "source_location": "L1927",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_config_tree_is_unchanged",
@@ -56325,7 +58188,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1816",
+      "source_location": "L1936",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_config_tree_is_unchanged",
@@ -56336,7 +58199,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2194",
+      "source_location": "L2314",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56347,7 +58210,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L1904",
+      "source_location": "L2024",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_report_absent_service_outcome",
@@ -56358,7 +58221,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2172",
+      "source_location": "L2292",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56369,7 +58232,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2170",
+      "source_location": "L2290",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56380,7 +58243,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2112",
+      "source_location": "L2232",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56391,7 +58254,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2167",
+      "source_location": "L2287",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56402,7 +58265,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2091",
+      "source_location": "L2211",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_wait_for_ssh_banner",
@@ -56413,7 +58276,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2256",
+      "source_location": "L2376",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_reload_sshd",
@@ -56424,7 +58287,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2456",
+      "source_location": "L2576",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -56435,7 +58298,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2362",
+      "source_location": "L2482",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_confirm_password_access_restored",
@@ -56446,7 +58309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2397",
+      "source_location": "L2517",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_rollback_dropin",
@@ -56457,7 +58320,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2457",
+      "source_location": "L2577",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -56468,7 +58331,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_ssh-hardening.sh",
-      "source_location": "L2435",
+      "source_location": "L2555",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_ssh_hardening_main",
@@ -56479,7 +58342,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2739",
+      "source_location": "L2614",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_assert_superpowers_routing",
@@ -56489,7 +58352,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3509",
+      "source_location": "L3387",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -56499,7 +58362,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3452",
+      "source_location": "L3330",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_clone_fork_upstream",
@@ -56509,7 +58372,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L188",
+      "source_location": "L171",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_codex_policy",
@@ -56519,7 +58382,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2623",
+      "source_location": "L2430",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_converge_claude_skills",
@@ -56529,7 +58392,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2547",
+      "source_location": "L2302",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_converge_dir",
@@ -56539,7 +58402,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2697",
+      "source_location": "L2572",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_converge_hermes_skills",
@@ -56549,7 +58412,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3477",
+      "source_location": "L3355",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_discard_fork_clone",
@@ -56559,7 +58422,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3494",
+      "source_location": "L3372",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_fork_clone_head_resolves",
@@ -56569,7 +58432,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3349",
+      "source_location": "L3227",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_fork_entry_is_object",
@@ -56579,7 +58442,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3379",
+      "source_location": "L3257",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_fork_entry_unusable_fields",
@@ -56589,7 +58452,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3338",
+      "source_location": "L3216",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_fork_table_is_object",
@@ -56599,7 +58462,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3324",
+      "source_location": "L3202",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_fork_table_is_present",
@@ -56609,7 +58472,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L663",
+      "source_location": "L656",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
@@ -56619,7 +58482,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1494",
+      "source_location": "L1504",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_assert_overlays",
@@ -56629,7 +58492,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1257",
+      "source_location": "L1267",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_build_candidate",
@@ -56639,7 +58502,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L484",
+      "source_location": "L467",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_custom_lock_hash",
@@ -56649,7 +58512,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1576",
+      "source_location": "L1591",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
@@ -56659,7 +58522,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1869",
+      "source_location": "L1887",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_dryrun_drift_report",
@@ -56669,7 +58532,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L563",
+      "source_location": "L556",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_exchange",
@@ -56679,7 +58542,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L523",
+      "source_location": "L516",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_exchange_tool_capable",
@@ -56689,17 +58552,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1953",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange_would_defer",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L621",
+      "source_location": "L614",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
@@ -56709,7 +58562,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L472",
+      "source_location": "L455",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_hash_file",
@@ -56719,7 +58572,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2145",
+      "source_location": "L2138",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
@@ -56729,7 +58582,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L602",
+      "source_location": "L595",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_is_complete",
@@ -56739,7 +58592,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1386",
+      "source_location": "L1396",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
@@ -56749,7 +58602,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1328",
+      "source_location": "L1338",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_lane_force_reinstall",
@@ -56759,7 +58612,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1347",
+      "source_location": "L1357",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_lane_npx",
@@ -56769,7 +58622,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1856",
+      "source_location": "L1874",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_merge_lane_failures",
@@ -56779,7 +58632,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L594",
+      "source_location": "L587",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_meta_field",
@@ -56789,7 +58642,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L611",
+      "source_location": "L604",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_meta_matches_desired",
@@ -56799,7 +58652,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1134",
+      "source_location": "L1153",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_migrate",
@@ -56809,7 +58662,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1129",
+      "source_location": "L1148",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_migration_needed",
@@ -56819,7 +58672,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L923",
+      "source_location": "L943",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_name_is_tracked",
@@ -56829,7 +58682,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L934",
+      "source_location": "L954",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_name_was_generation_owned",
@@ -56839,7 +58692,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L498",
+      "source_location": "L491",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_new_id",
@@ -56849,7 +58702,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L674",
+      "source_location": "L667",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
@@ -56859,7 +58712,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L645",
+      "source_location": "L638",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
@@ -56869,7 +58722,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1776",
+      "source_location": "L1794",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
@@ -56879,7 +58732,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L791",
+      "source_location": "L784",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_prune_generations",
@@ -56889,7 +58742,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L691",
+      "source_location": "L684",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_publish",
@@ -56899,7 +58752,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1534",
+      "source_location": "L1544",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_reconcile_candidate_npx_lock",
@@ -56909,7 +58762,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1729",
+      "source_location": "L1747",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
@@ -56919,7 +58772,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1021",
+      "source_location": "L1040",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_recover",
@@ -56929,7 +58782,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L982",
+      "source_location": "L1001",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
@@ -56939,7 +58792,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1940",
+      "source_location": "L1962",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_reset_failure_streaks",
@@ -56949,7 +58802,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L546",
+      "source_location": "L539",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_resolve_exchange_tool",
@@ -56959,7 +58812,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L858",
+      "source_location": "L874",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_roster_schema_ok",
@@ -56969,7 +58822,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2073",
+      "source_location": "L2070",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_roster_skill_health",
@@ -56979,7 +58832,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L914",
+      "source_location": "L934",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_roster_unchanged",
@@ -56989,7 +58842,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1615",
+      "source_location": "L1630",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_run_lanes",
@@ -56999,7 +58852,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L507",
+      "source_location": "L500",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_same_device",
@@ -57009,7 +58862,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L880",
+      "source_location": "L900",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_snapshot_roster",
@@ -57019,7 +58872,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L943",
+      "source_location": "L963",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
@@ -57029,7 +58882,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1462",
+      "source_location": "L1472",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_strip_codex_policy",
@@ -57039,7 +58892,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L633",
+      "source_location": "L626",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_sweep_garbage",
@@ -57049,7 +58902,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L810",
+      "source_location": "L803",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_tracked_names",
@@ -57059,7 +58912,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1901",
+      "source_location": "L1919",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_update_failure_streaks",
@@ -57069,7 +58922,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L485",
+      "source_location": "L478",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_updater_hash",
@@ -57079,7 +58932,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1647",
+      "source_location": "L1662",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_validate_candidate",
@@ -57089,7 +58942,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1812",
+      "source_location": "L1830",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
@@ -57099,7 +58952,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1964",
+      "source_location": "L1973",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
@@ -57109,7 +58962,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L580",
+      "source_location": "L573",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_gen_write_meta",
@@ -57119,7 +58972,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2652",
+      "source_location": "L2527",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_is_hermes_collision_name",
@@ -57129,7 +58982,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3309",
+      "source_location": "L3187",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_lock_is_readable_json_object",
@@ -57139,7 +58992,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L219",
+      "source_location": "L202",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_log",
@@ -57149,7 +59002,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3252",
+      "source_location": "L3130",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_clone_timeout",
@@ -57159,7 +59012,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3263",
+      "source_location": "L3141",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_clone_unstageable",
@@ -57169,7 +59022,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3192",
+      "source_location": "L3070",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_drift",
@@ -57179,7 +59032,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3397",
+      "source_location": "L3275",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_entry_malformed",
@@ -57189,7 +59042,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3276",
+      "source_location": "L3154",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_lock_missing",
@@ -57199,7 +59052,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3205",
+      "source_location": "L3083",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_path_missing",
@@ -57209,7 +59062,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3239",
+      "source_location": "L3117",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_upstream_headless",
@@ -57219,7 +59072,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3221",
+      "source_location": "L3099",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_upstream_unreachable",
@@ -57229,7 +59082,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3289",
+      "source_location": "L3167",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_notify_fork_walk_incomplete",
@@ -57239,7 +59092,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1319",
+      "source_location": "L1329",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_record_failed_skill",
@@ -57249,7 +59102,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1855",
+      "source_location": "L1873",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_record_failed_skill_parent",
@@ -57259,7 +59112,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L402",
+      "source_location": "L385",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_record_required_failure",
@@ -57269,7 +59122,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2868",
+      "source_location": "L2741",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_refresh_app_owned_cua_pack",
@@ -57279,7 +59132,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3181",
+      "source_location": "L3059",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_relay_fork_advisory",
@@ -57289,7 +59142,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3499",
+      "source_location": "L2479",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_update_skills",
+      "target": "dot_local_bin_executable_update_skills_report_unrostered_live_content",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3377",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_resolve_fork_upstream_hash",
@@ -57299,7 +59162,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3652",
+      "source_location": "L3530",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_run_fork_drift_watch",
@@ -57319,7 +59182,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3408",
+      "source_location": "L3286",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_stop_fork_clone",
@@ -57329,7 +59192,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2794",
+      "source_location": "L2667",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_hermes_registry_skills",
@@ -57339,7 +59202,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2253",
+      "source_location": "L2223",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_acquire_lock",
@@ -57349,17 +59212,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2442",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_activity_state",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L448",
+      "source_location": "L431",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_alert",
@@ -57369,7 +59222,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L309",
+      "source_location": "L292",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_change_snapshot",
@@ -57379,50 +59232,10 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3753",
+      "source_location": "L2412",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_cleanup",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2326",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_effective_program",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2405",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_harness_active",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2680",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_hermes_dir_safe",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2661",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_hermes_profile_universe",
+      "target": "dot_local_bin_executable_update_skills_update_skills_claude_delivery_malformed",
       "confidence_score": 1.0
     },
     {
@@ -57432,14 +59245,44 @@
       "source_location": "L2391",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_is_interactive_harness",
+      "target": "dot_local_bin_executable_update_skills_update_skills_claude_undelivered",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2515",
+      "source_location": "L3631",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_update_skills",
+      "target": "dot_local_bin_executable_update_skills_update_skills_cleanup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2555",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_update_skills",
+      "target": "dot_local_bin_executable_update_skills_update_skills_hermes_dir_safe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2536",
+      "weight": 1.0,
+      "source": "dot_local_bin_executable_update_skills",
+      "target": "dot_local_bin_executable_update_skills_update_skills_hermes_profile_universe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2271",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_is_owned_link",
@@ -57449,7 +59292,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L184",
+      "source_location": "L167",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_last_slot_hour",
@@ -57459,17 +59302,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2455",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_make_cutoff_sentinel",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L415",
+      "source_location": "L398",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_no_scheduled_slot_remains",
@@ -57479,7 +59312,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L439",
+      "source_location": "L422",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_note_scheduled_attempt",
@@ -57489,7 +59322,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L259",
+      "source_location": "L242",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_record",
@@ -57499,7 +59332,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L432",
+      "source_location": "L415",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_scheduled_budget_exhausted",
@@ -57509,17 +59342,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2481",
-      "weight": 1.0,
-      "source": "dot_local_bin_executable_update_skills",
-      "target": "dot_local_bin_executable_update_skills_update_skills_should_defer",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L492",
+      "source_location": "L485",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_stamp_value",
@@ -57529,7 +59352,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L383",
+      "source_location": "L366",
       "weight": 1.0,
       "source": "dot_local_bin_executable_update_skills",
       "target": "dot_local_bin_executable_update_skills_update_skills_take_snapshot",
@@ -57539,7 +59362,7 @@
       "relation": "imports",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L229",
+      "source_location": "L212",
       "weight": 1.0,
       "context": "import",
       "source": "dot_local_bin_executable_update_skills",
@@ -57550,7 +59373,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3677",
+      "source_location": "L3556",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57561,7 +59384,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3674",
+      "source_location": "L3552",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57572,7 +59395,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3675",
+      "source_location": "L3553",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57583,7 +59406,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2286",
+      "source_location": "L2256",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57594,7 +59417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3673",
+      "source_location": "L3551",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57605,7 +59428,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3693",
+      "source_location": "L3579",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57616,7 +59439,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3723",
+      "source_location": "L3601",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57627,7 +59450,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3721",
+      "source_location": "L3599",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57638,7 +59461,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2977",
+      "source_location": "L2868",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57649,7 +59472,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3848",
+      "source_location": "L3716",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57660,7 +59483,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3829",
+      "source_location": "L3697",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57671,7 +59494,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2943",
+      "source_location": "L2835",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57682,7 +59505,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3860",
+      "source_location": "L3728",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57693,7 +59516,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3696",
+      "source_location": "L3582",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57704,7 +59527,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3777",
+      "source_location": "L3655",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57715,7 +59538,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2901",
+      "source_location": "L2774",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57726,7 +59549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2924",
+      "source_location": "L2816",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57737,7 +59560,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3676",
+      "source_location": "L3555",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57748,7 +59571,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3662",
+      "source_location": "L3554",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_sh__entry",
+      "target": "dot_local_bin_executable_update_skills_report_unrostered_live_content",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3540",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57759,7 +59593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3678",
+      "source_location": "L3557",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57770,7 +59604,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2918",
+      "source_location": "L2791",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57781,7 +59615,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2925",
+      "source_location": "L2811",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57792,7 +59626,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3012",
+      "source_location": "L2899",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57803,7 +59637,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2921",
+      "source_location": "L2813",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57814,7 +59648,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3015",
+      "source_location": "L2808",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57825,18 +59659,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3013",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_sh__entry",
-      "target": "dot_local_bin_executable_update_skills_update_skills_should_defer",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3842",
+      "source_location": "L3710",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57847,7 +59670,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3760",
+      "source_location": "L3638",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_sh__entry",
@@ -57858,7 +59681,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2748",
+      "source_location": "L2623",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_assert_superpowers_routing",
@@ -57869,7 +59692,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3525",
+      "source_location": "L3403",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -57880,7 +59703,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2567",
+      "source_location": "L2449",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_converge_claude_skills",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2322",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_dir",
@@ -57891,7 +59725,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3480",
+      "source_location": "L3358",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_discard_fork_clone",
@@ -57902,7 +59736,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1272",
+      "source_location": "L1282",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_build_candidate",
@@ -57913,7 +59747,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1585",
+      "source_location": "L1600",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
@@ -57924,7 +59758,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1871",
+      "source_location": "L1889",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_dryrun_drift_report",
@@ -57935,7 +59769,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L565",
+      "source_location": "L558",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_exchange",
@@ -57946,1155 +59780,11 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2159",
+      "source_location": "L2151",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
       "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1391",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1373",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1158",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1789",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L706",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1751",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1042",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L990",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L883",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_snapshot_roster",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1932",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_update_failure_streaks",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1651",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_validate_candidate",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1821",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1970",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3254",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_clone_timeout",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3265",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_clone_unstageable",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3194",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_drift",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3399",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_entry_malformed",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3278",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_lock_missing",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3207",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_path_missing",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3241",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_headless",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3223",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_unreachable",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3291",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_notify_fork_walk_incomplete",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L404",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_record_required_failure",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2872",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_refresh_app_owned_cua_pack",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3654",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_run_fork_drift_watch",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2802",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_hermes_registry_skills",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2260",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_acquire_lock",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2688",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_hermes_dir_safe",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L265",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_record",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L390",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_take_snapshot",
-      "target": "dot_local_bin_executable_update_skills_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L385",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_take_snapshot",
-      "target": "dot_local_bin_executable_update_skills_update_skills_change_snapshot",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2749",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_assert_superpowers_routing",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2574",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_converge_dir",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1504",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_assert_overlays",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2185",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1392",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1376",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1199",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1800",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1560",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_candidate_npx_lock",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1736",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1822",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1972",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2803",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_hermes_registry_skills",
-      "target": "dot_local_bin_executable_update_skills_record_required_failure",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L434",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_scheduled_budget_exhausted",
-      "target": "dot_local_bin_executable_update_skills_update_skills_no_scheduled_slot_remains",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1937",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_update_failure_streaks",
-      "target": "dot_local_bin_executable_update_skills_update_skills_alert",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L484",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_custom_lock_hash",
-      "target": "dot_local_bin_executable_update_skills_gen_hash_file",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L485",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_updater_hash",
-      "target": "dot_local_bin_executable_update_skills_gen_hash_file",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L731",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_gen_same_device",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L550",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_resolve_exchange_tool",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange_tool_capable",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L564",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_exchange",
-      "target": "dot_local_bin_executable_update_skills_gen_resolve_exchange_tool",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1173",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L763",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1602",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
-      "target": "dot_local_bin_executable_update_skills_gen_write_meta",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1156",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_write_meta",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1884",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_dryrun_drift_report",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1139",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1131",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migration_needed",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L709",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1048",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2084",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_roster_skill_health",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1654",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_validate_candidate",
-      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1048",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_meta_matches_desired",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L667",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1261",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_build_candidate",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2186",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1141",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1790",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L802",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_generations",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L776",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1067",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1007",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1973",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L794",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_generations",
-      "target": "dot_local_bin_executable_update_skills_gen_sweep_garbage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1025",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_sweep_garbage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L669",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1202",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1736",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1101",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1749",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2233",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1214",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1091",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1988",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2217",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_publish",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L781",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_publish",
-      "target": "dot_local_bin_executable_update_skills_gen_prune_generations",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1983",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_publish",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L886",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_snapshot_roster",
-      "target": "dot_local_bin_executable_update_skills_gen_roster_schema_ok",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2202",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_roster_unchanged",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1971",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_roster_unchanged",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1271",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_build_candidate",
-      "target": "dot_local_bin_executable_update_skills_gen_name_is_tracked",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1788",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_name_is_tracked",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1788",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_name_was_generation_owned",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1185",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_migrate",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1795",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1755",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1102",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2091",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_roster_skill_health",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1818",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
-      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1024",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_recover",
-      "target": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2184",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_build_candidate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2003",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_build_candidate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1417",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
-      "target": "dot_local_bin_executable_update_skills_record_failed_skill",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1377",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
-      "target": "dot_local_bin_executable_update_skills_record_failed_skill",
       "confidence_score": 1.0
     },
     {
@@ -59105,139 +59795,953 @@
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
-      "target": "dot_local_bin_executable_update_skills_gen_lane_force_reinstall",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1363",
+      "source_location": "L1383",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
-      "target": "dot_local_bin_executable_update_skills_gen_lane_force_reinstall",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1586",
+      "source_location": "L1177",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
-      "target": "dot_local_bin_executable_update_skills_gen_lane_npx",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1588",
+      "source_location": "L1807",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
-      "target": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1518",
+      "source_location": "L699",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_assert_overlays",
-      "target": "dot_local_bin_executable_update_skills_gen_strip_codex_policy",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1590",
+      "source_location": "L1769",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
-      "target": "dot_local_bin_executable_update_skills_gen_assert_overlays",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1592",
+      "source_location": "L1061",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
-      "target": "dot_local_bin_executable_update_skills_gen_reconcile_candidate_npx_lock",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2191",
+      "source_location": "L1009",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_run_lanes",
+      "source": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2010",
+      "source_location": "L903",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_run_lanes",
+      "source": "dot_local_bin_executable_update_skills_gen_snapshot_roster",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2197",
+      "source_location": "L1954",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_validate_candidate",
+      "source": "dot_local_bin_executable_update_skills_gen_update_failure_streaks",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1683",
+      "source_location": "L1666",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_validate_candidate",
-      "target": "dot_local_bin_executable_update_skills_record_failed_skill_parent",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1967",
+      "source_location": "L1839",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1979",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_validate_candidate",
+      "target": "dot_local_bin_executable_update_skills_log",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2229",
+      "source_location": "L3132",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_clone_timeout",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3143",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_clone_unstageable",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3072",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_drift",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3277",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_entry_malformed",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3156",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_lock_missing",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3085",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_path_missing",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3119",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_headless",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3101",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_unreachable",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3169",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_notify_fork_walk_incomplete",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L387",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_record_required_failure",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2745",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_refresh_app_owned_cua_pack",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2506",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_report_unrostered_live_content",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L3532",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_run_fork_drift_watch",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2675",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_hermes_registry_skills",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2230",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_acquire_lock",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2563",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_hermes_dir_safe",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L248",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_record",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L373",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_take_snapshot",
+      "target": "dot_local_bin_executable_update_skills_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L368",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_take_snapshot",
+      "target": "dot_local_bin_executable_update_skills_update_skills_change_snapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2624",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_assert_superpowers_routing",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2438",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_converge_claude_skills",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2329",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_converge_dir",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1514",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_assert_overlays",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2164",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1402",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1386",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1218",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1818",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1575",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_candidate_npx_lock",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1754",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1840",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1981",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2676",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_hermes_registry_skills",
+      "target": "dot_local_bin_executable_update_skills_record_required_failure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L417",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_update_skills_scheduled_budget_exhausted",
+      "target": "dot_local_bin_executable_update_skills_update_skills_no_scheduled_slot_remains",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1959",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_update_failure_streaks",
+      "target": "dot_local_bin_executable_update_skills_update_skills_alert",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L467",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_custom_lock_hash",
+      "target": "dot_local_bin_executable_update_skills_gen_hash_file",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L724",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_gen_same_device",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L543",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_resolve_exchange_tool",
+      "target": "dot_local_bin_executable_update_skills_gen_exchange_tool_capable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L557",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_exchange",
+      "target": "dot_local_bin_executable_update_skills_gen_resolve_exchange_tool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1192",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_exchange",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L756",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_gen_exchange",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1617",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
+      "target": "dot_local_bin_executable_update_skills_gen_write_meta",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1175",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_write_meta",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1902",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_dryrun_drift_report",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1158",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1150",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migration_needed",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L702",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1067",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2081",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_roster_skill_health",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1669",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_validate_candidate",
+      "target": "dot_local_bin_executable_update_skills_gen_is_complete",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1067",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_meta_matches_desired",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L660",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1271",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_build_candidate",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2165",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1160",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1808",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L795",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_generations",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L769",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1086",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1026",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1982",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_garbage_destroy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L787",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_generations",
+      "target": "dot_local_bin_executable_update_skills_gen_sweep_garbage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1044",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_sweep_garbage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L662",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1221",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1754",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1120",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_store_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1767",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_absorb_store_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2203",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1233",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1110",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1991",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_plant_lock_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2187",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_publish",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L774",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_publish",
+      "target": "dot_local_bin_executable_update_skills_gen_prune_generations",
       "confidence_score": 1.0
     },
     {
@@ -59248,62 +60752,271 @@
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_publish",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1987",
+      "source_location": "L906",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "source": "dot_local_bin_executable_update_skills_gen_snapshot_roster",
+      "target": "dot_local_bin_executable_update_skills_gen_roster_schema_ok",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1823",
-      "weight": 1.0,
-      "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
-      "target": "dot_local_bin_executable_update_skills_record_failed_skill_parent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2192",
+      "source_location": "L2181",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_merge_lane_failures",
+      "target": "dot_local_bin_executable_update_skills_gen_roster_unchanged",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2011",
+      "source_location": "L1980",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_merge_lane_failures",
+      "target": "dot_local_bin_executable_update_skills_gen_roster_unchanged",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L1956",
+      "source_location": "L1281",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_gen_exchange_would_defer",
-      "target": "dot_local_bin_executable_update_skills_update_skills_should_defer",
+      "source": "dot_local_bin_executable_update_skills_gen_build_candidate",
+      "target": "dot_local_bin_executable_update_skills_gen_name_is_tracked",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1806",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_name_is_tracked",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1806",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_name_was_generation_owned",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1204",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_migrate",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1813",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1773",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1121",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2088",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_roster_skill_health",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1836",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
+      "target": "dot_local_bin_executable_update_skills_gen_store_link_correct",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1043",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_recover",
+      "target": "dot_local_bin_executable_update_skills_gen_recover_exchange_marker",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2163",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_build_candidate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2006",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_build_candidate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1427",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
+      "target": "dot_local_bin_executable_update_skills_record_failed_skill",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1387",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
+      "target": "dot_local_bin_executable_update_skills_record_failed_skill",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1411",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
+      "target": "dot_local_bin_executable_update_skills_gen_lane_force_reinstall",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1373",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_lane_npx",
+      "target": "dot_local_bin_executable_update_skills_gen_lane_force_reinstall",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1601",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
+      "target": "dot_local_bin_executable_update_skills_gen_lane_npx",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1603",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
+      "target": "dot_local_bin_executable_update_skills_gen_lane_clawhub",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1528",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_assert_overlays",
+      "target": "dot_local_bin_executable_update_skills_gen_strip_codex_policy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1605",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
+      "target": "dot_local_bin_executable_update_skills_gen_assert_overlays",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1607",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_do_build_lanes",
+      "target": "dot_local_bin_executable_update_skills_gen_reconcile_candidate_npx_lock",
       "confidence_score": 1.0
     },
     {
@@ -59314,7 +61027,40 @@
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange_would_defer",
+      "target": "dot_local_bin_executable_update_skills_gen_run_lanes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2013",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_run_lanes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2176",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_validate_candidate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L1701",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_validate_candidate",
+      "target": "dot_local_bin_executable_update_skills_record_failed_skill_parent",
       "confidence_score": 1.0
     },
     {
@@ -59325,47 +61071,80 @@
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
-      "target": "dot_local_bin_executable_update_skills_gen_exchange_would_defer",
+      "target": "dot_local_bin_executable_update_skills_gen_validate_candidate",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2412",
+      "source_location": "L2199",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_harness_active",
-      "target": "dot_local_bin_executable_update_skills_update_skills_is_interactive_harness",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2482",
+      "source_location": "L1989",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_should_defer",
-      "target": "dot_local_bin_executable_update_skills_update_skills_harness_active",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_reconcile_store_links",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2493",
+      "source_location": "L1990",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_executable_update_skills_update_skills_should_defer",
-      "target": "dot_local_bin_executable_update_skills_update_skills_activity_state",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_prune_delisted_store_links",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2565",
+      "source_location": "L1841",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_verify_live_overlays",
+      "target": "dot_local_bin_executable_update_skills_record_failed_skill_parent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2171",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_install_only_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_merge_lane_failures",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2014",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_gen_weekly_attempt",
+      "target": "dot_local_bin_executable_update_skills_gen_merge_lane_failures",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2320",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_dir",
@@ -59376,7 +61155,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2632",
+      "source_location": "L2456",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_claude_skills",
@@ -59387,7 +61166,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2724",
+      "source_location": "L2599",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_hermes_skills",
@@ -59398,7 +61177,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2718",
+      "source_location": "L2437",
+      "weight": 1.0,
+      "context": "call",
+      "source": "dot_local_bin_executable_update_skills_converge_claude_skills",
+      "target": "dot_local_bin_executable_update_skills_update_skills_claude_delivery_malformed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/executable_update-skills.sh",
+      "source_location": "L2593",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_hermes_skills",
@@ -59409,7 +61199,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L2714",
+      "source_location": "L2589",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_converge_hermes_skills",
@@ -59420,7 +61210,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3526",
+      "source_location": "L3404",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59431,7 +61221,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3256",
+      "source_location": "L3134",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_clone_timeout",
@@ -59442,7 +61232,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3266",
+      "source_location": "L3144",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_clone_unstageable",
@@ -59453,7 +61243,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3196",
+      "source_location": "L3074",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_drift",
@@ -59464,7 +61254,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3400",
+      "source_location": "L3278",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_entry_malformed",
@@ -59475,7 +61265,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3279",
+      "source_location": "L3157",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_lock_missing",
@@ -59486,7 +61276,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3209",
+      "source_location": "L3087",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_path_missing",
@@ -59497,7 +61287,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3243",
+      "source_location": "L3121",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_headless",
@@ -59508,7 +61298,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3228",
+      "source_location": "L3106",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_upstream_unreachable",
@@ -59519,7 +61309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3292",
+      "source_location": "L3170",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_notify_fork_walk_incomplete",
@@ -59530,7 +61320,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3627",
+      "source_location": "L3505",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59541,7 +61331,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3620",
+      "source_location": "L3498",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59552,7 +61342,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3610",
+      "source_location": "L3488",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59563,7 +61353,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3615",
+      "source_location": "L3493",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59574,7 +61364,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3604",
+      "source_location": "L3482",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59585,7 +61375,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3597",
+      "source_location": "L3475",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59596,7 +61386,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3521",
+      "source_location": "L3399",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59607,7 +61397,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3632",
+      "source_location": "L3510",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59618,7 +61408,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3524",
+      "source_location": "L3402",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59629,7 +61419,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3530",
+      "source_location": "L3408",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59640,7 +61430,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3536",
+      "source_location": "L3414",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59651,7 +61441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3575",
+      "source_location": "L3453",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59662,7 +61452,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3576",
+      "source_location": "L3454",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59673,7 +61463,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3468",
+      "source_location": "L3346",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_clone_fork_upstream",
@@ -59684,7 +61474,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3600",
+      "source_location": "L3478",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59695,7 +61485,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3603",
+      "source_location": "L3481",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59706,7 +61496,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3613",
+      "source_location": "L3491",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_check_fork_drift",
@@ -59717,7 +61507,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/executable_update-skills.sh",
-      "source_location": "L3655",
+      "source_location": "L3533",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_executable_update_skills_run_fork_drift_watch",
@@ -60421,7 +62211,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L458",
+      "source_location": "L505",
       "weight": 1.0,
       "source": "dot_local_bin_unattended_log_lib",
       "target": "dot_local_bin_unattended_log_lib_unattended_log_alert_delivery_failure",
@@ -60431,7 +62221,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L329",
+      "source_location": "L371",
       "weight": 1.0,
       "source": "dot_local_bin_unattended_log_lib",
       "target": "dot_local_bin_unattended_log_lib_unattended_log_change_line",
@@ -60441,10 +62231,20 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L376",
+      "source_location": "L423",
       "weight": 1.0,
       "source": "dot_local_bin_unattended_log_lib",
       "target": "dot_local_bin_unattended_log_lib_unattended_log_change_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/bin/unattended-log-lib.sh",
+      "source_location": "L326",
+      "weight": 1.0,
+      "source": "dot_local_bin_unattended_log_lib",
+      "target": "dot_local_bin_unattended_log_lib_unattended_log_change_tuples",
       "confidence_score": 1.0
     },
     {
@@ -60541,7 +62341,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L419",
+      "source_location": "L466",
       "weight": 1.0,
       "source": "dot_local_bin_unattended_log_lib",
       "target": "dot_local_bin_unattended_log_lib_unattended_log_post",
@@ -60581,7 +62381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L465",
+      "source_location": "L512",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_unattended_log_lib_unattended_log_alert_delivery_failure",
@@ -60592,10 +62392,10 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L348",
+      "source_location": "L339",
       "weight": 1.0,
       "context": "call",
-      "source": "dot_local_bin_unattended_log_lib_unattended_log_change_line",
+      "source": "dot_local_bin_unattended_log_lib_unattended_log_change_tuples",
       "target": "dot_local_bin_unattended_log_lib_unattended_log_lookup",
       "confidence_score": 1.0
     },
@@ -60603,7 +62403,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/bin/unattended-log-lib.sh",
-      "source_location": "L383",
+      "source_location": "L430",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_bin_unattended_log_lib_unattended_log_change_section",
@@ -62430,7 +64230,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L73",
+      "source_location": "L75",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_results_alerter",
       "target": "dot_local_libexec_osquery_executable_results_alerter_checkpoint",
@@ -62440,7 +64240,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L75",
+      "source_location": "L77",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_results_alerter",
       "target": "dot_local_libexec_osquery_executable_results_alerter_main",
@@ -62460,7 +64260,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L60",
+      "source_location": "L62",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_executable_results_alerter",
       "target": "dot_local_libexec_osquery_executable_results_alerter_take_single_instance_lock",
@@ -62470,7 +64270,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L207",
+      "source_location": "L209",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_results_alerter_sh__entry",
@@ -62481,7 +64281,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L84",
+      "source_location": "L86",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_results_alerter_main",
@@ -62492,7 +64292,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/executable_results-alerter.sh",
-      "source_location": "L203",
+      "source_location": "L205",
       "weight": 1.0,
       "context": "call",
       "source": "dot_local_libexec_osquery_executable_results_alerter_main",
@@ -62731,7 +64531,7 @@
       "relation": "imports",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L502",
+      "source_location": "L518",
       "weight": 1.0,
       "context": "import",
       "source": "test_integration_osquery_pipeline_manifest_agreement",
@@ -62767,6 +64567,66 @@
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_digest_store",
       "target": "dot_local_libexec_osquery_results_alerter_digest_store_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_disk_hash",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_recorded_hash",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_short",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L297",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_triage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L205",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_file_integrity_upgrade_line",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "dot_local/libexec/osquery/results-alerter/file-integrity-triage.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "dot_local_libexec_osquery_results_alerter_file_integrity_triage",
+      "target": "dot_local_libexec_osquery_results_alerter_file_integrity_triage_sh__entry",
       "confidence_score": 1.0
     },
     {
@@ -63010,7 +64870,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "dot_local/libexec/osquery/results-alerter/render-page.sh",
-      "source_location": "L22",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "dot_local_libexec_osquery_results_alerter_render_page",
       "target": "dot_local_libexec_osquery_results_alerter_render_page_render_page",
@@ -65075,7 +66935,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L217",
+      "source_location": "L233",
       "weight": 1.0,
       "source": "test_e2e_bashrc_brew_cache_self_heal",
       "target": "test_e2e_bashrc_brew_cache_self_heal_assert_did_not_regenerate",
@@ -65085,7 +66945,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L206",
+      "source_location": "L223",
       "weight": 1.0,
       "source": "test_e2e_bashrc_brew_cache_self_heal",
       "target": "test_e2e_bashrc_brew_cache_self_heal_assert_regenerated",
@@ -65185,6 +67045,16 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "test_e2e_bashrc_brew_cache_self_heal",
+      "target": "test_e2e_bashrc_brew_cache_self_heal_wait_for_file_content",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
       "source_location": "L197",
       "weight": 1.0,
       "source": "test_e2e_bashrc_brew_cache_self_heal",
@@ -65195,7 +67065,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L237",
+      "source_location": "L253",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65206,7 +67076,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L249",
+      "source_location": "L265",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65217,7 +67087,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L236",
+      "source_location": "L252",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65228,7 +67098,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L276",
+      "source_location": "L294",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65250,7 +67120,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L234",
+      "source_location": "L250",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65261,7 +67131,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L235",
+      "source_location": "L251",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65272,7 +67142,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L303",
+      "source_location": "L321",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65283,7 +67153,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L356",
+      "source_location": "L269",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
+      "target": "test_e2e_bashrc_brew_cache_self_heal_wait_for_file_content",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
+      "source_location": "L374",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_sh__entry",
@@ -65294,7 +67175,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L221",
+      "source_location": "L237",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_assert_did_not_regenerate",
@@ -65305,7 +67186,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L209",
+      "source_location": "L226",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_assert_regenerated",
@@ -65338,11 +67219,11 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/bashrc-brew-cache-self-heal.sh",
-      "source_location": "L208",
+      "source_location": "L225",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_bashrc_brew_cache_self_heal_assert_regenerated",
-      "target": "test_e2e_bashrc_brew_cache_self_heal_wait_for_invocations",
+      "target": "test_e2e_bashrc_brew_cache_self_heal_wait_for_file_content",
       "confidence_score": 1.0
     },
     {
@@ -65543,6 +67424,16 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/homebrew-weekly-lock.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "test_e2e_homebrew_weekly_lock",
+      "target": "test_e2e_homebrew_weekly_lock_homebrew_weekly_state_dir",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-lock.sh",
@@ -65567,7 +67458,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L138",
+      "source_location": "L142",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_alert_entries",
@@ -65577,7 +67468,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L221",
+      "source_location": "L225",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_brew_after",
@@ -65587,7 +67478,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L218",
+      "source_location": "L222",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_brew_before",
@@ -65597,7 +67488,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L141",
+      "source_location": "L145",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_brew_fail",
@@ -65607,7 +67498,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L142",
+      "source_location": "L146",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_brew_versions",
@@ -65617,7 +67508,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L379",
+      "source_location": "L410",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_clock_ticks",
@@ -65627,7 +67518,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L27",
+      "source_location": "L31",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_fail",
@@ -65637,7 +67528,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L137",
+      "source_location": "L141",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_log_entries",
@@ -65647,7 +67538,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L139",
+      "source_location": "L143",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_log_entry_count",
@@ -65657,7 +67548,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L225",
+      "source_location": "L229",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_mas_after",
@@ -65667,7 +67558,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L144",
+      "source_location": "L148",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_mas_versions",
@@ -65677,7 +67568,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L32",
+      "source_location": "L36",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_refute",
@@ -65687,7 +67578,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L352",
+      "source_location": "L383",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_relay_stub_outcome",
@@ -65697,7 +67588,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L124",
+      "source_location": "L128",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_run_helper",
@@ -65717,7 +67608,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L66",
+      "source_location": "L70",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_unattended_log_hermes_url",
@@ -65727,7 +67618,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L212",
+      "source_location": "L216",
       "weight": 1.0,
       "source": "test_e2e_homebrew_weekly_record",
       "target": "test_e2e_homebrew_weekly_record_upgrade_marker",
@@ -65737,7 +67628,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L40",
+      "source_location": "L44",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_homebrew_weekly_record_sh__entry",
@@ -65748,7 +67639,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L169",
+      "source_location": "L173",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_homebrew_weekly_record_sh__entry",
@@ -65759,7 +67650,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L149",
+      "source_location": "L153",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_homebrew_weekly_record_sh__entry",
@@ -65770,7 +67661,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L36",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_homebrew_weekly_record_refute",
@@ -65781,7 +67672,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/homebrew-weekly-record.sh",
-      "source_location": "L139",
+      "source_location": "L143",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_homebrew_weekly_record_log_entry_count",
@@ -65831,376 +67722,228 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L183",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L124",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_alerted",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_alert_entries",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L42",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L20",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_cleanup",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_fail",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L181",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L123",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_deferred",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_log_entries",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L182",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L25",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_early_exited",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_refute",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L36",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L113",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L118",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_fake_week",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L137",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_harness_absent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L138",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_harness_active",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L155",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_harness_file_aged",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L142",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_harness_stale",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L149",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_harness_unreadable",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L117",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_path",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L180",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_proceeded",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L133",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_reset_activity",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L169",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_run_gate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L178",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_run_gate_sched",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_run_helper",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
       "source_location": "L1",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_sh__entry",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_sh__entry",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L127",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L62",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_update_skills_claude_activity_dir",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_unattended_log_hermes_url",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L128",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L75",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_update_skills_codex_activity_dir",
+      "source": "test_e2e_report_plugin_updates_record",
+      "target": "test_e2e_report_plugin_updates_record_write_plugin_state",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_report_plugin_updates_record_sh__entry",
+      "target": "test_e2e_report_plugin_updates_record_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L134",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_report_plugin_updates_record_sh__entry",
+      "target": "test_e2e_report_plugin_updates_record_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L131",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_report_plugin_updates_record_sh__entry",
+      "target": "test_e2e_report_plugin_updates_record_run_helper",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_report_plugin_updates_record_sh__entry",
+      "target": "test_e2e_report_plugin_updates_record_write_plugin_state",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/report-plugin-updates-record.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_report_plugin_updates_record_refute",
+      "target": "test_e2e_report_plugin_updates_record_fail",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L129",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L132",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_update_skills_hermes_activity_dir",
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_assert_pids_reaped",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L277",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L122",
       "weight": 1.0,
-      "source": "test_e2e_update_skills_defer",
-      "target": "test_e2e_update_skills_defer_update_skills_idle_threshold",
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_build_tree_with_previous_policy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L97",
+      "weight": 1.0,
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_file_fingerprint",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_ssh_hardening_verify_deadline",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_wedge_cleanup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "test_e2e_ssh_hardening_verify_watchdog",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_working_file_leftovers",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L317",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L226",
       "weight": 1.0,
       "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_alerted",
+      "source": "test_e2e_ssh_hardening_verify_watchdog_sh__entry",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_assert_pids_reaped",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L214",
+      "source_file": "test/e2e/ssh-hardening-verify-watchdog.sh",
+      "source_location": "L179",
       "weight": 1.0,
       "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_deferred",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L331",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_early_exited",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L213",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L261",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_harness_absent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L227",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_harness_active",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L270",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_harness_file_aged",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L209",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_harness_stale",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L251",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_harness_unreadable",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L213",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_proceeded",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L208",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_reset_activity",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L212",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_run_gate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L358",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_sh__entry",
-      "target": "test_e2e_update_skills_defer_run_gate_sched",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L176",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_run_gate",
-      "target": "test_e2e_update_skills_defer_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-defer.sh",
-      "source_location": "L178",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_defer_run_gate_sched",
-      "target": "test_e2e_update_skills_defer_run_gate",
+      "source": "test_e2e_ssh_hardening_verify_watchdog_sh__entry",
+      "target": "test_e2e_ssh_hardening_verify_watchdog_build_tree_with_previous_policy",
       "confidence_score": 1.0
     },
     {
@@ -66371,10 +68114,20 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-lock-contention.sh",
-      "source_location": "L93",
+      "source_location": "L99",
       "weight": 1.0,
       "source": "test_e2e_update_skills_lock_contention",
       "target": "test_e2e_update_skills_lock_contention_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-lock-contention.sh",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_lock_contention",
+      "target": "test_e2e_update_skills_lock_contention_run_contended",
       "confidence_score": 1.0
     },
     {
@@ -66422,11 +68175,33 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-lock-contention.sh",
-      "source_location": "L96",
+      "source_location": "L181",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_lock_contention_sh__entry",
+      "target": "test_e2e_update_skills_lock_contention_run_contended",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-lock-contention.sh",
+      "source_location": "L102",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_lock_contention_sh__entry",
       "target": "test_e2e_update_skills_lock_contention_write_lock",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-lock-contention.sh",
+      "source_location": "L173",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_lock_contention_run_contended",
+      "target": "test_e2e_update_skills_lock_contention_fail",
       "confidence_score": 1.0
     },
     {
@@ -66534,8 +68309,217 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_cleanup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L140",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_clear_agent_activity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L157",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_early_exited",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_fake_week",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_proceeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_run_updater",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_unattended",
+      "target": "test_e2e_update_skills_unattended_stage_live_agent_activity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L184",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_clear_agent_activity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L192",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_early_exited",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L165",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L165",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_proceeded",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L166",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L164",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_run_updater",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_sh__entry",
+      "target": "test_e2e_update_skills_unattended_stage_live_agent_activity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L47",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_refute",
+      "target": "test_e2e_update_skills_unattended_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-unattended.sh",
+      "source_location": "L153",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_unattended_run_updater",
+      "target": "test_e2e_update_skills_unattended_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L246",
+      "source_location": "L221",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_alert_entries",
@@ -66545,7 +68529,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L101",
+      "source_location": "L102",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_clawhub_version",
@@ -66555,7 +68539,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L57",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_cleanup",
@@ -66565,7 +68549,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L40",
+      "source_location": "L41",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_fail",
@@ -66575,7 +68559,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L614",
+      "source_location": "L562",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_fake_week",
@@ -66585,27 +68569,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L231",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_harness_absent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L227",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_harness_active",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L244",
+      "source_location": "L219",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_log_entries",
@@ -66615,7 +68579,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L247",
+      "source_location": "L222",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_log_entry_count",
@@ -66625,7 +68589,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L215",
+      "source_location": "L197",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_path",
@@ -66635,7 +68599,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L46",
+      "source_location": "L47",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_refute",
@@ -66645,7 +68609,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L252",
+      "source_location": "L227",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_reset_state",
@@ -66655,7 +68619,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L70",
+      "source_location": "L71",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_restage_lock",
@@ -66665,7 +68629,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L87",
+      "source_location": "L88",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_restage_lock_with_routing",
@@ -66675,7 +68639,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L236",
+      "source_location": "L211",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_run_updater",
@@ -66695,57 +68659,27 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L217",
+      "source_location": "L206",
+      "weight": 1.0,
+      "source": "test_e2e_update_skills_weekly_record",
+      "target": "test_e2e_update_skills_weekly_record_stage_refused_roster",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-weekly-record.sh",
+      "source_location": "L199",
       "weight": 1.0,
       "source": "test_e2e_update_skills_weekly_record",
       "target": "test_e2e_update_skills_weekly_record_unattended_log_hermes_url",
       "confidence_score": 1.0
     },
     {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L219",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_update_skills_claude_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L220",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_update_skills_codex_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L221",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_update_skills_hermes_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L222",
-      "weight": 1.0,
-      "source": "test_e2e_update_skills_weekly_record",
-      "target": "test_e2e_update_skills_weekly_record_update_skills_idle_threshold",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L105",
+      "source_location": "L106",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66756,7 +68690,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L54",
+      "source_location": "L55",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66767,29 +68701,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L297",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_weekly_record_sh__entry",
-      "target": "test_e2e_update_skills_weekly_record_harness_absent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L261",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_weekly_record_sh__entry",
-      "target": "test_e2e_update_skills_weekly_record_harness_active",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L354",
+      "source_location": "L329",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66800,7 +68712,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L260",
+      "source_location": "L234",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66811,7 +68723,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L90",
+      "source_location": "L91",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66822,7 +68734,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L503",
+      "source_location": "L477",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66833,7 +68745,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L262",
+      "source_location": "L236",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_sh__entry",
@@ -66844,7 +68756,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L50",
+      "source_location": "L235",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_e2e_update_skills_weekly_record_sh__entry",
+      "target": "test_e2e_update_skills_weekly_record_stage_refused_roster",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/e2e/update-skills-weekly-record.sh",
+      "source_location": "L51",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_refute",
@@ -66855,7 +68778,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L88",
+      "source_location": "L89",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_restage_lock_with_routing",
@@ -66866,18 +68789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L254",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_e2e_update_skills_weekly_record_reset_state",
-      "target": "test_e2e_update_skills_weekly_record_harness_absent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/e2e/update-skills-weekly-record.sh",
-      "source_location": "L247",
+      "source_location": "L222",
       "weight": 1.0,
       "context": "call",
       "source": "test_e2e_update_skills_weekly_record_log_entry_count",
@@ -70008,7 +71920,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L37",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "test_integration_homebrew_weekly_upgrade",
       "target": "test_integration_homebrew_weekly_upgrade_assert_all_sections",
@@ -70028,7 +71940,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L49",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "test_integration_homebrew_weekly_upgrade",
+      "target": "test_integration_homebrew_weekly_upgrade_homebrew_weekly_state_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/homebrew-weekly-upgrade.sh",
+      "source_location": "L56",
       "weight": 1.0,
       "source": "test_integration_homebrew_weekly_upgrade",
       "target": "test_integration_homebrew_weekly_upgrade_make_brew",
@@ -70048,7 +71970,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L73",
+      "source_location": "L80",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_weekly_upgrade_sh__entry",
@@ -70070,7 +71992,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L65",
+      "source_location": "L72",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_weekly_upgrade_sh__entry",
@@ -70081,7 +72003,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/homebrew-weekly-upgrade.sh",
-      "source_location": "L42",
+      "source_location": "L49",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_homebrew_weekly_upgrade_assert_all_sections",
@@ -73022,7 +74944,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-page-allowlist-seed.sh",
-      "source_location": "L30",
+      "source_location": "L32",
       "weight": 1.0,
       "source": "test_integration_osquery_page_allowlist_seed",
       "target": "test_integration_osquery_page_allowlist_seed_fail",
@@ -73042,7 +74964,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-page-allowlist-seed.sh",
-      "source_location": "L39",
+      "source_location": "L41",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_page_allowlist_seed_sh__entry",
@@ -73133,7 +75055,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L496",
+      "source_location": "L512",
       "weight": 1.0,
       "source": "test_integration_osquery_pipeline_manifest_agreement",
       "target": "test_integration_osquery_pipeline_manifest_agreement_run_allowlist_verdict",
@@ -73216,7 +75138,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L549",
+      "source_location": "L566",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
@@ -73227,7 +75149,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-pipeline-manifest-agreement.sh",
-      "source_location": "L393",
+      "source_location": "L400",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_pipeline_manifest_agreement_sh__entry",
@@ -73333,7 +75255,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L41",
+      "source_location": "L39",
       "weight": 1.0,
       "source": "test_integration_osquery_queue_counts_wal",
       "target": "test_integration_osquery_queue_counts_wal_assert_eq",
@@ -73343,7 +75265,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L60",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "test_integration_osquery_queue_counts_wal",
       "target": "test_integration_osquery_queue_counts_wal_cleanup",
@@ -73363,7 +75285,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L36",
+      "source_location": "L34",
       "weight": 1.0,
       "source": "test_integration_osquery_queue_counts_wal",
       "target": "test_integration_osquery_queue_counts_wal_osquery_undelivered_alerts_db",
@@ -73383,7 +75305,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L50",
+      "source_location": "L48",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_queue_counts_wal_sh__entry",
@@ -73394,7 +75316,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L33",
+      "source_location": "L30",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_queue_counts_wal_sh__entry",
@@ -73405,7 +75327,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/osquery-queue-counts-wal.sh",
-      "source_location": "L42",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_osquery_queue_counts_wal_assert_eq",
@@ -73523,6 +75445,79 @@
       "weight": 1.0,
       "source": "test_integration_relay_agent",
       "target": "test_integration_relay_agent_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "test_integration_render_without_package_manager",
+      "target": "test_integration_render_without_package_manager_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "test_integration_render_without_package_manager",
+      "target": "test_integration_render_without_package_manager_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_render_without_package_manager",
+      "target": "test_integration_render_without_package_manager_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "test_integration_render_without_package_manager",
+      "target": "test_integration_render_without_package_manager_write_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_render_without_package_manager_sh__entry",
+      "target": "test_integration_render_without_package_manager_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L91",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_render_without_package_manager_sh__entry",
+      "target": "test_integration_render_without_package_manager_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/render-without-package-manager.sh",
+      "source_location": "L88",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_render_without_package_manager_sh__entry",
+      "target": "test_integration_render_without_package_manager_write_config",
       "confidence_score": 1.0
     },
     {
@@ -75393,7 +77388,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-converge.sh",
-      "source_location": "L143",
+      "source_location": "L157",
       "weight": 1.0,
       "source": "test_integration_update_skills_converge",
       "target": "test_integration_update_skills_converge_path",
@@ -75403,7 +77398,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-converge.sh",
-      "source_location": "L147",
+      "source_location": "L161",
       "weight": 1.0,
       "source": "test_integration_update_skills_converge",
       "target": "test_integration_update_skills_converge_run",
@@ -75423,11 +77418,22 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-converge.sh",
-      "source_location": "L148",
+      "source_location": "L162",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_converge_sh__entry",
       "target": "test_integration_update_skills_converge_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-converge.sh",
+      "source_location": "L281",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_update_skills_converge_sh__entry",
+      "target": "test_integration_update_skills_converge_run",
       "confidence_score": 1.0
     },
     {
@@ -75864,118 +77870,6 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L19",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L94",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_path",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L1",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_sh__entry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L60",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_update_skills_claude_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L61",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_update_skills_codex_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L34",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_update_skills_gmv",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L62",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_update_skills_hermes_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L63",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_update_skills_idle_threshold",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L40",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_exchange_reprobe",
-      "target": "test_integration_update_skills_exchange_reprobe_write_lock",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L27",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_integration_update_skills_exchange_reprobe_sh__entry",
-      "target": "test_integration_update_skills_exchange_reprobe_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-exchange-reprobe.sh",
-      "source_location": "L97",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_integration_update_skills_exchange_reprobe_sh__entry",
-      "target": "test_integration_update_skills_exchange_reprobe_write_lock",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-exchange-tool.sh",
       "source_location": "L20",
       "weight": 1.0,
@@ -76070,7 +77964,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L26",
+      "source_location": "L23",
       "weight": 1.0,
       "source": "test_integration_update_skills_first_install",
       "target": "test_integration_update_skills_first_install_fail",
@@ -76080,7 +77974,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L125",
+      "source_location": "L122",
       "weight": 1.0,
       "source": "test_integration_update_skills_first_install",
       "target": "test_integration_update_skills_first_install_path",
@@ -76090,7 +77984,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L49",
+      "source_location": "L46",
       "weight": 1.0,
       "source": "test_integration_update_skills_first_install",
       "target": "test_integration_update_skills_first_install_render_fixture",
@@ -76110,7 +78004,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-first-install.sh",
-      "source_location": "L32",
+      "source_location": "L29",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_first_install_sh__entry",
@@ -76696,141 +78590,8 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L22",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L83",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_path",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L141",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_render",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L1",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_sh__entry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L86",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_update_skills_claude_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L87",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_update_skills_codex_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L38",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_update_skills_gmv",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L88",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_update_skills_hermes_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L89",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_update_skills_idle_threshold",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L44",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_defer_retry",
-      "target": "test_integration_update_skills_install_defer_retry_write_lock",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L30",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_integration_update_skills_install_defer_retry_sh__entry",
-      "target": "test_integration_update_skills_install_defer_retry_fail",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L143",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_integration_update_skills_install_defer_retry_sh__entry",
-      "target": "test_integration_update_skills_install_defer_retry_render",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-defer-retry.sh",
-      "source_location": "L92",
-      "weight": 1.0,
-      "context": "call",
-      "source": "test_integration_update_skills_install_defer_retry_sh__entry",
-      "target": "test_integration_update_skills_install_defer_retry_write_lock",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L19",
+      "source_location": "L18",
       "weight": 1.0,
       "source": "test_integration_update_skills_install_only_gate",
       "target": "test_integration_update_skills_install_only_gate_fail",
@@ -76840,20 +78601,10 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L97",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_gen_id",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
       "source_location": "L92",
       "weight": 1.0,
       "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_harness_active",
+      "target": "test_integration_update_skills_install_only_gate_gen_id",
       "confidence_score": 1.0
     },
     {
@@ -76883,24 +78634,14 @@
       "source_location": "L88",
       "weight": 1.0,
       "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_update_skills_claude_activity_dir",
+      "target": "test_integration_update_skills_install_only_gate_stage_live_agent_activity",
       "confidence_score": 1.0
     },
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L89",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_update_skills_codex_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L34",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "test_integration_update_skills_install_only_gate",
       "target": "test_integration_update_skills_install_only_gate_update_skills_gmv",
@@ -76910,27 +78651,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L90",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_update_skills_hermes_activity_dir",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L91",
-      "weight": 1.0,
-      "source": "test_integration_update_skills_install_only_gate",
-      "target": "test_integration_update_skills_install_only_gate_update_skills_idle_threshold",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L40",
+      "source_location": "L39",
       "weight": 1.0,
       "source": "test_integration_update_skills_install_only_gate",
       "target": "test_integration_update_skills_install_only_gate_write_lock",
@@ -76940,7 +78661,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L27",
+      "source_location": "L26",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_install_only_gate_sh__entry",
@@ -76951,18 +78672,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L125",
+      "source_location": "L137",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_install_only_gate_sh__entry",
-      "target": "test_integration_update_skills_install_only_gate_harness_active",
+      "target": "test_integration_update_skills_install_only_gate_stage_live_agent_activity",
       "confidence_score": 1.0
     },
     {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install-only-gate.sh",
-      "source_location": "L103",
+      "source_location": "L98",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_install_only_gate_sh__entry",
@@ -77054,6 +78775,99 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L154",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_update_skills_gmv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "test_integration_update_skills_install_retry_marker",
+      "target": "test_integration_update_skills_install_retry_marker_write_lock",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_update_skills_install_retry_marker_sh__entry",
+      "target": "test_integration_update_skills_install_retry_marker_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L156",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_update_skills_install_retry_marker_sh__entry",
+      "target": "test_integration_update_skills_install_retry_marker_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/integration/update-skills-install-retry-marker.sh",
+      "source_location": "L84",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_integration_update_skills_install_retry_marker_sh__entry",
+      "target": "test_integration_update_skills_install_retry_marker_write_lock",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install.sh",
       "source_location": "L48",
       "weight": 1.0,
@@ -77085,7 +78899,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-install.sh",
-      "source_location": "L167",
+      "source_location": "L168",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_install_sh__entry",
@@ -77880,7 +79694,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L252",
+      "source_location": "L332",
       "weight": 1.0,
       "source": "test_integration_update_skills_roster_table_types",
       "target": "test_integration_update_skills_roster_table_types_assert_advisory_not_refusal",
@@ -77900,7 +79714,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L243",
+      "source_location": "L323",
       "weight": 1.0,
       "source": "test_integration_update_skills_roster_table_types",
       "target": "test_integration_update_skills_roster_table_types_assert_lock_level_advisory_names_deployed_lock",
@@ -77990,7 +79804,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L297",
+      "source_location": "L377",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_roster_table_types_sh__entry",
@@ -78012,7 +79826,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L299",
+      "source_location": "L379",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_roster_table_types_sh__entry",
@@ -78045,7 +79859,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L255",
+      "source_location": "L335",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_roster_table_types_assert_advisory_not_refusal",
@@ -78067,7 +79881,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/integration/update-skills-roster-table-types.sh",
-      "source_location": "L247",
+      "source_location": "L327",
       "weight": 1.0,
       "context": "call",
       "source": "test_integration_update_skills_roster_table_types_assert_lock_level_advisory_names_deployed_lock",
@@ -82527,8 +84341,379 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_all_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_bare_gh_allowlist_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_bare_gh_call_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L169",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_command_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_commands_dir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_commit_message_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_destructive_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_frontmatter_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_github_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L224",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_heading_line_number",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_inline_body_flag_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L217",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_literal_line_number",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L154",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_merge_subject_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_pr_create_call",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_pr_creating_commands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L196",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_refuse_literal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_refuse_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L209",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_require_heading",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_require_literal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L174",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_require_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_review_checklist_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_review_step_heading",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "test_unit_claude_commands_govern",
+      "target": "test_unit_claude_commands_govern_template_headings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L234",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L253",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_refuse_literal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L256",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_refuse_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L285",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_require_heading",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L272",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_require_literal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L264",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_sh__entry",
+      "target": "test_unit_claude_commands_govern_require_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L200",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_refuse_literal",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L192",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_refuse_pattern",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L212",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_require_heading",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L184",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_require_literal",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-commands-govern.sh",
+      "source_location": "L177",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_commands_govern_require_pattern",
+      "target": "test_unit_claude_commands_govern_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1075",
+      "source_location": "L1169",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_apply_settings_target",
@@ -82538,7 +84723,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L210",
+      "source_location": "L238",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_array_valued_declared_plugin",
@@ -82548,7 +84733,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1019",
+      "source_location": "L1113",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_fixture_precondition",
@@ -82558,7 +84743,17 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L996",
+      "source_location": "L1309",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_assert_operator_marketplace_survived",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L1090",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_passthrough_field",
@@ -82568,7 +84763,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1086",
+      "source_location": "L1180",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_rendered_enabled_plugins",
@@ -82578,7 +84773,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1212",
+      "source_location": "L1324",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_stable_block_is_invariant",
@@ -82588,7 +84783,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1136",
+      "source_location": "L1230",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_stable_fields_survived",
@@ -82598,7 +84793,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L974",
+      "source_location": "L1054",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_assert_test_constants",
@@ -82608,7 +84803,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L626",
+      "source_location": "L697",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_bootstrap_config",
@@ -82618,7 +84813,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L641",
+      "source_location": "L712",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_apply_stderr_path",
@@ -82628,7 +84823,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1010",
+      "source_location": "L1104",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_carries_passthrough",
@@ -82638,7 +84833,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L629",
+      "source_location": "L700",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_config_path",
@@ -82648,7 +84843,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L633",
+      "source_location": "L704",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_destination_directory",
@@ -82658,7 +84853,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L763",
+      "source_location": "L839",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_expected_fixture_plugin_container_kind",
@@ -82668,7 +84863,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L776",
+      "source_location": "L856",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_expected_fixture_plugin_records",
@@ -82678,7 +84873,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L815",
+      "source_location": "L895",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_expected_rendered_plugin_records",
@@ -82688,7 +84883,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L747",
+      "source_location": "L822",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_fixture_template",
@@ -82698,7 +84893,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L728",
+      "source_location": "L803",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_literal_fixture",
@@ -82708,7 +84903,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L637",
+      "source_location": "L708",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_case_settings_path",
@@ -82718,7 +84913,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L664",
+      "source_location": "L735",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_chezmoi_isolated",
@@ -82728,7 +84923,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L192",
+      "source_location": "L199",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_declared_plugins",
@@ -82738,7 +84933,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L301",
+      "source_location": "L336",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_deny_record",
@@ -82748,7 +84943,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L208",
+      "source_location": "L236",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_disabled_declared_plugin",
@@ -82758,7 +84953,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L209",
+      "source_location": "L237",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_enabled_declared_plugin",
@@ -82768,7 +84963,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L582",
+      "source_location": "L653",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_fail",
@@ -82778,7 +84973,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1268",
+      "source_location": "L1383",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_file_bytes",
@@ -82788,7 +84983,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L587",
+      "source_location": "L658",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_finish",
@@ -82798,7 +84993,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L434",
+      "source_location": "L493",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_fixture_array_enabled_plugins_template",
@@ -82808,7 +85003,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L450",
+      "source_location": "L509",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_fixture_declared_plugin_disabled_template",
@@ -82818,7 +85013,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L460",
+      "source_location": "L519",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_fixture_non_boolean_plugin_values_template",
@@ -82828,7 +85023,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L427",
+      "source_location": "L486",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_fixture_null_enabled_plugins_template",
@@ -82838,300 +85033,10 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L441",
+      "source_location": "L530",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_fixture_undeclared_plugins_only_template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L302",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_hook_command_record",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L325",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_json_array_kind",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L312",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_json_boolean_kind",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L314",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_json_false_value",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L313",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_json_true_value",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L247",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_live_file_cases",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L185",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_live_undeclared_disabled_plugin",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L184",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_live_undeclared_enabled_plugin",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L326",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_live_version_constraint_entry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L327",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_live_version_constraint_rendered",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L213",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_null_valued_declared_plugin",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L212",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_number_valued_declared_plugin",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L898",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_parse_settings_report",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L299",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_passthrough_record",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L177",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_passthrough_setting_key",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L298",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_plugin_container_record",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L297",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_plugin_record",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L703",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_populate_sandbox_source",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L685",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_render_fixture_template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L679",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_render_template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L296",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_report_field_delimiter",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L398",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_required_deny_entries",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L411",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_required_hook_command_fragments",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L620",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_sandbox_cache",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L476",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_sandbox_config_template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L619",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_sandbox_persistent_state",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L618",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_sandbox_source",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L160",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_sandbox_source_files",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "defines",
-      "confidence": "EXTRACTED",
-      "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L870",
-      "weight": 1.0,
-      "source": "test_unit_claude_enabled_plugins",
-      "target": "test_unit_claude_enabled_plugins_settings_report",
+      "target": "test_unit_claude_enabled_plugins_fixture_operator_added_marketplace_template",
       "confidence_score": 1.0
     },
     {
@@ -83141,6 +85046,346 @@
       "source_location": "L500",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_fixture_undeclared_plugins_only_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_hook_command_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L360",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_json_array_kind",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L347",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_json_boolean_kind",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L349",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_json_false_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L348",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_json_true_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_autoupdate_disabled_marketplace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L230",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_autoupdate_disabled_marketplace_repo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L281",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_file_cases",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L192",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_undeclared_disabled_plugin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L191",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_undeclared_enabled_plugin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L361",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_version_constraint_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L362",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_live_version_constraint_rendered",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L241",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_null_valued_declared_plugin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L240",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_number_valued_declared_plugin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_operator_added_marketplace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L220",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_operator_added_marketplace_repo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L978",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_parse_settings_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L334",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_passthrough_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_passthrough_setting_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L333",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_plugin_container_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L332",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_plugin_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L778",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_populate_sandbox_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L756",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_render_fixture_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L750",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L331",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_report_field_delimiter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L457",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_required_deny_entries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L470",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_required_hook_command_fragments",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L691",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_sandbox_cache",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L547",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_sandbox_config_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L690",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_sandbox_persistent_state",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L689",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_sandbox_source",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_sandbox_source_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L950",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
+      "target": "test_unit_claude_enabled_plugins_settings_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L571",
+      "weight": 1.0,
+      "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_settings_report_template",
       "confidence_score": 1.0
     },
@@ -83148,7 +85393,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L153",
+      "source_location": "L160",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_settings_target_relative_path",
@@ -83168,7 +85413,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L966",
+      "source_location": "L1046",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_sorted_lines",
@@ -83178,7 +85423,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L366",
+      "source_location": "L417",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_container_fields",
@@ -83188,7 +85433,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L956",
+      "source_location": "L1036",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_field_detail",
@@ -83198,7 +85443,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L345",
+      "source_location": "L388",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_field_kinds",
@@ -83208,7 +85453,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L858",
+      "source_location": "L938",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_field_paths",
@@ -83218,7 +85463,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L942",
+      "source_location": "L1022",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_field_record",
@@ -83228,7 +85473,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L380",
+      "source_location": "L431",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_field_values",
@@ -83238,7 +85483,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L300",
+      "source_location": "L335",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_stable_record",
@@ -83248,7 +85493,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L392",
+      "source_location": "L451",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_status_line_command_path",
@@ -83258,7 +85503,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L393",
+      "source_location": "L452",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_status_line_command_suffix",
@@ -83268,7 +85513,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L211",
+      "source_location": "L239",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_string_valued_declared_plugin",
@@ -83278,7 +85523,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L168",
+      "source_location": "L175",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_target_operating_systems",
@@ -83288,7 +85533,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L284",
+      "source_location": "L319",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_unparseable_apply_error_fragment",
@@ -83298,7 +85543,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L274",
+      "source_location": "L309",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_unparseable_live_file_cases",
@@ -83308,7 +85553,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1230",
+      "source_location": "L1342",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_verify_case",
@@ -83318,7 +85563,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1278",
+      "source_location": "L1393",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_verify_unparseable_case",
@@ -83328,7 +85573,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L837",
+      "source_location": "L917",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_write_case_fixture",
@@ -83338,7 +85583,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L717",
+      "source_location": "L792",
       "weight": 1.0,
       "source": "test_unit_claude_enabled_plugins",
       "target": "test_unit_claude_enabled_plugins_write_sandbox_config",
@@ -83348,7 +85593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1311",
+      "source_location": "L1426",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83359,7 +85604,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1324",
+      "source_location": "L1439",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83370,7 +85615,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1312",
+      "source_location": "L1427",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83381,7 +85626,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1317",
+      "source_location": "L1432",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83392,7 +85637,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1320",
+      "source_location": "L1435",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83403,7 +85648,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1315",
+      "source_location": "L1430",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_sh__entry",
@@ -83414,7 +85659,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1028",
+      "source_location": "L1122",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_fixture_precondition",
@@ -83425,7 +85670,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L999",
+      "source_location": "L1313",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_enabled_plugins_assert_operator_marketplace_survived",
+      "target": "test_unit_claude_enabled_plugins_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L1093",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_passthrough_field",
@@ -83436,7 +85692,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1096",
+      "source_location": "L1190",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_rendered_enabled_plugins",
@@ -83447,7 +85703,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1225",
+      "source_location": "L1337",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_stable_block_is_invariant",
@@ -83458,7 +85714,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1147",
+      "source_location": "L1241",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_stable_fields_survived",
@@ -83469,7 +85725,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L981",
+      "source_location": "L1061",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_test_constants",
@@ -83480,7 +85736,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L591",
+      "source_location": "L662",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_finish",
@@ -83491,7 +85747,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L935",
+      "source_location": "L1015",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_parse_settings_report",
@@ -83502,7 +85758,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1244",
+      "source_location": "L1356",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83513,7 +85769,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1290",
+      "source_location": "L1405",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_unparseable_case",
@@ -83524,7 +85780,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L848",
+      "source_location": "L928",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_write_case_fixture",
@@ -83535,7 +85791,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1029",
+      "source_location": "L1123",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_fixture_precondition",
@@ -83546,7 +85802,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1000",
+      "source_location": "L1094",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_passthrough_field",
@@ -83557,7 +85813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1097",
+      "source_location": "L1191",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_rendered_enabled_plugins",
@@ -83568,7 +85824,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L988",
+      "source_location": "L1082",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_test_constants",
@@ -83579,7 +85835,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L849",
+      "source_location": "L929",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_write_case_fixture",
@@ -83590,7 +85846,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1077",
+      "source_location": "L1171",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_apply_settings_target",
@@ -83601,7 +85857,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L680",
+      "source_location": "L751",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_render_template",
@@ -83612,7 +85868,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L686",
+      "source_location": "L757",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_render_fixture_template",
@@ -83623,7 +85879,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L871",
+      "source_location": "L951",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_settings_report",
@@ -83634,7 +85890,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L721",
+      "source_location": "L796",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_write_sandbox_config",
@@ -83645,7 +85901,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L851",
+      "source_location": "L931",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_write_case_fixture",
@@ -83656,7 +85912,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L844",
+      "source_location": "L924",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_write_case_fixture",
@@ -83667,7 +85923,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1011",
+      "source_location": "L1105",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_case_carries_passthrough",
@@ -83678,7 +85934,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1234",
+      "source_location": "L1346",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83689,7 +85945,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1282",
+      "source_location": "L1397",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_unparseable_case",
@@ -83700,7 +85956,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1051",
+      "source_location": "L1145",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_fixture_precondition",
@@ -83711,7 +85967,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1252",
+      "source_location": "L1364",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83722,7 +85978,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1052",
+      "source_location": "L1146",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_assert_fixture_precondition",
@@ -83733,7 +85989,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1255",
+      "source_location": "L1367",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83744,7 +86000,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1254",
+      "source_location": "L1366",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83755,7 +86011,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1235",
+      "source_location": "L1347",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83766,7 +86022,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1283",
+      "source_location": "L1398",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_unparseable_case",
@@ -83777,7 +86033,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1243",
+      "source_location": "L1355",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83788,7 +86044,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1289",
+      "source_location": "L1404",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_unparseable_case",
@@ -83799,7 +86055,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1258",
+      "source_location": "L1370",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83810,7 +86066,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1259",
+      "source_location": "L1371",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83821,7 +86077,18 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/claude-enabled-plugins.sh",
-      "source_location": "L1260",
+      "source_location": "L1374",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_enabled_plugins_verify_case",
+      "target": "test_unit_claude_enabled_plugins_assert_operator_marketplace_survived",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-enabled-plugins.sh",
+      "source_location": "L1372",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_claude_enabled_plugins_verify_case",
@@ -83867,6 +86134,206 @@
       "context": "call",
       "source": "test_unit_claude_retirement_ordering_sh__entry",
       "target": "test_unit_claude_retirement_ordering_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_assert_untouched",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_backup_name_pattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_backups",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_collect_backups",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_run_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_claude_settings_quarantine",
+      "target": "test_unit_claude_settings_quarantine_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L120",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_sh__entry",
+      "target": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L138",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_sh__entry",
+      "target": "test_unit_claude_settings_quarantine_assert_untouched",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L132",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_sh__entry",
+      "target": "test_unit_claude_settings_quarantine_collect_backups",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L44",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_sh__entry",
+      "target": "test_unit_claude_settings_quarantine_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L130",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_sh__entry",
+      "target": "test_unit_claude_settings_quarantine_run_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L84",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "target": "test_unit_claude_settings_quarantine_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L110",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_assert_untouched",
+      "target": "test_unit_claude_settings_quarantine_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L83",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "target": "test_unit_claude_settings_quarantine_run_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L109",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_assert_untouched",
+      "target": "test_unit_claude_settings_quarantine_run_script",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/claude-settings-quarantine.sh",
+      "source_location": "L86",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_claude_settings_quarantine_assert_quarantined",
+      "target": "test_unit_claude_settings_quarantine_collect_backups",
       "confidence_score": 1.0
     },
     {
@@ -84215,8 +86682,151 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_count_lines_containing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_expected_binary_by_config_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_expected_prefix_by_platform",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_git_config_nosystem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_git_pager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_line_numbers_containing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_pager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L120",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L131",
+      "weight": 1.0,
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_site_binary_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L144",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation_sh__entry",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L190",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation_sh__entry",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_render_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/gitconfig-homebrew-prefix-derivation.sh",
+      "source_location": "L114",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_gitconfig_homebrew_prefix_derivation_count_lines_containing",
+      "target": "test_unit_gitconfig_homebrew_prefix_derivation_line_numbers_containing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L318",
+      "source_location": "L335",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
@@ -84226,7 +86836,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L337",
+      "source_location": "L354",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
@@ -84236,7 +86846,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L301",
+      "source_location": "L318",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
@@ -84246,7 +86856,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L216",
+      "source_location": "L226",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_core_excludesfile",
@@ -84256,7 +86866,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L152",
+      "source_location": "L162",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
@@ -84266,7 +86876,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L130",
+      "source_location": "L140",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_classify_path_resolution",
@@ -84276,7 +86886,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L168",
+      "source_location": "L178",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_explain_rejected_delivery",
@@ -84286,7 +86896,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L99",
+      "source_location": "L109",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_fail",
@@ -84296,7 +86906,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_config_nosystem",
@@ -84306,7 +86916,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_pager",
@@ -84316,7 +86926,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L231",
+      "source_location": "L241",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_git_resolves_tool_name",
@@ -84326,7 +86936,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L208",
+      "source_location": "L218",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_is_tool_binary_path_key",
@@ -84336,7 +86946,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L109",
+      "source_location": "L119",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_list_chezmoi_delivered_target_paths",
@@ -84346,7 +86956,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L119",
+      "source_location": "L129",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_listing_contains_target_path",
@@ -84356,7 +86966,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L97",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_pager",
@@ -84366,7 +86976,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L198",
+      "source_location": "L208",
       "weight": 1.0,
       "source": "test_unit_gitconfig_tool_and_url_hygiene",
       "target": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
@@ -84386,7 +86996,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L325",
+      "source_location": "L342",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84397,7 +87007,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L349",
+      "source_location": "L366",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84408,7 +87018,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L307",
+      "source_location": "L324",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84419,7 +87029,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L240",
+      "source_location": "L250",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84430,7 +87040,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L275",
+      "source_location": "L292",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84441,7 +87051,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L281",
+      "source_location": "L298",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84452,7 +87062,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L358",
+      "source_location": "L375",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_sh__entry",
@@ -84463,7 +87073,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L323",
+      "source_location": "L340",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_delivered_classification",
@@ -84474,7 +87084,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L347",
+      "source_location": "L364",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
@@ -84485,7 +87095,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L305",
+      "source_location": "L322",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_path_resolution",
@@ -84496,7 +87106,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L203",
+      "source_location": "L213",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_require_delivered_readable_file",
@@ -84507,7 +87117,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L154",
+      "source_location": "L164",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
@@ -84518,7 +87128,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L159",
+      "source_location": "L169",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_classify_delivered_target_path",
@@ -84529,7 +87139,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/gitconfig-tool-and-url-hygiene.sh",
-      "source_location": "L342",
+      "source_location": "L359",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_gitconfig_tool_and_url_hygiene_assert_guard_verdict",
@@ -84855,6 +87465,228 @@
       "context": "call",
       "source": "test_unit_homebrew_weekly_plist_assert_kv",
       "target": "test_unit_homebrew_weekly_plist_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_assert_called",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_assert_not_called",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L97",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_assert_status",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_assert_stderr_mentions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_assert_stderr_silent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_install_password_manager_hook",
+      "target": "test_unit_install_password_manager_hook_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L148",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_assert_called",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_assert_not_called",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_assert_status",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L155",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_assert_stderr_mentions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L143",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_assert_stderr_silent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L140",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_sh__entry",
+      "target": "test_unit_install_password_manager_hook_run_case",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L107",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_assert_called",
+      "target": "test_unit_install_password_manager_hook_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L115",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_assert_not_called",
+      "target": "test_unit_install_password_manager_hook_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L99",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_assert_status",
+      "target": "test_unit_install_password_manager_hook_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L123",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_assert_stderr_mentions",
+      "target": "test_unit_install_password_manager_hook_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/install-password-manager-hook.sh",
+      "source_location": "L131",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_install_password_manager_hook_assert_stderr_silent",
+      "target": "test_unit_install_password_manager_hook_report",
       "confidence_score": 1.0
     },
     {
@@ -87305,6 +90137,153 @@
     {
       "relation": "defines",
       "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_assert_json",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_iso_at",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_triage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "test_unit_osquery_file_integrity_triage",
+      "target": "test_unit_osquery_file_integrity_triage_write_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L120",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "target": "test_unit_osquery_file_integrity_triage_assert_json",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "target": "test_unit_osquery_file_integrity_triage_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L142",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "target": "test_unit_osquery_file_integrity_triage_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_sh__entry",
+      "target": "test_unit_osquery_file_integrity_triage_write_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_assert_json",
+      "target": "test_unit_osquery_file_integrity_triage_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_refute",
+      "target": "test_unit_osquery_file_integrity_triage_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-file-integrity-triage.sh",
+      "source_location": "L93",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_file_integrity_triage_assert_json",
+      "target": "test_unit_osquery_file_integrity_triage_refute",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-firewall-gatekeeper-monitor-launchagent.sh",
       "source_location": "L47",
       "weight": 1.0,
@@ -87442,7 +90421,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L52",
+      "source_location": "L50",
       "weight": 1.0,
       "source": "test_unit_osquery_local_notify_durable",
       "target": "test_unit_osquery_local_notify_durable_query",
@@ -87452,7 +90431,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L56",
+      "source_location": "L54",
       "weight": 1.0,
       "source": "test_unit_osquery_local_notify_durable",
       "target": "test_unit_osquery_local_notify_durable_row_count",
@@ -87462,7 +90441,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L44",
+      "source_location": "L42",
       "weight": 1.0,
       "source": "test_unit_osquery_local_notify_durable",
       "target": "test_unit_osquery_local_notify_durable_run_durable",
@@ -87472,7 +90451,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L37",
+      "source_location": "L35",
       "weight": 1.0,
       "source": "test_unit_osquery_local_notify_durable",
       "target": "test_unit_osquery_local_notify_durable_set_alerter_stub",
@@ -87492,7 +90471,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L60",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "test_unit_osquery_local_notify_durable",
       "target": "test_unit_osquery_local_notify_durable_wait_for_row_count",
@@ -87502,7 +90481,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L30",
+      "source_location": "L27",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_local_notify_durable_sh__entry",
@@ -87513,7 +90492,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L162",
+      "source_location": "L160",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_local_notify_durable_sh__entry",
@@ -87524,7 +90503,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L74",
+      "source_location": "L72",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_local_notify_durable_sh__entry",
@@ -87535,7 +90514,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-local-notify-durable.sh",
-      "source_location": "L99",
+      "source_location": "L97",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_local_notify_durable_sh__entry",
@@ -87556,7 +90535,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L95",
+      "source_location": "L93",
       "weight": 1.0,
       "source": "test_unit_osquery_loud_local_status",
       "target": "test_unit_osquery_loud_local_status_osquery_delivery_log",
@@ -87566,7 +90545,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L97",
+      "source_location": "L95",
       "weight": 1.0,
       "source": "test_unit_osquery_loud_local_status",
       "target": "test_unit_osquery_loud_local_status_osquery_drain_max_attempts",
@@ -87576,7 +90555,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L94",
+      "source_location": "L92",
       "weight": 1.0,
       "source": "test_unit_osquery_loud_local_status",
       "target": "test_unit_osquery_loud_local_status_osquery_undelivered_alerts_db",
@@ -87586,7 +90565,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-loud-local-status.sh",
-      "source_location": "L96",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "test_unit_osquery_loud_local_status",
       "target": "test_unit_osquery_loud_local_status_osquery_webhook_secret",
@@ -88058,7 +91037,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L36",
+      "source_location": "L34",
       "weight": 1.0,
       "source": "test_unit_osquery_queue_counts",
       "target": "test_unit_osquery_queue_counts_assert_eq",
@@ -88078,7 +91057,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L31",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "test_unit_osquery_queue_counts",
       "target": "test_unit_osquery_queue_counts_osquery_undelivered_alerts_db",
@@ -88098,7 +91077,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L45",
+      "source_location": "L43",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_queue_counts_sh__entry",
@@ -88109,7 +91088,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L27",
+      "source_location": "L24",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_queue_counts_sh__entry",
@@ -88120,7 +91099,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-queue-counts.sh",
-      "source_location": "L37",
+      "source_location": "L35",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_queue_counts_assert_eq",
@@ -88354,10 +91333,30 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "test_unit_osquery_render_page",
+      "target": "test_unit_osquery_render_page_triage_absent_renders_the_old_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "test_unit_osquery_render_page",
+      "target": "test_unit_osquery_render_page_triage_lines_render_when_present",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-render-page.sh",
-      "source_location": "L112",
+      "source_location": "L154",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_render_page_sh__entry",
@@ -88379,7 +91378,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-render-page.sh",
-      "source_location": "L111",
+      "source_location": "L153",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_render_page_sh__entry",
@@ -88390,7 +91389,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-render-page.sh",
-      "source_location": "L110",
+      "source_location": "L152",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_render_page_sh__entry",
@@ -88401,11 +91400,33 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-render-page.sh",
-      "source_location": "L113",
+      "source_location": "L155",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_render_page_sh__entry",
       "target": "test_unit_osquery_render_page_page_cap_hard_limits_length",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L157",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_render_page_sh__entry",
+      "target": "test_unit_osquery_render_page_triage_absent_renders_the_old_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L156",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_render_page_sh__entry",
+      "target": "test_unit_osquery_render_page_triage_lines_render_when_present",
       "confidence_score": 1.0
     },
     {
@@ -88449,6 +91470,28 @@
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_render_page_page_cap_hard_limits_length",
+      "target": "test_unit_osquery_render_page_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L147",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_render_page_triage_absent_renders_the_old_block",
+      "target": "test_unit_osquery_render_page_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/osquery-render-page.sh",
+      "source_location": "L126",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_osquery_render_page_triage_lines_render_when_present",
       "target": "test_unit_osquery_render_page_fail",
       "confidence_score": 1.0
     },
@@ -88747,7 +91790,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L74",
+      "source_location": "L85",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_assert_paged",
@@ -88757,7 +91800,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L29",
+      "source_location": "L30",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_fail",
@@ -88767,7 +91810,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L48",
+      "source_location": "L49",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_fe",
@@ -88777,7 +91820,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L77",
+      "source_location": "L88",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_refute_paged",
@@ -88787,7 +91830,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L55",
+      "source_location": "L60",
       "weight": 1.0,
       "source": "test_unit_osquery_route_pipeline",
       "target": "test_unit_osquery_route_pipeline_run_gate",
@@ -88807,7 +91850,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L96",
+      "source_location": "L107",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_sh__entry",
@@ -88818,7 +91861,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_sh__entry",
@@ -88829,7 +91872,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L99",
+      "source_location": "L110",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_sh__entry",
@@ -88840,7 +91883,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L75",
+      "source_location": "L86",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_assert_paged",
@@ -88851,7 +91894,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-route-pipeline.sh",
-      "source_location": "L78",
+      "source_location": "L89",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_route_pipeline_refute_paged",
@@ -89018,7 +92061,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L43",
+      "source_location": "L41",
       "weight": 1.0,
       "source": "test_unit_osquery_store_quote_safety",
       "target": "test_unit_osquery_store_quote_safety_osquery_delivery_log",
@@ -89028,7 +92071,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L42",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "test_unit_osquery_store_quote_safety",
       "target": "test_unit_osquery_store_quote_safety_osquery_undelivered_alerts_db",
@@ -89038,7 +92081,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L45",
+      "source_location": "L43",
       "weight": 1.0,
       "source": "test_unit_osquery_store_quote_safety",
       "target": "test_unit_osquery_store_quote_safety_query",
@@ -89058,7 +92101,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/osquery-store-quote-safety.sh",
-      "source_location": "L34",
+      "source_location": "L31",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_osquery_store_quote_safety_sh__entry",
@@ -89366,6 +92409,69 @@
       "context": "call",
       "source": "test_unit_rendered_template_shellcheck_wrapper_sh__entry",
       "target": "test_unit_rendered_template_shellcheck_wrapper_check",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "test_unit_report_plugin_updates_plist",
+      "target": "test_unit_report_plugin_updates_plist_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "test_unit_report_plugin_updates_plist",
+      "target": "test_unit_report_plugin_updates_plist_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_report_plugin_updates_plist",
+      "target": "test_unit_report_plugin_updates_plist_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L32",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_report_plugin_updates_plist_sh__entry",
+      "target": "test_unit_report_plugin_updates_plist_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L51",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_report_plugin_updates_plist_sh__entry",
+      "target": "test_unit_report_plugin_updates_plist_render",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/report-plugin-updates-plist.sh",
+      "source_location": "L45",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_report_plugin_updates_plist_render",
+      "target": "test_unit_report_plugin_updates_plist_fail",
       "confidence_score": 1.0
     },
     {
@@ -90931,7 +94037,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L99",
+      "source_location": "L105",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_claude_declarations",
@@ -90941,7 +94047,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L453",
+      "source_location": "L518",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_documented_count_is",
@@ -90951,7 +94057,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L64",
+      "source_location": "L70",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_fail",
@@ -90961,7 +94067,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L260",
+      "source_location": "L325",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_hermes_declaration_dirs",
@@ -90971,7 +94077,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L89",
+      "source_location": "L95",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_roster",
@@ -90991,7 +94097,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L74",
+      "source_location": "L80",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_target_name",
@@ -91001,7 +94107,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L334",
+      "source_location": "L399",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_vendored_content_dirs",
@@ -91011,7 +94117,7 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L82",
+      "source_location": "L88",
       "weight": 1.0,
       "source": "test_unit_skills_roster_fanout",
       "target": "test_unit_skills_roster_fanout_vendored_dirs",
@@ -91021,7 +94127,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L470",
+      "source_location": "L535",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_sh__entry",
@@ -91032,7 +94138,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L69",
+      "source_location": "L75",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_sh__entry",
@@ -91043,7 +94149,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L109",
+      "source_location": "L115",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_claude_declarations",
@@ -91054,7 +94160,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L458",
+      "source_location": "L523",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_documented_count_is",
@@ -91065,7 +94171,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L338",
+      "source_location": "L403",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_vendored_content_dirs",
@@ -91076,7 +94182,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L85",
+      "source_location": "L91",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_vendored_dirs",
@@ -91087,7 +94193,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/skills-roster-fanout.sh",
-      "source_location": "L90",
+      "source_location": "L96",
       "weight": 1.0,
       "context": "call",
       "source": "test_unit_skills_roster_fanout_roster",
@@ -91758,6 +94864,16 @@
       "relation": "defines",
       "confidence": "EXTRACTED",
       "source_file": "test/unit/unattended-log-lib.sh",
+      "source_location": "L701",
+      "weight": 1.0,
+      "source": "test_unit_unattended_log_lib",
+      "target": "test_unit_unattended_log_lib_tuples",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/unattended-log-lib.sh",
       "source_location": "L566",
       "weight": 1.0,
       "source": "test_unit_unattended_log_lib",
@@ -91911,6 +95027,57 @@
       "context": "call",
       "source": "test_unit_update_skills_change_report_refute",
       "target": "test_unit_update_skills_change_report_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "test_unit_update_skills_json_stream_reads",
+      "target": "test_unit_update_skills_json_stream_reads_fail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "test_unit_update_skills_json_stream_reads",
+      "target": "test_unit_update_skills_json_stream_reads_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "test_unit_update_skills_json_stream_reads",
+      "target": "test_unit_update_skills_json_stream_reads_update_skills_lib_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "test_unit_update_skills_json_stream_reads",
+      "target": "test_unit_update_skills_json_stream_reads_xdg_state_home",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "test/unit/update-skills-json-stream-reads.sh",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "call",
+      "source": "test_unit_update_skills_json_stream_reads_sh__entry",
+      "target": "test_unit_update_skills_json_stream_reads_fail",
       "confidence_score": 1.0
     },
     {
@@ -92313,37 +95480,37 @@
       "source_location": "L7",
       "weight": 1.0,
       "source": "agents",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L282",
+      "source_location": "L300",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L798",
+      "source_location": "L862",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_code_style",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_code_style",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L824",
+      "source_location": "L888",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_commits",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_commits",
       "confidence_score": 1.0
     },
     {
@@ -92352,18 +95519,18 @@
       "source_file": "AGENTS.md",
       "source_location": "L18",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L831",
+      "source_location": "L895",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_security",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_security",
       "confidence_score": 1.0
     },
     {
@@ -92372,8 +95539,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L11",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_md",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_what_this_is",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_md",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_what_this_is",
       "confidence_score": 1.0
     },
     {
@@ -92382,8 +95549,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L86",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_chezmoi_operations",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_chezmoi_operations",
       "confidence_score": 1.0
     },
     {
@@ -92392,18 +95559,18 @@
       "source_file": "AGENTS.md",
       "source_location": "L114",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_claude_code_settings",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_claude_code_settings",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L215",
+      "source_location": "L233",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_hooks",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_hooks",
       "confidence_score": 1.0
     },
     {
@@ -92412,8 +95579,8 @@
       "source_file": "AGENTS.md",
       "source_location": "L20",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_linting_formatting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_linting_formatting",
       "confidence_score": 1.0
     },
     {
@@ -92422,18 +95589,68 @@
       "source_file": "AGENTS.md",
       "source_location": "L46",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_key_commands",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_testing",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_key_commands",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_testing",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L426",
+      "source_location": "L444",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_agent_skills_cross_harness_store",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_agent_skills_cross_harness_store",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "AGENTS.md",
+      "source_location": "L837",
+      "weight": 1.0,
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_ai_commit_messages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "AGENTS.md",
+      "source_location": "L706",
+      "weight": 1.0,
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_bashrc_init_ordering",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "AGENTS.md",
+      "source_location": "L434",
+      "weight": 1.0,
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_ci",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "AGENTS.md",
+      "source_location": "L423",
+      "weight": 1.0,
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_dev_environment_nix_flake",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "AGENTS.md",
+      "source_location": "L699",
+      "weight": 1.0,
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_git_worktrees_worktrunk",
       "confidence_score": 1.0
     },
     {
@@ -92442,188 +95659,148 @@
       "source_file": "AGENTS.md",
       "source_location": "L773",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_ai_commit_messages",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_happy_daemon_remote_agent_control",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L672",
+      "source_location": "L856",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_bashrc_init_ordering",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_herdr_native_status",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L416",
+      "source_location": "L679",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_ci",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_herdr_workspace_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L405",
+      "source_location": "L850",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_dev_environment_nix_flake",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_long_running_command_notifier",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L665",
+      "source_location": "L346",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_git_worktrees_worktrunk",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_macos_defaults_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L709",
+      "source_location": "L310",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_happy_daemon_remote_agent_control",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_minimum_chezmoi_version",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L792",
+      "source_location": "L418",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_herdr_native_status",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_os_targeting",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L645",
+      "source_location": "L743",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_herdr_workspace_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_plugin_update_record",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L786",
+      "source_location": "L314",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_long_running_command_notifier",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_secrets_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L328",
+      "source_location": "L714",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_macos_defaults_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_shell_history_atuin",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L292",
+      "source_location": "L302",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_minimum_chezmoi_version",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_source_only_files",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L400",
+      "source_location": "L321",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_os_targeting",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_system_package_management",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L296",
+      "source_location": "L800",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_secrets_management",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_tailscale_headless_daemon",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L680",
+      "source_location": "L391",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_shell_history_atuin",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_template_files",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "AGENTS.md",
-      "source_location": "L284",
+      "source_location": "L397",
       "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_source_only_files",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "AGENTS.md",
-      "source_location": "L303",
-      "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_system_package_management",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "AGENTS.md",
-      "source_location": "L736",
-      "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_tailscale_headless_daemon",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "AGENTS.md",
-      "source_location": "L373",
-      "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_template_files",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "AGENTS.md",
-      "source_location": "L379",
-      "weight": 1.0,
-      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_architecture",
-      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_worktrees_hermes_drift_agents_template_shellcheck_workaround",
+      "source": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_architecture",
+      "target": "users_stephen_workspaces_ivy_webdavis_dotfiles_claude_worktrees_agent_aa23ba59490f3a5a0_agents_template_shellcheck_workaround",
       "confidence_score": 1.0
     },
     {
@@ -92640,7 +95817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L282",
+      "source_location": "L300",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_architecture",
@@ -92650,7 +95827,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L798",
+      "source_location": "L862",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_code_style",
@@ -92660,7 +95837,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L824",
+      "source_location": "L888",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_git_commits",
@@ -92680,7 +95857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L831",
+      "source_location": "L895",
       "weight": 1.0,
       "source": "claude_claude_md",
       "target": "claude_security",
@@ -92720,7 +95897,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L215",
+      "source_location": "L233",
       "weight": 1.0,
       "source": "claude_key_commands",
       "target": "claude_git_hooks",
@@ -92750,7 +95927,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L426",
+      "source_location": "L444",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_agent_skills_cross_harness_store",
@@ -92760,7 +95937,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L773",
+      "source_location": "L837",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_ai_commit_messages",
@@ -92770,7 +95947,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L672",
+      "source_location": "L706",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_bashrc_init_ordering",
@@ -92780,7 +95957,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L416",
+      "source_location": "L434",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_ci",
@@ -92790,7 +95967,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L405",
+      "source_location": "L423",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_dev_environment_nix_flake",
@@ -92800,7 +95977,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L665",
+      "source_location": "L699",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_git_worktrees_worktrunk",
@@ -92810,7 +95987,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L709",
+      "source_location": "L773",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_happy_daemon_remote_agent_control",
@@ -92820,7 +95997,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L792",
+      "source_location": "L856",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_herdr_native_status",
@@ -92830,7 +96007,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L645",
+      "source_location": "L679",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_herdr_workspace_management",
@@ -92840,7 +96017,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L786",
+      "source_location": "L850",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_long_running_command_notifier",
@@ -92850,7 +96027,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L328",
+      "source_location": "L346",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_macos_defaults_management",
@@ -92860,7 +96037,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L292",
+      "source_location": "L310",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_minimum_chezmoi_version",
@@ -92870,7 +96047,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L400",
+      "source_location": "L418",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_os_targeting",
@@ -92880,7 +96057,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L296",
+      "source_location": "L743",
+      "weight": 1.0,
+      "source": "claude_architecture",
+      "target": "claude_plugin_update_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "CLAUDE.md",
+      "source_location": "L314",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_secrets_management",
@@ -92890,7 +96077,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L680",
+      "source_location": "L714",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_shell_history_atuin",
@@ -92900,7 +96087,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L284",
+      "source_location": "L302",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_source_only_files",
@@ -92910,7 +96097,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L303",
+      "source_location": "L321",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_system_package_management",
@@ -92920,7 +96107,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L736",
+      "source_location": "L800",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_tailscale_headless_daemon",
@@ -92930,7 +96117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L373",
+      "source_location": "L391",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_template_files",
@@ -92940,7 +96127,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L379",
+      "source_location": "L397",
       "weight": 1.0,
       "source": "claude_architecture",
       "target": "claude_template_shellcheck_workaround",
@@ -111129,6 +114316,156 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_amend",
+      "target": "private_dot_claude_commands_amend_amend",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_amend_amend",
+      "target": "private_dot_claude_commands_amend_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/amend.md",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_amend_amend",
+      "target": "private_dot_claude_commands_amend_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_clean_gone",
+      "target": "private_dot_claude_commands_clean_gone_clean_gone_branches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_clean_gone_clean_gone_branches",
+      "target": "private_dot_claude_commands_clean_gone_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/clean-gone.md",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_clean_gone_clean_gone_branches",
+      "target": "private_dot_claude_commands_clean_gone_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L87",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_post_the_pull_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_pull_request_body_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_review_the_draft_before_posting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L98",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit-push-pr.md",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_push_pr_commit_push_pr",
+      "target": "private_dot_claude_commands_commit_push_pr_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit",
+      "target": "private_dot_claude_commands_commit_commit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_commit",
+      "target": "private_dot_claude_commands_commit_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/commit.md",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_commit_commit",
+      "target": "private_dot_claude_commands_commit_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "private_dot_claude/commands/pr-merge.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -111140,7 +114477,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "private_dot_claude/commands/pr-merge.md",
-      "source_location": "L12",
+      "source_location": "L22",
       "weight": 1.0,
       "source": "private_dot_claude_commands_pr_merge_pr_merge",
       "target": "private_dot_claude_commands_pr_merge_safeguards",
@@ -111150,13 +114487,133 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "private_dot_claude/commands/pr-merge.md",
-      "source_location": "L5",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "private_dot_claude_commands_pr_merge_pr_merge",
       "target": "private_dot_claude_commands_pr_merge_steps",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr",
+      "target": "private_dot_claude_commands_pr_pr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr_pr",
+      "target": "private_dot_claude_commands_pr_post_the_pull_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr_pr",
+      "target": "private_dot_claude_commands_pr_pull_request_body_template",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr_pr",
+      "target": "private_dot_claude_commands_pr_review_the_draft_before_posting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr_pr",
+      "target": "private_dot_claude_commands_pr_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/pr.md",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_pr_pr",
+      "target": "private_dot_claude_commands_pr_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_sync_worktrees",
+      "target": "private_dot_claude_commands_sync_worktrees_sync_worktrees",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_sync_worktrees_sync_worktrees",
+      "target": "private_dot_claude_commands_sync_worktrees_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/sync-worktrees.md",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_sync_worktrees_sync_worktrees",
+      "target": "private_dot_claude_commands_sync_worktrees_steps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_uncommit",
+      "target": "private_dot_claude_commands_uncommit_uncommit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_uncommit_uncommit",
+      "target": "private_dot_claude_commands_uncommit_safeguards",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "private_dot_claude/commands/uncommit.md",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "private_dot_claude_commands_uncommit_uncommit",
+      "target": "private_dot_claude_commands_uncommit_steps",
+      "confidence_score": 1.0
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "2561061e4e75ff4ae400e2c4a24994bc8b1cf1e7"
+  "built_at_commit": "5b2aa0df6f868fe188d71101834716970b2b55b3"
 }

--- a/test/e2e/update-skills-lock-contention.sh
+++ b/test/e2e/update-skills-lock-contention.sh
@@ -87,8 +87,14 @@ for s in "${skills[@]}"; do
     "$cli_lock" >"$cli_lock.tmp" && mv "$cli_lock.tmp" "$cli_lock"
 done
 EOF
-# no-op alerter: the real one blocks for its --timeout waiting for interaction.
-printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/alerter"
+# alerter stub: the real one blocks for its --timeout waiting for interaction.
+# It RECORDS rather than no-ops, because part C asserts that an alert fired.
+ALERTER_LOG="$tmp/alerter.log"
+: >"$ALERTER_LOG"
+cat >"$stub/alerter" <<EOF
+#!/usr/bin/env bash
+printf 'alerter %s\n' "\$*" >>"$ALERTER_LOG"
+EOF
 chmod +x "$stub/npx" "$stub/alerter"
 export PATH="$stub:$PATH"
 
@@ -138,5 +144,61 @@ chmod 700 "$AGENTS"
   fail "a hard lock-acquisition failure did not exit 1 (got $rc_hard): $out_hard"
 grep -qi 'REQUIRED-FAILURE' <<<"$out_hard" ||
   fail "a hard lock-acquisition failure recorded no required failure: $out_hard"
+
+# ── Part C: contention on the LAST scheduled slot is loud ─────────────────────
+# A deferral is retryable only while a later slot exists. On the last Monday
+# slot there is none: the holder (an --install-only run from an apply, say)
+# writes no weekly stamp, so a week can end with the full update never run and
+# nothing said about it, which reads exactly like a week that simply worked.
+# Contention stays a deferral (exit 75, not a required failure, nothing was
+# attempted); what the last slot adds is the alert. A slot with time left behind
+# it must stay quiet, which the control below pins.
+cat >"$stub/date" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  +%H) printf '%s\n' "${FAKE_HOUR:-04}" ;;
+  +%u) printf '%s\n' "${FAKE_DOW:-1}" ;;
+  *) exec /bin/date "$@" ;;
+esac
+EOF
+chmod +x "$stub/date"
+
+# run_contended <hour> <dow> [--scheduled] : hold the lock for the whole run.
+run_contended() {
+  local hour="$1" dow="$2" sched="${3:-}"
+  local -a run_args=()
+  [[ $sched == "--scheduled" ]] && run_args=(--scheduled)
+  : >"$ALERTER_LOG"
+  exec 8>>"$LOCKFILE"
+  /usr/bin/lockf -s -t 0 8 || fail "the test could not pre-acquire the serialize lock"
+  set +e
+  CONTENDED_OUT="$(FAKE_HOUR="$hour" FAKE_DOW="$dow" bash "$SCRIPT" "${run_args[@]}" 8>&- 2>&1)"
+  CONTENDED_RC=$?
+  set -e
+  exec 8>&-
+}
+
+run_contended 23 1 --scheduled
+[[ $CONTENDED_RC -eq 75 ]] ||
+  fail "last-slot contention did not exit the retryable 75 (got $CONTENDED_RC): $CONTENDED_OUT"
+grep -qi 'EXHAUSTED' <<<"$CONTENDED_OUT" ||
+  fail "contention on the last scheduled slot did not log exhaustion: $CONTENDED_OUT"
+[[ -s $ALERTER_LOG ]] ||
+  fail "contention on the last scheduled slot fired no alert, so the week ends silently: $CONTENDED_OUT"
+if grep -qi 'REQUIRED-FAILURE' <<<"$CONTENDED_OUT"; then
+  fail "a deferral was recorded as a required failure; nothing was attempted: $CONTENDED_OUT"
+fi
+
+# Control: same contention with slots still to come stays quiet.
+run_contended 04 1 --scheduled
+[[ $CONTENDED_RC -eq 75 ]] ||
+  fail "mid-week contention did not exit the retryable 75 (got $CONTENDED_RC): $CONTENDED_OUT"
+[[ ! -s $ALERTER_LOG ]] ||
+  fail "contention on a slot with later slots remaining alerted: $(cat "$ALERTER_LOG")"
+
+# Control: a MANUAL run never claims scheduled-budget exhaustion, whatever the hour.
+run_contended 23 1
+[[ ! -s $ALERTER_LOG ]] ||
+  fail "a manual contended run claimed scheduled-budget exhaustion: $(cat "$ALERTER_LOG")"
 
 echo "update-skills-lock-contention: OK"

--- a/test/e2e/update-skills-unattended.sh
+++ b/test/e2e/update-skills-unattended.sh
@@ -193,11 +193,19 @@ early_exited || fail "a run whose week already succeeded did not early-exit: $RU
 proceeded && fail "a stamped week re-ran the full pass instead of early-exiting: $RUN_OUTPUT"
 
 # A stamp for the same week but a DIFFERENT roster hash must NOT early-exit (a
-# roster change un-stamps the week).
+# roster change un-stamps the week). "Did not early-exit" is not the claim worth
+# making on its own: any other early return, under any other message, satisfies
+# it while the rebuild never happens. So the run has to REACH ITS WORK, which
+# means the npx lane ran and the run reached its end.
 printf '%s %s %s' "$FAKE_WEEK" "deadbeef" "$updater_hash" >"$HOME/.local/state/update-skills/last-success"
+: >"$NPX_LOG"
 RUN_OUTPUT="$(FAKE_PS="$UNRELATED_PYTHON" FAKE_HOUR=08 bash "$SCRIPT" 2>&1)" ||
   fail "the roster-changed run exited non-zero: $RUN_OUTPUT"
 early_exited && fail "a stamp with a stale roster hash early-exited instead of rebuilding: $RUN_OUTPUT"
+proceeded ||
+  fail "a stamp with a stale roster hash did not reach the end of a full run: $RUN_OUTPUT"
+[[ -s $NPX_LOG ]] ||
+  fail "a stamp with a stale roster hash skipped the npx lane, so nothing was rebuilt: $RUN_OUTPUT"
 
 # A completed run writes a stamp that begins with the current ISO week.
 run_updater "$UNRELATED_PYTHON"

--- a/test/e2e/update-skills-weekly-record.sh
+++ b/test/e2e/update-skills-weekly-record.sh
@@ -384,13 +384,15 @@ grep -qF -- '--state deferred' <<<"$entries" ||
 grep -qiE 'refus|roster' <<<"$entries" ||
   fail "the refusal entry does not say why nothing was attempted: $entries"
 
-# ── 10. LOCK CONTENTION is the second way a slot ends up attempting nothing, and
-#       it reaches a DIFFERENT record call site than the harness-activity
-#       deferral above (the lock is taken before the activity check, so nothing
-#       else in this file can reach it). Deferred is the class that actually
-#       fires on this machine, so every path that produces one is pinned. It is a
-#       record and not an alert: nothing was attempted, so there is nothing to
-#       act on. ────────────────────────────────────────────────────────────────
+# ── 10. LOCK CONTENTION is the second way a slot ends up attempting nothing (the
+#       roster refusal above is the first), and it reaches its own record call
+#       site: the lock is taken before anything else, so no other case in this
+#       file passes through it. Deferred is the class that actually fires on this
+#       machine, so every path that produces one is pinned. It is a record and
+#       not an alert, because nothing was attempted and a later slot retries;
+#       the one exception is contention on the LAST slot, which has no later slot
+#       behind it and does alert (pinned in
+#       test/e2e/update-skills-lock-contention.sh). ─────────────────────────────
 reset_state
 export FAKE_WEEK="2026-38"
 restage_lock

--- a/test/integration/update-skills-converge.sh
+++ b/test/integration/update-skills-converge.sh
@@ -294,9 +294,16 @@ done
 # CONSUMER itself must refuse. nonclaude has no Claude link now (convergence
 # removed it above). Rewrite claudeDelivery to an array and preview: the fan-out
 # must NOT offer to create nonclaude's link, and must report the malformed table.
-LOCK_FILE="$HOME/.agents/custom-skill-lock.json"
 jq '.claudeDelivery = ["nonclaude"]' "$LOCK_FILE" >"$LOCK_FILE.tmp" && mv "$LOCK_FILE.tmp" "$LOCK_FILE"
+set +e
 dry_out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1)"
+dry_rc=$?
+set -e
+# A preview that refused part of its work must SAY SO in its exit status:
+# automation that reads exit 0 otherwise accepts an incomplete preview as the
+# whole picture.
+[[ $dry_rc -ne 0 ]] ||
+  fail "a --dry-run that refused the Claude fan-out still exited 0: $dry_out"
 if grep -qE 'would create .*/\.claude/skills/nonclaude' <<<"$dry_out"; then
   printf '%s\n' "$dry_out" >&2
   fail "a malformed claudeDelivery failed OPEN; the Claude fan-out offered to restore the de-delivered nonclaude link"

--- a/test/integration/update-skills-converge.sh
+++ b/test/integration/update-skills-converge.sh
@@ -248,6 +248,43 @@ grep -qiE 'claudeDelivery.*(malformed|refus)' <<<"$stream_dry" ||
   fail "the --dry-run fan-out did not report the multi-document lock's claudeDelivery table: $stream_dry"
 cp "$GOOD_LOCK" "$LOCK_FILE"
 
+# ── A claudeDelivery KEY holding a newline forges a second exemption.
+# The undelivered-name reader is line-oriented (one name per line), so the single
+# key "keeper\nmover" is one entry to the schema and TWO names to the reader, and
+# converge_dir reaps every updater-owned link outside the desired set: one forged
+# key removed BOTH skills' ~/.claude links. Both must survive, and the run must
+# say why.
+jq '.claudeDelivery = {"keeper\nmover": "none"}' "$GOOD_LOCK" >"$LOCK_FILE"
+set +e
+newline_out="$(run)"
+newline_rc=$?
+set -e
+for s in keeper mover; do
+  [[ -L "$CLAUDE/$s" && "$(readlink "$CLAUDE/$s")" == "../../.agents/skills/$s" ]] ||
+    fail "a newline inside a claudeDelivery key removed the Claude link for $s: $newline_out"
+done
+[[ $newline_rc -ne 0 ]] ||
+  fail "a claudeDelivery key holding a newline ran to completion instead of failing closed: $newline_out"
+# The preview reaches the fan-out without the roster gate in front of it, so the
+# fan-out's own check has to refuse the forged key too, or the preview announces
+# a reap that the gate is the only thing preventing.
+newline_dry="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1 || true)"
+if grep -qE 'would remove stale .*/\.claude/skills/(keeper|mover)' <<<"$newline_dry"; then
+  printf '%s\n' "$newline_dry" >&2
+  fail "the --dry-run fan-out previewed reaping a link forged by a newline inside a claudeDelivery key"
+fi
+grep -qiE 'claudeDelivery.*(malformed|refus)' <<<"$newline_dry" ||
+  fail "the --dry-run fan-out did not report the forged claudeDelivery key: $newline_dry"
+cp "$GOOD_LOCK" "$LOCK_FILE"
+# ...and the legitimate single-key table still de-delivers exactly its own name:
+# a validator that refused every key would leave nonclaude linked instead.
+run >/dev/null || fail "the run refused a legitimate single-key claudeDelivery table"
+[[ ! -e "$CLAUDE/nonclaude" && ! -L "$CLAUDE/nonclaude" ]] ||
+  fail "the legitimate claudeDelivery 'none' entry stopped taking effect"
+for s in keeper mover; do
+  [[ -L "$CLAUDE/$s" ]] || fail "the legitimate run removed the Claude link for $s"
+done
+
 # ── A MALFORMED claudeDelivery must not fail OPEN in the Claude fan-out.
 # __update_skills_claude_undelivered fails open (an empty undelivered set) on a
 # wrong-shaped table, and the fan-out would then RESTORE nonclaude's de-delivered

--- a/test/integration/update-skills-converge.sh
+++ b/test/integration/update-skills-converge.sh
@@ -212,6 +212,42 @@ if printf '%s\n' "$second" | grep -qiE 'converge: (created|replaced|removed)'; t
   fail "a no-op convergence run still logged create/replace/remove actions: $second"
 fi
 
+# ── A MULTI-DOCUMENT roster lock must not resurrect a de-delivered link.
+# `jq -e '<filter>' file` reads a STREAM and evaluates the filter once per
+# document, so its exit status is the LAST document's while every extractor still
+# reads them all. A roster with claudeDelivery emptied and a second top-level
+# `{}` appended therefore satisfied the schema gate on that trailing object, the
+# undelivered-name reader came back empty, and the full run RECREATED
+# nonclaude's deliberately absent ~/.claude link and stamped the week a success.
+# Both readers are pinned here: the FULL run must refuse at the roster gate, and
+# the --dry-run preview (which skips that gate entirely) must refuse at the
+# fan-out's own claudeDelivery check.
+LOCK_FILE="$HOME/.agents/custom-skill-lock.json"
+GOOD_LOCK="$tmp/good-lock.json"
+cp "$LOCK_FILE" "$GOOD_LOCK"
+STAMP="$HOME/.local/state/update-skills/last-success"
+rm -f "$STAMP"
+jq '.claudeDelivery = []' "$GOOD_LOCK" >"$LOCK_FILE"
+printf '{}' >>"$LOCK_FILE"
+set +e
+stream_out="$(run)"
+stream_rc=$?
+set -e
+[[ $stream_rc -ne 0 ]] ||
+  fail "a multi-document roster lock ran to completion instead of failing closed: $stream_out"
+[[ ! -e "$CLAUDE/nonclaude" && ! -L "$CLAUDE/nonclaude" ]] ||
+  fail "a multi-document roster lock recreated the de-delivered nonclaude Claude link: $(readlink "$CLAUDE/nonclaude" 2>/dev/null)"
+[[ ! -f $STAMP ]] ||
+  fail "a multi-document roster lock still stamped the week: $(cat "$STAMP")"
+stream_dry="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --dry-run 2>&1 || true)"
+if grep -qE 'would create .*/\.claude/skills/nonclaude' <<<"$stream_dry"; then
+  printf '%s\n' "$stream_dry" >&2
+  fail "the --dry-run fan-out offered to restore nonclaude's link from a multi-document lock"
+fi
+grep -qiE 'claudeDelivery.*(malformed|refus)' <<<"$stream_dry" ||
+  fail "the --dry-run fan-out did not report the multi-document lock's claudeDelivery table: $stream_dry"
+cp "$GOOD_LOCK" "$LOCK_FILE"
+
 # ── A MALFORMED claudeDelivery must not fail OPEN in the Claude fan-out.
 # __update_skills_claude_undelivered fails open (an empty undelivered set) on a
 # wrong-shaped table, and the fan-out would then RESTORE nonclaude's de-delivered

--- a/test/integration/update-skills-delist.sh
+++ b/test/integration/update-skills-delist.sh
@@ -113,7 +113,23 @@ done
 write_lock alpha
 mkdir -p "$AGENTS/skills/gamma"
 printf 'FOREIGN-GAMMA\n' >"$AGENTS/skills/gamma/keep.txt"
+# gamma is also what a DELISTED skill leaves behind: a store dir the roster no
+# longer names, plus the skillOverrides entry the settings template stops
+# declaring but never erases. Nothing removes either, by ruling, so the run has
+# to at least NAME them; before this they were found by reading files by hand.
+mkdir -p "$HOME/.claude"
+printf '{"skillOverrides":{"gamma":"user-invocable-only","alpha":"user-invocable-only"}}\n' \
+  >"$HOME/.claude/settings.json"
 out2="$(run_full)" || fail "phase 2 run exited non-zero: $out2"
+
+grep -q "UNROSTERED: $AGENTS/skills/gamma is not in the roster" <<<"$out2" ||
+  fail "the run said nothing about store content the roster no longer declares: $out2"
+grep -qi 'skillOverrides entry for it' <<<"$out2" ||
+  fail "the run named the unrostered store dir but not the settings override left with it: $out2"
+# A ROSTERED skill is never reported, whatever settings.json says about it.
+if grep -q "UNROSTERED.*skills/alpha" <<<"$out2"; then
+  fail "a rostered skill was reported as unrostered leftover content: $out2"
+fi
 
 # beta is gone from the store (no symlink, no dir).
 [[ ! -e "$AGENTS/skills/beta" && ! -L "$AGENTS/skills/beta" ]] ||

--- a/test/integration/update-skills-install.sh
+++ b/test/integration/update-skills-install.sh
@@ -162,8 +162,9 @@ cat >"$HOME/.agents/custom-skill-lock.json" <<'EOF'
 }
 EOF
 
-# The real script, unmodified. FORCE bypasses the weekly stamp, which would
-# otherwise refuse to run while a harness (the one executing this test) is up.
+# The real script, unmodified. FORCE is inert here and kept only so the command
+# reads the same as its siblings: --install-only never consults or writes the
+# weekly success stamp, which is what FORCE bypasses.
 output="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only 2>&1)" || fail "update-skills.sh --install-only exited non-zero: $output"
 
 # 1) Absent npx-tracked skills get installed into the store.

--- a/test/integration/update-skills-roster-failclosed.sh
+++ b/test/integration/update-skills-roster-failclosed.sh
@@ -177,6 +177,21 @@ rc4=$?
 set -e
 assert_unchanged_and_failed "case 4 (empty tracked set, live generation non-empty)" "$rc4" "$out4"
 
+# --- Case 4b: a MULTI-DOCUMENT roster lock -------------------------------------
+# `jq -e '<filter>' file` reads a STREAM and evaluates the filter once per
+# document, so its exit status is the LAST document's. A valid roster with a
+# second top-level `{}` appended passed every schema check on that trailing empty
+# object (an absent table is legal there) while every extractor downstream still
+# read the real tables out of the first document. Whatever the documents say,
+# more than one of them is a lock nobody wrote on purpose: fail closed.
+printf '%s\n' "$good_lock_bytes" >"$LOCK"
+printf '{}' >>"$LOCK"
+set +e
+out4b="$(run_full)"
+rc4b=$?
+set -e
+assert_unchanged_and_failed "case 4b (multi-document lock)" "$rc4b" "$out4b"
+
 # --- Case 5: --install-only under a broken roster also fails closed ------------
 printf 'not json at all' >"$LOCK"
 set +e

--- a/test/integration/update-skills-stamp.sh
+++ b/test/integration/update-skills-stamp.sh
@@ -129,4 +129,70 @@ run "" 16 1 --scheduled
 stamp_fields="$(wc -w <"$STAMP" | tr -d ' ')"
 [[ $stamp_fields -eq 3 ]] || fail "the stamp is not <week> <lock-hash> <updater-hash> (got $stamp_fields fields): $(<"$STAMP")"
 
+# 4) The updater hash is THIS run's identity, captured at start-up. A chezmoi
+#    apply landing mid-run must not make an old parent stamp the NEW updater's
+#    hash: that stamp matches what the next slot computes, so the new updater
+#    early-exits and the code recorded as having run never runs.
+#
+#    The run is a COPY of the script (the repo file is never touched), and the
+#    npx stub replaces that copy mid-run, by rename, exactly as an apply does:
+#    the running process keeps its open inode, and only the path's bytes change.
+copy="$tmp/update-skills-copy.sh"
+cp "$SCRIPT" "$copy"
+chmod +x "$copy"
+old_hash="$(shasum -a 256 "$copy" | awk '{print $1}')"
+cat >"$stub/npx" <<EOF
+#!/usr/bin/env bash
+# Replace the updater on disk mid-run (rename, like an apply), then behave like
+# the install stub above.
+if [[ ! -e "$tmp/updater-replaced" ]]; then
+  cp "$copy" "$tmp/updater-new.sh"
+  printf '# a new updater landed mid-run\n' >>"$tmp/updater-new.sh"
+  mv "$tmp/updater-new.sh" "$copy"
+  chmod +x "$copy"
+  : >"$tmp/updater-replaced"
+fi
+mode=""
+skill=""
+prev=""
+for a in "\$@"; do
+  case "\$a" in add) mode=add ;; esac
+  [[ \$prev == "--skill" ]] && skill="\$a"
+  prev="\$a"
+done
+if [[ \$mode == "add" ]]; then
+  mkdir -p "\$HOME/.agents/skills/\$skill"
+  printf -- '---\nname: %s\ndescription: fixture\n---\n' "\$skill" >"\$HOME/.agents/skills/\$skill/SKILL.md"
+  cli_lock="\${XDG_STATE_HOME:-\$HOME/.local/state}/skills/.skill-lock.json"
+  mkdir -p "\$(dirname "\$cli_lock")"
+  [[ -f \$cli_lock ]] || printf '{"version":3,"skills":{}}\n' >"\$cli_lock"
+  jq --arg s "\$skill" '.skills[\$s] = {source: "github:fixture"}' \
+    "\$cli_lock" >"\$cli_lock.tmp" && mv "\$cli_lock.tmp" "\$cli_lock"
+fi
+echo stub
+EOF
+chmod +x "$stub/npx"
+rm -rf "$HOME/.local/state" "$HOME/.agents/.skills-current" "$HOME/.agents/.skills-generations"
+rm -f "$tmp/updater-replaced" "$tmp/npx-add-fail"
+OUT="$(FAKE_HOUR=04 FAKE_DOW=1 UPDATE_SKILLS_FORCE=1 bash "$copy" 2>&1)" ||
+  fail "the mid-run-replacement run exited non-zero: $OUT"
+[[ -e "$tmp/updater-replaced" ]] ||
+  fail "the stub never replaced the updater, so this case proved nothing: $OUT"
+new_hash="$(shasum -a 256 "$copy" | awk '{print $1}')"
+[[ $new_hash != "$old_hash" ]] || fail "the replacement did not change the updater's bytes"
+[[ -f $STAMP ]] || fail "the mid-run-replacement run wrote no stamp: $OUT"
+stamped_updater="$(awk '{print $3}' <"$STAMP")"
+[[ $stamped_updater == "$old_hash" ]] ||
+  fail "the stamp records an updater this run never executed (want $old_hash, got $stamped_updater)"
+gen_updater="$(jq -r '.updaterHash' "$HOME/.agents/.skills-current/generation.json")"
+[[ $gen_updater == "$old_hash" ]] ||
+  fail "generation.json records an updater this run never executed (want $old_hash, got $gen_updater)"
+# ...and the consequence: the replacement updater does NOT read that stamp as
+# its own, so a later slot rebuilds instead of early-exiting.
+OUT="$(FAKE_HOUR=05 FAKE_DOW=1 bash "$copy" 2>&1)" ||
+  fail "the follow-up run under the new updater exited non-zero: $OUT"
+if grep -qi 'already succeeded' <<<"$OUT"; then
+  fail "the replacement updater early-exited on a stamp written for the old one: $OUT"
+fi
+
 echo "update-skills-stamp: OK"

--- a/test/unit/update-skills-json-stream-reads.sh
+++ b/test/unit/update-skills-json-stream-reads.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# update-skills-json-stream-reads.sh: jq reads a file as a STREAM of values, so
+# `jq -e . file` says YES to `{"a":1}{"b":2}` and every later filter answers from
+# whichever document it happens to land on. The roster gate's version of this bug
+# is pinned end to end elsewhere (test/integration/update-skills-roster-failclosed.sh
+# and update-skills-converge.sh); this file pins the three sibling reads found in
+# the same audit, at the function level:
+#
+#   1. __gen_validate_candidate     the candidate npx lock must be ONE value, or
+#                                   the readers that later ask `.skills | has($n)`
+#                                   answer from the last document alone.
+#   2. __gen_reconcile_candidate_npx_lock
+#                                   its two inputs reach jq --argjson, which
+#                                   refuses a stream outright, so a stream has to
+#                                   reach the '{}' fallback instead of failing the
+#                                   whole reconcile (and discarding the candidate).
+#   3. __gen_update_failure_streaks the state file must be ONE object, or every
+#                                   per-name read yields a line per document, no
+#                                   week ever compares equal, and the file grows a
+#                                   document per slot.
+#
+# Sourced with UPDATE_SKILLS_LIB_ONLY=1, so the main flow never runs; everything
+# happens inside a sandbox HOME.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+HOME="$tmp/home"
+export HOME
+mkdir -p "$HOME/.agents/skills"
+printf '{"npxTracked":{"alpha":{"repo":"x/a"}},"clawhubTracked":{},"tiers":{}}\n' \
+  >"$HOME/.agents/custom-skill-lock.json"
+
+export UPDATE_SKILLS_LIB_ONLY=1
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# ── 1. A candidate whose npx lock is two documents is INVALID ────────────────
+# The candidate is ADDITIVE on purpose: a full candidate's key-set comparison
+# already trips over a stream (two lines where one is expected), so only the
+# additive path (what --install-only publishes) exposes the read itself.
+candidate="$tmp/candidate/.agents"
+mkdir -p "$candidate/skills/alpha"
+printf -- '---\nname: alpha\n---\n' >"$candidate/skills/alpha/SKILL.md"
+printf '{"skills":{"alpha":{}}}\n{"skills":{"alpha":{}}}\n' >"$candidate/.skill-lock.json"
+__gen_write_meta "$candidate" "cand-1" additive
+if __gen_validate_candidate "$candidate" >/dev/null 2>&1; then
+  fail "a candidate whose .skill-lock.json holds two JSON documents validated"
+fi
+# ...and the same candidate with ONE document still validates, so the check
+# rejects the stream rather than the lock.
+printf '{"skills":{"alpha":{}}}\n' >"$candidate/.skill-lock.json"
+__gen_validate_candidate "$candidate" >/dev/null 2>&1 ||
+  fail "a candidate with a single-document npx lock no longer validates"
+
+# ── 2. The npx lock reconcile treats a stream as unreadable, not as fatal ────
+export XDG_STATE_HOME="$tmp/xdg-state"
+mkdir -p "$XDG_STATE_HOME/skills"
+printf '{"version":3,"skills":{"alpha":{"source":"github:x/a"}}}\n' \
+  >"$XDG_STATE_HOME/skills/.skill-lock.json"
+printf '{"skills":{"alpha":{}}}\n{"skills":{"beta":{}}}\n' >"$AGENTS/.skill-lock.json"
+__gen_reconcile_candidate_npx_lock additive ||
+  fail "the npx lock reconcile failed the candidate over a two-document seed instead of falling back to {}"
+[[ "$(jq -s 'length' "$AGENTS/.skill-lock.json")" == "1" ]] ||
+  fail "the reconciled npx lock is not a single JSON document: $(cat "$AGENTS/.skill-lock.json")"
+jq -e '.skills | has("alpha")' "$AGENTS/.skill-lock.json" >/dev/null ||
+  fail "the reconciled lock dropped the CLI-recorded entry: $(cat "$AGENTS/.skill-lock.json")"
+
+# ── 3. A two-document streak file is replaced, not appended to ───────────────
+mkdir -p "$STATE_DIR"
+printf '{"alpha":{"last_failed_week":"1970-01","consecutive_failed_weeks":1}}\n{}\n' \
+  >"$STREAK_FILE"
+GEN_FAILED_SKILLS=(alpha)
+__gen_update_failure_streaks
+[[ "$(jq -s 'length' "$STREAK_FILE")" == "1" ]] ||
+  fail "the failure-streak file is not a single JSON document after a run: $(cat "$STREAK_FILE")"
+streak_count="$(jq -r '.alpha.consecutive_failed_weeks' "$STREAK_FILE")"
+[[ $streak_count == "1" ]] ||
+  fail "a fresh streak from an unreadable state file counted $streak_count instead of 1"
+
+echo "update-skills-json-stream-reads: OK"

--- a/test/unit/update-skills-json-stream-reads.sh
+++ b/test/unit/update-skills-json-stream-reads.sh
@@ -80,6 +80,7 @@ jq -e '.skills | has("alpha")' "$AGENTS/.skill-lock.json" >/dev/null ||
 mkdir -p "$STATE_DIR"
 printf '{"alpha":{"last_failed_week":"1970-01","consecutive_failed_weeks":1}}\n{}\n' \
   >"$STREAK_FILE"
+# shellcheck disable=SC2034 # read by __gen_update_failure_streaks in the sourced script
 GEN_FAILED_SKILLS=(alpha)
 __gen_update_failure_streaks
 [[ "$(jq -s 'length' "$STREAK_FILE")" == "1" ]] ||


### PR DESCRIPTION
## Context

`~/.local/bin/update-skills.sh` is the weekly job that keeps the cross-harness skills store
(`~/.agents/skills`) matching the roster this repo declares in `dot_agents/custom-skill-lock.json`. It
builds a candidate generation, publishes it with one atomic exchange, and fans the store out to Claude
Code and hermes as symlinks. PR #143 deleted its harness-activity idle gate (which had deferred every
scheduled slot on a machine in daily use) and delisted the `website-to-video` skill.

A review of that merged work found seven defects, one ranked HIGH, plus three comments still describing
mechanisms that no longer exist. This PR fixes them on top of `main`. Two other HIGH findings about
generation pinning are deliberately not addressed here: they belong to the Rust work and the operator
owns that trade.

## Summary

- A lock holding more than one JSON document no longer passes the roster gate in
  `dot_local/bin/executable_update-skills.sh`. `jq -e '<filter>'` reads a file as a stream and answers
  for the LAST document, so a roster with `{}` appended passed every check on that empty object while the
  readers still used the first document's tables.
- The same stream-acceptance hole is closed in four sibling reads, found by auditing every `jq` read of a
  lock or state file in the script: the fan-out's own `claudeDelivery` check, the candidate npx lock
  validation, the two npx-lock reconcile inputs, and the failure-streak state file.
- A `claudeDelivery` key containing a control character is refused. The reader is line-oriented, so the
  single key `"gh-axi\nhumanizer"` was two names to it, and convergence reaped both skills' Claude links.
- A `--dry-run` that refused part of its work now exits non-zero, and lock contention on the last
  scheduled slot of the week now alerts instead of ending the week silently with no update and no stamp.
- The updater's own hash is captured once at start-up, so a `chezmoi apply` landing mid-run can no longer
  make an old parent stamp the new updater's identity (which made every later slot early-exit on work
  that never ran).
- The run now names live content the roster no longer declares, a delisted skill's store directory and
  the `skillOverrides` entry left with it, and removes neither.

## What changed

One commit per finding, plus the map refresh. A separate commit carries the treefmt follow-ups (shfmt
realigning a comment column and one reasoned shellcheck directive).

| Commit | Finding |
| --- | --- |
| `refuse a multi-document lock` | HIGH: the schema gate answered from the last document; four sibling reads audited and fixed with it |
| `refuse a claudeDelivery key holding a control character` | a newline in a key forged a second exemption and reaped two links |
| `exit non-zero when a dry run refused part of its work` | a refused preview looked like a clean one |
| `alert when the last scheduled slot defers over contention` | a contended last slot ended the week silently |
| `capture the updater's identity once, at start-up` | an old parent stamped the new updater's hash |
| `name the live content the roster no longer declares` | delist leftovers were invisible |
| `make the stale-stamp case prove a rebuild happened` | the test passed on any silent early exit |
| `correct three comments about gates that no longer exist` | the plist slot comment, the weekly-record test, the install test |
| `refresh the graphify map` | the committed map still indexed deleted functions |

Two decisions worth naming, both recorded in comments next to the code:

**Contention on the last slot stays a deferral, and alerts.** Nothing was attempted, so it is not a
required-phase failure and the exit stays the retryable 75. What the last slot adds is the alert, on the
route exhaustion already uses. Waiting for the lock instead was rejected: a holder can run for many
minutes, and blocking the last slot on it trades a visible miss for an invisible stall inside a launchd
job nobody watches.

**The delist report removes nothing, by ruling.** It compares the store against the lock's `tiers` table
(which covers exactly the roster, so vendored and app-owned entries stay quiet) and names what is left
over. The `skillOverrides` half is reported only for a name the store also carries, which is the delist
shape: Claude Code takes overrides for skills this vertical does not deliver, and naming those would be a
weekly false positive.

## How it was verified

Every fix has a test that fails without it. RED was measured by stashing the source change and running
the test against the pre-fix script, GREEN by the same test on the fixed one. Each fix was then mutated
against an unmutated control, and the killing test recorded.

| # | Fix | Mutation applied | Test that went RED |
| --- | --- | --- | --- |
| 1 | roster schema gate slurps | judge the last document (`length >= 1 and (.[-1] \| ...)`) | `test/integration/update-skills-roster-failclosed.sh` case 4b |
| 2 | fan-out `claudeDelivery` check slurps | same shape on that filter | `test/integration/update-skills-converge.sh` (the dry run offered to restore the link) |
| 3 | candidate npx lock validation slurps | back to `jq -e .` | `test/unit/update-skills-json-stream-reads.sh` |
| 4 | reconcile inputs slurp | back to `jq -e .` | same (the reconcile failed the candidate instead of falling back) |
| 5 | streak file read slurps | back to `jq -e .` | same (the state file was left holding two documents) |
| 6 | control-char keys refused (fan-out) | `test("[[:cntrl:]]")` never matches | `update-skills-converge.sh` (the dry run previewed reaping both links) |
| 7 | control-char keys refused (gate) | the same, in the gate | `update-skills-converge.sh` (the run completed instead of failing closed) |
| 8 | dry run exits non-zero on refusal | `exit 1` back to `exit 0` | `update-skills-converge.sh` |
| 9 | last-slot contention alerts | exhaustion check forced false | `test/e2e/update-skills-lock-contention.sh` (no exhaustion logged) |
| 10 | ...and only on the last slot | exhaustion check forced true | the same file (a mid-week slot alerted) |
| 11 | updater hash captured at start | read the path at write time again | `test/integration/update-skills-stamp.sh` (the stamp recorded an updater the run never executed) |
| 12 | unrostered content reported | call site removed | `test/integration/update-skills-delist.sh` |
| 13 | ...including the stale override | override lookup forced false | the same file (it named the directory, not the override) |
| 14 | ...and only for unrostered names | membership test inverted | the same file |
| 15 | stale-stamp case proves a rebuild | one silent early exit added to the updater | the new assertion failed; **the old assertion passed**, which is the finding |

The multi-document scenario is pinned end to end as reported: the fixture roster with `claudeDelivery`
emptied and `{}` appended made the pre-fix full run print
`converge: created .../.claude/skills/nonclaude`, recreating a deliberately de-delivered link. After the
fix the run refuses, the link stays absent, and no stamp is written.

### The jq-stream audit

Every `jq` read of a lock or state file in the script, and where it stands now:

**Fixed (5).** `__gen_roster_schema_ok` (the roster lock, the HIGH);
`__update_skills_claude_delivery_malformed` (the roster lock at the point of use, the only gate
`--dry-run` reaches); `__gen_validate_candidate` (the candidate `.skill-lock.json`, whose later readers
ask `.skills | has($n)` and would have answered from the last document);
`__gen_reconcile_candidate_npx_lock` (both inputs reach `jq --argjson`, which refuses a stream outright,
so a stream turned a fallback into a hard failure); `__gen_update_failure_streaks` (a stream
re-incremented every slot and grew the file by a document per run, and a bare scalar was fatal under
`errexit`).

**Audited, unchanged, with the reason.** Every other roster read in a mutating mode goes through the
run-private snapshot taken after the gate, so the gate covers them; in `--dry-run` they read the live
lock, and the fan-out check now refuses a multi-document lock before any of them can mislead, with a
non-zero exit. `check_fork_drift` already required a single document
(`__gen_fork_lock_single_document`), which is where the shape came from. `generation.json` and the
exchange-in-flight marker are written by this script with `jq -n`, and a stream makes their id
comparisons unequal, which fails toward "rebuild" or "drop the marker", never toward accepting.
`.clawhub/origin.json` is publisher-controlled, but its value is already scrubbed of control characters
before it is printed, so a multi-document marker collapses to one line and cannot forge a row in the
weekly record.

### Gates

`just l` clean, `just test` green across all four suites, with `main` merged in at `8fe01fed`.

## Effect of merging

Nothing changes on this machine. Every file here is chezmoi source state and no apply runs before the D1
cutover, so the deployed `~/.local/bin/update-skills.sh` and the loaded LaunchAgent keep their current
behaviour until then.

Three things happen at the first apply after cutover. The weekly run gains the refusals and the two new
reports. The updater's bytes change, so the current week un-stamps and the next scheduled slot rebuilds
once. And the plist's comment edit changes the rendered file, so `run_onchange_after_63` (which keys on
that file's hash) reloads the LaunchAgent, bootout then bootstrap, with the same schedule it has now.
The delist report will name `website-to-video`'s leftovers on that run; it removes neither, and removing
them stays a hand operation.

### On the two out-of-scope HIGHs

Neither is touched, and nothing here makes either more likely. The exchange still resolves generations
per lookup rather than pinning one per invocation, and the serialize lock still does not cover the
out-of-band HyperFrames writer. One second-order note for completeness: capturing the updater hash means
a mid-run replacement now leaves a real mismatch, so a later slot rebuilds where it used to early-exit,
which is one more exchange in exactly the case where the old behaviour was recording work that never ran.

## Review guide

Read `dot_local/bin/executable_update-skills.sh` first; the fixes are small and each carries its reason
above it. Three are worth the most attention:

- `__gen_roster_schema_ok` and `__update_skills_claude_delivery_malformed`, the two slurped gates. The
  question to ask is whether any reader can still reach a lock that neither of them has judged.
- the contention branch at the lock acquisition, for the semantics: a deferral, exit 75, and an alert
  only on the last scheduled slot.
- `report_unrostered_live_content`, for the false-positive argument: it fires on a store name absent from
  `tiers`, and mentions `skillOverrides` only for such a name.

For the tests, `test/integration/update-skills-converge.sh` carries the multi-document and forged-key
scenarios with both the full run and the preview, and `test/unit/update-skills-json-stream-reads.sh` pins
the three sibling reads at the function level in about a second.
