### PR TITLE
fix(cutover): treat a path both branches deleted as agreement

### DIFF
--- a/scripts/cutover-gate.sh
+++ b/scripts/cutover-gate.sh
@@ -478,10 +478,27 @@ build_delta_ledger() {
     int_entry="$(tree_entry "$INT_SHA" "$path")"
     main_entry="$(tree_entry "$MAIN_SHA" "$path")"
     if [[ -z $int_entry && -z $main_entry ]]; then
-      # the path is in the manifest, so it exists on at least one side; two
-      # empty lookups mean the lookup itself failed, never "identical"
-      printf 'missing\t%s\tneither side resolved, so this path could not be classified\n' \
-        "$path" >>"$missing"
+      # BOTH SIDES EMPTY IS TWO DIFFERENT SITUATIONS, and the first version of
+      # this branch conflated them. The manifest is `git diff PHASE_A_BASE
+      # INT_SHA`, so a path integration DELETED is in the manifest yet absent at
+      # INT_SHA. When main deleted it too, both lookups come back empty and the
+      # two branches AGREE in the strongest way available: the file is gone from
+      # both. Measured on dresden 2026-08-05, 92 of the 201 remaining blockers
+      # were exactly this (the tmux helpers, the retired Claude LaunchAgent, the
+      # sesh configs, the retired skills), and demanding a written reason for
+      # each would have meant asserting a decision for 92 non-events.
+      #
+      # The discriminator is the base: a path that existed at PHASE_A_BASE and
+      # is gone from both pins was deleted deliberately, twice. A path absent
+      # from the base as well has no business being in a diff against the base,
+      # so that one is still a real anomaly and still refuses.
+      if git -C "$repo" cat-file -e "$PHASE_A_BASE:$path" 2>/dev/null; then
+        printf 'landed-unchanged\t%s\tdeleted at the pinned integration and at the pinned main, so both sides agree it is gone\n' \
+          "$path" >>"$ledger"
+      else
+        printf 'missing\t%s\tabsent from the base and from both pins, so the manifest entry itself is unexplained\n' \
+          "$path" >>"$missing"
+      fi
       continue
     fi
     if [[ $int_entry == "$main_entry" ]]; then

--- a/test/unit/cutover-gate-deletion-agreement.sh
+++ b/test/unit/cutover-gate-deletion-agreement.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# cutover-gate-deletion-agreement.sh: a path both branches deleted is agreement,
+# not an unclassified blocker.
+#
+# WHY THIS EXISTS. Measured on dresden 2026-08-05, mid-cutover: after the real
+# differences were classified and accepted, gate 1 still refused with 92
+# blockers. Every one of them was a file that existed at the Phase A base and
+# was deleted by BOTH integration and main, the tmux helpers, the retired Claude
+# LaunchAgent, the sesh configs, the retired skills. The classifier treated two
+# empty tree lookups as a failed lookup, on the stated premise that "the path is
+# in the manifest, so it exists on at least one side". That premise is wrong:
+# the manifest is `git diff PHASE_A_BASE INT_SHA`, which lists deletions, so a
+# path integration removed is in the manifest and absent at INT_SHA.
+#
+# The cost of getting this wrong is not a missed defect, it is the opposite: the
+# gate demands a written reason for 92 non-events, which trains the operator to
+# write reasons that assert nothing, and a ledger full of hollow reasons is
+# worse evidence than no ledger. The cases below pin the discriminator in both
+# directions so the fix cannot decay into "empty means fine".
+set -euo pipefail
+
+# git exports GIT_DIR/GIT_INDEX_FILE when this runs under the pre-commit hook;
+# unset so nothing here can reach the outer repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/cutover-gate.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# A throwaway history covering the three states the classifier must tell apart.
+# EVERY fixture path must be one INTEGRATION changed relative to the base, because
+# the manifest is `git diff PHASE_A_BASE INT_SHA`; a path only main touched never
+# enters the manifest and so proves nothing. An earlier draft of this test got
+# that wrong and its one-sided case silently exercised nothing.
+#
+#   both-deleted.txt   int deletes, main deletes  -> agreement, must NOT block
+#   int-deleted-kept.txt  int deletes, main KEEPS -> one-sided, must still block
+#   both-changed.txt   int edits, main edits the same way -> ordinary agreement
+repo="$work/repo"
+mkdir -p "$repo"
+git -C "$repo" init -q
+git_c() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+printf 'base\n' >"$repo/both-deleted.txt"
+printf 'base\n' >"$repo/int-deleted-kept.txt"
+printf 'base\n' >"$repo/both-changed.txt"
+git_c add -A && git_c commit -qm base
+BASE="$(git -C "$repo" rev-parse HEAD)"
+
+# integration deletes two and edits the third
+git_c rm -q both-deleted.txt int-deleted-kept.txt
+printf 'edited\n' >"$repo/both-changed.txt"
+git_c add -A && git_c commit -qm integration
+INT="$(git -C "$repo" rev-parse HEAD)"
+
+# main deletes only the first and makes the identical edit, so it KEEPS
+# int-deleted-kept.txt: that path is the one-sided delta the gate must catch
+git_c checkout -q -b mainline "$BASE"
+git_c rm -q both-deleted.txt
+printf 'edited\n' >"$repo/both-changed.txt"
+git_c add -A && git_c commit -qm mainline
+MAIN="$(git -C "$repo" rev-parse HEAD)"
+
+ledger_dir="$work/state"
+mkdir -p "$ledger_dir"
+
+# Drive the runner's own classifier rather than reimplementing it, so an edit to
+# the runner is what this test sees.
+run_classifier() {
+  local scratch
+  scratch="$(mktemp -d "$work/scratch.XXXXXX")"
+  # shellcheck disable=SC2317,SC2329  # invoked by the sourced function on failure
+  die() {
+    printf 'die: %s\n' "$*" >&2
+    exit 9
+  }
+  # shellcheck disable=SC2317,SC2329  # invoked by the sourced classifier
+  tree_entry() { # <ref> <path>
+    git -C "$repo" ls-tree "$1" -- "$2" | awk '{print $1" "$3}'
+  }
+  # Same predicate as the runner's (scripts/cutover-gate.sh). Without it the
+  # sourced function calls an undefined command, the pin check fails, and the
+  # whole test dies at exit 9 while a piped invocation still reports success.
+  # shellcheck disable=SC2317,SC2329  # invoked by the sourced classifier
+  valid_sha() { [[ $1 =~ ^[0-9a-f]{40}$ ]]; }
+  # The runner's reporting helpers. They only print, so stubbing them to no-ops
+  # keeps the classifier's control flow identical while the test stays quiet.
+  # shellcheck disable=SC2317,SC2329
+  ok() { :; }
+  # shellcheck disable=SC2317,SC2329
+  say() { :; }
+  # shellcheck disable=SC2317,SC2329
+  checkpoint() { :; }
+  # shellcheck source=/dev/null
+  source /dev/stdin <<<"$(awk '/^build_delta_ledger\(\) \{/,/^\}/' "$RUNNER")"
+  # stderr goes to a file rather than /dev/null: the refusal text is expected
+  # here (case 2 asserts it), but a DIFFERENT failure would otherwise vanish and
+  # leave the assertions reading empty ledgers, which is how an earlier draft of
+  # this test reported success while dying at exit 9.
+  repo="$repo" scratch="$scratch" LEDGER="$ledger_dir" \
+    PHASE_A_BASE="$BASE" INT_SHA="$INT" MAIN_SHA="$MAIN" \
+    build_delta_ledger >/dev/null 2>"$work/classifier.err" || true
+}
+
+[[ -n "$(awk '/^build_delta_ledger\(\) \{/,/^\}/' "$RUNNER")" ]] ||
+  fail "build_delta_ledger is missing from $RUNNER; the classifier moved and this test is blind"
+
+# In a SUBSHELL: the classifier ends by refusing whenever anything is still
+# unclassified, and that refusal is exactly what case 2 asserts. Running it
+# inline would let its exit kill this test before a single assertion ran. The
+# ledger and blocker files are already on disk by then, so the subshell keeps
+# the evidence while discarding the exit.
+(run_classifier) || true
+ledger="$ledger_dir/delta-ledger.tsv"
+missing="$ledger_dir/delta-missing.tsv"
+[[ -f $ledger ]] || fail "the classifier wrote no ledger"
+
+kind_of() { # <path> -> the classification recorded for it, or empty
+  awk -F'\t' -v p="$2" '$2 == p {print $1; exit}' "$1"
+}
+
+# 1. Deleted on BOTH sides is agreement, and must never reach the blocker list.
+[[ "$(kind_of "$ledger" both-deleted.txt)" == landed-unchanged ]] ||
+  fail "a path deleted by both branches was not recorded as agreement; the gate would demand a reason for a non-event"
+if [[ -f $missing ]] && grep -q 'both-deleted.txt' "$missing"; then
+  fail "a path deleted by both branches still blocks the cutover"
+fi
+
+# 2. Deleted by integration but KEPT on main is a real delta and MUST still
+#    block. Without this the fix would degrade into treating every absence as
+#    agreement, which is the failure the ledger exists to prevent.
+grep -q 'int-deleted-kept.txt' "$missing" 2>/dev/null ||
+  fail "a path integration deleted while main kept it did NOT block; the fix over-reached into treating any absence as agreement"
+
+# 3. An ordinary matched edit is still agreement, so case 1 is not passing
+#    because the classifier now calls everything agreement.
+[[ "$(kind_of "$ledger" both-changed.txt)" == landed-unchanged ]] ||
+  fail "a path both branches edited identically was not recorded as agreement"
+
+# 4. The discriminator itself is pinned. A future edit that drops the base check
+#    reintroduces the 92-blocker refusal, and cases 1 through 3 would still pass
+#    on a fixture where every manifest path happens to exist at the base.
+fn="$(awk '/^build_delta_ledger\(\) \{/,/^\}/' "$RUNNER")"
+# shellcheck disable=SC2016  # the literal source text is the subject, not an expansion
+grep -q 'PHASE_A_BASE:\$path' <<<"$fn" ||
+  fail "the classifier no longer distinguishes a deletion from a failed lookup by checking the base"
+
+printf 'cutover-gate-deletion-agreement: OK (both-deleted is agreement, one-sided deletion still blocks, survivor unchanged, discriminator pinned)\n'


### PR DESCRIPTION
## Context

The D1 cutover reached gate 1 with its real differences classified and accepted, and the gate still
refused with 92 blockers. Every one of the 92 was a file that existed at the Phase A base and was deleted
by BOTH the pinned integration and the pinned main: the tmux helpers, the retired Claude LaunchAgent, the
sesh configs, the retired skills. Nothing about them is in dispute; both branches removed them on purpose.

That is the strongest agreement two trees can express, and the classifier was calling it an unclassified
blocker.

## Summary

- `managed_but_untracked`'s sibling in `scripts/cutover-gate.sh`, the delta classifier, treated two empty
  tree lookups as a failed lookup. Its stated premise was that a path in the manifest exists on at least
  one side. The manifest is `git diff PHASE_A_BASE INT_SHA`, which lists deletions, so a path integration
  removed is in the manifest and absent at `INT_SHA`.
- A path present at the base and gone from both pins is now recorded as `landed-unchanged` with a reason
  that says both sides agree it is gone.
- A path absent from the base as well still refuses. That case has no business appearing in a diff
  against the base, so it stays a real anomaly rather than being swept into the same bucket.
- New `test/unit/cutover-gate-deletion-agreement.sh` pins both directions, because the danger of this fix
  is over-reach: if every absence became agreement, main could silently drop something integration had and
  the ledger would say nothing.

## How it was verified

On the live cutover state, the classifier goes from 92 blockers to 0 for this class, and the remaining
ledger is unchanged.

| Mutation | Result |
| --- | --- |
| Revert the fix, both-empty back to unconditional missing | RED |
| Control, unmutated | GREEN |

The test's own fixture caught a mistake worth recording: an earlier draft asserted the one-sided case
using a path that only main had deleted. That path never enters the manifest, so the assertion exercised
nothing and passed vacuously. The fixture now builds every case from a path integration changed relative
to the base, and the one-sided case is a file integration deleted while main kept it.

`just l` clean. `just test` exit 0 across all four suites, zero failures.

## Effect of merging

Nothing changes on the live machine. Gate 1 stops demanding a written reason for files both branches
already agreed to delete, and still blocks on a file integration had that main dropped.

## Review guide

One function: the both-empty branch in `build_delta_ledger`. Read its comment first, then the base check
that discriminates a deliberate deletion from a failed lookup. In the test, case 2 is the one that matters
most: it is what stops this fix from degrading into treating every absence as agreement.
