### PR TITLE
fix(osquery): read every monitor state file as one JSON document, not a stream

### DIFF
--- a/dot_local/libexec/osquery/executable_allowlist.sh
+++ b/dot_local/libexec/osquery/executable_allowlist.sh
@@ -67,13 +67,31 @@ take_allowlist_write_lock() {
   "$lockf_bin" -s 9
 }
 
-# The JSON label of an allowlist line, or empty for a comment/blank/non-JSON line.
+# The JSON label of an allowlist line, or empty for a comment/blank/non-tuple line.
+# `-R` reads the LINE as a raw string and `fromjson?` parses it, so a line counts as
+# an entry only when it holds EXACTLY ONE JSON value. That is the rule
+# allowlist_verdict applies when it consults the deployed file, and matching it is
+# what keeps writer and consumer agreeing on what an entry is: read as a STREAM
+# instead, a line holding two concatenated tuples reports two labels, matches
+# neither, and survives a rewrite the consumer honors it for nothing.
 # 9>&- so this jq (spawned under the write lock) never inherits the lock fd - see the
 # fd-inheritance note on take_allowlist_write_lock.
-entry_label() { jq -r '.label // empty' 9>&- <<<"$1" 2>/dev/null || true; }
+entry_label() { jq -Rr 'fromjson? | .label // empty' 9>&- <<<"$1" 2>/dev/null || true; }
+
+# line_is_one_tuple <line> -- status 0 when the line holds exactly one JSON object.
+# The refusal predicate below; same one-value-per-line rule as entry_label, so the
+# two can never disagree about which lines are entries.
+line_is_one_tuple() { jq -Re 'fromjson? | type == "object"' 9>&- <<<"$1" >/dev/null 2>&1; }
 
 # Rewrite an allowlist file, preserving comment/blank lines and dropping any tuple for
 # <label>. Reads <file>, writes the filtered result to stdout (a no-op if it is absent).
