### PR TITLE
fix(cutover): exempt app-owned store links from the reconcile blockers

### DIFF
--- a/scripts/live-reconcile.sh
+++ b/scripts/live-reconcile.sh
@@ -244,7 +244,31 @@ while IFS= read -r skill; do
     continue
   fi
   if [[ -L "$STORE/$skill" ]]; then
-    blocker "on-demand skill '$skill' has no Codex overlay and its store entry is a symlink; nothing is written through a store link"
+    # WHERE the link points decides whether this is a defect or the documented
+    # design. A link OUT of ~/.agents points at content another application
+    # owns, and docs/runbooks/agent-skills-store.md is explicit that such an
+    # entry never gets an overlay, because writing through the link would
+    # modify content this repository does not own. cua-driver is that case and
+    # it is permanent: reporting it as a divergence "to resolve before the
+    # cutover proceeds" asked for a resolution that must never happen, and
+    # since the tool exits non-zero on any blocker, gate 3 could never pass.
+    #
+    # A link that stays INSIDE ~/.agents is the generation exchange's own, and
+    # the updater owns it. That one keeps its blocker: another lane really is
+    # responsible, and staying silent would hide a real handoff gap.
+    link_target="$(cd "$(dirname "$STORE/$skill")" && readlink "$STORE/$skill")"
+    case "$link_target" in
+      /*) resolved="$link_target" ;;
+      *) resolved="$STORE/$link_target" ;;
+    esac
+    case "$resolved" in
+      "$HOME"/.agents/*)
+        blocker "on-demand skill '$skill' has no Codex overlay and its store entry links inside the agents store; the skills updater owns that content"
+        ;;
+      *)
+        say "  exempt: on-demand skill $skill is app-owned content at $resolved, so no Codex overlay is written through the link (documented in docs/runbooks/agent-skills-store.md)"
+        ;;
+    esac
     continue
   fi
   plan "assert the Codex overlay for on-demand skill $skill ($overlay)"

--- a/test/integration/live-reconcile.sh
+++ b/test/integration/live-reconcile.sh
@@ -257,15 +257,38 @@ rm -f "$hF/app-owned/gamma/agents/openai.yaml"
 snapshot "$hF" >"$work/beforeF"
 tool "$hF"
 snapshot "$hF" >"$work/afterF"
-if [[ $RC -eq 1 ]] && grep -q 'gamma' "$err_file"; then
-  report ok "F: a missing overlay behind a store symlink is reported, not fixed"
+# gamma links OUT of ~/.agents, so it is app-owned content. The runbook
+# (docs/runbooks/agent-skills-store.md) says such an entry never gets an
+# overlay, which makes the state permanent. This case used to demand rc=1, and
+# that made gate 3 unpassable: the tool exits non-zero on any blocker, so it
+# refused a condition that must never be resolved. The exemption is now
+# reported and NOT counted.
+if [[ $RC -eq 0 ]] && grep -q 'exempt.*gamma' "$out_file"; then
+  report ok "F: an app-owned store symlink is an exemption, not a counted divergence"
 else
-  report bad "F: an app-owned store symlink was not reported (rc=$RC, err: $(cat "$err_file"))"
+  report bad "F: an app-owned store symlink did not read as an exemption (rc=$RC, out: $(cat "$out_file"), err: $(cat "$err_file"))"
 fi
 if [[ ! -e "$hF/app-owned/gamma/agents/openai.yaml" ]]; then
   report ok "F: nothing was written through the store symlink"
 else
   report bad "F: the tool wrote through an app-owned store symlink"
+fi
+
+# ── Case F2: a link INSIDE the store is the updater's, and still blocks ────
+# The exemption must turn on WHERE the link points, not on a link existing. A
+# store entry pointing into ~/.agents belongs to the generation exchange, and
+# staying silent there would hide a real handoff gap.
+hF2="$work/homeF2"
+build_home "$hF2"
+rm -rf "$hF2/.agents/skills/gamma"
+mkdir -p "$hF2/.agents/.skills-current/skills/gamma"
+printf -- '---\nname: gamma\n---\n' >"$hF2/.agents/.skills-current/skills/gamma/SKILL.md"
+ln -s "$hF2/.agents/.skills-current/skills/gamma" "$hF2/.agents/skills/gamma"
+tool "$hF2"
+if [[ $RC -eq 1 ]] && grep -q 'gamma' "$err_file"; then
+  report ok "F2: a store link inside the agents store is still an unfixable divergence"
+else
+  report bad "F2: an in-store link stopped being reported, so the exemption covers every symlink (rc=$RC, err: $(cat "$err_file"))"
 fi
 
 # ── Case G: the deployed lock diverges from the committed one ──────────────

--- a/test/unit/live-reconcile-app-owned-exemption.sh
+++ b/test/unit/live-reconcile-app-owned-exemption.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# live-reconcile-app-owned-exemption.sh: an on-demand skill whose store entry
+# links at another application's content is a documented exemption, not a
+# divergence to resolve.
+#
+# WHY THIS EXISTS. Measured on dresden 2026-08-05, preflighting gate 3 before
+# the operator's apply: live-reconcile reported cua-driver as a divergence "to
+# resolve before the cutover proceeds" and exited 1, and gate 3 dies on that
+# exit. The resolution it asked for is one docs/runbooks/agent-skills-store.md
+# forbids: cua-driver's store entry is a symlink into ~/.cua-driver, and writing
+# an overlay through it would modify content this repository does not own. The
+# condition is permanent, so gate 3 could never have passed.
+#
+# WHAT THE FIX MUST NOT DO is exempt every symlink. A store entry that links
+# INSIDE ~/.agents belongs to the skills updater's generation exchange, and that
+# one is a real handoff gap worth reporting. The two cases below are the whole
+# point: the discriminator is where the link goes, not that a link exists.
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TOOL="$REPO_ROOT/scripts/live-reconcile.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x $TOOL ]] || fail "$TOOL is missing or not executable"
+
+# A sandbox HOME with the two link shapes plus a real directory, so all three
+# arms of the branch are exercised in one run.
+home="$work/home"
+store="$home/.agents/skills"
+mkdir -p "$store" "$home/.agents/.skills-current/skills/updater-owned" \
+  "$home/.otherapp/skills/app-owned" "$store/plain-dir"
+
+# app-owned: links OUT of ~/.agents  -> documented exemption
+ln -s "$home/.otherapp/skills/app-owned" "$store/app-owned"
+# updater-owned: links INSIDE ~/.agents -> still a blocker
+ln -s "$home/.agents/.skills-current/skills/updater-owned" "$store/updater-owned"
+# plain-dir gets a real overlay written, which proves the happy path still works
+
+# The tool derives its repo handle from $HOME with no env seam, so the sandbox
+# needs the checkout at the path it expects. Building it here rather than adding
+# an override to production keeps the real path derivation under test.
+sandbox_repo="$home/workspaces/Ivy/webdavis/dotfiles"
+mkdir -p "$sandbox_repo/dot_agents"
+git -C "$sandbox_repo" init -q
+
+# A lock declaring all three on-demand, with the tables the tool reads present
+# and empty so nothing else in the run has an opinion.
+cat >"$home/.agents/custom-skill-lock.json" <<'JSON'
+{
+  "version": 1,
+  "tiers": {
+    "app-owned": "on-demand",
+    "updater-owned": "on-demand",
+    "plain-dir": "on-demand"
+  },
+  "npxTracked": {},
+  "clawhubTracked": {},
+  "forks": {},
+  "hermesProfiles": {},
+  "hermesRegistry": {},
+  "claudeDelivery": {},
+  "superpowersRouting": {}
+}
+JSON
+
+# The committed lock must match the deployed one, or that unrelated divergence
+# fires and this test would be reading a run that stopped for another reason.
+cp "$home/.agents/custom-skill-lock.json" "$sandbox_repo/dot_agents/custom-skill-lock.json"
+
+out="$work/out.txt"
+HOME="$home" "$TOOL" --dry-run >"$out" 2>&1 || true
+
+# 1. The app-owned link is exempt: named as such, and NOT counted as a
+#    divergence. Both halves matter, because a tool that prints an exemption
+#    while still counting it keeps gate 3 unpassable.
+grep -q "exempt: on-demand skill app-owned" "$out" ||
+  fail "an app-owned store link was not reported as an exemption:"$'\n'"$(cat "$out")"
+grep -E 'DIVERGENCE.*app-owned' "$out" >/dev/null &&
+  fail "an app-owned store link is still counted as a divergence, so gate 3 stays unpassable"
+
+# 2. The updater-owned link IS still a blocker. Without this the fix would
+#    exempt every symlink and hide a real handoff gap.
+grep -E "DIVERGENCE.*updater-owned" "$out" >/dev/null ||
+  fail "a link inside the agents store stopped being reported; the exemption over-reached to every symlink"
+
+# 3. A real directory still gets its overlay planned, so cases 1 and 2 are not
+#    passing because the whole overlay pass stopped running.
+grep -q 'plain-dir' "$out" ||
+  fail "the overlay pass no longer reaches a plain on-demand directory"
+
+# 4. The discriminator itself is pinned. An edit that drops the target check
+#    reintroduces the unpassable gate, and cases 1 through 3 could still pass on
+#    a fixture whose links all happen to point the same way.
+grep -q 'link_target' "$TOOL" ||
+  fail "live-reconcile no longer inspects where a store link points; the exemption cannot be distinguishing anything"
+
+printf 'live-reconcile-app-owned-exemption: OK (app-owned link exempt and uncounted, updater-owned link still blocks, plain dir still planned, discriminator pinned)\n'


### PR DESCRIPTION
## Context

Preflighting gate 3 before the operator's staged apply, `live-reconcile.sh --dry-run` reported
`cua-driver` as a divergence "to resolve before the cutover proceeds" and exited 1. Gate 3 runs that dry
run and dies on a non-zero exit, so gate 3 could never have passed.

The resolution it demanded is one the repository forbids. cua-driver's store entry is a symlink into
`~/.cua-driver`, and `docs/runbooks/agent-skills-store.md` states that an app-owned entry never receives a
Codex overlay, because writing through the link would modify content this repository does not own. The
condition is permanent by design.

## Summary

- `scripts/live-reconcile.sh` now decides by where the link points. A store entry linking OUT of
  `~/.agents` is app-owned: it is reported as an exemption and does not count toward the blocker total.
- A store entry linking INSIDE `~/.agents` belongs to the skills updater's generation exchange and keeps
  its blocker, because that one is a real handoff gap.
- New `test/unit/live-reconcile-app-owned-exemption.sh` pins both directions.
- `test/integration/live-reconcile.sh` case F asserted the old contract and is updated; its assertion that
  nothing is ever written through the link is unchanged. New case F2 covers the in-store link, which the
  fixture never exercised.

## How it was verified

Against the live machine, the dry run goes from 3 divergences to 2. The two that remain both dissolve at
the operator's apply: the deployed lock is rewritten by chezmoi, and the routing script is created by it.

| Mutation | Result |
| --- | --- |
| Revert the exemption, every symlink blocks again | RED |
| Over-reach, exempt every symlink regardless of target | RED |
| Control, unmutated | GREEN |

`just l` clean. `just test` exit 0 across all four suites, zero failures.

## Effect of merging

Nothing changes on the live machine. Gate 3 stops refusing on a documented permanent exemption, and still
refuses when the skills updater has left a real gap.

## Review guide

One branch in `scripts/live-reconcile.sh`, the symlink arm of the Codex overlay pass. Read its comment,
then the target check. In the tests, the pair that matters is the app-owned case and the in-store case:
either one alone would let the fix be wrong in one direction.
