### PR TITLE
fix(plugin-record): harden the weekly plugin record, and sweep the jq stream reads

### DIFF
--- a/.chezmoiscripts/run_onchange_after_69-load-report-plugin-updates-launchagent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_69-load-report-plugin-updates-launchagent.sh.tmpl
@@ -7,6 +7,34 @@ set -euo pipefail
 
 mkdir -p "$HOME/.local/log/plugins"
 
+# SEED THE BASELINE HERE, and mind the order. The record compares this week's
+# plugin versions against a stored previous reading, and whichever run records
+# that first reading reports nothing itself. If the FIRST scheduled run is the
+# one that does it, everything Claude Code's own auto-update changed between this
+# apply and that Monday is baked into the baseline and reported never: deploy on
+# Tuesday, a plugin moves on Wednesday, Monday records the new version as the
+# starting point and says nothing moved.
+#
+# ORDERING REQUIREMENT: this apply is also the apply that enables marketplace
+# auto-updates (the extraKnownMarketplaces entries in
+# private_dot_claude/modify_settings.json, applied with the other targets before
+# any run_after script), so the seed has to happen in the SAME apply, and nothing
+# between that settings write and this line may start Claude Code. It must also
+# stay AFTER the helper itself is deployed and BEFORE the agent is bootstrapped
+# below, so the first scheduled run always finds a baseline waiting.
+#
+# Seeding is idempotent: an existing baseline is left alone, so re-running this
+# on every plist change costs nothing and cannot swallow a change.
+HELPER="$HOME/.local/bin/report-plugin-updates.sh"
+if [[ -x $HELPER ]]; then
+  # Never fatal. A chezmoiscript that exits non-zero aborts the whole apply, and
+  # a machine with no plugin inventory yet has no first transition to lose.
+  "$HELPER" --seed-baseline ||
+    printf 'report-plugin-updates: the baseline could not be seeded at apply time; the first scheduled run will record it instead, and anything that moves before then goes unreported\n' >&2
+else
+  printf 'report-plugin-updates: %s is not deployed yet, so no baseline was seeded\n' "$HELPER" >&2
+fi
+
 PLIST="$HOME/Library/LaunchAgents/com.webdavis.report-plugin-updates.plist"
 TARGET="gui/$(id -u)/com.webdavis.report-plugin-updates"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,6 +509,13 @@ names no other delivery mechanism and reads no other lock, per the operator's st
 `"none"` is the only legal value, and a malformed table refuses the run rather than failing open, in
 every mode including `--dry-run`.
 
+**Retiring an EXISTING link is manual, and the run says so.** Deleting the chezmoi declaration does not
+remove a `~/.claude/skills` link already on the machine (chezmoi never deletes a target it no longer
+manages), and the apply-time `--install-only` pass is additive, so it removes nothing either. The link
+therefore survives until the next FULL weekly run reaps it, and for that window Claude Code sees two
+sources under one name. `converge_dir` now WARNS with the absolute path in the additive mode, naming what
+it is leaving behind for the operator to delete. No removal is scripted, by operator ruling.
+
 **Tier model (the lock's `tiers` table):** every roster skill is `core` (8) or `on-demand` (27). Core
 skills auto-load in every harness; on-demand skills stay installed everywhere but load only when
 explicitly invoked: in Claude Code via `skillOverrides.<name> = "user-invocable-only"`, one
@@ -765,10 +772,25 @@ shared entry shape and the reasoning behind it).
 - **Schedule:** `com.webdavis.report-plugin-updates`, Monday 13:00, `RunAtLoad=false`, logging to
   `~/.local/log/plugins/report-updates.log`. It passes `--scheduled`, and only a scheduled run posts,
   moves the snapshot or advances the marker; a manual run prints the comparison and changes nothing.
-- **First run** records a baseline and posts nothing. **A quiet week still posts**, naming zero changes,
-  because a clean week and a dead LaunchAgent otherwise produce identical silence. **An unreadable state
-  file posts no record at all** and alerts on the priority route instead, since the only change list it
-  could build from a file it cannot read is a false "nothing changed".
+- **The baseline is seeded at APPLY time**, by the loader chezmoiscript calling `--seed-baseline`, not by
+  the first scheduled run. The apply that deploys this record is the apply that turns the marketplace
+  auto-updates on, so a baseline first recorded the following Monday absorbs everything Claude Code
+  changed in between and reports it never. Seeding is idempotent, an existing baseline is left alone, so
+  a routine apply cannot re-baseline over a change nobody has reported yet. It is also best effort and
+  never pages: a machine with no readable inventory yet seeds nothing, says so, and leaves the baseline
+  to the first scheduled run.
+- **A first run with no baseline** records one and posts nothing. **A quiet week still posts**, naming
+  zero changes, because a clean week and a dead LaunchAgent otherwise produce identical silence. **An
+  inventory it cannot read posts no record at all** and alerts on the priority route instead, since the
+  only change list it could build from a file it cannot read is a false "nothing changed". That set
+  includes a file holding more than one top-level JSON document (jq accepts a stream, and both copies
+  would reach the reading) and an install record whose shape it cannot interpret (dropping one out of the
+  reading announces the plugin as REMOVED). An inventory with no USER-scope records is NOT in that set:
+  it is a real reading of a real machine, and its removals are reported.
+- **The snapshot is replaced by rename**, never written in place, so a run interrupted halfway cannot
+  leave a short file that the next run reads as a batch of new plugins. A snapshot path that exists and
+  is not a regular file refuses the run, and a reading that cannot be persisted alerts, because both
+  otherwise produce a machine that reports nothing while looking healthy.
 
 ### Happy Daemon (Remote Agent Control)
 

--- a/dot_local/bin/executable_assert-hermes-superpowers-routing.sh
+++ b/dot_local/bin/executable_assert-hermes-superpowers-routing.sh
@@ -75,6 +75,20 @@ if [[ ! -f $LOCK ]]; then
   exit 0
 fi
 
+# EXACTLY ONE JSON VALUE, checked once, before any read below trusts the file.
+# jq reads a file as a STREAM and runs its filter per document, so a doubled or
+# appended lock parses without complaint and each read here answers differently:
+# the pair walk collects the union of both documents, and the slash-command skill
+# becomes whichever document happened to carry it. Every one of those feeds an
+# in-place rewrite of the files in the mirror, so the routing this script exists
+# to assert would come from a document nobody chose. Slurping and counting is the
+# single-value test, the same shape run_before_12-quarantine-unparseable-claude-settings.sh
+# uses on ~/.claude/settings.json.
+if ! jq -e -s 'length == 1 and (.[0] | type == "object")' "$LOCK" >/dev/null 2>&1; then
+  log "refusing: $LOCK is not a single JSON object; a multi-document or unparseable lock would route the mirror from a document nobody chose"
+  exit 2
+fi
+
 # Read the routing pairs. Every name feeds a regex and a written line, so
 # validate the shape hard: lowercase kebab, legacy names superpowers-prefixed.
 legacy_names=()

--- a/dot_local/bin/executable_find-and-remove-json-objects.sh
+++ b/dot_local/bin/executable_find-and-remove-json-objects.sh
@@ -26,6 +26,15 @@ REGEX="${2:-}"
   exit 1
 }
 
+# The selector is the one argument that stays PROGRAM text: a jq path is what
+# this tool takes, and a path cannot be passed as data without changing that.
+# So its shape is bounded rather than trusted, and anything beyond a plain
+# dotted path is refused before it reaches the filter below.
+[[ $JSON_OBJECT =~ ^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$ ]] || {
+  printf "Error: first argument must be a plain dotted jq path such as .name or .meta.id (got '%s').\n" "$JSON_OBJECT" >&2
+  exit 1
+}
+
 timestamp="$(date +%Y%m%d%H%M%S)"
 backup_dir="backup_$timestamp"
 mkdir -p "$backup_dir"
@@ -37,7 +46,11 @@ mkdir -p "$backup_dir"
 rg --files-with-matches "$REGEX" | while IFS= read -r file; do
   cp "$file" "${backup_dir}/"
   tmp=$(mktemp "${file}.XXXXXX")
-  if jq "del(.[] | select(${JSON_OBJECT}? == '$REGEX'))" "$file" >"$tmp"; then
+  # The value is DATA, through --arg. It used to be spliced into the program in
+  # single quotes, which jq has no such thing as: the filter was a compile error
+  # and this helper failed on the first file it matched, every time. A value
+  # carrying jq syntax would otherwise be compiled as part of the filter too.
+  if jq --arg value "$REGEX" "del(.[] | select(${JSON_OBJECT}? == \$value))" "$file" >"$tmp"; then
     mv "$tmp" "$file"
   else
     rm -f "$tmp"

--- a/dot_local/bin/executable_relay-codex-hooks.sh
+++ b/dot_local/bin/executable_relay-codex-hooks.sh
@@ -39,7 +39,10 @@ merged="$(printf '%s' "$base" | jq \
   ensure("Stop"; $d) | ensure("PermissionRequest"; $b)
 ')" || exit 0
 
