### PR TITLE
feat(pns): suppress the phone card for the pane watched via Moshi

### DIFF
--- a/dot_local/libexec/pns/executable_relay.sh
+++ b/dot_local/libexec/pns/executable_relay.sh
@@ -111,6 +111,21 @@ if [[ -z $want_phone && -z $local_only && -z $remote_only && -z ${RELAY_SKIP_PHO
   want_phone=1
 fi
 
+# THE VIEWED-PANE CHECK. A card about the pane the operator is watching
+# through Moshi right now describes what is already on their screen, so that
+# one card is dropped; every other pane still cards. Decided fresh at send
+# time: whatever is true THIS second wins, however the backtap, the agent
+# start and the Moshi open interleaved. Ordered cheapest first, so the
+# one-second viewing probe runs only when the panes already match. The Back
+# Tap marker never suppresses (it says "phone in hand", not "pane on screen"),
+# which is why the last check is pns_moshi_viewing and not pns_phone_attention.
+# RELAY_FORCE_PHONE is caller intent, and caller intent is never overridden.
+if [[ -n $want_phone && -z ${RELAY_FORCE_PHONE:-} && -n $pane ]] &&
+  pns_viewed_pane_redundant "$pane" "$(pns_herdr_focused_pane)" &&
+  pns_moshi_viewing; then
+  want_phone=""
+fi
+
 # ---------------------------------------------------------------------------
 # Channel dispatch
 #

--- a/dot_local/libexec/pns/helpers/event.sh
+++ b/dot_local/libexec/pns/helpers/event.sh
@@ -114,6 +114,21 @@ pns_channel_plan() {
   return 0
 }
 
+# pns_viewed_pane_redundant <event_pane> <focused_pane>
+# 0 when a phone card would describe the very pane the operator is watching:
+# both ids are present and identical. herdr mirrors focus across every
+# attached client, so the focused pane IS what a phone viewing the session
+# shows. Either id missing is unknown, and unknown fails OPEN (the card
+# fires): a duplicate card costs a glance, a dropped one costs the event.
+#
+# This is only half the verdict. The caller must ALSO hold proof the phone is
+# actively viewing (pns_moshi_viewing); the Back Tap marker never counts,
+# because a phone in hand is not a pane on screen.
+pns_viewed_pane_redundant() {
+  local event="${1:-}" focused="${2:-}"
+  [[ -n $event && -n $focused && $event == "$focused" ]]
+}
+
 # pns_pane_is_safe <pane>
 # 0 when a pane id may be interpolated into terminal-notifier's -execute, which
 # takes a SHELL STRING. A pane carrying `; curl ... | sh` would otherwise run

--- a/dot_local/libexec/pns/helpers/presence.sh
+++ b/dot_local/libexec/pns/helpers/presence.sh
@@ -141,6 +141,25 @@ pns_phone_attention() {
     0) return 1 ;;
   esac
   pns_phone_marker_fresh && return 0
+  pns_moshi_viewing
+}
+
+# pns_moshi_viewing
+# 0 when the phone is ACTIVELY VIEWING a Moshi session right now: the
+# one-second nettop sample, judged by pns_mosh_rate_active. Split out of
+# pns_phone_attention because the two answer different questions: attention
+# ("phone in hand", marker OR rate) routes cards TO the phone, viewing ("this
+# session on screen", rate ONLY) is what may suppress the one card about the
+# pane being watched. The marker deliberately does not reach this function.
+#
+# RELAY_MOSHI_VIEWING forces the verdict (1 yes, 0 no) for tests and manual
+# runs; the real probe samples live counters for a full second and must never
+# run in a test.
+pns_moshi_viewing() {
+  case "${RELAY_MOSHI_VIEWING:-}" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
   command -v pgrep >/dev/null 2>&1 || return 1
   command -v nettop >/dev/null 2>&1 || return 1
   local pid
@@ -155,4 +174,20 @@ pns_phone_attention() {
   # field 5, which is the shape pns_mosh_rate_active parses.
   nettop -P -L 2 -x -n -J time,interface,state,bytes_in,bytes_out "${pid_args[@]}" 2>/dev/null |
     pns_mosh_rate_active
+}
+
+# pns_herdr_focused_pane
+# Prints the pane id herdr currently has focused, or nothing when that cannot
+# be read. Focus is mirrored across every attached client, so this is also
+# what a phone viewing the session through Moshi is looking at. The same query
+# the banner channel runs; RELAY_HERDR_FOCUSED_PANE overrides it for tests.
+pns_herdr_focused_pane() {
+  if [[ -n ${RELAY_HERDR_FOCUSED_PANE:-} ]]; then
+    printf '%s' "$RELAY_HERDR_FOCUSED_PANE"
+    return 0
+  fi
+  command -v herdr >/dev/null 2>&1 || return 0
+  herdr pane list 2>/dev/null |
+    jq -r '.result.panes[]? | select(.focused == true) | .pane_id' 2>/dev/null |
+    head -1 || true
 }

--- a/test/unit/pns-channel-dispatch.bats
+++ b/test/unit/pns-channel-dispatch.bats
@@ -156,3 +156,37 @@ mode_of() { jq -r '.mode' <"$BATS_TEST_TMPDIR/$1.event"; }
     "$RELAY" --agent claude --state blocked --detail x >/dev/null 2>&1
   refute_fired moshi
 }
+
+@test "the watched pane's card is suppressed, other channels untouched" {
+  rm -f "$BATS_TEST_TMPDIR"/*.event
+  PNS_CHANNELS_DIR="$CHANNELS" RELAY_IDLE_SECS=99999 RELAY_MOSHI_VIEWING=1 \
+    RELAY_HERDR_FOCUSED_PANE=wW:p1 \
+    "$RELAY" --agent claude --state done --detail x --pane wW:p1 >/dev/null 2>&1
+  refute_fired moshi
+  fired hermes
+  fired macos-banner
+}
+
+@test "a pane the phone is not watching still cards" {
+  rm -f "$BATS_TEST_TMPDIR"/*.event
+  PNS_CHANNELS_DIR="$CHANNELS" RELAY_IDLE_SECS=99999 RELAY_MOSHI_VIEWING=1 \
+    RELAY_HERDR_FOCUSED_PANE=wW:p2 \
+    "$RELAY" --agent claude --state done --detail x --pane wW:p1 >/dev/null 2>&1
+  fired moshi
+}
+
+@test "phone in hand without Moshi on screen still cards the focused pane" {
+  rm -f "$BATS_TEST_TMPDIR"/*.event
+  PNS_CHANNELS_DIR="$CHANNELS" RELAY_IDLE_SECS=99999 RELAY_MOSHI_VIEWING=0 \
+    RELAY_HERDR_FOCUSED_PANE=wW:p1 \
+    "$RELAY" --agent claude --state done --detail x --pane wW:p1 >/dev/null 2>&1
+  fired moshi
+}
+
+@test "RELAY_FORCE_PHONE is caller intent and beats the viewed-pane check" {
+  rm -f "$BATS_TEST_TMPDIR"/*.event
+  PNS_CHANNELS_DIR="$CHANNELS" RELAY_IDLE_SECS=99999 RELAY_FORCE_PHONE=1 \
+    RELAY_MOSHI_VIEWING=1 RELAY_HERDR_FOCUSED_PANE=wW:p1 \
+    "$RELAY" --agent claude --state done --detail x --pane wW:p1 >/dev/null 2>&1
+  fired moshi
+}

--- a/test/unit/pns-event.bats
+++ b/test/unit/pns-event.bats
@@ -174,3 +174,29 @@ macos-banner async" ]
   RELAY_PHONE_ATTENTION=1 pns_phone_attention
   ! RELAY_PHONE_ATTENTION=0 pns_phone_attention
 }
+
+@test "a card about the watched pane is redundant when both ids agree" {
+  pns_viewed_pane_redundant "wW:p21" "wW:p21"
+}
+
+@test "a different focused pane is not redundant: that card must fire" {
+  ! pns_viewed_pane_redundant "wW:p21" "wW:p7"
+}
+
+@test "an event without a pane can never be redundant" {
+  ! pns_viewed_pane_redundant "" "wW:p21"
+}
+
+@test "unknown focus fails open: no focused pane means not redundant" {
+  ! pns_viewed_pane_redundant "wW:p21" ""
+}
+
+@test "RELAY_MOSHI_VIEWING forces the viewing verdict both ways" {
+  RELAY_MOSHI_VIEWING=1 pns_moshi_viewing
+  ! RELAY_MOSHI_VIEWING=0 pns_moshi_viewing
+}
+
+@test "a fresh Back Tap marker does not count as viewing" {
+  m="$BATS_TEST_TMPDIR/marker"; touch "$m"
+  ! PNS_PHONE_MARKER_FILE="$m" RELAY_MOSHI_VIEWING=0 pns_moshi_viewing
+}


### PR DESCRIPTION
## Context

When the operator watches an agent's pane through Moshi on the phone, every agent response still
raises a Moshi card about that same pane, so the phone badgers about the thing already on its
screen. Cards for the other panes are wanted; the card for the watched pane is noise.

herdr mirrors focus across every attached client, so the pane a phone views through Moshi is the
session's focused pane. That makes the fix a send-time check rather than any new state.

## Summary

- `dot_local/libexec/pns/executable_relay.sh`: before the phone leg fires, a viewed-pane check
  drops exactly that card when the event's pane equals herdr's focused pane and the mosh byte rate
  proves a session is on the phone's screen. Checks run cheapest first, so the one-second probe
  only runs when the panes already match. RELAY_FORCE_PHONE is caller intent and bypasses the
  check entirely.
- `dot_local/libexec/pns/helpers/presence.sh`: `pns_moshi_viewing` (byte rate only, with a
  RELAY_MOSHI_VIEWING test seam) is split out of `pns_phone_attention` (marker or rate). Routing
  cards to the phone and suppressing the watched pane now sit on separate signals, so the Back Tap
  marker can never suppress: it says the phone is in hand, not that a pane is on screen.
  `pns_herdr_focused_pane` is the focus probe, the same query the banner channel runs.
- `dot_local/libexec/pns/helpers/event.sh`: `pns_viewed_pane_redundant`, the pure half of the
  verdict. Either pane id missing fails open and the card sends.
- Ten new bats tests across `test/unit/pns-event.bats` and
  `test/unit/pns-channel-dispatch.bats` pin the predicate table, the viewing seam, the
  marker-does-not-suppress rule, and the routing (suppressed card, unaffected siblings, force
  override).

## How it was verified

- `just test-unit`: 198 tests, zero failures.
- Mutation check (python string replacement): gutting the relay suppression turns the
  suppressed-card test red; removing the pane comparison from the predicate turns the
  different-pane test red; both files restored and re-run green.
- `just ship`: lint-check, the full suite, and lint-actions-security all green.

## Effect of merging

Merging changes nothing live; the next `chezmoi apply` deploys the three pns files. After that,
while the phone is actively viewing a Moshi session, the card for herdr's focused pane is
skipped and every other pane cards as before. Approval round trips do not pass through this path
and are never suppressed. With the phone in a pocket or on another app, behavior is unchanged.

## Review guide

Read `pns_viewed_pane_redundant` in `helpers/event.sh`, then the relay block that calls it; those
two carry the behavior. The `presence.sh` change is mostly a mechanical split of an existing
probe. A second pair of eyes helps most on the fail-open cases: any unreadable input must send
the card, never drop it.
