### PR TITLE
fix(cutover): compare the deployable set against tracked files honestly

### DIFF
--- a/scripts/cutover-gate.sh
+++ b/scripts/cutover-gate.sh
@@ -154,20 +154,36 @@ require_clean_tree() {
   ok "tree is clean, fully visible (no dirty, no untracked, no graphify-out residue, nothing deployable untracked)"
 }
 
-# Every source path `chezmoi managed` names that `git ls-files` does not.
+# Every source FILE `chezmoi managed` names that `git ls-files` does not.
 # chezmoi managed honours .chezmoiignore (it is not one of the data-only reads
 # twpayne/chezmoi#4940 breaks), so it is the honest authority on what deploys.
+#
+# TWO THINGS THIS COMPARISON MUST GET RIGHT, both measured on dresden 2026-08-04
+# when the first version reported 281 offenders against a tree that had none:
+#
+#   --exclude=dirs. `chezmoi managed` names managed DIRECTORIES as well as
+#   files; `git ls-files` never names a directory. Without the exclusion every
+#   managed directory is an offender that no commit can ever clear, so the gate
+#   is unpassable by construction. 73 of the 281 were directories.
+#
+#   LC_ALL=C on comm, not only on sort. comm assumes its inputs are sorted in
+#   ITS OWN collation. Pinning the sorts to C while comm ran under the login
+#   locale (en_US.UTF-8 here) made comm treat correctly-sorted input as
+#   unsorted and emit nonsense: 208 of the 281 were files that ARE tracked and
+#   appear verbatim in both lists. A gate that names tracked files as
+#   deployable-but-unclassified teaches the operator to disbelieve it, which is
+#   worse than no gate.
 managed_but_untracked() {
   local managed tracked
   managed="$scratch/managed"
   tracked="$scratch/tracked"
-  chezmoi managed --source "$repo" --path-style source-relative >"$managed" ||
+  chezmoi managed --source "$repo" --path-style source-relative --exclude=dirs >"$managed" ||
     die "chezmoi managed failed against $repo; the deployable set cannot be established"
   git -C "$repo" ls-files >"$tracked" ||
     die "git ls-files failed in $repo"
   LC_ALL=C sort -o "$managed" "$managed"
   LC_ALL=C sort -o "$tracked" "$tracked"
-  comm -23 "$managed" "$tracked"
+  LC_ALL=C comm -23 "$managed" "$tracked"
 }
 
 # chezmoi's DATA-ONLY reads (`chezmoi data`, `chezmoi execute-template`) walk