-# Validate the merged candidate before writing: it must still be a single object with an object "hooks".
+# Validate the merged candidate before writing: it must still be an object with an object "hooks".
+# SINGLENESS is not re-checked here and does not need to be: this value came out of the jq above,
+# which emitted one document from the one document the -es read at line 24 admitted. The check that
+# a STREAM never gets in is that read, not this one.
 printf '%s' "$merged" | jq -e 'type=="object" and (.hooks|type=="object")' >/dev/null 2>&1 || {
   printf 'relay-codex-hooks: refusing to write a non-object merge result; leaving %s untouched.\n' "$hooks" >&2
   exit 0

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -363,6 +363,17 @@ read_error="$work_dir/read-error"
 if ! plugin_snapshot >"$current" 2>"$read_error"; then
   printf '%s: %s could not be read as an installed-plugin inventory:\n%s\n' \
     "$AGENT_NAME" "$INSTALLED_PLUGINS_FILE" "$(cat "$read_error")" >&2
+  # A DEPLOY-TIME SEED NEVER PAGES. Every fresh machine reaches this line during
+  # its first apply, before Claude Code has written an inventory at all, and
+  # there is no first transition to lose and nobody at a keyboard to act on it.
+  # The exit status still says the seed did not happen, which is all the loader
+  # needs. The SCHEDULED run stays the loud path: if the file is still
+  # unreadable on Monday, that is a weekly record that cannot report, and it
+  # alerts.
+  if [[ -n $SEED_BASELINE ]]; then
+    printf '%s: no baseline was seeded; the first scheduled run records one instead\n' "$AGENT_NAME" >&2
+    exit 1
+  fi
   alert plugin-state-unreadable \
     "$(printf 'The Claude Code plugin record on %s could not read %s as an installed-plugin inventory, so it reported NOTHING rather than a false quiet week. The snapshot was left alone, so the next successful run reports the whole gap. jq said: %s' \
       "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" \

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -230,6 +230,28 @@ plugin_snapshot() {
   ' "$INSTALLED_PLUGINS_FILE" | sort
 }
 
+# write_snapshot <reading> -- replace the snapshot ALL AT ONCE, or say so.
+#
+# A plain copy onto the live snapshot truncates it before it holds the new
+# content, so a run interrupted between those two moments (a full disk, a reboot,
+# a killed launchd job) leaves a short file behind, and the next run reads every
+# plugin missing from it as newly added. A fabricated change list is the one
+# thing this record must never produce, and it is worse than no record at all.
+#
+# The staging file is a SIBLING in the state directory, not in TMPDIR: rename(2)
+# is atomic only within one filesystem, and nothing guarantees TMPDIR is on this
+# one. Both callers go through here, so the baseline write and the post-delivery
+# write get the same guarantee.
+write_snapshot() {
+  local reading="$1" staged=""
+  if staged="$(mktemp "$SNAPSHOT_FILE.XXXXXX" 2>/dev/null)" && [[ -n $staged ]] &&
+    cp "$reading" "$staged" && mv -f "$staged" "$SNAPSHOT_FILE"; then
+    return 0
+  fi
+  [[ -n $staged ]] && rm -f "$staged"
+  return 1
+}
+
 mkdir -p "$STATE_DIR" 2>/dev/null || {
   printf '%s: the state directory %s could not be created; nothing can be compared or remembered\n' \
     "$AGENT_NAME" "$STATE_DIR" >&2
@@ -312,7 +334,7 @@ if [[ ! -f $SNAPSHOT_FILE ]]; then
     printf '%s: this is not a scheduled run, so the baseline was NOT written\n' "$AGENT_NAME"
     exit 0
   fi
-  if ! cp "$current" "$SNAPSHOT_FILE"; then
+  if ! write_snapshot "$current"; then
     printf '%s: the baseline could not be written to %s\n' "$AGENT_NAME" "$SNAPSHOT_FILE" >&2
     exit 1
   fi
@@ -336,7 +358,7 @@ fi
 # a change consumed by a run that told nobody is reported by the next one
 # instead. The success marker follows the same rule, so the gap in the next entry
 # is measured from a run that actually posted.
-if ! cp "$current" "$SNAPSHOT_FILE"; then
+if ! write_snapshot "$current"; then
   printf '%s: the entry was delivered but the snapshot at %s could not be updated; the next entry will repeat this change\n' \
     "$AGENT_NAME" "$SNAPSHOT_FILE" >&2
   exit 1

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -168,6 +168,18 @@ record_entry() {
 # and the exit status carries it: pipefail hands the jq failure back through the
 # sort.
 #
+# EXACTLY ONE DOCUMENT, which is why this slurps. jq reads its input as a
+# SEQUENCE of JSON values, so a file holding the inventory twice (what a crashed
+# writer, an interrupted rewrite, or two writers racing leave behind) parses
+# without complaint and this key-walk emits rows from BOTH copies. The snapshot
+# then carries two fingerprints for one plugin id, and a machine where nothing
+# moved reports a version transition every week until someone notices. Slurping
+# and counting is the single-value test (the same shape as
+# .chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh).
+# `== 1` and not that script's `<= 1`: it tolerates a zero-value file because the
+# template it protects treats an empty file as an absent one, whereas an empty
+# inventory here is a reading nobody can compare against.
+#
 # STDERR IS THE CALLER'S TO REDIRECT, and is deliberately not merged into stdout
 # here. Merged, any line jq ever writes to stderr on an otherwise SUCCESSFUL run
 # would be sorted into the snapshot as a row with no tab, which
@@ -176,8 +188,11 @@ record_entry() {
 # never produce, so the two streams stay apart.
 plugin_snapshot() {
   # shellcheck disable=SC2016 # a jq program: $id is a jq binding, not a shell variable
-  "$JQ" -er '
-    if (.plugins? | type) != "object" then
+  "$JQ" -ers '
+    if length != 1 then
+      error("installed_plugins.json holds \(length) top-level JSON documents; exactly one is expected")
+    else .[0] end
+    | if (.plugins? | type) != "object" then
       error("installed_plugins.json has no plugins object")
     elif (.plugins | length) == 0 then
       error("installed_plugins.json records no installed plugins")

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -239,6 +239,22 @@ mkdir -p "$STATE_DIR" 2>/dev/null || {
   exit 1
 }
 
+# The snapshot has to be a REGULAR FILE, and anything else is refused here rather
+# than discovered later. A DIRECTORY at that path (a stray mkdir, a restore that
+# recreated the tree wrong, an interrupted move) makes the absent-snapshot test
+# below true on every run: each one takes its copy INSIDE the directory, finds no
+# baseline next time, and exits 0 having recorded nothing. That is the shape of
+# failure this record exists to end, a machine that looks healthy while saying
+# nothing, and it never resolves on its own.
+if [[ -e $SNAPSHOT_FILE && ! -f $SNAPSHOT_FILE ]]; then
+  printf '%s: the snapshot path %s is not a regular file; nothing can be compared or remembered\n' \
+    "$AGENT_NAME" "$SNAPSHOT_FILE" >&2
+  alert plugin-record-broken \
+    "$(printf 'The Claude Code plugin record on %s cannot use its snapshot path %s, which exists but is not a regular file. Every run would read it as a first run, write inside it and report nothing. Remove whatever is at that path.' \
+      "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" "$SNAPSHOT_FILE")"
+  exit 1
+fi
+
 # Without the library there is no entry shape, no week guard and no gap figure,
 # so this helper can do nothing but exit. That has to be ALERTED rather than
 # logged, because the symptom of leaving it at a stderr line is a channel that

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -34,7 +34,15 @@
 #                would look alive, inverting the one signal the record carries.
 #                A manual run still prints the comparison to stdout, which is
 #                what makes it useful for checking the helper by hand.
-set -uo pipefail
+#
+# ERREXIT IS ON, and every failure this helper means to TOLERATE is guarded where
+# it happens rather than by leaving errexit off: the relay call inside alert(),
+# the host lookup that falls back to unknown-host, and the library's own
+# bookkeeping write, which warns and returns 0 by design so a weekly job never
+# dies over its marker file. Everything else that fails stops the run, because
+# the alternative is this record continuing past a broken step and posting an
+# entry assembled from whatever survived.
+set -euo pipefail
 
 # The state Claude Code owns, and the state this helper owns. Both are
 # overridable so the tests can point the whole mechanism at a sandbox.
@@ -101,6 +109,22 @@ readonly RECORD_CAVEAT='Versions are what Claude Code records in installed_plugi
 
 readonly RECORD_LABEL='Claude Code plugins'
 readonly RECORD_SOURCE_DESCRIPTION='reading ~/.claude/plugins/installed_plugins.json'
+
+# mark_success_or_exit -- record this run, and stop if the record did not land.
+#
+# The library's own writer warns and returns 0 whatever happened, on purpose: no
+# weekly job should die over its bookkeeping file. That leaves this helper to
+# check the result, because the marker is what the NEXT entry measures its gap
+# from, and an entry claiming a gap from a run that never happened is a lie in
+# the only field a reader uses to judge whether this channel is alive. Errexit
+# cannot catch this one for us, which is exactly why it is spelled out.
+mark_success_or_exit() {
+  unattended_log_mark_success "$LOG_SUCCESS_MARKER"
+  [[ -f $LOG_SUCCESS_MARKER && -s $LOG_SUCCESS_MARKER ]] && return 0
+  printf '%s: this run finished but could not record itself at %s; the next entry would measure its gap from a run that never happened\n' \
+    "$AGENT_NAME" "$LOG_SUCCESS_MARKER" >&2
+  exit 1
+}
 
 # alert <state> <detail> -- the EXISTING relay route, so this lands in the
 # priority channel beside every other alert on this machine. Best effort: a
@@ -346,15 +370,19 @@ if [[ ! -f $SNAPSHOT_FILE ]]; then
         "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" "$SNAPSHOT_FILE")"
     exit 1
   fi
-  unattended_log_mark_success "$LOG_SUCCESS_MARKER"
+  mark_success_or_exit
   exit 0
 fi
 
 # The one sentence describing what moved, in the shape the other two weekly jobs
 # use. Both readings succeeded by this point, which is why the ok flag is a
 # literal: the failure path above exits rather than reaching here.
-change_line="$(unattended_log_change_section 1 "$SNAPSHOT_FILE" "$current" \
-  "$RECORD_LABEL" "$RECORD_CAVEAT" versions "$RECORD_SOURCE_DESCRIPTION")"
+if ! change_line="$(unattended_log_change_section 1 "$SNAPSHOT_FILE" "$current" \
+  "$RECORD_LABEL" "$RECORD_CAVEAT" versions "$RECORD_SOURCE_DESCRIPTION")"; then
+  printf '%s: the two readings could not be compared; nothing was posted and the snapshot was left alone\n' \
+    "$AGENT_NAME" >&2
+  exit 1
+fi
 printf '%s\n' "$change_line"
 
 if ! record_entry completed "$change_line"; then
@@ -374,5 +402,5 @@ if ! write_snapshot "$current"; then
       "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" "$SNAPSHOT_FILE")"
   exit 1
 fi
-unattended_log_mark_success "$LOG_SUCCESS_MARKER"
+mark_success_or_exit
 exit 0

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -25,7 +25,7 @@
 # WHAT REACHES THE CHANNEL: plugin ids and version fingerprints, nothing else.
 # Never an installPath (an absolute home path), never a marketplace source URL.
 #
-# Usage: report-plugin-updates.sh [--scheduled]
+# Usage: report-plugin-updates.sh [--scheduled | --seed-baseline]
 #   --scheduled  marks this as the LaunchAgent's run. ONLY a scheduled run posts
 #                an entry, advances the success marker or moves the snapshot,
 #                mirroring homebrew-weekly-upgrade.sh and update-skills.sh.
@@ -34,6 +34,19 @@
 #                would look alive, inverting the one signal the record carries.
 #                A manual run still prints the comparison to stdout, which is
 #                what makes it useful for checking the helper by hand.
+#   --seed-baseline
+#                records the FIRST reading and stops. This is the apply-time
+#                mode, called by the loader chezmoiscript, and it exists because
+#                of an ordering the schedule cannot satisfy on its own: the same
+#                apply that deploys this record also turns marketplace
+#                auto-updates on. Baselining at the first SCHEDULED run instead
+#                means a machine deployed on Tuesday whose plugin moves on
+#                Wednesday has Monday record the NEW version as the baseline and
+#                report nothing. That first transition is then lost for good, and
+#                lost invisibly, which is the failure this whole record exists to
+#                prevent. Seeding is idempotent: an existing baseline is left
+#                exactly as it is, because applies are routine and a seed that
+#                overwrote would swallow the change it was meant to catch.
 #
 # ERREXIT IS ON, and every failure this helper means to TOLERATE is guarded where
 # it happens rather than by leaving errexit off: the relay call inside alert(),
@@ -68,16 +81,26 @@ AGENT_NAME='report-plugin-updates'
 # the plist would otherwise run every week and quietly post nothing, which looks
 # exactly like a dead LaunchAgent.
 SCHEDULED=""
+SEED_BASELINE=""
 for arg in "$@"; do
   case "$arg" in
     --scheduled) SCHEDULED=1 ;;
+    --seed-baseline) SEED_BASELINE=1 ;;
     *)
