### PR TITLE
fix(packages): give npm installs a deadline, and fail only what must not fail

### DIFF
--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -208,11 +208,33 @@ fi
 
 # Install npm global packages (runs after Homebrew so node is available). Same
 # command -v guard so a missing npm skips cleanly rather than aborting the apply.
+#
+# `npm install -g` is deliberately unconditional for INSTALLED packages too: it
+# is also the updater. The two cases fail differently, by ruling:
+#   missing package: MUST install. A failure fails this script, which aborts
+#     the apply: a declared tool that cannot land is not a passing apply.
+#   update pass: best effort. Each attempt gets a deadline so a wedged npm
+#     cannot hang the apply (node 26.7.0/npm 11.19.0 hangs on install even as
+#     a no-op); the first timeout skips the remaining updates with a warning,
+#     and installed versions simply stay put.
 {{ if .packages.macos.npm -}}
 if command -v npm >/dev/null 2>&1; then
+  npm_updates_broken=""
+  npm_missing_failed=()
 {{- range .packages.macos.npm }}
-  npm install -g {{ . | quote }}
+  if ! npm ls -g {{ . | quote }} >/dev/null 2>&1; then
+    gtimeout 180 npm install -g {{ . | quote }} || npm_missing_failed+=({{ . | quote }})
+  elif [[ -z $npm_updates_broken ]]; then
+    if ! gtimeout 180 npm install -g {{ . | quote }}; then
+      npm_updates_broken=1
+      printf 'WARNING: npm update timed out or failed; skipping the remaining npm updates this apply. Installed versions stay as they are.\n' >&2
+    fi
+  fi
 {{- end }}
+  if [[ ${#npm_missing_failed[@]} -gt 0 ]]; then
+    printf 'FAILED TO INSTALL (declared but absent): %s\n' "${npm_missing_failed[*]}" >&2
+    exit 1
+  fi
 fi
 {{ end -}}
 


### PR DESCRIPTION
## Context

Tonight's cutover apply wedged on the first npm global: node 26.7.0 with npm 11.19.0 hangs on
`npm install -g` even as a no-op re-run of an installed package (pre-network, near-zero CPU, silent
at every log level, while the registry answers in 44ms and `npm ls -g` works). The lane ran every
install unconditionally because the same command is also the updater, so one broken npm held the
whole apply hostage.

## Summary

- `.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl`: the npm lane now checks presence
  first. A missing declared package must install; failure exits 1 and aborts the apply.
- Updates of already-installed packages are best effort under a 180s `gtimeout` deadline; the first
  timeout warns and skips the remaining updates for that apply, leaving installed versions as they
  are.
- The one warning and the one failure block both print to the apply's own stderr; the runner stays
  free of any dependency on the notification stack.

## How it was verified

- Rendered with `chezmoi execute-template` and shellchecked at `-S warning`: clean.
- The hang itself was reproduced four independent ways (dry-run, another package, clean env,
  `--ignore-scripts`) and survives `brew reinstall node` and `npm cache clean --force`, so the
  deadline path is the one that will run tonight.
- All ten declared globals are currently installed (`npm ls -g` verified), so tonight's apply takes
  the update path: one 180s timeout, one warning, lane passes.

## Effect of merging

Applies stop being hostage to npm's install path when nothing is missing. A genuinely missing
declared tool now aborts the apply loudly instead of hanging or passing silently. No live-machine
change until the operator's next apply, which is waiting on this merge.

## Review guide

One template block. The ruling it encodes: fail closed on installs, fail open on updates. Check the
two branches against that sentence; `gtimeout` is coreutils, already declared.
