### PR TITLE
feat(apply): label the loud apply stages with G2 section headers

### DIFF
--- a/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
+++ b/.chezmoiscripts/run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl
@@ -131,7 +131,12 @@ disk_inode="$(stat -f '%i' "$resolved" 2>/dev/null || true)"
 case $running_inode in '' | *[!0-9]*) exit 0 ;; esac
 case $disk_inode in '' | *[!0-9]*) exit 0 ;; esac
 
+# G2 section header for the bounce; the warnings above already name moshi-hook
+# inline, so this block is the only one that takes a header. The library is
+# inlined at render time, so no runtime sourcing.
+{{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
 if [[ $running_inode != "$disk_inode" ]]; then
+  report_section "moshi-hook" "upgrade bounce"
   printf 'moshi-hook daemon is running a replaced binary (image %s, on disk %s); bouncing the LaunchAgent...\n' \
     "$running_inode" "$disk_inode"
   launchctl kickstart -k "gui/$(id -u)/$SERVICE_LABEL"

--- a/.chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl
@@ -44,12 +44,12 @@ if [[ -x $binary ]]; then
     seed_rc=0
     "$herdr_timeout_bin" 10 "$binary" seed || seed_rc=$?
     if [[ $seed_rc -eq 124 ]]; then
-      printf 'herdr-last-workspace seed timed out (herdr socket wedged?); MRU seed skipped (best-effort), apply continues.\n' >&2
+      report_line 'herdr-last-workspace seed timed out (herdr socket wedged?); MRU seed skipped (best-effort), apply continues.' >&2
     elif [[ $seed_rc -ne 0 ]]; then
       printf 'herdr-last-workspace seed exited %d; MRU seed skipped (best-effort), apply continues.\n' "$seed_rc" >&2
     fi
   else
-    printf 'no coreutils timeout binary (timeout/gtimeout absent); cannot bound the herdr-last-workspace seed safely, MRU seed skipped (best-effort), apply continues.\n' >&2
+    report_line 'no coreutils timeout binary (timeout/gtimeout absent); cannot bound the herdr-last-workspace seed safely, MRU seed skipped (best-effort), apply continues.' >&2
   fi
 fi
 {{ end -}}

--- a/.chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl
@@ -8,6 +8,9 @@ set -euo pipefail
 # [[build]] step, so the binary is compiled here. Re-runs whenever the plugin
 # source changes (run_onchange keyed on the rendered content below).
 #
+# G2 section headers; the build partial calls report_section, so the library has
+# to be inlined ahead of it or the call is command-not-found under set -e.
+{{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
 {{ includeTemplate "herdr-plugin-build.sh.tmpl" (dict "id" "herdr-last-workspace") }}
 # Seed the MRU 'current' with the live focused workspace so the first bounce
 # after install works. The plugin learns workspaces only as they are focused, so

--- a/.chezmoiscripts/run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl
@@ -7,6 +7,9 @@ set -euo pipefail
 # action). `herdr plugin link` does NOT run the manifest's [[build]] step, so the
 # binary is compiled here. Re-runs whenever the plugin source changes.
 #
+# G2 section headers; the build partial calls report_section, so the library has
+# to be inlined ahead of it or the call is command-not-found under set -e.
+{{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
 {{ includeTemplate "herdr-plugin-build.sh.tmpl" (dict "id" "herdr-smart-nav") }}
 # Remove the retired standalone binary (superseded by the plugin action).
 rm -f "$HOME/.local/bin/herdr-smart-nav"

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -11,6 +11,9 @@ set -euo pipefail
 # this and re-syncs.
 exit 0
 {{ end -}}
+# G2 section headers for the loud stages below (operator ruling 2026-08-05); the
+# library is inlined at render time, so no runtime sourcing.
+{{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
 # Resolve the Homebrew prefix once (honoring HOMEBREW_PREFIX) so every
 # brew/uv/fnm call goes through one place.
 brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
@@ -146,6 +149,7 @@ cask {{ . | quote }}
 mas {{ .name | quote }}, id: {{ .id }}
 {{ end -}}
 EOF
+report_section "homebrew" "bundle sync"
 "$brew_bin" bundle --file="$brewfile"
 trust_checkpoint '20-after-brew-bundle'
 {{ includeTemplate "brew-bundle-cleanup-guard.sh.tmpl" }}
@@ -174,9 +178,19 @@ if [[ $multiplexer_present == false ]]; then
   # precondition and redoing the step it botched. This is deliberately not a
   # blanket `|| true`: the retry runs the same command against a restored trust
   # store, and a second failure is a real one that aborts the apply under set -e.
+  #
+  # Stdout is CAPTURED so the header can be withheld when the cleanup has
+  # nothing to say: with no removals and an empty `brew cleanup`,
+  # `brew bundle cleanup --force` prints nothing at all (Homebrew's
+  # bundle/subcommand/cleanup.rb only `puts` a non-empty result). The guard's own
+  # refusal warning is on stderr and still streams live.
   cleanup_rc=0
-  brew_bundle_cleanup_guarded "$brewfile" || cleanup_rc=$?
+  cleanup_output="$(brew_bundle_cleanup_guarded "$brewfile")" || cleanup_rc=$?
   trust_checkpoint '40-after-cleanup'
+  if [[ -n $cleanup_output ]]; then
+    report_section "homebrew" "bundle cleanup"
+    report_line "$cleanup_output"
+  fi
   if [[ $cleanup_rc -ne 0 ]]; then
     printf 'brew bundle cleanup exited %d. Restoring the trust store it destroys and retrying the cleanup once; a second failure aborts.\n' \
       "$cleanup_rc" >&2
@@ -200,6 +214,9 @@ export PATH="$brew_prefix/bin:$PATH"
 # skips cleanly instead of aborting under set -e when uv is genuinely absent.
 {{ if .packages.macos.uv -}}
 if command -v uv >/dev/null 2>&1; then
+  # uv narrates an already-installed tool on STDERR, so the header rides that
+  # stream rather than landing above a block it does not label.
+  report_section "uv" "tool installs" >&2
 {{- range .packages.macos.uv }}
   uv tool install {{ . | quote }}
 {{- end }}
@@ -225,6 +242,7 @@ if command -v fnm >/dev/null 2>&1; then
   PATH="$HOME/.local/share/fnm/aliases/default/bin:$PATH"
   npm_updates_broken=""
   npm_missing_failed=()
+  report_section "fnm" "node + npm CLI tools"
 {{- range .packages.macos.fnm }}
   fnm install {{ .node | quote }}
   fnm default {{ .node | quote }}

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -83,7 +83,7 @@ assert_taps_trusted() {
   [[ ${#missing[@]} -eq 0 ]] && return 0
   printf 'brew tap trust did not persist for %d of %d declared tap(s): %s\n' \
     "${#missing[@]}" "${#trusted_taps[@]}" "${missing[*]}" >&2
-  printf 'Homebrew refuses to load casks from an untrusted tap, so the cleanup stage below would fail with an error that names the cask rather than the trust. Trust them by hand, then re-apply:\n' >&2
+  report_line 'Homebrew refuses to load casks from an untrusted tap, so the cleanup stage below would fail with an error that names the cask rather than the trust. Trust them by hand, then re-apply:' >&2
   printf '  brew trust --tap %s\n' "${missing[@]}" >&2
   return 1
 }
@@ -121,8 +121,8 @@ for multiplexer in tmux sesh; do
   fi
 done
 if [[ $multiplexer_present == true ]]; then
-  printf 'Legacy multiplexer (tmux/sesh) still installed: running brew bundle WITHOUT cleanup so it is not removed before herdr is verified.\n' >&2
-  printf 'run_after_58 owns the teardown and completes the migration once herdr is healthy: open an interactive terminal (bashrc auto-attaches and starts the herdr server), then run chezmoi apply again so after_58 verifies herdr and removes tmux/sesh.\n' >&2
+  report_line 'Legacy multiplexer (tmux/sesh) still installed: running brew bundle WITHOUT cleanup so it is not removed before herdr is verified.' >&2
+  report_line 'run_after_58 owns the teardown and completes the migration once herdr is healthy: open an interactive terminal (bashrc auto-attaches and starts the herdr server), then run chezmoi apply again so after_58 verifies herdr and removes tmux/sesh.' >&2
 fi
 
 # Install all taps, formulae, casks, and macOS App Store apps, then uninstall
@@ -252,7 +252,7 @@ if command -v fnm >/dev/null 2>&1; then
   elif [[ -z $npm_updates_broken ]]; then
     if ! gtimeout 180 npm install -g {{ . | quote }}; then
       npm_updates_broken=1
-      printf 'WARNING: npm update timed out or failed; skipping the remaining npm updates this apply. Installed versions stay as they are.\n' >&2
+      report_line 'WARNING: npm update timed out or failed; skipping the remaining npm updates this apply. Installed versions stay as they are.' >&2
     fi
   fi
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-system-packages.sh.tmpl
@@ -179,11 +179,8 @@ if [[ $multiplexer_present == false ]]; then
   # blanket `|| true`: the retry runs the same command against a restored trust
   # store, and a second failure is a real one that aborts the apply under set -e.
   #
-  # Stdout is CAPTURED so the header can be withheld when the cleanup has
-  # nothing to say: with no removals and an empty `brew cleanup`,
-  # `brew bundle cleanup --force` prints nothing at all (Homebrew's
-  # bundle/subcommand/cleanup.rb only `puts` a non-empty result). The guard's own
-  # refusal warning is on stderr and still streams live.
+  # Stdout is CAPTURED because `brew bundle cleanup --force` prints nothing at
+  # all when it has nothing to remove, and a header must not stand over no body.
   cleanup_rc=0
   cleanup_output="$(brew_bundle_cleanup_guarded "$brewfile")" || cleanup_rc=$?
   trust_checkpoint '40-after-cleanup'

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -153,7 +153,7 @@ report_section "herdr plugin" "$plugin_id" >&2
 if [[ ! -x $cargo_bin ]]; then
   bump_retry_marker
   printf 'cargo not found at %s; %s plugin build deferred (trigger left retryable).\n' "$cargo_bin" "$plugin_id" >&2
-  printf 'rustup (run_once_before_20) has not provisioned it yet; the next chezmoi apply retries automatically once cargo exists.\n' >&2
+  report_line 'rustup (run_once_before_20) has not provisioned it yet; the next chezmoi apply retries automatically once cargo exists.' >&2
   exit 0
 fi
 

--- a/.chezmoitemplates/herdr-plugin-build.sh.tmpl
+++ b/.chezmoitemplates/herdr-plugin-build.sh.tmpl
@@ -141,6 +141,11 @@ register_plugin() {
 }
 
 # --- build phase ---
+# Both paths below print, and both print to stderr (cargo puts even its
+# do-nothing "Finished" line there), so one header on stderr owns the block.
+# Requires the caller to have included cli-print-style-lib.sh.tmpl first.
+report_section "herdr plugin" "$plugin_id" >&2
+
 # A MISSING toolchain is a retryable non-success, not a satisfied trigger: warn
 # loudly, leave the trigger retryable via the marker, and exit 0 so the rest of
 # the apply proceeds (this partial is includeTemplate'd into a run_onchange

--- a/test/unit/moshi-hook-bounce-on-upgrade.sh
+++ b/test/unit/moshi-hook-bounce-on-upgrade.sh
@@ -26,8 +26,15 @@ sandbox="$(mktemp -d)"
 trap 'rm -rf "$sandbox"' EXIT
 
 rendered="$sandbox/bounce.sh"
-CI=1 chezmoi execute-template --no-tty <"$TEMPLATE" >"$rendered" 2>/dev/null ||
-  fail 'chezmoi could not render the template'
+# --source pins the render to THIS checkout. The script includeTemplate's the
+# print library, and a bare `chezmoi execute-template` resolves includes against
+# whatever source dir the ambient config names, which is another tree here and
+# nothing at all in CI. The render error is reported rather than swallowed,
+# because a hidden one reads as "the template is broken".
+mkdir -p "$sandbox/render-home" # chezmoi's read-source-state pre hook chdirs into HOME
+HOME="$sandbox/render-home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$TEMPLATE" >"$rendered" 2>"$sandbox/render.err" ||
+  fail "chezmoi could not render the template:"$'\n'"$(cat "$sandbox/render.err")"
 
 mkdir -p "$sandbox/bin"
 kickstart_log="$sandbox/kickstart.log"

--- a/test/unit/moshi-hook-bounce-on-upgrade.sh
+++ b/test/unit/moshi-hook-bounce-on-upgrade.sh
@@ -26,11 +26,9 @@ sandbox="$(mktemp -d)"
 trap 'rm -rf "$sandbox"' EXIT
 
 rendered="$sandbox/bounce.sh"
-# --source pins the render to THIS checkout. The script includeTemplate's the
-# print library, and a bare `chezmoi execute-template` resolves includes against
-# whatever source dir the ambient config names, which is another tree here and
-# nothing at all in CI. The render error is reported rather than swallowed,
-# because a hidden one reads as "the template is broken".
+# --source pins the render to THIS checkout: the template includeTemplate's the
+# print library, which has to resolve against this tree rather than against
+# whatever source dir an ambient chezmoi config happens to name.
 mkdir -p "$sandbox/render-home" # chezmoi's read-source-state pre hook chdirs into HOME
 HOME="$sandbox/render-home" CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
   <"$TEMPLATE" >"$rendered" 2>"$sandbox/render.err" ||


### PR DESCRIPTION
## Context

A `chezmoi apply` interleaves output from brew bundle, uv, fnm and npm, the two cargo plugin builds and
moshi-hook with this repo's own printf lines, and nothing marks where one tool's block ends and the next
begins. The design has two tiers: our own lines go through the shared G2 print library, and
every loud third-party block gets a G2 header naming the tool. Quieting third-party output was rejected,
so there is no `--quiet` flag and no log-level change here.

G2 is the style already living in `.chezmoitemplates/cli-print-style-lib.sh.tmpl`: a bold colored tool
name, a faint context after a rule, no boxes. Two scripts adopted it already
(`run_after_35-setup-yt-dlp`, `run_after_59-hermes-config-migrate`); this extends it to the stages that
produce the bulk of an apply's output.

## Summary

- `run_onchange_before_10-system-packages.sh.tmpl` inlines the library after its `SKIP_SYSTEM_PACKAGES`
  early exit and adds four headers: `"homebrew" "bundle sync"` before `brew bundle`,
  `"homebrew" "bundle cleanup"` around the guarded cleanup, `"uv" "tool installs"` before the uv lane,
  and `"fnm" "node + npm CLI tools"` before the node lane.
- Inside `run_onchange_before_10-system-packages.sh.tmpl`, the `brew_bundle_cleanup_guarded` call site
  now captures its stdout, and the cleanup
  header plus body print only when that capture is non-empty. `brew bundle cleanup --force` prints
  nothing when it removes nothing, so an unconditional header there would put a label over an empty body
  on a quiet apply.
- `.chezmoitemplates/herdr-plugin-build.sh.tmpl` prints one parameterized `"herdr plugin" "$plugin_id"`
  header at the top of its build phase, and both callers
  (`run_onchange_after_55-build-herdr-last-workspace-plugin.sh.tmpl`,
  `run_onchange_after_57-build-herdr-smart-nav-plugin.sh.tmpl`) inline the print library ahead of the
  build partial so that call resolves under `set -e`.
- `run_after_46-bounce-moshi-hook-on-upgrade.sh.tmpl` prints `"moshi-hook" "upgrade bounce"` before the
  daemon bounce, and its warning paths keep their bare printf because each one already names moshi-hook
  inline.
- Each header rides the stream its body writes to instead of the library's default stdout: uv and cargo
  print to stderr, so those two headers are redirected with `>&2`; brew bundle and the fnm lane print to
  stdout, so theirs are not. No existing line was moved to a different stream.
- `test/unit/moshi-hook-bounce-on-upgrade.sh` renders its template with `--source "$REPO_ROOT"` and a
  throwaway HOME now, the form the other template tests already use. The bare `chezmoi
  execute-template` it used before resolved the new include against the ambient config's source dir,
  which is a different tree on a developer machine and nothing at all in CI.

## How it was verified

Every lane was measured in its no-change form on dresden before a header was placed over it:

- `uv tool install graphifyy`: exit 0, 0 bytes on stdout, 33 bytes on stderr, `` `graphifyy` is already
  installed ``. Loud, stderr, once per declared tool.
- `brew bundle --file=<one already-installed formula>`: stdout carries `Using jq` and `` `brew bundle`
  complete! 1 Brewfile dependency now installed. `` Loud, stdout.
- `fnm install v24.19.0` (the installed version): stdout `Installing Node v24.19.0 (arm64)`.
  `npm install -g happy --dry-run`: 11347 bytes on stdout. Loud, stdout.
- `cargo build --release --locked`, second run against an already-built throwaway crate: 0 bytes on
  stdout, ``    Finished `release` profile [optimized] target(s) in 0.00s`` on stderr. Loud, stderr, even
  with nothing to do.
- `brew bundle cleanup --force` with nothing to remove: read out of
  `/opt/homebrew/Homebrew/Library/Homebrew/bundle/subcommand/cleanup.rb`, whose force branch `puts` only
  for a non-empty cask list, a non-empty formula list, or a non-empty trailing `brew cleanup`. It can be
  completely silent, which is why that one header is gated on a captured stdout rather than printed up
  front.

Rendering, via `CI=1 chezmoi --source "$PWD" execute-template --no-tty < file` per the treefmt formatter,
returned rc=0 for all four edited scripts, with exactly one copy of the library in each rendered file and
every `report_section` call below its definition:

```
run_onchange_before_10-...rendered:393: report_section "homebrew" "bundle sync"
                                   :394: "$brew_bin" bundle --file="$brewfile"
                                   :471:   cleanup_output="$(brew_bundle_cleanup_guarded "$brewfile")" || cleanup_rc=$?
                                   :473:   if [[ -n $cleanup_output ]]; then
                                   :474:     report_section "homebrew" "bundle cleanup"
                                   :475:     report_line "$cleanup_output"
                                   :501:   report_section "uv" "tool installs" >&2
                                   :502:   uv tool install "graphifyy"
                                   :525:   report_section "fnm" "node + npm CLI tools"
                                   :526:   fnm install "24"
run_onchange_after_55-...rendered  : 34: report_section() {          (library)
                                   : 88: plugin_id="herdr-last-workspace"
                                   :198: report_section "herdr plugin" "$plugin_id" >&2
                                   :216: if ! (cd "$plugin_dir" && "$cargo_bin" build --release --locked); then
run_onchange_after_57-...rendered  : 33: report_section() {          (library)
                                   :197: report_section "herdr plugin" "$plugin_id" >&2
                                   :215: if ! (cd "$plugin_dir" && "$cargo_bin" build --release --locked); then
run_after_46-...rendered           :183: if [[ $running_inode != "$disk_inode" ]]; then
                                   :184:   report_section "moshi-hook" "upgrade bounce"
                                   :185:   printf 'moshi-hook daemon is running a replaced binary ...
```

The six labels render like this (`REPORT_LIB_PLAIN=1`, sourcing the real library):

```
homebrew ── bundle sync
homebrew ── bundle cleanup
uv ── tool installs
fnm ── node + npm CLI tools
herdr plugin ── herdr-smart-nav
moshi-hook ── upgrade bounce
```

The cleanup gate was exercised against a stubbed guard in four states. A silent guard printed nothing at
all; a guard that wrote only to stderr printed its warning and no header; a guard with stdout content
printed the header and the body; a failing guard printed the header, the body, and still returned
`cleanup_rc=1` for the existing retry path.

The first CI run failed on `test/unit/moshi-hook-bounce-on-upgrade.sh` while the local suite was green,
because that test rendered with a bare `chezmoi execute-template` and swallowed the error. Reproduced
locally by scrubbing `HOME` and the XDG variables, which is what makes a developer machine stop looking
like CI: the bare render exits 1 with `error calling includeTemplate ... .local/share/chezmoi/cli-print-style-lib.sh.tmpl:
no such file or directory`, while the same render with `--source "$REPO_ROOT"` exits 0 and carries one
copy of the library. The fixed test passes in that same scrubbed environment.

`just ship` exits 0: `just lint-check` reported `formatted 230 files (0 changed)`, `just test` ran the
three shell suites plus 25 Rust tests green, and `just lint-actions-security` reported no findings.

No new tests. Wiring a print library into scripts is declaration work, outside the 2026-08-05 test-scope
ruling, and the library's own output format is already pinned byte for byte by
`test/unit/cli-print-style-lib-format.sh`. The one test edit is a fix to an existing test, not new
coverage.

## Effect of merging

Three of the five edited scripts are `run_onchange_` and the library's bytes are welded into their
rendered content, so the first apply after this merges re-runs all three: `run_onchange_before_10` does a
full `brew bundle` sync followed by the guarded cleanup, and `run_onchange_after_55` and
`run_onchange_after_57` each re-enter their cargo build and herdr plugin registration. Any future edit to
`cli-print-style-lib.sh.tmpl` re-fires the same three the same way. Merging this has a real cost on the
next apply, and calling it inert would be wrong.

The other two edited scripts carry no trigger of their own: `run_after_46` runs on every apply as it
always did, and `.chezmoitemplates/herdr-plugin-build.sh.tmpl` only ever runs through the two callers
above. The test edit changes nothing on a live machine. Nothing here changes a package set, a plist, or
a target file's content. The single behavioral difference at runtime is that the bundle cleanup's stdout
now arrives after the guard returns instead of streaming while it works.

## Review guide

Start with `run_onchange_before_10-system-packages.sh.tmpl`: it carries four of the six headers and the
only behavioral edit, the captured stdout at the `brew_bundle_cleanup_guarded` call site (the guard
partial itself is untouched, since `run_after_58-herdr-migration-verify` shares it and does not include
the print library). `.chezmoitemplates/herdr-plugin-build.sh.tmpl` comes next, because its single header
serves two callers and depends on both of them inlining the library first. The three remaining hunks are
one to three lines each and mechanical.

A second pair of eyes helps most on the cleanup capture. It buffers the forced cleanup's stdout until the
guard returns, trading live output during an uninstall for never printing a header with nothing under it.
The guard's refusal warning is on stderr and still streams as it always did.