-      printf 'usage: report-plugin-updates.sh [--scheduled]\n%s: unknown argument: %s\n' \
+      printf 'usage: report-plugin-updates.sh [--scheduled | --seed-baseline]\n%s: unknown argument: %s\n' \
         "$AGENT_NAME" "$arg" >&2
       exit 2
       ;;
   esac
 done
+
+# Two different jobs, so asking for both is an error rather than a quiet win for
+# whichever the code happens to test first.
+if [[ -n $SCHEDULED && -n $SEED_BASELINE ]]; then
+  printf 'usage: report-plugin-updates.sh [--scheduled | --seed-baseline]\n%s: --scheduled and --seed-baseline are different modes; pass one\n' \
+    "$AGENT_NAME" >&2
+  exit 2
+fi
 
 # The shared entry shape. A missing library is LOUD and never silent: this whole
 # helper is a record, and a record that quietly stops being posted is the
@@ -354,7 +377,7 @@ printf 'read %d user-scope plugin(s) from %s\n' "$(wc -l <"$current" | tr -d ' '
 # every installed plugin as newly added, on a machine where nothing happened.
 if [[ ! -f $SNAPSHOT_FILE ]]; then
   printf '%s: no snapshot yet; recording this reading as the baseline and posting nothing\n' "$AGENT_NAME"
-  if [[ -z $SCHEDULED ]]; then
+  if [[ -z $SCHEDULED && -z $SEED_BASELINE ]]; then
     printf '%s: this is not a scheduled run, so the baseline was NOT written\n' "$AGENT_NAME"
     exit 0
   fi
@@ -371,6 +394,15 @@ if [[ ! -f $SNAPSHOT_FILE ]]; then
     exit 1
   fi
   mark_success_or_exit
+  exit 0
+fi
+
+# A baseline already exists, so the deploy-time seed has nothing left to do.
+# Leaving it exactly as it is, is the point: applies are routine and a plugin may
+# well have moved since the last one, so a seed that re-baselined would swallow
+# the very transition it was added to capture.
+if [[ -n $SEED_BASELINE ]]; then
+  printf '%s: a baseline is already recorded at %s; nothing to seed\n' "$AGENT_NAME" "$SNAPSHOT_FILE"
   exit 0
 fi
 

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -334,8 +334,16 @@ if [[ ! -f $SNAPSHOT_FILE ]]; then
     printf '%s: this is not a scheduled run, so the baseline was NOT written\n' "$AGENT_NAME"
     exit 0
   fi
+  # A reader that cannot remember what it read is a reader that reports nothing,
+  # every week, for as long as the write keeps failing: the next run finds no
+  # snapshot, records another baseline and stays quiet. That has to reach the
+  # route that buzzes, because the run log is the one place nobody looks and the
+  # symptom on the record channel is indistinguishable from a healthy machine.
   if ! write_snapshot "$current"; then
     printf '%s: the baseline could not be written to %s\n' "$AGENT_NAME" "$SNAPSHOT_FILE" >&2
+    alert plugin-record-broken \
+      "$(printf 'The Claude Code plugin record on %s read its plugins but could not persist the baseline to %s. Until that write succeeds every run records a baseline afresh and reports NOTHING, which looks exactly like a week in which nothing moved.' \
+        "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" "$SNAPSHOT_FILE")"
     exit 1
   fi
   unattended_log_mark_success "$LOG_SUCCESS_MARKER"
@@ -361,6 +369,9 @@ fi
 if ! write_snapshot "$current"; then
   printf '%s: the entry was delivered but the snapshot at %s could not be updated; the next entry will repeat this change\n' \
     "$AGENT_NAME" "$SNAPSHOT_FILE" >&2
