### PR TITLE
feat(packages): move the node runtime and CLI tools to an fnm lane

### DIFF
--- a/.chezmoidata/system_packages_autoinstall.yaml
+++ b/.chezmoidata/system_packages_autoinstall.yaml
@@ -81,9 +81,9 @@ packages:
         - fd
         - felixkratz/formulae/borders
         - ffmpeg
+        - fnm
         - fzf
         - gawk
-        - gemini-cli
         - gh
         - git
         - git-crypt
@@ -113,7 +113,6 @@ packages:
         - netcat
         - ngrep
         - nmap
-        - node
         - obsidian-cli
         - ollama
         - onefetch
@@ -157,7 +156,6 @@ packages:
         - treefmt
         - uv
         - vapor
-        - volta
         - websocat
         - wget
         - wireshark
@@ -247,20 +245,21 @@ packages:
       - nano-pdf
       - sherlock-project
       - whisply[mlx,app]
-    npm:
-      - "@doist/todoist-cli"
-      - agentmail-cli
-      - clawhub
-      - "@colbymchenry/codegraph"
-      - happy
-      - hyperframes
-      - "@clawdbot/lobster"
-      - "@mistweaverco/kulala-ls"
-      - mcporter
-      - "@elevenlabs/cli"
-    # Volta-managed CLI tools, each pinned to a specific Node major so the tool
-    # keeps working regardless of the active Homebrew `node` version. See
-    # https://docs.volta.sh/advanced/packages for how pinning works.
-    volta:
-      - package: "@tobilu/qmd"
-        node: "24"
+    # fnm-managed node plus the npm CLI tools that run on it. One node version
+    # per group; bumping `node` reinstalls every package under the new version
+    # at the next apply.
+    fnm:
+      - node: "24"
+        packages:
+          - "@clawdbot/lobster"
+          - "@colbymchenry/codegraph"
+          - "@doist/todoist-cli"
+          - "@elevenlabs/cli"
+          - "@google/gemini-cli"
+          - "@mistweaverco/kulala-ls"
+          - "@tobilu/qmd"
+          - agentmail-cli
+          - clawhub
+          - happy
+          - hyperframes
+          - mcporter

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -12,7 +12,7 @@ set -euo pipefail
 exit 0
 {{ end -}}
 # Resolve the Homebrew prefix once (honoring HOMEBREW_PREFIX) so every
-# brew/uv/volta call goes through one place.
+# brew/uv/fnm call goes through one place.
 brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
 brew_bin="$brew_prefix/bin/brew"
 
@@ -187,7 +187,7 @@ if [[ $multiplexer_present == false ]]; then
   fi
 fi
 
-# The ecosystem tools (uv, node/npm, volta) were just installed by the bundle at
+# The ecosystem tools (uv, fnm) were just installed by the bundle at
 # $brew_prefix/bin, which the apply shell's PATH may not yet include (a fresh
 # machine, or `bash -lc` reaching an unsourced shell). Prepend it once so the
 # `command -v` guards and the invocations below see the SAME binaries -- without
@@ -206,22 +206,29 @@ if command -v uv >/dev/null 2>&1; then
 fi
 {{ end -}}
 
-# Install npm global packages (runs after Homebrew so node is available). Same
-# command -v guard so a missing npm skips cleanly rather than aborting the apply.
+# Install the fnm-managed node and the npm CLI tools that run on it. fnm owns
+# the runtime: `fnm default` retargets the version-free aliases/default
+# symlink, and each node ships its own npm, which is what installs the
+# packages. fnm's bin dir is prepended for these calls because npm resolves
+# node through PATH (env-node shebang): without the prepend it runs on
+# whatever node PATH finds first and installs into THAT node's prefix.
 #
 # `npm install -g` is deliberately unconditional for INSTALLED packages too: it
 # is also the updater. The two cases fail differently, by ruling:
 #   missing package: MUST install. A failure fails this script, which aborts
 #     the apply: a declared tool that cannot land is not a passing apply.
 #   update pass: best effort. Each attempt gets a deadline so a wedged npm
-#     cannot hang the apply (node 26.7.0/npm 11.19.0 hangs on install even as
-#     a no-op); the first timeout skips the remaining updates with a warning,
-#     and installed versions simply stay put.
-{{ if .packages.macos.npm -}}
-if command -v npm >/dev/null 2>&1; then
+#     cannot hang the apply; the first timeout skips the remaining updates
+#     with a warning, and installed versions simply stay put.
+{{ if .packages.macos.fnm -}}
+if command -v fnm >/dev/null 2>&1; then
+  PATH="$HOME/.local/share/fnm/aliases/default/bin:$PATH"
   npm_updates_broken=""
   npm_missing_failed=()
-{{- range .packages.macos.npm }}
+{{- range .packages.macos.fnm }}
+  fnm install {{ .node | quote }}
+  fnm default {{ .node | quote }}
+{{- range .packages }}
   if ! npm ls -g {{ . | quote }} >/dev/null 2>&1; then
     gtimeout 180 npm install -g {{ . | quote }} || npm_missing_failed+=({{ . | quote }})
   elif [[ -z $npm_updates_broken ]]; then
