### PR TITLE
fix(nix): restore the nix-installer repair LaunchDaemon management

### DIFF
--- a/.chezmoidata/macos_system_setup.yaml
+++ b/.chezmoidata/macos_system_setup.yaml
@@ -70,6 +70,10 @@
 
 macos:
   system_setup:
+    - description: "Install self-healing nix-installer repair LaunchDaemon (NixOS fork)"
+      command: '"$HOME/.local/libexec/install-nix-repair-hook.sh"'
+      sudo: true
+      tier: enforce
     - description: "Firewall: enable the application firewall (must stay before the records below so a partial run leaves the firewall on, never policies stored with the firewall off)"
       command: "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
       sudo: true

--- a/dot_local/libexec/executable_install-nix-repair-hook.sh
+++ b/dot_local/libexec/executable_install-nix-repair-hook.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Install the self-healing nix-installer repair LaunchDaemon, mirroring the
+# `systems.determinate.nix-installer.nix-hook` pattern from Determinate's
+# installer but pointed at the NixOS-maintained fork's binary (same path:
+# `/nix/nix-installer`).
+#
+# Invoked from .chezmoidata/macos_system_setup.yaml via the tier-2
+# (sudo-required) system-setup runner. Idempotent: only writes/bootstraps when
+# the plist differs from disk or the daemon isn't loaded.
+#
+# Why: on macOS the NixOS fork's installer drops a `nix-installer repair`
+# subcommand that fixes shell-profile and remote-building integration after
+# system upgrades, but does not auto-install a LaunchDaemon to run it. This
+# script reproduces Determinate's hook so reboots self-heal the Nix install.
+
+set -euo pipefail
+
+PLIST_PATH=/Library/LaunchDaemons/systems.nixos.nix-installer.nix-hook.plist
+LABEL=systems.nixos.nix-installer.nix-hook
+
+EXPECTED=$(
+  cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>systems.nixos.nix-installer.nix-hook</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>/bin/wait4path /nix/nix-installer &amp;&amp; /nix/nix-installer repair</string>
+	</array>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>StandardErrorPath</key>
+	<string>/nix/.nix-installer-hook.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/nix/.nix-installer-hook.out.log</string>
+</dict>
+</plist>
+EOF
+)
+
+# Skip silently when /nix/nix-installer doesn't exist yet (fresh machine pre-Nix install).
+if [[ ! -x /nix/nix-installer ]]; then
+  echo "  /nix/nix-installer not present yet, skipping nix-hook install."
+  exit 0
+fi
+
+needs_write=1
+if [[ -f $PLIST_PATH ]] && diff -q <(printf '%s\n' "$EXPECTED") "$PLIST_PATH" >/dev/null 2>&1; then
+  needs_write=0
+fi
+
+if [[ $needs_write == 1 ]]; then
+  printf '%s\n' "$EXPECTED" >"$PLIST_PATH"
+  chown root:wheel "$PLIST_PATH"
+  chmod 644 "$PLIST_PATH"
+  launchctl bootout "system/$LABEL" 2>/dev/null || true
+  launchctl bootstrap system "$PLIST_PATH"
+  echo "  Installed $PLIST_PATH"
+else
+  # Plist matches; ensure it's loaded.
+  if ! launchctl print "system/$LABEL" >/dev/null 2>&1; then
+    launchctl bootstrap system "$PLIST_PATH"
+    echo "  Bootstrapped existing $LABEL"
+  fi
+fi


### PR DESCRIPTION
## Context

The de-nix work removed nix from this repo's dev toolchain, and the libexec reorg deleted one
machine-maintenance piece along with it: the installer for the boot-time LaunchDaemon that runs the
official `/nix/nix-installer repair`, which fixes nix's shell integration after every macOS update.
The operator's ruling is that de-nix meant the dev environment only; the machine keeps nix and the
repo keeps maintaining dresden's tooling, so this comes back. Cutover gate 1 flagged the orphan.

## Summary

- `dot_local/libexec/executable_install-nix-repair-hook.sh` restored verbatim from history, relocated
  from `~/.local/bin` because the operator never types it; the system-setup runner is its only caller.
- Its `macos_system_setup.yaml` entry restored at the head of `system_setup`, pointing at the new
  path.

## How it was verified

- `shellcheck -S warning` clean on the restored script.
- `just y` (yq validation) clean on the yaml.
- `git show` confirms the script body is byte-identical to the pre-deletion version apart from the
  path comment.

## Effect of merging

Main resumes managing the repair daemon; the cutover gate's retirement list becomes empty. Nothing
changes on the live machine until the next apply, and the daemon it manages is already installed and
loaded there.

## Review guide

One restored script and four yaml lines. Check the yaml path matches the libexec location; the script
body is history, not new code.