+  alert plugin-record-broken \
+    "$(printf 'The Claude Code plugin record on %s delivered this week entry but could not persist the new reading to %s, so every later run re-reports the same change. The state directory needs attention.' \
+      "$(unattended_log_host 2>/dev/null || printf 'unknown-host')" "$SNAPSHOT_FILE")"
   exit 1
 fi
 unattended_log_mark_success "$LOG_SUCCESS_MARKER"

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -180,6 +180,15 @@ record_entry() {
 # template it protects treats an empty file as an absent one, whereas an empty
 # inventory here is a reading nobody can compare against.
 #
+# NO USER-SCOPE RECORDS IS AN ANSWER, not a failure, which is why `-e` is not on
+# that jq. `-e` exits 4 when a filter produced no output at all, and the filter
+# produces none on a file that parses perfectly and says every installed plugin
+# is project-scope. Uninstalling the last user-scope plugin while a project-scope
+# one remains would then raise plugin-state-unreadable every week from then on
+# and report the removal never, which inverts this record twice over: silent
+# about a real change, loud about a file that is fine. The degraded shapes above
+# are refused by their own error() calls, so the exit status still carries them.
+#
 # EVERY RECORD IS SHAPE-CHECKED BEFORE THE SCOPE FILTER, which is the order that
 # matters. Selecting on `.scope == "user"` first makes a record whose key reads
 # `scop` (or holds a number, or is not an object at all) simply drop out of the
@@ -195,7 +204,7 @@ record_entry() {
 # never produce, so the two streams stay apart.
 plugin_snapshot() {
   # shellcheck disable=SC2016 # a jq program: $id is a jq binding, not a shell variable
-  "$JQ" -ers '
+  "$JQ" -rs '
     if length != 1 then
       error("installed_plugins.json holds \(length) top-level JSON documents; exactly one is expected")
     else .[0] end

--- a/dot_local/bin/executable_report-plugin-updates.sh
+++ b/dot_local/bin/executable_report-plugin-updates.sh
@@ -180,6 +180,13 @@ record_entry() {
 # template it protects treats an empty file as an absent one, whereas an empty
 # inventory here is a reading nobody can compare against.
 #
+# EVERY RECORD IS SHAPE-CHECKED BEFORE THE SCOPE FILTER, which is the order that
+# matters. Selecting on `.scope == "user"` first makes a record whose key reads
+# `scop` (or holds a number, or is not an object at all) simply drop out of the
+# reading, and a plugin that drops out of a reading is reported as REMOVED. A
+# typo in a file this helper only ever reads must not be announced as software
+# leaving the machine, so a record it cannot interpret refuses the whole run.
+#
 # STDERR IS THE CALLER'S TO REDIRECT, and is deliberately not merged into stdout
 # here. Merged, any line jq ever writes to stderr on an otherwise SUCCESSFUL run
 # would be sorted into the snapshot as a row with no tab, which
@@ -202,6 +209,8 @@ plugin_snapshot() {
     | .key as $id
     | (if (.value | type) == "array" then .value else error("the entry for \($id) is not an array of install records") end)
     | .[]
+    | (if type == "object" then . else error("an install record for \($id) is not an object") end)
+    | (if (.scope | type) == "string" then . else error("an install record for \($id) carries no scope string") end)
     | select(.scope == "user")
     | [$id, (if ((.version | type) == "string" and .version != "" and .version != "unknown")
              then .version

--- a/dot_local/bin/executable_update-skills.sh
+++ b/dot_local/bin/executable_update-skills.sh
@@ -2307,8 +2307,14 @@ converge_dir() {
     done
   fi
   # 2) remove updater-owned links no longer desired (stale drift). Additive
-  #    --install-only never removes; only the full weekly path reconciles.
-  [[ -n $additive ]] && return 0
+  #    --install-only never removes; only the full weekly path reconciles. It
+  #    does NAME what it leaves behind, though, because the apply that
+  #    de-delivers a skill is exactly an --install-only run: the live link
+  #    survives until some later FULL weekly run reaps it, and for that whole
+  #    window the harness sees two sources under one name (this link and
+  #    whatever replaced the skill, e.g. a plugin providing the same capability).
+  #    Nothing here removes it, by operator ruling; the warning IS the mechanism
+  #    and the named path is the operator's to delete by hand.
   for path in "$dir"/*; do
     [[ -e $path || -L $path ]] || continue # skip the un-globbed literal when the dir is empty
     name="${path##*/}"
@@ -2324,7 +2330,9 @@ converge_dir() {
     [[ -n $is_desired ]] && continue
     if __update_skills_is_owned_link "$path" "$prefix"; then
       old_target="$(readlink "$path" 2>/dev/null || true)"
-      if [[ -n $dry ]]; then
+      if [[ -n $additive ]]; then
+        log "converge: WARN $path is no longer delivered and --install-only never removes; REMOVE IT BY HAND or it stays a second source under that name until a full weekly run reaps it (currently $old_target)"
+      elif [[ -n $dry ]]; then
         log "converge: would remove stale $path (currently $old_target)"
       elif rm -f "$path"; then
         log "converge: removed stale $path (was $old_target)"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -293,4 +293,27 @@ refute "url=$UNATTENDED_LOG_HERMES_URL" "$(cat "$RELAY_LOG")" \
 [[ "$(cat "$SNAPSHOT")" == "$snapshot_before" ]] ||
   fail "a doubled inventory moved the snapshot: $(cat "$SNAPSHOT")"
 
+# ── 10. A MALFORMED install record is refused, not filtered out. Records used to
+#       be selected by scope BEFORE their shape was checked, so a record whose
+#       key reads `scop` instead of `scope` simply vanished from the reading and
+#       the entry announced the plugin as REMOVED. A typo in a file this helper
+#       only reads must never be reported as something leaving the machine. ────
+rm -rf "$STATE_DIR/log-week-claims"
+write_plugin_state "5.0.0"
+awk '/"scope": "user"/ && !done { sub(/"scope"/, "\"scop\""); done = 1 } { print }' \
+  "$PLUGIN_STATE" >"$tmp/typo.json"
+grep -qF '"scop"' "$tmp/typo.json" || fail "the fixture for the typo case did not actually mistype a scope key"
+cp "$tmp/typo.json" "$PLUGIN_STATE"
+run_helper --scheduled
+[[ $RUN_RC -ne 0 ]] ||
+  fail "an install record with a mistyped scope key exited 0: $RUN_OUTPUT"
+refute 'exa@claude-plugins-official.*removed' "$(log_entries)" \
+  "a mistyped scope key was reported as the plugin being removed"
+refute "url=$UNATTENDED_LOG_HERMES_URL" "$(cat "$RELAY_LOG")" \
+  "an install record this helper could not read still produced a record"
+[[ -n "$(alert_entries)" ]] ||
+  fail "an install record with a mistyped scope key alerted nobody: $RUN_OUTPUT"
+[[ "$(cat "$SNAPSHOT")" == "$snapshot_before" ]] ||
+  fail "an install record with a mistyped scope key moved the snapshot: $(cat "$SNAPSHOT")"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -362,4 +362,30 @@ shopt -u nullglob dotglob
   fail "the run wrote its reading INSIDE the directory sitting at the snapshot path: ${snapshot_dir_contents[*]}"
 rmdir "$SNAPSHOT"
 
+# ── 13. THE SNAPSHOT IS REPLACED, NEVER OVERWRITTEN IN PLACE. A plain copy onto
+#       the live snapshot truncates it before it has the new content, so a run
+#       interrupted mid-write (a full disk, a reboot, a killed launchd job)
+#       leaves a short file behind and the NEXT run reads every plugin missing
+#       from it as newly added: a fabricated change list, the one thing this
+#       record must never produce. Rename is what makes the swap all-or-nothing,
+#       and a rename gives the path a new inode while a copy keeps the old one,
+#       so the inode is what this asserts. ────────────────────────────────────
+# GNU form first, BSD fallback second. The BSD flag means "file system status"
+# under GNU coreutils, so it SUCCEEDS with the wrong output instead of failing
+# over, and the fallback would never run.
+inode_of() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
+rm -rf "$HOME/.local/state"
+write_plugin_state "8.0.0"
+run_helper --scheduled
+[[ -f $SNAPSHOT ]] || fail "the baseline for the atomic-replacement case was not recorded: $RUN_OUTPUT"
+snapshot_inode_before="$(inode_of "$SNAPSHOT")"
+rm -rf "$STATE_DIR/log-week-claims"
+write_plugin_state "8.1.0"
+run_helper --scheduled
+[[ $RUN_RC -eq 0 ]] || fail "the run that should have replaced the snapshot exited $RUN_RC: $RUN_OUTPUT"
+grep -qF 'exa@claude-plugins-official	8.1.0' "$SNAPSHOT" ||
+  fail "the snapshot does not carry the new reading: $(cat "$SNAPSHOT")"
+[[ "$(inode_of "$SNAPSHOT")" != "$snapshot_inode_before" ]] ||
+  fail "the snapshot was written in place rather than renamed over; a write interrupted halfway leaves a truncated snapshot and the next run reports every plugin as newly added"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -272,4 +272,25 @@ run_helper --schedule
 grep -qF 'unknown argument' <<<"$RUN_OUTPUT" ||
   fail "the unknown-argument error does not name the problem: $RUN_OUTPUT"
 
+# ── 9. A DOUBLED inventory is REFUSED. jq reads its input as a SEQUENCE of JSON
+#      documents, so a file holding the same object twice parses fine and the
+#      key-walk emits rows from BOTH copies. Left unchecked the snapshot carries
+#      two fingerprints for one plugin, and a machine where nothing moved reports
+#      a version transition every single week. Concatenation is what a crashed or
+#      racing writer leaves behind, and it is the shape most parsers reject. ────
+rm -rf "$STATE_DIR/log-week-claims"
+write_plugin_state "5.0.0"
+snapshot_before="$(cat "$SNAPSHOT")"
+sed 's/5\.0\.0/9.9.9/g' "$PLUGIN_STATE" >"$tmp/second-document.json"
+cat "$tmp/second-document.json" >>"$PLUGIN_STATE"
+run_helper --scheduled
+[[ $RUN_RC -ne 0 ]] ||
+  fail "a doubled inventory exited 0; two documents were read as one reading: $RUN_OUTPUT"
+refute "url=$UNATTENDED_LOG_HERMES_URL" "$(cat "$RELAY_LOG")" \
+  "a doubled inventory still posted a record, so a machine where nothing moved reports a transition"
+[[ -n "$(alert_entries)" ]] ||
+  fail "a doubled inventory alerted nobody: $RUN_OUTPUT"
+[[ "$(cat "$SNAPSHOT")" == "$snapshot_before" ]] ||
+  fail "a doubled inventory moved the snapshot: $(cat "$SNAPSHOT")"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -432,4 +432,41 @@ grep -qF "$MARKER" <<<"$RUN_OUTPUT" ||
 grep -qF 'set -euo pipefail' "$HELPER" ||
   fail "the helper does not run under set -euo pipefail"
 
+# ── 16. THE BASELINE IS ESTABLISHED AT DEPLOY TIME, not at the first scheduled
+#       run. The apply that deploys this record is also the apply that turns on
+#       marketplace auto-updates, so a machine set up on Tuesday whose plugin
+#       moves on Wednesday would have had Monday record the NEW version as its
+#       baseline and report nothing: the first transition, lost for good and
+#       invisible by construction. --seed-baseline is what the apply-time loader
+#       calls to close that window. ──────────────────────────────────────────
+rm -rf "$HOME/.local/state"
+write_plugin_state "11.0.0"
+run_helper --seed-baseline
+[[ $RUN_RC -eq 0 ]] || fail "--seed-baseline exited $RUN_RC: $RUN_OUTPUT"
+[[ -f $SNAPSHOT ]] || fail "--seed-baseline recorded no baseline: $RUN_OUTPUT"
+grep -qF 'exa@claude-plugins-official	11.0.0' "$SNAPSHOT" ||
+  fail "the seeded baseline does not hold the reading taken at deploy time: $(cat "$SNAPSHOT")"
+refute '.' "$(cat "$RELAY_LOG")" "the deploy-time seed posted to a channel; it has nothing to report yet"
+
+# Seeding again leaves the baseline alone. Applies are routine and a plugin may
+# well have moved since the last one, so a seed that overwrote would swallow
+# exactly the transition it exists to capture.
+write_plugin_state "11.5.0"
+run_helper --seed-baseline
+[[ $RUN_RC -eq 0 ]] || fail "a second --seed-baseline exited $RUN_RC: $RUN_OUTPUT"
+grep -qF 'exa@claude-plugins-official	11.0.0' "$SNAPSHOT" ||
+  fail "a second seed overwrote the baseline, swallowing the change since the first: $(cat "$SNAPSHOT")"
+
+# And the first scheduled run reports what moved between the deploy and it.
+rm -rf "$STATE_DIR/log-week-claims"
+run_helper --scheduled
+entries="$(log_entries)"
+grep -qE '11\.0\.0.*->.*11\.5\.0' <<<"$entries" ||
+  fail "the transition between the deploy-time seed and the first scheduled run was not reported: $entries"
+
+# The two modes are different jobs, so asking for both is an error rather than a
+# quiet win for whichever the code happens to check first.
+run_helper --scheduled --seed-baseline
+[[ $RUN_RC -eq 2 ]] || fail "--scheduled together with --seed-baseline did not exit 2 (got $RUN_RC): $RUN_OUTPUT"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -388,4 +388,22 @@ grep -qF 'exa@claude-plugins-official	8.1.0' "$SNAPSHOT" ||
 [[ "$(inode_of "$SNAPSHOT")" != "$snapshot_inode_before" ]] ||
   fail "the snapshot was written in place rather than renamed over; a write interrupted halfway leaves a truncated snapshot and the next run reports every plugin as newly added"
 
+# ── 14. A BASELINE THAT CANNOT BE PERSISTED is alerted, not just logged. A run
+#       that reads fine and cannot remember what it read finds no snapshot again
+#       next week, records another baseline, and reports nothing for as long as
+#       the state directory stays unwritable. The local log is the one place
+#       nobody looks, so this goes on the route that buzzes. ─────────────────
+rm -rf "$HOME/.local/state"
+mkdir -p "$STATE_DIR"
+chmod 555 "$STATE_DIR"
+write_plugin_state "9.0.0"
+run_helper --scheduled
+chmod 755 "$STATE_DIR"
+[[ $RUN_RC -ne 0 ]] ||
+  fail "a run that could not persist its baseline exited 0: $RUN_OUTPUT"
+[[ -n "$(alert_entries)" ]] ||
+  fail "a run that could not persist its baseline alerted nobody, so it reports nothing every week in silence: $RUN_OUTPUT"
+grep -qF "$SNAPSHOT" <<<"$(alert_entries)" ||
+  fail "the alert does not name the path that could not be written: $(alert_entries)"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -406,4 +406,30 @@ chmod 755 "$STATE_DIR"
 grep -qF "$SNAPSHOT" <<<"$(alert_entries)" ||
   fail "the alert does not name the path that could not be written: $(alert_entries)"
 
+# ── 15. A RUN THAT CANNOT RECORD ITSELF does not exit 0. The success marker is
+#       what the next entry measures its gap from, so a delivered entry followed
+#       by an unwritable marker leaves the channel claiming a gap from a run that
+#       never happened. The library warns and returns 0 by design (a job must not
+#       die over its own bookkeeping), so the helper has to check the marker
+#       itself rather than lean on errexit to notice. ─────────────────────────
+rm -rf "$HOME/.local/state"
+write_plugin_state "10.0.0"
+run_helper --scheduled
+[[ -f $SNAPSHOT ]] || fail "the baseline for the marker case was not recorded: $RUN_OUTPUT"
+rm -rf "$STATE_DIR/log-week-claims" "$MARKER"
+mkdir -p "$MARKER"
+write_plugin_state "10.1.0"
+run_helper --scheduled
+rmdir "$MARKER"
+[[ $RUN_RC -ne 0 ]] ||
+  fail "a run that could not record its own success exited 0, so the next entry reports a gap from a run that did not happen: $RUN_OUTPUT"
+grep -qF "$MARKER" <<<"$RUN_OUTPUT" ||
+  fail "the failure does not name the marker it could not write: $RUN_OUTPUT"
+
+# The repo requires errexit everywhere, and this helper spent its first release
+# without it. Pinned in source because the failures errexit catches are the ones
+# nobody has thought of yet, which is exactly what no behavioural test can reach.
+grep -qF 'set -euo pipefail' "$HELPER" ||
+  fail "the helper does not run under set -euo pipefail"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -316,4 +316,28 @@ refute "url=$UNATTENDED_LOG_HERMES_URL" "$(cat "$RELAY_LOG")" \
 [[ "$(cat "$SNAPSHOT")" == "$snapshot_before" ]] ||
   fail "an install record with a mistyped scope key moved the snapshot: $(cat "$SNAPSHOT")"
 
+# ── 11. NO USER-SCOPE RECORDS is legitimately empty, not unreadable. Uninstalling
+#       the last user-scope plugin while a project-scope one remains leaves a file
+#       that parses and describes a real machine state, and the removal is the
+#       single most worth-seeing line this record can carry. Refusing it raises
+#       plugin-state-unreadable every week from then on and reports the removal
+#       never. ─────────────────────────────────────────────────────────────────
+rm -rf "$HOME/.local/state"
+write_plugin_state "6.0.0"
+run_helper --scheduled
+[[ -f $SNAPSHOT ]] || fail "the baseline for the empty-user-scope case was not recorded: $RUN_OUTPUT"
+rm -rf "$STATE_DIR/log-week-claims"
+sed 's/"scope": "user"/"scope": "project"/g' "$PLUGIN_STATE" >"$tmp/project-only.json"
+cp "$tmp/project-only.json" "$PLUGIN_STATE"
+run_helper --scheduled
+[[ $RUN_RC -eq 0 ]] ||
+  fail "an inventory with no user-scope records exited $RUN_RC; an empty reading is not an unreadable one: $RUN_OUTPUT"
+refute 'url=<default>' "$(cat "$RELAY_LOG")" \
+  "an inventory with no user-scope records raised the unreadable alert instead of reporting the removals"
+entries="$(log_entries)"
+grep -qF 'Claude Code plugins: 3 of 3 tracked entries changed' <<<"$entries" ||
+  fail "the removal of every user-scope plugin was not reported as three changes over three entries: $entries"
+grep -qF '(removed)' <<<"$entries" ||
+  fail "the entry does not mark the plugins as removed: $entries"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -469,4 +469,22 @@ grep -qE '11\.0\.0.*->.*11\.5\.0' <<<"$entries" ||
 run_helper --scheduled --seed-baseline
 [[ $RUN_RC -eq 2 ]] || fail "--scheduled together with --seed-baseline did not exit 2 (got $RUN_RC): $RUN_OUTPUT"
 
+# ── 17. THE DEPLOY-TIME SEED DOES NOT PAGE. A machine whose plugin inventory
+#       does not exist yet has no first transition to lose and nobody at a
+#       keyboard to act on an alert, and every fresh machine reaches this line
+#       during its first apply. The scheduled run stays the loud path. ────────
+rm -rf "$HOME/.local/state"
+rm -f "$PLUGIN_STATE"
+run_helper --seed-baseline
+[[ $RUN_RC -ne 0 ]] || fail "a seed with no inventory to read exited 0: $RUN_OUTPUT"
+refute '.' "$(cat "$RELAY_LOG")" \
+  "the deploy-time seed alerted about an inventory Claude Code has not written yet; every fresh machine would page during its first apply"
+[[ ! -f $SNAPSHOT ]] || fail "a seed that read nothing still recorded a baseline"
+
+# The asymmetry is the point: the SCHEDULED run on the same unreadable file does
+# alert, because by then it is a weekly record that cannot report.
+run_helper --scheduled
+[[ -n "$(alert_entries)" ]] ||
+  fail "the scheduled run did not alert on an inventory it could not read: $RUN_OUTPUT"
+
 echo "report-plugin-updates-record: OK"

--- a/test/e2e/report-plugin-updates-record.sh
+++ b/test/e2e/report-plugin-updates-record.sh
@@ -340,4 +340,26 @@ grep -qF 'Claude Code plugins: 3 of 3 tracked entries changed' <<<"$entries" ||
 grep -qF '(removed)' <<<"$entries" ||
   fail "the entry does not mark the plugins as removed: $entries"
 
+# ── 12. A SNAPSHOT PATH THAT IS NOT A REGULAR FILE is refused loudly. A directory
+#       there (a stray mkdir, a restore that recreated the tree wrong) reads as
+#       "no baseline yet" on every run, takes every copy INSIDE itself, and exits
+#       0 having recorded nothing: a machine that looks healthy and permanently
+#       reports nothing at all. ──────────────────────────────────────────────────
+rm -rf "$HOME/.local/state"
+mkdir -p "$SNAPSHOT"
+write_plugin_state "7.0.0"
+run_helper --scheduled
+[[ $RUN_RC -ne 0 ]] ||
+  fail "a snapshot path that is a directory exited 0, so nothing will ever be compared or reported: $RUN_OUTPUT"
+[[ -n "$(alert_entries)" ]] ||
+  fail "a snapshot path that is a directory alerted nobody: $RUN_OUTPUT"
+refute "url=$UNATTENDED_LOG_HERMES_URL" "$(cat "$RELAY_LOG")" \
+  "a run that could not use its snapshot path still posted a record"
+shopt -s nullglob dotglob
+snapshot_dir_contents=("$SNAPSHOT"/*)
+shopt -u nullglob dotglob
+[[ ${#snapshot_dir_contents[@]} -eq 0 ]] ||
+  fail "the run wrote its reading INSIDE the directory sitting at the snapshot path: ${snapshot_dir_contents[*]}"
+rmdir "$SNAPSHOT"
+
 echo "report-plugin-updates-record: OK"

--- a/test/integration/hermes-superpowers-routing.sh
+++ b/test/integration/hermes-superpowers-routing.sh
@@ -363,4 +363,23 @@ mkdir -p "$HOME"
 skip_output="$(bash "$SCRIPT" 2>&1)" || fail "absent mirror dir must exit 0: $skip_output"
 printf '%s\n' "$skip_output" | grep -qi 'skip' || fail "absent mirror dir did not log a skip: $skip_output"
 
+# 10) A LOCK HOLDING TWO DOCUMENTS IS REFUSED. jq reads a file as a STREAM, so a
+#     doubled or appended document parses fine and each read here answers from a
+#     different copy: the pair walk collects both sets, and the slash-command
+#     skill becomes whichever document happened to carry it. Both then drive an
+#     in-place rewrite of every file in the mirror, so the routing this asserts
+#     would come from a document nobody chose.
+HOME="$tmp/stream-home"
+export HOME
+mkdir -p "$HOME/.agents" "$HOME/.hermes/skills/hermes-superpowers"
+printf 'mirror\n' >"$HOME/.hermes/skills/hermes-superpowers/SKILL.md"
+cp "$tmp/alt-lock.json" "$HOME/.agents/custom-skill-lock.json"
+jq '.superpowersRouting.map = {"superpowers-forged": "forged"}' "$tmp/alt-lock.json" \
+  >>"$HOME/.agents/custom-skill-lock.json"
+stream_output="$(bash "$SCRIPT" --check 2>&1)" && stream_rc=0 || stream_rc=$?
+[[ $stream_rc -ne 0 ]] ||
+  fail "a lock holding two JSON documents was accepted, so the mirror is routed from whichever document answered last: $stream_output"
+printf '%s\n' "$stream_output" | grep -qiE 'single JSON object|one JSON value|document' ||
+  fail "the refusal does not say the lock is not one JSON value: $stream_output"
+
 echo "hermes-superpowers-routing: OK"

--- a/test/integration/update-skills-converge.sh
+++ b/test/integration/update-skills-converge.sh
@@ -231,4 +231,22 @@ fi
 grep -qiE 'claudeDelivery.*(malformed|refus)' <<<"$dry_out" ||
   fail "the fan-out did not report the malformed claudeDelivery table, so a wrong-shaped table would silently fail open: $dry_out"
 
+# ── A LEFTOVER LINK THE ADDITIVE MODE WILL NOT REMOVE IS NAMED. --install-only
+# is what runs at apply time, and it never removes anything, so the apply that
+# de-delivers a skill leaves the live ~/.claude link in place until some later
+# FULL weekly run reaps it. For that whole window the harness sees two sources
+# under one name. Removing it here is ruled out (this repo scripts no removals),
+# which makes saying so the entire mechanism: the run has to name the path, and
+# the operator deletes it. A silent leftover is the failure.
+jq '.claudeDelivery = {"nonclaude": "none"}' "$LOCK_FILE" >"$LOCK_FILE.tmp" && mv "$LOCK_FILE.tmp" "$LOCK_FILE"
+ln -s "../../.agents/skills/nonclaude" "$CLAUDE/nonclaude"
+install_out="$(UPDATE_SKILLS_FORCE=1 bash "$SCRIPT" --install-only 2>&1)" ||
+  fail "the --install-only run exited non-zero: $install_out"
+[[ -L "$CLAUDE/nonclaude" ]] ||
+  fail "--install-only removed a link; the additive apply-time mode must never remove anything"
+grep -qF "$CLAUDE/nonclaude" <<<"$install_out" ||
+  fail "the apply-time run left a de-delivered link behind without naming it, so nothing tells the operator there are now two sources under that name: $install_out"
+grep -qiE "(remove it by hand|by hand)" <<<"$install_out" ||
+  fail "the leftover link is mentioned but the run does not say it is the operator's to remove: $install_out"
+
 echo "update-skills-converge: OK"

--- a/test/unit/find-and-remove-json-objects.sh
+++ b/test/unit/find-and-remove-json-objects.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# find-and-remove-json-objects.sh deletes objects from JSON files whose selected
+# field equals a value, keeping a backup copy first.
+#
+# The value it compares against arrives as an ARGUMENT and used to be spliced
+# into the jq PROGRAM in single quotes. jq has no single-quoted strings, so the
+# filter was a compile error and the helper failed on the first file it matched,
+# every time; and a value carrying jq syntax would have been compiled as part of
+# the filter rather than compared as data. Both are pinned below.
+#
+# Unit test: the real helper against fixture files in a throwaway directory.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dot_local/bin/executable_find-and-remove-json-objects.sh"
+
+fail() {
+  printf 'find-and-remove-json-objects: FAIL -- %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $SCRIPT ]] || fail "missing helper: $SCRIPT"
+command -v jq >/dev/null 2>&1 || {
+  printf 'SKIP: jq not on PATH\n'
+  exit 0
+}
+command -v rg >/dev/null 2>&1 || {
+  printf 'SKIP: rg not on PATH, and the helper requires it\n'
+  exit 0
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# ── 1. The plain case: the matching object goes, the other stays, and a backup
+#      of the original is kept. This is the whole job, and it exited 1 without
+#      touching a file for as long as the value was program text. ────────────
+mkdir -p "$tmp/plain"
+cd "$tmp/plain" || fail "could not enter the sandbox"
+jq -n '[{name: "keep"}, {name: "drop"}]' >inventory.json
+out="$(bash "$SCRIPT" .name drop 2>&1)" ||
+  fail "the helper exited non-zero on a plain value: $out"
+jq -e 'length == 1 and .[0].name == "keep"' inventory.json >/dev/null 2>&1 ||
+  fail "the matching object was not removed (or the wrong one was): $(cat inventory.json)"
+
+shopt -s nullglob
+backups=(backup_*/inventory.json)
+shopt -u nullglob
+[[ ${#backups[@]} -eq 1 ]] ||
+  fail "the original was not backed up before being rewritten (found ${#backups[@]} backups)"
+jq -e 'length == 2' "${backups[0]}" >/dev/null 2>&1 ||
+  fail "the backup does not hold the original two objects: $(cat "${backups[0]}")"
+
+# ── 2. A VALUE CARRYING jq SYNTAX is compared, not compiled. Spliced into the
+#      program, these characters are operators rather than the string somebody
+#      asked to match. ─────────────────────────────────────────────────────
+mkdir -p "$tmp/quoted"
+cd "$tmp/quoted" || fail "could not enter the sandbox"
+jq -n '[{name: "safe"}, {name: "a|b"}]' >inventory.json
+out="$(bash "$SCRIPT" .name 'a|b' 2>&1)" ||
+  fail "the helper exited non-zero on a value containing jq operators: $out"
+jq -e 'length == 1 and .[0].name == "safe"' inventory.json >/dev/null 2>&1 ||
+  fail "a value containing jq operators did not match its object as data: $(cat inventory.json)"
+
+# ── 3. A SELECTOR THAT IS NOT A PLAIN PATH is refused. It is the one argument
+#      that stays program text, because a jq path is what this tool takes, so
+#      the shape it may have is bounded rather than trusted. ────────────────
+mkdir -p "$tmp/selector"
+cd "$tmp/selector" || fail "could not enter the sandbox"
+jq -n '[{name: "keep"}]' >inventory.json
+selector_rc=0
+bash "$SCRIPT" '.name) | .[] | halt_error, (.x' keep >/dev/null 2>&1 || selector_rc=$?
+[[ $selector_rc -ne 0 ]] ||
+  fail "a selector carrying filter code was accepted"
+jq -e 'length == 1' inventory.json >/dev/null 2>&1 ||
+  fail "a refused selector still altered the file: $(cat inventory.json)"
+# Refused BEFORE any work starts, which is what distinguishes a validated
+# argument from one jq happens to choke on later: without the check the helper
+# gets as far as creating a backup directory and copying files into it.
+shopt -s nullglob
+selector_backups=(backup_*)
+shopt -u nullglob
+[[ ${#selector_backups[@]} -eq 0 ]] ||
+  fail "a refused selector still created ${selector_backups[*]}, so the argument is checked only after this tool has started working"
+
+cd "$REPO_ROOT" || fail "could not leave the sandbox"
+echo "find-and-remove-json-objects: OK"

--- a/test/unit/report-plugin-updates-plist.sh
+++ b/test/unit/report-plugin-updates-plist.sh
@@ -66,6 +66,14 @@ weekday="$(jq -r '.StartCalendarInterval.Weekday' "$plist_json")"
 [[ $weekday == "1" ]] || fail "the agent does not fire on Monday (Weekday $weekday)"
 [[ "$(jq -r '.StartCalendarInterval.Minute' "$plist_json")" == "0" ]] ||
   fail "the agent does not fire on the hour"
+# The HOUR is pinned, not just the weekday and minute. It is chosen: an hour
+# after com.webdavis.homebrew-weekly-upgrade so the two records do not land in
+# the channel together, and well into a working day so a Claude Code session has
+# had the chance to start and perform the auto-update this reports on. Without
+# this line, retiming the job to 14:00 keeps every other assertion green.
+report_hour="$(jq -r '.StartCalendarInterval.Hour' "$plist_json")"
+[[ $report_hour == "13" ]] ||
+  fail "the agent no longer fires at 13:00 (Hour $report_hour); if the retime is deliberate, move this assertion and check the reasoning in the plist comment still holds"
 
 [[ "$(jq -r '.RunAtLoad' "$plist_json")" == "false" ]] ||
   fail "RunAtLoad is not false; loading the agent would post an entry out of schedule"

--- a/test/unit/report-plugin-updates-plist.sh
+++ b/test/unit/report-plugin-updates-plist.sh
@@ -89,6 +89,22 @@ log_directory="$(dirname "$log_directory")"
 grep -qF -- "$log_directory" "$LOADER" ||
   fail "the loader does not create $log_directory, the directory the agent writes its log into; launchd refuses to start an agent whose log directory is absent"
 
+# THE BASELINE IS SEEDED AT DEPLOY TIME, by this loader, because the first run
+# to record a baseline reports nothing itself. Leave that to the first SCHEDULED
+# run and everything Claude Code's own auto-update changed between the apply and
+# that Monday is baked into the baseline and reported never, on the same apply
+# that turned those auto-updates on. It must also come BEFORE the bootstrap, so
+# the agent never has a Monday without a baseline waiting.
+# `|| true` so a loader that stopped seeding reaches the message below instead of
+# ending the run on errexit with nothing said about why.
+seed_line="$(grep -n -- '--seed-baseline' "$LOADER" | head -1 | cut -d: -f1 || true)"
+[[ -n $seed_line ]] ||
+  fail "the loader never seeds the baseline (--seed-baseline), so the first scheduled run records one and every plugin that moved between the deploy and it is reported nowhere"
+bootstrap_line="$(grep -n 'launchctl bootstrap' "$LOADER" | head -1 | cut -d: -f1 || true)"
+[[ -n $bootstrap_line ]] || fail "the loader no longer bootstraps the agent"
+[[ $seed_line -lt $bootstrap_line ]] ||
+  fail "the loader seeds the baseline after bootstrapping the agent (line $seed_line, bootstrap line $bootstrap_line)"
+
 # The sibling weekly job posts to the same channel, so the two must not share a
 # minute. Compared against the rendered sibling rather than a hardcoded hour, so
 # moving either job keeps this honest.

--- a/test/unit/skills-roster-fanout.sh
+++ b/test/unit/skills-roster-fanout.sh
@@ -163,9 +163,23 @@ fi
 # kept a bare `grep -q claudeDelivery` green, so the guard has to name the
 # expression the value actually comes from.
 UPDATER_SCRIPT="$REPO_ROOT/dot_local/bin/executable_update-skills.sh"
+CLAUDE_DELIVERY_READER='__update_skills_claude_undelivered'
 CLAUDE_DELIVERY_LOCK_READ='.claudeDelivery // {}'
-grep -qF -- "$CLAUDE_DELIVERY_LOCK_READ" "$UPDATER_SCRIPT" ||
-  fail "update-skills.sh no longer reads '$CLAUDE_DELIVERY_LOCK_READ' out of the lock, so its weekly Claude fan-out would re-create every exempted link. If the read was deliberately respelled, update this constant and confirm test/integration/update-skills-converge.sh still passes"
+# Scoped to the READER'S OWN BODY, not the whole file. The same expression also
+# appears in the roster schema gate, which only VALIDATES the table, so a
+# file-wide grep stayed green while the runtime filter was repointed at a
+# misspelled table: the exemption set came back empty, convergence treated every
+# skill as deliverable, and the tripwire that exists for exactly that said
+# nothing. The gate's copy cannot satisfy this one.
+reader_body="$(awk -v marker="$CLAUDE_DELIVERY_READER() {" '
+  index($0, marker) == 1 { inside = 1 }
+  inside { print }
+  inside && $0 == "}" { exit }
+' "$UPDATER_SCRIPT")"
+[[ -n $reader_body ]] ||
+  fail "update-skills.sh no longer defines $CLAUDE_DELIVERY_READER(), the function its weekly Claude fan-out reads the exemption set from. If it was renamed, update this constant and confirm test/integration/update-skills-converge.sh still passes"
+grep -qF -- "$CLAUDE_DELIVERY_LOCK_READ" <<<"$reader_body" ||
+  fail "$CLAUDE_DELIVERY_READER() no longer reads '$CLAUDE_DELIVERY_LOCK_READ' out of the lock, so the weekly Claude fan-out would re-create every exempted link. If the read was deliberately respelled, update this constant and confirm test/integration/update-skills-converge.sh still passes"
 
 # --- Rule 2: tiers covers exactly the roster -------------------------------
 tier_keys="$(jq -r '.tiers // {} | keys[]' "$LOCK" | sort)"


### PR DESCRIPTION
## Context

`~/.local/bin/report-plugin-updates.sh` is the weekly record of what Claude Code's own plugin
auto-update changed on this machine. Claude Code refreshes marketplaces and their installed plugins at
startup by itself and leaves no trace, so this helper reads
`~/.claude/plugins/installed_plugins.json`, compares it against last week's reading, and posts one
entry to the `#unattended-upgrades` channel. It landed in PR #141 along with the plugin declarations
in the settings modify-template. A review of that work raised ten findings against it.

Seven are in the reporter, two are in `update-skills.sh` and its roster test, and one is a repo-wide
sweep of a bug class that has now turned up in three consecutive slices: `jq` reads a file as a
SEQUENCE of JSON documents, so a doubled or appended document is accepted everywhere a single one is
meant. The sweep covered every `jq` invocation under `dot_local/bin/`, `dot_local/libexec/`,
`.chezmoiscripts/` and `scripts/`, and its full disposition is below.

Two groups of sweep sites belong to other branches: PR #153 fixed `update-skills.sh` while this branch
was in flight (main is merged in, so this branch carries that fix), and the osquery helpers are held by
`fix/osquery-jq-stream-guards`, which has not merged yet. The disposition table says which sites came
from where.

## Summary

- The reporter no longer accepts an inventory it cannot trust: a file holding two JSON documents is
  refused, and an install record whose shape it cannot read refuses the run instead of dropping out of
  the reading and being announced as a plugin removal
  (`dot_local/bin/executable_report-plugin-updates.sh`).
- An inventory with no user-scope records is now reported as the removals it describes, rather than
  raising `plugin-state-unreadable` every week from then on.
- Snapshot handling is fixed in three ways: a snapshot path that is not a regular file is refused
  loudly, the snapshot is renamed into place instead of copied over, and a reading that cannot be
  persisted alerts on the priority route instead of only reaching the local log.
- The baseline is seeded at deploy time by
  `.chezmoiscripts/run_onchange_after_69-load-report-plugin-updates-launchagent.sh.tmpl` through a new
  `--seed-baseline` mode, so the first transition after an apply is reported rather than absorbed into
  the baseline.
- Four fixes outside the reporter: `update-skills.sh` names the de-delivered link its apply-time mode
  leaves behind (no removal is scripted), `test/unit/skills-roster-fanout.sh` ties its delivery
  tripwire to the runtime read rather than to a string the schema validator also carries,
  `dot_local/bin/executable_assert-hermes-superpowers-routing.sh` refuses a lock holding more than one
  document, and `dot_local/bin/executable_find-and-remove-json-objects.sh` passes its value to jq as
  data, which also fixes a compile error that made it fail on every file it matched.

## What changed

### The reporter, `dot_local/bin/executable_report-plugin-updates.sh`

The inventory reader is now slurped (`jq -rs`), so the document count is checked before anything is
read out of it. That is a semantic fix and not only a status one: an `error()` raised while processing
one document of a stream does not make jq exit non-zero when another document succeeds, so the
degraded-file refusals underneath could not refuse anything on a doubled file. `-e` came off in the
same pass, because it exits 4 when a filter produces no output, and no user-scope records is an answer
rather than a failure. Every install record is now shape-checked before the scope filter rather than
after it.

`write_snapshot()` stages the reading as a sibling in the state directory and renames it over the
snapshot, so a write interrupted halfway cannot leave a short file that the next run reads as a batch
of new plugins. Both callers go through it. A snapshot path that exists and is not a regular file is
refused before the comparison, since a directory there reads as "no baseline yet" on every run
forever. Both persistence failures now alert.

The script runs under `set -euo pipefail`. The conversion is only safe once the failures it means to
tolerate are guarded where they happen, so the relay call, the host lookup and the library's
bookkeeping write say so explicitly. That last one was not tolerated on purpose: the library warns and
returns 0 whatever happened, by design, so a run that delivered its entry and could not record itself
exited 0 and left the next entry measuring its gap from a run that never happened.

`--seed-baseline` records the first reading and stops. The loader calls it after deploying the helper
and before bootstrapping the agent. The ordering requirement is stated in the loader: the same apply
enables the marketplace auto-updates this record reports on, so the seed has to happen in that apply,
and nothing between the settings write and the seed may start Claude Code. Seeding is idempotent, so a
routine apply cannot re-baseline over a change nobody has reported yet.

### Outside the reporter

`converge_dir()` in `update-skills.sh` warns, with the absolute path, about an updater-owned link that
is no longer delivered while running `--install-only`. That mode is what runs at apply time and it
removes nothing, so the link survives until a full weekly run reaps it and the harness sees two
sources under one name for that whole window. No removal is scripted here.

`test/unit/skills-roster-fanout.sh` scopes its grep to `__update_skills_claude_undelivered`'s own
body. The expression it looks for also appears in the roster schema gate, which only validates the
table, so a file-wide grep stayed green while the runtime filter was repointed at a misspelled table.

`assert-hermes-superpowers-routing.sh` checks the lock is one JSON object before any of its three
reads. On a doubled lock the pair walk collected the union of both documents and the slash-command
skill became whichever document carried it, and both drive an in-place rewrite of the mirror.

`find-and-remove-json-objects.sh` passes its value with `--arg`. It was spliced into the jq program in
single quotes, which jq has no such thing as, so the filter was a compile error and the helper failed
on the first file it matched, every time. The selector stays program text because a jq path is what
the tool takes, so its shape is bounded to a plain dotted path and refused before any backup directory
is created.

## How it was verified

Every fix was written test-first: the assertion was run against the unmutated tree and observed to
fail for the stated reason, then the fix was applied and the assertion observed to pass. Each fix was
then mutated back individually against an otherwise-unmutated control, and the control re-run green
afterwards.

| # | Finding | Test | RED evidence before the fix | Mutation applied after | Assertion that fired |
|---|---------|------|------------------------------|------------------------|----------------------|
| 3 | Doubled inventory accepted | `test/e2e/report-plugin-updates-record.sh` section 9 | exit 0, and the entry read `2 of 6 tracked entries changed (exa 4.0.0 -> 5.0.0, exa 4.0.0 -> 9.9.9)` | slurp removed | a doubled inventory exited 0 |
| 4 | Records filtered before validation | section 10 | exit 0, entry read `1 of 3 tracked entries changed (exa (removed))` from a `scop` typo | shape checks removed | mistyped scope key exited 0 |
| 2 | Empty user scope read as unreadable | section 11 | exit 1 with an empty `jq said:` reason | `-e` restored | an inventory with no user-scope records exited 1 |
| 5 | Directory at the snapshot path | section 12 | exit 0, "recording this reading as the baseline", copy written inside the directory | guard removed | a snapshot path that is a directory exited 0 |
| 6 | Snapshot overwritten in place | section 13 | inode unchanged across a delivering run | `write_snapshot` reverted to `cp` | the snapshot was written in place rather than renamed over |
| 7 | Persistence failure only logged | section 14 | exit 1 with no alert on the relay | alert removed | a run that could not persist its baseline alerted nobody |
| Q | `set -uo pipefail` | section 15 | a run that could not record itself exited 0 | marker check removed | a run that could not record its own success exited 0 |
| 1 | Baseline seeded at first scheduled run | section 16 and `test/unit/report-plugin-updates-plist.sh` | `--seed-baseline` exited 2 as an unknown argument | seed call removed from the loader | the loader never seeds the baseline |
| Q | Hour unpinned in the plist test | `test/unit/report-plugin-updates-plist.sh` | retiming to 14:00 stayed green | plist Hour set to 14 | the agent no longer fires at 13:00 (Hour 14) |
| 10 | Tripwire matched the validator | `test/unit/skills-roster-fanout.sh` | the file-wide grep stayed green with the runtime filter repointed at `.claudeDelivry` | runtime filter repointed at `.claudeDelivry` | `__update_skills_claude_undelivered()` no longer reads `.claudeDelivery // {}` |
| 9 | Leftover link left unnamed | `test/integration/update-skills-converge.sh` | the apply-time run said nothing about the link it left | warning removed | the apply-time run left a de-delivered link behind without naming it |
| S | Routing lock read as a stream | `test/integration/hermes-superpowers-routing.sh` section 10 | refused for the wrong reason, reporting a malformed slash-command skill that was two copies of a valid one | guard removed | the refusal does not say the lock is not one JSON value |
| S | jq value spliced as program text | `test/unit/find-and-remove-json-objects.sh` | `jq: error: syntax error, unexpected INVALID_CHARACTER`, helper exited 1 without touching a file | `--arg` reverted to interpolation | the helper exited non-zero on a plain value |
| S | Selector accepted unbounded | same file | new guard, no prior behaviour | selector pattern widened to `.*` | a refused selector still created `backup_20260804115633` |

The one behaviour with no runnable check is rename atomicity itself, which cannot be interrupted on
demand. The inode assertion stands in for it: `cp` keeps the inode, `rename` replaces it, so the test
pins the mechanism that provides the guarantee rather than the guarantee.

### The jq sweep

Every `jq` invocation under `dot_local/bin/`, `dot_local/libexec/`, `.chezmoiscripts/` and `scripts/`
was read and classified: 160 invocations across 32 files. `scripts/` contains none.

Verified behaviour that the sweep rests on, measured in this repo with jq 1.8.2:

- `jq -e 'F' file` on a two-document stream takes its exit status from the LAST document alone, so a
  file whose first document is malformed passes a gate when the trailing one is valid.
- `jq -r 'F' file` on a two-document stream emits rows from BOTH documents.
- An `error()` refusal inside a stream does not set a non-zero exit when another document succeeds, so
  an error-based guard cannot refuse multi-document input at all without slurping first.

Fixed here:

| Site | Consequence of a stream | Fix |
|------|--------------------------|-----|
| `report-plugin-updates.sh`, the inventory read in `plugin_snapshot()` | duplicated fingerprint rows, a fabricated weekly transition, and the degraded-file refusals bypassed | slurp, require exactly one document |
| `assert-hermes-superpowers-routing.sh`, the routing-pair walk | contradictory pairs merged into the rewritten map | one slurp-and-count guard before all three reads |
| `assert-hermes-superpowers-routing.sh`, the `slashCommandsSkill` read | picks whichever document carried the key, choosing which `SKILL.md` gets rewritten | same guard |
| `assert-hermes-superpowers-routing.sh`, the pairs handed to perl | prints a null error and still exits 0 with the other document's pairs, then rewrites every file in the mirror | same guard |

Audited and not changed here, with reasons:

| Site or group | Verdict |
|---------------|---------|
| `update-skills.sh`: roster schema gate, fan-out `claudeDelivery` check, the two npx reconcile inputs, candidate lock validation, failure-streak state | Needs the fix, and got it in PR #153 (`fix/update-skills-sol-findings`, commit dfd8c986) while this branch was in flight. That work is merged into main and into this branch, so the fix is present here without being duplicated. |
| `update-skills.sh`: 21 roster reads (795, 1339, 1353, 1373, 1437, 1499, 1504, 1656, 1685, 1696, 1833, 1865, 2063, 2070, 2357, 2441, 2500, 2526, 2578, 2596, 2629) | Guarded. In every mutating mode these read the validated run-private roster snapshot, which the gate above admits. |
| `update-skills.sh`: 7 fork-table reads (3089, 3103, 3114, 3144, 3324, 3348, 3349, 3350) | Guarded by the pre-existing `__fork_lock_single_document` (3074), which already slurps and counts. |
| `update-skills.sh`: self-written state (580 `generation.json`, 980, 981, 1027 exchange marker) | A truncating writer plus a rename produces a truncated file on a crash, never a doubled one, and each of these already tolerates an unreadable read. |
| `update-skills.sh`: the published npx lock and `origin.json` reads in `__update_skills_change_snapshot` | Written by third-party CLIs, and both feed the advisory weekly change record, so the worst outcome is a wrong line in a record rather than a mutation. The lock is validated before publish by PR #153's candidate check; `origin.json` is not, and is reported here as information rather than changed, since PR #153 audited this file. |
| `update-skills.sh`: 565, 739, 1531, 1912 | `jq -n` constructs JSON and reads no input. |
| `dot_local/libexec/osquery/**`, 17 sites | Needs the fix, covered by the sibling branch `fix/osquery-jq-stream-guards`. Not duplicated here. |
| `dot_local/libexec/osquery/**`, results-log readers | Legitimate stream: `osqueryd.results.log` is newline-delimited JSON by design. |
| `.chezmoiscripts/run_before_12-quarantine-unparseable-claude-settings.sh` | Already correct, and is the reference implementation this PR follows. |
| `dot_local/bin/executable_relay-codex-hooks.sh:43` | Guarded at line 24, whose `jq -es` read is what admits the value. The comment above line 43 claimed the check itself tested singleness; the comment is corrected, the code is not. |
| `dot_local/bin/executable_relay-agent.sh` JSONL read | Reads raw with `-R -s`, so document framing does not apply. |
| Hook-payload stdin reads (`claude-user-prompt-start`, `claude-stop-pulse`, `relay-codex-hooks`), single-response CLI pipelines (`smart-lights`, `hue-pulse`, `herdr-jump`, `claude-audit`), the `.chezmoiscripts` captures | One document per invocation by the producer's contract. |

One defect of a different class surfaced during the sweep and is fixed here because it sits in the
same file set: `find-and-remove-json-objects.sh` interpolated both of its arguments into the jq program
text. See the table above.

### Gates

`just l` reports no drift (386 files, 0 changed). `just test` passes.

## Effect of merging

Nothing is applied by merging. Every change here is source state, and this repo has not applied since
before the cutover, so the live machine is untouched until the next `chezmoi apply`.

At that apply, three things happen that did not before. The loader records a plugin baseline before
bootstrapping the agent, so the first weekly entry reports what moved since the apply instead of
starting from whatever the machine looked like the following Monday. The apply-time `--install-only`
pass prints a warning naming any updater-owned link that is no longer delivered, including
`~/.claude/skills/last30days`, which the operator then removes by hand; nothing removes it
automatically, and the full weekly run reaps it as before. And the reporter refuses inputs it used to
accept, so a degraded `installed_plugins.json` produces an alert and no entry rather than an entry
nobody should trust.

`find-and-remove-json-objects.sh` starts working. It has been a compile error on every invocation that
matched a file, so nothing depended on its previous behaviour.

## Review guide

Read the reporter as one file: `dot_local/bin/executable_report-plugin-updates.sh` carries seven of the
findings, and the reasoning for each sits above the code it explains.

Two judgement calls worth a second opinion:

- `--seed-baseline` is called from `run_onchange_after_69`, which fires when the plist or its own
  content changes. That covers the first deploy, which is the window the finding is about, and it does
  not re-seed if the state directory is wiped later. The alternative, a `run_before_` script seeding
  strictly before the settings write, would close a sub-second window that requires Claude Code to
  start mid-apply. The loader was chosen because it already exists.
- Finding 8 and the `update-skills.sh` half of the sweep are not in this PR's own commits. PR #153
  fixed both delivery gates and three more reads while this branch was in flight, so duplicating them
  here would have meant two conflicting edits to the same functions. Main is merged in, so those fixes
  are present in this branch; the only change this PR makes to `update-skills.sh` is in
  `converge_dir`.

Test placement follows the repo's suites: reporter behaviour is end-to-end because it runs the real
helper against fixture state, the schedule and argument checks are unit, and the two convergence cases
are integration.