+#
+# A non-comment line that is not exactly one JSON tuple REFUSES the whole rewrite
+# (nonzero, reason on stderr). Editing around it silently is the failure this
+# closes: the label read cannot match such a line, so the line survives while the
+# command reports a removal it did not make, or an add lands a second tuple for a
+# label the file already mentions. A corrupt source is fixed by hand, not curated
+# around.
 _without_label() {
   local drop="$1" file="$2" line
   [[ -f $file ]] || return 0
@@ -84,6 +102,11 @@ _without_label() {
         continue
         ;;
     esac
+    if ! line_is_one_tuple "$line"; then
+      printf 'refused: the allowlist source holds a line that is not a single JSON tuple; repair %s by hand before curating it\n' \
+        "$file" >&2
+      return 1
+    fi
     [[ "$(entry_label "$line")" == "$drop" ]] && continue
     printf '%s\n' "$line"
   done <"$file"
@@ -244,7 +267,10 @@ allow_label() {
   fi
   local temp
   temp=$(mktemp 9>&-)
-  _without_label "$label" "$source_file" >"$temp"
+  if ! _without_label "$label" "$source_file" >"$temp"; then
+    rm -f "$temp" 9>&-
+    exit 1
+  fi
   jq -cn --arg label "$label" --arg path "$rel_path" --arg program "$rel_prog" --arg sha256 "$sha" \
     '{label:$label, path:$path, program:$program, sha256:$sha256}' 9>&- >>"$temp"
   publish_allowlist "$temp" "$source_file" || exit 1
@@ -273,7 +299,10 @@ deny_label() {
   fi
   local temp
   temp=$(mktemp 9>&-)
-  _without_label "$label" "$source_file" >"$temp"
+  if ! _without_label "$label" "$source_file" >"$temp"; then
+    rm -f "$temp" 9>&-
+    exit 1
+  fi
   publish_allowlist "$temp" "$source_file" || exit 1
   printf 'denied: %s\n' "$label"
 }

--- a/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
+++ b/dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh
@@ -625,11 +625,21 @@ page_gap_once() {
 }
 
 # Validate any existing baseline BEFORE trusting it (and before write_state
-# overwrites it): it must be owner-only (mode 600) AND parse to three in-domain
-# built-in scalars (same domains as the gap gate below). A group/world-readable,
-# corrupt, or out-of-domain baseline is not trustworthy (it could be planted to
-# mask a disabled protection, or fabricate a transition), so it is treated as no
-# prior baseline. GNU-first stat, BSD fallback.
+# overwrites it): it must be owner-only (mode 600), slurp (-s) to exactly ONE
+# top-level object, AND carry three in-domain built-in scalars (same domains as
+# the gap gate below). A group/world-readable, corrupt, multi-document, or
+# out-of-domain baseline is not trustworthy (it could be planted to mask a
+# disabled protection, or fabricate a transition), so it is treated as no prior
+# baseline. GNU-first stat, BSD fallback.
+#
+# The whole-file rule is the same one load_controls applies, and for the same
+# reason: a multi-document file parses per document, so the three reads below
+# would each emit one result PER document. A document that LACKS the field emits
+# nothing, so a prior followed by a second document lacking the trio collapses
+# back to one clean value and would pass as a trustworthy baseline. Validating
+# once here is also what keeps the fold-in below from writing the doubling back
+# into the state file. Every read after this queries the validated value, so
+# nothing re-reads the file.
 prev_valid=0
 prev_fw=""
 prev_gk=""
@@ -637,7 +647,7 @@ prev_sl=""
 prev_json=""
 if [[ -f $STATE ]]; then
   st_mode=$(stat -c '%a' "$STATE" 2>/dev/null || stat -f '%Lp' "$STATE" 2>/dev/null || echo "")
-  prev_json=$(cat "$STATE" 2>/dev/null || echo "")
+  prev_json=$(jq -ce -s 'if (length == 1 and (.[0] | type == "object")) then .[0] else error("not one object") end' <"$STATE" 2>/dev/null) || prev_json=""
   prev_fw=$(jq -r '.firewall // empty' <<<"$prev_json" 2>/dev/null || echo "")
   prev_gk=$(jq -r '.gatekeeper // empty' <<<"$prev_json" 2>/dev/null || echo "")
   prev_sl=$(jq -r '.screenlock // empty' <<<"$prev_json" 2>/dev/null || echo "")
@@ -769,6 +779,11 @@ else
     '{firewall: $fw, gatekeeper: $gk, screenlock: $sl}')
 fi
 if [[ -n $controls_problem && $prev_valid -eq 1 ]]; then
+  # One document in, one document out. prev_valid is only ever 1 for a baseline
+  # that slurped to exactly one object, which is what stops this fold-in from
+  # AMPLIFYING a corrupt prior: over a multi-document prior it would emit one
+  # object per document and write_state would persist the whole stream, so the
+  # doubling would outlive the tick that read it.
   baseline_json=$(jq -c --argjson trio "$baseline_json" '. + $trio' <<<"$prev_json")
 fi
 for control_index in "${!control_ids[@]}"; do

--- a/dot_local/libexec/osquery/executable_tailscale-monitor.sh
+++ b/dot_local/libexec/osquery/executable_tailscale-monitor.sh
@@ -149,12 +149,21 @@ page_exposure_and_persist() {
   persist_baseline active
 }
 
-# Read the prior baseline. Only active/inactive is a valid funnel baseline; a
-# corrupt/absent value is treated as no trustworthy baseline (R2-5b).
+# Read the prior baseline ONCE, as a WHOLE FILE: it must slurp (-s) to exactly
+# ONE top-level object before its funnel value is even looked at. Only
+# active/inactive is then a valid funnel baseline; a corrupt/absent value is
+# treated as no trustworthy baseline (R2-5b).
+#
+# The whole-file rule is not decoration. Read per document, `.funnel // empty`
+# emits one result PER document and nothing for a document that lacks the key,
+# so an active baseline followed by a second document collapses back to a clean
+# "active" that would be trusted as a steady exposure, and the public-exposure
+# page below would never fire. A public-exposure detector must not read a corrupt
+# file as steady state.
 prev_funnel=""
 state_was_corrupt=0
 if [[ -f $STATE ]]; then
-  prev_funnel=$(jq -r '.funnel // empty' <"$STATE" 2>/dev/null || echo "")
+  prev_funnel=$(jq -re -s 'if (length == 1 and (.[0] | type == "object")) then (.[0].funnel // "") else error("not one object") end' <"$STATE" 2>/dev/null) || prev_funnel=""
 fi
 case "$prev_funnel" in
   active | inactive) ;;
@@ -211,8 +220,14 @@ fi
 if [[ -z $funnel_json ]]; then
   gap_and_exit "- ${bt}tailscale funnel status --json${bt} returned no output, so the funnel state is unreadable."
 fi
-# Malformed (non-JSON) output is a gap, not a silent inactive. jq empty validates
-# JSON (any value, including {} and null) and fails only on a PARSE error.
+# Malformed (non-JSON) output is a gap, not a silent inactive. This is a PARSE
+# check and nothing more: jq empty accepts any value ({} and null included), and
+# it accepts a multi-document stream too, so it says nothing about the SHAPE of
+# what came back. That is fine here and only here, because the input is one
+# capture of one CLI run rather than a file something else may have appended to,
+# and because the classifier below decides the funnel state on its own terms and
+# gaps on any shape it does not recognize. The prior-baseline read above, which
+# DOES read a file, takes the stricter whole-file rule instead.
 if ! printf '%s' "$funnel_json" | jq empty >/dev/null 2>&1; then
   gap_and_exit "- ${bt}tailscale funnel status --json${bt} returned output that is not valid JSON, so the funnel state is unreadable."
 fi

--- a/dot_local/libexec/osquery/executable_uptime-watchdog.sh
+++ b/dot_local/libexec/osquery/executable_uptime-watchdog.sh
@@ -111,13 +111,26 @@ field_raw() {
   printf '%s' "${line#*"$label = "}"
 }
 
-# Prior cross-run state. Absent or corrupt (unparseable) starts fresh, never a
-# crash: a fresh start means empty streaks and no false growth signal.
+# Prior cross-run state, read ONCE and validated as a WHOLE FILE: it must slurp
+# (-s) to exactly ONE top-level object. Absent, unparseable, or anything else
+# starts fresh, never a crash: a fresh start means empty streaks and no false
+# growth signal.
+#
+# Slurped rather than checked with a bare `jq -e .`, which takes its exit status
+# from the LAST document of a concatenated stream and so passes a file holding
+# two documents. That matters because every read below queries this value, and a
+# stream fans a query out to one result PER document: the numeric guards reject
+# the resulting two-line values, but a `// ""` fallback emits an EMPTY line for a
+# document lacking the key, which command substitution strips - so a trailing {}
+# collapses the fan-out back to a single clean value that passes its guard. The
+# audit's paged-fingerprint marker reads that way, and adopting one from a
+# corrupt file silences the manifest-audit page for that tamper permanently.
+# Validating here fixes every later read at once: each one queries this
+# in-memory document, and none of them re-reads the file.
 prev_state="{}"
 if [[ -r $STATE ]]; then
-  prev_state="$(cat "$STATE" 2>/dev/null || printf '{}')"
+  prev_state="$(jq -ce -s 'if (length == 1 and (.[0] | type == "object")) then .[0] else error("not one object") end' <"$STATE" 2>/dev/null)" || prev_state="{}"
 fi
-printf '%s' "$prev_state" | jq -e . >/dev/null 2>&1 || prev_state="{}"
 
 uid="$(id -u)"
 problems=()

--- a/test/fixtures/osquery-allowlist-lib.bash
+++ b/test/fixtures/osquery-allowlist-lib.bash
@@ -144,6 +144,26 @@ seed_allowlist_tuple() {
   "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1
 }
 
+# Seed a raw line into the allowlist source verbatim (same source-then-apply route
+# as seed_allowlist_tuple), for the shapes a well-formed tuple cannot express: a
+# line holding two concatenated JSON documents, a comment, a blank.
+seed_allowlist_raw_line() {
+  printf '%s\n' "$1" >>"$ALLOWLIST_SOURCE_FILE"
+  "$ALLOWLIST_CHEZMOI" apply --force >/dev/null 2>&1
+}
+
+# One line holding TWO concatenated tuples for <label>: what a doubled write, or
+# a lost newline between two appends, leaves behind. Each document parses alone,
+# so a per-document read reports a label for it; only a one-value-per-line rule
+# refuses it. The consumer (allowlist-verdict) already applies that rule, so a
+# line like this can never suppress anything.
+doubled_tuple_line() {
+  local tuple
+  tuple="$(jq -cn --arg label "$1" --arg path "$2" --arg program "$3" \
+    '{label:$label, path:$path, program:$program, sha256:""}')"
+  printf '%s%s' "$tuple" "$tuple"
+}
+
 # Membership by the JSON .label field (the file is NDJSON tuples now, R2-1).
 assert_allowlisted() {
   if ! grep -qF "\"label\":\"$1\"" "$OSQUERY_LAUNCHD_ALLOWLIST" 2>/dev/null; then

--- a/test/fixtures/osquery-tailscale-lib.bash
+++ b/test/fixtures/osquery-tailscale-lib.bash
@@ -120,7 +120,11 @@ teardown_tailscale_harness() {
 # seed_funnel_state <token> -- write the prior baseline (and gap marker) the run
 # starts from. "" removes it (first run); active/inactive write the 0600 JSON
 # baseline; gap writes an inactive baseline PLUS the page-once gap marker (a prior
-# blind window); corrupt writes non-JSON garbage.
+# blind window); corrupt writes non-JSON garbage; concatenated-active writes two
+# valid JSON documents (an active baseline, then an empty object), the shape a
+# per-document read collapses back into a clean "active" it must not trust;
+# pretty-active writes the same active baseline indented across several lines,
+# which is still ONE document and must stay trusted.
 seed_funnel_state() {
   local marker="$OSQUERY_TAILSCALE_STATE.gap"
   rm -f "$OSQUERY_TAILSCALE_STATE" "$marker"
@@ -128,6 +132,11 @@ seed_funnel_state() {
     "") : ;;
     active) _write_state_0600 '{"funnel":"active"}' ;;
     inactive) _write_state_0600 '{"funnel":"inactive"}' ;;
+    concatenated-active) _write_state_0600 '{"funnel":"active"}
+{}' ;;
+    pretty-active) _write_state_0600 '{
+  "funnel": "active"
+}' ;;
     gap)
       _write_state_0600 '{"funnel":"inactive"}'
       : >"$marker"