@@ -231,24 +238,11 @@ if command -v npm >/dev/null 2>&1; then
     fi
   fi
 {{- end }}
+{{- end }}
   if [[ ${#npm_missing_failed[@]} -gt 0 ]]; then
     printf 'FAILED TO INSTALL (declared but absent): %s\n' "${npm_missing_failed[*]}" >&2
     exit 1
   fi
-fi
-{{ end -}}
-
-# Install Volta-pinned CLI tools. `volta install node@X` ensures the runtime is
-# present (and resets Volta's default to X, harmless because Homebrew's `node`
-# wins in PATH). `volta run --node X npm install -g <pkg>` pins the resulting
-# shim in ~/.volta/bin/<bin> to Node X so the tool keeps working when Homebrew
-# bumps node majors. Guarded on volta being on PATH so it skips cleanly if absent.
-{{ if .packages.macos.volta -}}
-if command -v volta >/dev/null 2>&1; then
-{{- range .packages.macos.volta }}
-  volta install {{ printf "node@%s" .node | quote }}
-  volta run --node {{ .node | quote }} npm install -g {{ .package | quote }}
-{{- end }}
 fi
 {{ end -}}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,13 +188,17 @@ Whole-file secrets use `age` encryption (identity at `~/.config/chezmoi/key.txt`
 ### System package management
 
 Packages are declared in `.chezmoidata/system_packages_autoinstall.yaml` under `packages.macos.homebrew`
-with keys `taps`, `formulae`, `casks` and `mas`, plus three siblings of `homebrew` under
-`packages.macos`: `uv` (uv tool installs, e.g. `graphifyy`, which provides the `graphify` CLI behind the
-post-commit dispatcher), `npm` (npm globals, e.g. `@colbymchenry/codegraph` and `happy`), and `volta`.
-One script, `.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl`, consumes all of them: it
-generates a Brewfile from the data, runs `brew bundle`, then runs a guarded
-`brew bundle cleanup --force`. Prerequisite: `run_once_before_00-install-homebrew.sh.tmpl` runs the
-upstream installer when `command -v brew` finds nothing.
+with keys `taps`, `formulae`, `casks` and `mas`, plus two siblings of `homebrew` under `packages.macos`:
+`uv` (uv tool installs, e.g. `graphifyy`, which provides the `graphify` CLI behind the post-commit
+dispatcher) and `fnm` (the node runtime plus the npm CLI tools that run on it, e.g. `happy` and
+`@tobilu/qmd`, grouped under one `node` version; bump that one value to move every tool to a new LTS).
+fnm's `~/.local/share/fnm/aliases/default/bin` is a version-free path that LaunchAgents and the bashrc
+rely on. Gotcha: npm is an env-node script, so every scripted npm call must put that fnm dir first in
+PATH, or npm runs on whatever `node` PATH finds and installs into that node's prefix. One script,
+`.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl`, consumes all of them: it generates a
+Brewfile from the data, runs `brew bundle`, then runs a guarded `brew bundle cleanup --force`.
+Prerequisite: `run_once_before_00-install-homebrew.sh.tmpl` runs the upstream installer when
+`command -v brew` finds nothing.
 
 Two behaviors of the cleanup stage matter. Cleanup is **withheld entirely** while `tmux` or `sesh` is
 still installed, because the herdr migration owns their teardown. And

--- a/Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl
@@ -6,7 +6,7 @@
   <string>com.webdavis.happy-daemon</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/happy</string>
+    <string>{{ .chezmoi.homeDir }}/.local/share/fnm/aliases/default/bin/happy</string>
     <string>daemon</string>
     <!-- start-sync runs the daemon in the FOREGROUND so launchd can supervise
          and KeepAlive it. `happy daemon start` detaches (forks, then returns),
@@ -27,8 +27,10 @@
   <dict>
     <key>HOME</key>
     <string>{{ .chezmoi.homeDir }}</string>
+    <!-- fnm's dir leads: happy is an env-node script, so its node comes from
+         this PATH, and it must be fnm's, not Homebrew's. -->
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <string>{{ .chezmoi.homeDir }}/.local/share/fnm/aliases/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
   </dict>
 </dict>
 </plist>

--- a/Library/LaunchAgents/com.webdavis.yt-dlp-pot-provider.plist.tmpl
+++ b/Library/LaunchAgents/com.webdavis.yt-dlp-pot-provider.plist.tmpl
@@ -15,7 +15,7 @@
        `cd .../server && npm ci && npx tsc` to refresh build/main.js. -->
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/node</string>
+    <string>{{ .chezmoi.homeDir }}/.local/share/fnm/aliases/default/bin/node</string>
     <string>build/main.js</string>
   </array>
   <key>WorkingDirectory</key>

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -134,13 +134,11 @@ export PATH="$COMPOSIO_INSTALL_DIR:$PATH"
 # Direct PATH add instead of sourcing .cargo/env (avoids a file read every start).
 [[ -d "$HOME/.cargo/bin" ]] && path_prepend "$HOME/.cargo/bin"
 
-# Volta: https://volta.sh/
-# Append (not prepend) so Volta's node/npm shims do NOT win over Homebrew's
-# `node`. Volta-installed CLI tools (e.g. qmd) still resolve here because nothing
-# earlier in PATH provides those binaries, and their shims dispatch to their
-# pinned Node version internally, independent of PATH order.
-export VOLTA_HOME="$HOME/.volta"
-[[ -d "$VOLTA_HOME/bin" ]] && PATH="$PATH:$VOLTA_HOME/bin"
+# fnm: https://github.com/Schniz/fnm
+# aliases/default is a version-free symlink (`fnm default` retargets it), so
+# node/npm/npx and the fnm-installed CLI tools resolve here in every shell,
+# non-interactive included, ahead of Homebrew.
+path_prepend "$HOME/.local/share/fnm/aliases/default/bin"
 
 # Nix: https://github.com/NixOS/nix-installer
 # Sets PATH/env for nix; needed by non-interactive shells too.
@@ -205,6 +203,10 @@ if [[ $- == *i* ]]; then
 
   # Direnv: https://github.com/direnv/direnv (PROMPT_COMMAND hook; before starship).
   eval "$(direnv hook bash)"
+
+  # fnm cd hook: a project with a .node-version/.nvmrc gets its pinned node on
+  # cd. Wraps `cd` (nothing else here does); writes no PROMPT_COMMAND.
+  command -v fnm &>/dev/null && eval "$(fnm env --use-on-cd --shell bash)"
 
   # Carapace: universal shell completion engine (v2 §16.3).
   # Ref: https://github.com/carapace-sh/carapace-bin


### PR DESCRIPTION
## Context

Homebrew's node 26.7.0 ships npm 11.19.0, which hangs on every `npm install`, silently and before
any network traffic. npm 11.17 installs fine on the same node 26.7 runtime, so the regression is in
npm 11.19's code. The hang wedged the cutover apply twice.

This moves the node runtime for the declared CLI tools to fnm (Fast Node Manager), whose node 24
LTS bundles a working npm. gemini-cli moves off its brew formula to its npm package, which leaves
Homebrew's node formula with no dependents, so node, volta (unmaintained) and gemini-cli all leave
the declarations.

## Summary

- `.chezmoidata/system_packages_autoinstall.yaml`: the `npm` and `volta` lanes become one `fnm`
  lane with twelve packages grouped under `node: "24"`; `fnm` joins the formulae; `node`, `volta`
  and `gemini-cli` leave them.
- `.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl`: the fnm block installs and
  defaults the declared node, then installs each package with the existing lane semantics: a
  missing package must install or the apply fails, updates are best-effort under a 180s deadline.
- `dot_bashrc.tmpl`: fnm's version-free `aliases/default/bin` is prepended to PATH for every
  shell, and the interactive block gains fnm's cd hook so a project carrying a `.node-version` or
  `.nvmrc` gets its pinned node automatically.
- `Library/LaunchAgents/com.webdavis.happy-daemon.plist.tmpl` and
  `com.webdavis.yt-dlp-pot-provider.plist.tmpl` reference fnm's alias path instead of
  `/opt/homebrew/bin`, so both agents survive the eventual brew node removal.
- `CLAUDE.md` documents the lane, the one-line LTS bump, and the PATH gotcha: npm is an env-node
  script, so scripted npm calls must lead PATH with fnm's bin dir or npm runs on whatever node
  PATH finds and installs into that node's prefix.

## How it was verified

- Live on this machine: fnm 1.39.0 with node 24.19.0. `npm install -g` through fnm's npm completed
  in 441ms where brew's npm hangs indefinitely; the global landed in fnm's tree and was served
  through `aliases/default/bin`; `npx -y gh-axi --help` works through fnm's node. The scratch
  package was removed afterward.
- `chezmoi execute-template` render of the package script: the fnm block emits `fnm install "24"`,
  `fnm default "24"`, and all twelve packages with the fail-closed install / best-effort update
  split intact.
- `just ship`: lint-check, the full test suite, and lint-actions-security all green.
- fnm cd hook cost measured: +14ms shell start against a 535ms baseline, +7ms per cd.

## Effect of merging

Merging changes nothing on a live machine. The next `chezmoi apply` installs fnm's node 24 and the
twelve tools, deploys the new bashrc, and reloads the two LaunchAgents from their new paths.
Brew's node, volta and gemini-cli stay installed until removed by hand after the apply is
verified (this repo builds no removal mechanisms); PATH order decides which copies win until then.

## Review guide

Read the yaml first, then the template's fnm block, which is the load-bearing change: the PATH
line above the loop is what keeps npm on fnm's node. The bashrc and plist edits are mechanical
repoints. A second pair of eyes helps most on the template block's `set -e` interactions:
`fnm install` and `fnm default` failures abort the apply on purpose.