--- a/test/unit/cutover-gate-managed-comparison.sh
+++ b/test/unit/cutover-gate-managed-comparison.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# cutover-gate-managed-comparison.sh: gate 1's deployable-but-untracked check
+# must name exactly the files that would deploy without a commit describing
+# them, and nothing else.
+#
+# WHY THIS EXISTS. Measured on dresden 2026-08-04, mid-cutover: gate 1 refused
+# with 281 offenders against a source tree that had none, so D1 could not start.
+# Two independent defects stacked in one comparison, and each alone is enough to
+# make the gate unpassable:
+#
+#   1. `chezmoi managed` names managed DIRECTORIES; `git ls-files` never names a
+#      directory. Every managed directory was therefore an offender no commit
+#      could clear. 73 of the 281.
+#   2. The two inputs were sorted under LC_ALL=C while `comm` ran under the
+#      login locale, so comm judged correctly-sorted input to be unsorted and
+#      emitted nonsense. 208 of the 281 were files that ARE tracked and appear
+#      verbatim in both lists.
+#
+# The second is the dangerous one: a gate that names tracked files as
+# unclassified-and-deployable trains the operator to disbelieve its refusals,
+# which is worse than having no gate. Both cases are pinned below against a
+# throwaway repository, so neither can come back.
+set -euo pipefail
+
+# git exports GIT_DIR/GIT_INDEX_FILE when this runs under the pre-commit hook;
+# unset so nothing here can reach the outer repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/cutover-gate.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v chezmoi >/dev/null 2>&1 ||
+  fail "chezmoi is required to exercise the managed-set comparison"
+
+# The function under test, sourced out of the runner rather than reimplemented,
+# so a future edit to the runner is what this test sees.
+extract_function() {
+  awk '/^managed_but_untracked\(\) \{/,/^\}/' "$RUNNER"
+}
+[[ -n "$(extract_function)" ]] ||
+  fail "managed_but_untracked is missing from $RUNNER; the comparison moved and this test is blind"
+
+# A throwaway chezmoi source tree: one tracked file in a managed DIRECTORY (the
+# directory is what defect 1 flagged), one tracked file whose sorted position
+# differs between the C and en_US collations (defect 2's shape), and one
+# genuinely untracked deployable file that the gate MUST still catch.
+src="$work/src"
+mkdir -p "$src/dot_config/nested"
+printf 'tracked\n' >"$src/dot_config/nested/tracked.conf"
+printf 'tracked\n' >"$src/dot_Aa_collation_probe"
+printf 'tracked\n' >"$src/dot_ab_collation_probe"
+git -C "$src" init -q
+git -C "$src" add dot_config/nested/tracked.conf dot_Aa_collation_probe dot_ab_collation_probe
+git -C "$src" -c user.email=t@t -c user.name=t commit -qm seed
+
+# The sourced function calls die on a chezmoi or git failure. shellcheck cannot
+# see that call site (the definition it belongs to arrives at runtime through
+# source), so it reads the body as unreachable and the function as uninvoked.
+# shellcheck disable=SC2317,SC2329
+die() {
+  printf 'die: %s\n' "$*" >&2
+  exit 9
+}
+
+run_comparison() { # prints the offenders the runner's own function reports
+  local repo=$1 scratch
+  scratch="$(mktemp -d "$work/scratch.XXXXXX")"
+  # shellcheck source=/dev/null
+  source /dev/stdin <<<"$(extract_function)"
+  repo="$repo" scratch="$scratch" managed_but_untracked
+}
+
+# 1. A tree whose every deployable file is tracked reports NOTHING. This is the
+#    case that was impossible before: directories and collation noise each made
+#    it fail.
+offenders="$(run_comparison "$src" 2>/dev/null || true)"
+[[ -z $offenders ]] ||
+  fail "a fully tracked source tree reported offenders, so the gate cannot pass:"$'\n'"$offenders"
+
+# 2. Directories are never offenders. Prove the managed set really did contain
+#    one, so case 1 is not passing because the fixture happens to be flat.
+managed_all="$(chezmoi managed --source "$src" --path-style source-relative 2>/dev/null || true)"
+grep -qx 'dot_config/nested' <<<"$managed_all" ||
+  fail "the fixture no longer exercises a managed directory; case 1 proves nothing"
+
+# 3. A genuinely untracked deployable file IS caught. Without this the gate
+#    could be made to pass by never reporting anything, which is the failure
+#    mode the whole check exists to prevent.
+printf 'unclassified\n' >"$src/dot_config/nested/stowaway.conf"
+offenders="$(run_comparison "$src" 2>/dev/null || true)"
+grep -qx 'dot_config/nested/stowaway.conf' <<<"$offenders" ||
+  fail "an untracked deployable file was NOT reported; the gate would pass a source tree carrying it"
+rm -f "$src/dot_config/nested/stowaway.conf"
+
+# 4. The runner still pins both mechanisms explicitly. A future edit that drops
+#    either one reintroduces a 281-offender refusal on a clean tree, and cases 1
+#    through 3 would still pass on a fixture small enough to hide it.
+fn="$(extract_function)"
+grep -q -- '--exclude=dirs' <<<"$fn" ||
+  fail "managed_but_untracked no longer excludes directories; every managed dir becomes an offender"
+grep -qE 'LC_ALL=C[[:space:]]+comm' <<<"$fn" ||
+  fail "comm no longer runs under LC_ALL=C; it will judge C-sorted input unsorted and emit nonsense"
+
+printf 'cutover-gate-managed-comparison: OK (clean tree silent, directories exempt, stowaway caught, both mechanisms pinned)\n'


### PR DESCRIPTION
## Context

The D1 cutover began on 2026-08-04 and stopped at gate 1. `scripts/cutover-gate.sh 1` refused with 281
files it called deployable but unclassified, against a source tree that had none of them. Every one was
checked by hand: 208 are tracked files, 73 are directories, and zero were genuinely untracked.

The gate cannot pass as written, so the cutover cannot start. This is the smallest change that makes the
check tell the truth.

## Summary

- `managed_but_untracked` in `scripts/cutover-gate.sh` now passes `--exclude=dirs` to `chezmoi managed`.
  That command names managed directories; `git ls-files` never names a directory, so all 73 managed
  directories were offenders no commit could ever clear.
- The same function now runs `comm` under `LC_ALL=C`, matching the collation its two inputs were sorted
  with. `comm` had been judging correctly-sorted input as unsorted and emitting nonsense, which is where
  the 208 tracked files came from.
- New `test/unit/cutover-gate-managed-comparison.sh` sources the runner's own function and pins four
  properties: a fully tracked tree reports nothing, a managed directory is never an offender, a genuinely
  untracked deployable file is still caught, and both mechanisms remain present in the source.
- The comment above the function records both measurements, so the next reader learns why the two options
  are load-bearing rather than deleting them as noise.

## How it was verified

Against the live source tree, the fixed comparison reports zero offenders where the old one reported 281.
The same tree, same command.

Mutations, each reverting one half of the fix, run against the otherwise-fixed tree:

| Mutation | Result |
| --- | --- |
| Remove `--exclude=dirs` | RED: `a fully tracked source tree reported offenders` naming `dot_config` |
| Remove `LC_ALL=C` from `comm` | RED: `comm no longer runs under LC_ALL=C` |
| Control, unmutated | GREEN |

The stowaway case proves the check still does its job: planting an untracked deployable file makes the
comparison name it.

`just l` clean. `just test` exit 0 across all four suites, zero failures.

## Effect of merging

Nothing changes on the live machine. Gate 1 becomes passable on a tree that deserves to pass, and still
refuses a tree carrying an untracked deployable file. The cutover can proceed.

## Review guide

One function matters: `managed_but_untracked` in `scripts/cutover-gate.sh`. Read its comment first, then
the two changed lines. The test file is straightforward: it extracts the function from the runner rather
than reimplementing it, so a future edit to the runner is what the test sees.