--- a/test/integration/osquery-allowlist.bats
+++ b/test/integration/osquery-allowlist.bats
@@ -146,6 +146,84 @@ stub_launchd() {
   }
 }
 
+@test "denying (-d) refuses a source line holding two concatenated tuples instead of reporting a removal it did not make" {
+  # The per-line label read parsed the line as a JSON STREAM, so two concatenated
+  # tuples yielded two labels, matched neither, and the line survived the rewrite
+  # while the command reported "denied" and refreshed the manifest. The consumer
+  # reads one value per line and ignores such a line entirely, so nothing was ever
+  # suppressed by it; what is wrong is the writer editing around a corrupt source
+  # and calling it a removal. Refuse the whole mutation instead: loud, non-zero,
+  # nothing deployed.
+  seed_allowlist_raw_line "$(doubled_tuple_line com.foo.agent '~/Library/LaunchAgents/com.foo.agent.plist' /opt/homebrew/opt/foo/bin/foo)"
+  local before
+  before="$(cat "$ALLOWLIST_SOURCE_FILE")"
+
+  run run_allowlist -d com.foo.agent
+  [ "$status" -ne 0 ] || {
+    echo "expected -d to refuse a malformed source, got exit 0: $output"
+    false
+  }
+  [[ $output == *"single JSON tuple"* ]] || {
+    echo "expected stderr to name the malformed line; got: $output"
+    false
+  }
+  [ "$(cat "$ALLOWLIST_SOURCE_FILE")" = "$before" ] || {
+    echo "expected the source untouched by a refused deny; source: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+  refute_manifest_refreshed
+}
+
+@test "adding (-a) refuses a source line holding two concatenated tuples instead of appending beside it" {
+  # Same refusal for the add path: appending a fresh tuple beside a corrupt line
+  # the rewrite could not drop is how a label ends up stored twice.
+  local plist="$ALLOWLIST_HOME/Library/LaunchAgents/com.foo.agent.plist"
+  mkdir -p "$(dirname "$plist")"
+  printf 'plist-bytes\n' >"$plist"
+  stub_launchd "$plist" /opt/homebrew/opt/foo/bin/foo
+  seed_allowlist_raw_line "$(doubled_tuple_line com.foo.agent '~/Library/LaunchAgents/com.foo.agent.plist' /opt/homebrew/opt/foo/bin/foo)"
+  local before
+  before="$(cat "$ALLOWLIST_SOURCE_FILE")"
+
+  run run_allowlist -a com.foo.agent
+  [ "$status" -ne 0 ] || {
+    echo "expected -a to refuse a malformed source, got exit 0: $output"
+    false
+  }
+  [[ $output == *"single JSON tuple"* ]] || {
+    echo "expected stderr to name the malformed line; got: $output"
+    false
+  }
+  [ "$(cat "$ALLOWLIST_SOURCE_FILE")" = "$before" ] || {
+    echo "expected the source untouched by a refused add; source: $(cat "$ALLOWLIST_SOURCE_FILE")"
+    false
+  }
+  refute_manifest_refreshed
+}
+
+@test "curating around comments and blank lines still round-trips: one tuple per line is the only rule" {
+  # The refusal is about a line carrying more than one JSON value, nothing else:
+  # comments and blanks are preserved verbatim, and a well-formed tuple on its own
+  # line is still dropped by -d.
+  seed_allowlist_raw_line '# operator-curated own agents'
+  seed_allowlist_raw_line ''
+  seed_allowlist_tuple com.foo.agent '~/Library/LaunchAgents/com.foo.agent.plist' /opt/homebrew/opt/foo/bin/foo
+  seed_allowlist_tuple com.bar.agent '~/Library/LaunchAgents/com.bar.agent.plist' /opt/homebrew/opt/bar/bin/bar
+
+  run run_allowlist -d com.foo.agent
+  [ "$status" -eq 0 ] || {
+    echo "expected -d of a present label to exit 0, got $status: $output"
+    false
+  }
+  assert_not_allowlisted com.foo.agent
+  assert_allowlisted com.bar.agent
+  run grep -qxF '# operator-curated own agents' "$OSQUERY_LAUNCHD_ALLOWLIST"
+  [ "$status" -eq 0 ] || {
+    echo "expected the comment line preserved; file: $(cat "$OSQUERY_LAUNCHD_ALLOWLIST")"
+    false
+  }
+}
+
 @test "listing (-l) prints exactly the current entry lines to stdout and exits 0" {
   seed_allowlist_tuple com.foo.agent '~/Library/LaunchAgents/com.foo.agent.plist' /opt/homebrew/opt/foo/bin/foo
   seed_allowlist_tuple com.bar.agent '~/Library/LaunchAgents/com.bar.agent.plist' /opt/homebrew/opt/bar/bin/bar

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -509,21 +509,23 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
 
 @test "T-PCTL-pretty-printed-baseline-round-trips: a valid single-document baseline is trusted whatever its whitespace" {
   # The baseline rule counts DOCUMENTS, not lines: a hand-inspected (indented,
-  # multi-line) baseline is still one document, so its control priors stay
-  # trusted and a steady-deviant control stays silent instead of re-paging as a
-  # first observation.
+  # multi-line) baseline is still ONE document and stays trusted. Pinned through a
+  # STEADY-DEVIANT control, because that is what needs a trusted prior to stay
+  # quiet: distrust the baseline and the Guest account pages all over again as a
+  # first observation, every 60 seconds.
   declare_posture_controls
-  seed_baseline "$(jq -n --argjson seed "$healthy_seed" '$seed')"
+  seed_baseline "$(jq -n --argjson seed "$healthy_seed" '$seed + {guest: "enabled"}')"
   set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+  export POLLER_SYSADMINCTL_GUEST_OUTPUT="2026-07-27 00:00:00.000 sysadminctl[100:100] Guest account enabled."
 
   run run_poller
   [[ $status -eq 0 ]] || {
     echo "status $status: $output"
     false
   }
-  assert_no_page
+  assert_no_page # already reported: the prior is what keeps this quiet
   assert_baseline_scalar filevault on
-  assert_baseline_scalar guest disabled
+  assert_baseline_scalar guest enabled
 }
 
 @test "T-PCTL-empty-controls-file-gaps: a controls file declaring zero controls pages a gap instead of silently watching nothing" {

--- a/test/integration/osquery-poller-posture-fields.bats
+++ b/test/integration/osquery-poller-posture-fields.bats
@@ -466,6 +466,66 @@ healthy_seed='{"firewall":"1","gatekeeper":"1","screenlock":"1","filevault":"on"
   assert_baseline_unchanged
 }
 
+@test "T-PCTL-multidoc-baseline-distrusted: a baseline holding two concatenated documents is no prior, and its doubling is never written back" {
+  # The same whole-file rule the controls file gets, for the BASELINE. Reading
+  # it with `.field // empty` queries a concatenated stream and emits one result
+  # per document; a document that LACKS the field emits nothing, so a prior
+  # followed by {} collapses to one clean value and passes the trio validation
+  # as a trustworthy baseline. It is not one.
+  #
+  # The refused-controls-file path then folds the fresh trio into that prior
+  # (`. + $trio`), which over a two-document prior emits TWO documents and
+  # persists the doubling. That is the amplifier: the next tick reads a trio
+  # fanned across two documents, fails the domain guards, and re-pages every
+  # declared control as a first observation.
+  seed_baseline "$healthy_seed
+{}"
+  set_posture_controls '{"not":"an array"}' # refused, so the fold-in path runs
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+
+  assert_page_count 1 # the controls-file gap, and nothing fabricated from the prior
+  assert_page_body_has 'not a JSON array'
+  # Persisted as exactly ONE document: the doubling is not amplified.
+  run jq -e -s 'length == 1 and (.[0] | type == "object")' "$OSQUERY_POSTURE_STATE"
+  [[ $status -eq 0 ]] || {
+    echo "expected exactly one JSON object in the baseline; baseline:"
+    cat "$OSQUERY_POSTURE_STATE"
+    false
+  }
+  # And no field carried over from the distrusted prior.
+  run jq -e 'has("filevault") | not' "$OSQUERY_POSTURE_STATE"
+  [[ $status -eq 0 ]] || {
+    echo "expected no control field lifted from the distrusted baseline; baseline:"
+    cat "$OSQUERY_POSTURE_STATE"
+    false
+  }
+}
+
+@test "T-PCTL-pretty-printed-baseline-round-trips: a valid single-document baseline is trusted whatever its whitespace" {
+  # The baseline rule counts DOCUMENTS, not lines: a hand-inspected (indented,
+  # multi-line) baseline is still one document, so its control priors stay
+  # trusted and a steady-deviant control stays silent instead of re-paging as a
+  # first observation.
+  declare_posture_controls
+  seed_baseline "$(jq -n --argjson seed "$healthy_seed" '$seed')"
+  set_posture '[{"firewall":"1","gatekeeper":"1","screenlock":"1"}]'
+
+  run run_poller
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_scalar filevault on
+  assert_baseline_scalar guest disabled
+}
+
 @test "T-PCTL-empty-controls-file-gaps: a controls file declaring zero controls pages a gap instead of silently watching nothing" {
   seed_baseline '{"firewall":"1","gatekeeper":"1","screenlock":"1"}'
   snapshot_baseline

--- a/test/integration/osquery-tailscale.bats
+++ b/test/integration/osquery-tailscale.bats
@@ -421,6 +421,40 @@ SERVE_ONLY='{"Web":{"dresden.tailnet.ts.net:443":{"Handlers":{"/":{"Proxy":"http
   assert_baseline_funnel inactive # the garbage is recovered to a valid baseline
 }
 
+@test "T-TS-concatenated-state-active-pages: a state holding two concatenated documents is not a baseline, so a live funnel still pages" {
+  # `.funnel // empty` emits one result PER document of a concatenated stream and
+  # nothing at all for a document that lacks the key, so an active baseline
+  # followed by {} collapses back to a clean "active". Trusted, that reads as a
+  # steady exposure and the public-exposure page never fires: the one detector
+  # for a Funnel opened to the public internet goes silent on a corrupt file.
+  seed_funnel_state concatenated-active
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'PUBLIC internet'
+  assert_baseline_funnel active
+}
+
+@test "T-TS-pretty-printed-state-round-trips: a valid single-document baseline is trusted whatever its whitespace" {
+  # The rule counts DOCUMENTS, not lines: an indented, hand-inspected baseline is
+  # still one document, so a steady active funnel stays silent rather than
+  # re-paging an exposure the operator has already been told about.
+  seed_funnel_state pretty-active
+  set_funnel "$FUNNEL_ON"
+  run run_tailscale_monitor
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_baseline_funnel active
+}
+
 # --- B14: a funnel found active on recovery from a blind window pages ------------
 
 @test "T-TS-funnel-after-blind-pages: a funnel found active on recovery from a blind window pages" {

--- a/test/integration/osquery-watchdog.bats
+++ b/test/integration/osquery-watchdog.bats
@@ -415,6 +415,73 @@ teardown() { teardown_watchdog_harness; }
   }
 }
 
+@test "T-WATCH-state-concatenated-starts-fresh: a state file holding two concatenated documents is not trusted, so a confirmed tamper still pages" {
+  # A corruption gate of the shape `jq -e .` takes its exit status from the LAST
+  # document of a concatenated stream, so two valid documents back to back read
+  # as healthy. Each later read then runs against the stream: a `// -1` fallback
+  # emits one line PER document (which every numeric guard rejects), but a `// ""`
+  # fallback emits an EMPTY line for a document that lacks the key, and command
+  # substitution strips it - so a trailing {} collapses the fan-out back to one
+  # clean value that passes its guard. The paged-fingerprint marker is read that
+  # way, and a marker resurrected from a corrupt state silences the manifest-audit
+  # page for that exact tamper forever (a fingerprint already paged for never
+  # pages again). A whole-file "exactly one object" read is what refuses it.
+  local fingerprint corrupt_document
+  tamper_manifested_file
+  run run_watchdog # tick 1: the divergence is seen once (confirming), silent
+  [[ $status -eq 0 ]] || {
+    echo "tick1 status $status: $output"
+    false
+  }
+  assert_no_page
+  fingerprint="$(jq -r '.pipeline_audit.fingerprint' "$OSQUERY_WATCHDOG_STATE")"
+
+  # A state claiming this exact divergence was ALREADY paged for, as two valid
+  # concatenated documents. The second document is what collapses the fan-out.
+  corrupt_document="$(jq -cn --arg fp "$fingerprint" \
+    '{agents: {}, pending: {count: -1, growth_streak: 0},
+      pipeline_audit: {fingerprint: $fp, streak: 1, paged_fingerprint: $fp}}')"
+  seed_watchdog_state "$corrupt_document
+{}"
+
+  run run_watchdog # tick 2: the corrupt state must start fresh, not adopt its marker
+  [[ $status -eq 0 ]] || {
+    echo "tick2 status $status: $output"
+    false
+  }
+  assert_no_page
+  assert_state_has '"paged_fingerprint":""'
+
+  run run_watchdog # tick 3: confirmed against a fresh baseline, so it pages
+  [[ $status -eq 0 ]] || {
+    echo "tick3 status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_severity_is CRIT
+  assert_page_body_has 'divergence'
+}
+
+@test "T-WATCH-state-pretty-printed-round-trips: a valid single-document state is trusted whatever its whitespace" {
+  # The corruption gate counts DOCUMENTS, not lines: a hand-inspected (indented,
+  # multi-line) state file is still exactly one document and must keep its
+  # streak memory, or the crash-loop alarm would silently reset every tick.
+  set_agent com.webdavis.osquery-digest 40 1 # observation 1: streak 1
+  run run_watchdog
+  assert_no_page
+  jq . "$OSQUERY_WATCHDOG_STATE" >"$WD_HOME/pretty-state.json"
+  cp "$WD_HOME/pretty-state.json" "$OSQUERY_WATCHDOG_STATE"
+
+  set_agent com.webdavis.osquery-digest 41 1 # it re-ran and failed again
+  run run_watchdog
+  [[ $status -eq 0 ]] || {
+    echo "status $status: $output"
+    false
+  }
+  assert_page_count 1
+  assert_page_body_has 'crash'
+}
+
 @test "T-WATCH-state-unpersistable-pages: an unwritable state dir pages CRIT (the streak alarms would otherwise silently degrade)" {
   # With the state unwritable, prev_state resets to {} every tick, so a crash-looping
   # agent's streak resets to 1 each run and never reaches the loop threshold: the


### PR DESCRIPTION
## Context

This repository is a chezmoi dotfiles tree, and part of what it deploys is an osquery-based security
monitoring pipeline: small bash scripts run by launchd that watch the machine (firewall, Gatekeeper,
screen lock, Tailscale Funnel exposure, the health of the pipeline itself) and page when something
changes for the worse. Each of those monitors keeps a small JSON state file between runs so it can tell
a fresh problem from one it has already reported.

An audit of how those scripts read JSON found one bug class repeated across four of them. jq accepts a
stream of concatenated documents, and these reads never said that a state file must be exactly one of
them. `jq -e .` takes its exit status from the LAST document, so a file holding two valid documents
passed the corruption check. `.key // default` then runs once per document, so a query over such a file
emits one line per document, and a document that lacks the key contributes an empty line that command
substitution strips. All four scripts already documented that a corrupt state starts fresh; this makes
that promise true rather than incidental.

The honest blast radius: these state files live in `~/.local/state` at mode 0600, every monitor rewrites
its file at the end of a healthy tick, and none of this grants an attacker capability they did not have
(anyone who can write the state file can write it with one document just as easily). What a doubled file
bought was silence, for as long as it lasted: a live Funnel that read as steady state, a manifest tamper
whose page was suppressed by a resurrected marker, and a poller that wrote the doubling back into its own
baseline.

## Summary

- `dot_local/libexec/osquery/executable_uptime-watchdog.sh`: the state file is read once through a
  slurped "exactly one object" guard instead of `cat` plus `jq -e .`; the seven later reads already query
  that in-memory value, so nothing re-reads the file.
- `dot_local/libexec/osquery/executable_firewall-gatekeeper-monitor.sh`: the posture baseline gets the
  same whole-file rule `load_controls` already applies to the controls file, which also disarms the
  fold-in on the refused-controls path that used to persist a multi-document baseline.
- `dot_local/libexec/osquery/executable_tailscale-monitor.sh`: the funnel baseline is slurped to one
  object before its value is read, so a concatenated file can no longer read as a steady exposure.
- `dot_local/libexec/osquery/executable_allowlist.sh`: the per-line label read now uses `fromjson?`, the
  same one-value-per-line rule `results-alerter/allowlist-verdict.sh` applies when it consults the file,
  and a source line that is not exactly one JSON tuple refuses the whole mutation instead of being edited
  around.
- Three comments that described guards the code did not have now describe the mechanism that exists,
  including the `jq empty` parse check in the Tailscale monitor, which stays deliberately permissive and
  now says why.
- Nine bats cases across four suites: a concatenated-file case per script (two for the allowlist writer,
  which has two curation verbs), a single-document round-trip case for each of the three monitors, and a
  comment/blank-line round-trip case for the allowlist writer.

## What changed

The shape is the same at all four sites, copied from the one place in the repo that already had it
(`load_controls` in the posture monitor):

```
jq -ce -s 'if (length == 1 and (.[0] | type == "object")) then .[0] else error("not one object") end'
```

Read the file once, validate the whole file, then query the validated value. Per site:

- uptime-watchdog: The corruption gate accepted two documents. Downstream, the numeric guards
  (`// -1`, `// 0`, each behind a regex) reject the two-line values a stream produces, but the two
  `// ""` fingerprint reads do not: a trailing `{}` collapses the fan-out back to one clean 64-hex value.
  The one that matters is `paged_fingerprint`, the marker that says this exact divergence was already
  reported. Adopted from a corrupt file, it silences the manifest-audit page for that tamper permanently,
  and the manifest audit is the only detector for a hard-linked, symlinked, or chmodded script (osquery
  watches paths, so those generate no file event).

- firewall-gatekeeper-monitor: `prev_fw`, `prev_gk` and `prev_sl` are read with `// empty`, which
  emits nothing for a document lacking the field, so a baseline followed by a second document collapsed
  to a clean trio and passed `prev_valid`. The per-control priors read the same way. That armed the
  amplifier: with the controls file refused, `jq -c '. + $trio' <<<"$prev_json"` runs over the
  multi-document prior, emits one object per document, and `write_state` persists the whole stream, so
  the doubling outlives the tick that read it and the next tick re-pages every declared control as a
  first observation.

- tailscale-monitor: `.funnel // empty` read straight from the state file collapsed the same way, so
  a live Funnel matched an "active" baseline and the public-exposure page never fired. The status-output
  parse check keeps `jq empty`: that input is one capture of one CLI run rather than a file, and the
  classifier below re-checks the shape and gaps on anything it does not recognize. Its comment says that
  now instead of reading like a shape check.

- allowlist: The writer read each line as a stream, so a line holding two concatenated tuples
  reported two labels, matched neither, and survived the rewrite, while `-d` printed "denied" and
  refreshed the manifest and `-a` appended a second tuple beside it. The consumer already reads one value
  per line with `fromjson?` and ignores such a line, so nothing was suppressed by it either way; what
  needed fixing is a writer that edits around a corrupt source and reports success. It now reads labels
  by the consumer's rule and refuses the mutation outright: non-zero, reason and path on stderr, nothing
  deployed, no manifest refresh. The committed seed file passes the rule (7 entry lines, none refused).

## How it was verified

The audited mechanics were re-verified against the installed jq (1.8.2) before any edit: `jq -e .`
returns 0 for two concatenated objects and for `false` followed by an object; `// -1` over two documents
yields two lines; `// ""` and `// empty` over `{obj}{}` yield one; the slurp guard exits 5 on both
concatenated files and 0 on the single one; `fromjson?` yields nothing for a two-document line.

Every case was written first and observed RED for the audited reason, then GREEN. Each guard was then
reverted on its own and its suite re-run beside the unmutated single-document control.

| Guard reverted | Corruption case | Control case | Observed failure |
| --- | --- | --- | --- |
| watchdog slurp to `cat` + `jq -e .` | RED | GREEN | the state persisted a `paged_fingerprint` lifted from the corrupt file, and the confirmed tamper never paged |
| poller slurp to `cat` | RED | GREEN | the baseline persisted as two documents, carrying `filevault` from the distrusted prior |
| tailscale slurp to `.funnel // empty` | RED | GREEN | 0 pages with a live public Funnel |
| allowlist refusal to `return 0` | RED (both verbs) | GREEN | `-d` exited 0 reporting "denied" and `-a` exited 0 reporting "allowed", over a corrupt source |
| allowlist reader to the stream read | GREEN | GREEN | survives: the refusal short-circuits before the label read ever sees a multi-document line (see the review guide) |

Suite state: `just l` reports 0 files changed, and `just test` passes all four suites.

## Effect of merging

Nothing on the live machine changes on merge. These are chezmoi-managed source files under
`dot_local/libexec/osquery/`, so the deployed copies in `~/.local/libexec/osquery/` are replaced only by
a `chezmoi apply`, which is held until the D1 cutover. No test ran against live osquery state: every case
runs in its own temp HOME with stubbed osqueryi, launchctl, tailscale, and dispatch.

Once applied, monitor behavior is unchanged for every state file that is a single JSON object, which is
every file these monitors write themselves. A file that is not one starts fresh, or for the allowlist
writer refuses the mutation, rather than being partly believed.

## Review guide

- The four guards are one line each, and the same line. Compare against `load_controls` at
  `executable_firewall-gatekeeper-monitor.sh:463`, which is where the shape came from.
- For the uptime-watchdog, check the change against its seven reads: they all query `$prev_state` and
  none re-reads `$STATE`.
  `grep -n 'prev_state' dot_local/libexec/osquery/executable_uptime-watchdog.sh` shows the whole set.
- The allowlist refusal is the one behavior change beyond validation, and it is deliberate: reading
  labels the consumer's way is not observable on its own, because a two-document line matches no label
  either way and survives the rewrite either way. Without the refusal, `-d` keeps reporting a removal it
  did not make. That is also why the reader mutation survives in the table above: both predicates enforce
  the same one-value-per-line rule, and the refusal runs first. It cannot fire on the shipped file either:
  `test/integration/osquery-page-allowlist-seed.sh` already pins that every entry line there is one NDJSON
  tuple with exactly the four fields.
- Each corruption case is paired with a pretty-printed (indented, multi-line, still one document)
  round-trip case, because the rule counts documents and a plausible wrong implementation counts lines.
