### PR TITLE
fix(chezmoi): apply every entry type instead of excluding templates

### DIFF
--- a/.chezmoiscripts/run_after_05-osquery-known-good-manifests.sh
+++ b/.chezmoiscripts/run_after_05-osquery-known-good-manifests.sh
@@ -49,11 +49,9 @@
 # bin arm starts, so a failure in the bin arm cannot leave the pipeline manifest
 # stale. errexit then aborts the runner, which fails the apply loudly.
 #
-# NOT a template, deliberately. The mandated agent apply is
-# `chezmoi apply --exclude=templates`, which skips template scripts but still
-# applies the pipeline's plain executable_*.sh files. As a .tmpl this runner would
-# never refresh the manifests on that path, so every agent apply would leave each
-# updated file paging a false CRIT until someone ran a full interactive apply.
+# NOT a template. This runner refreshes the manifests, so it must run on every
+# apply that can change a manifested file. Keeping it plain removes any dependence
+# on which entry types a given apply processes.
 # Darwin is therefore gated at runtime, not with a Go-template guard.
 #
 # Runs in the EARLIEST after-phase slot (05): all target files are written before
@@ -368,10 +366,9 @@ refresh_manifest() {
     return 0
   fi
 
-  # Fresh host: /var/osquery is created by the osquery setup script, which is a
-  # TEMPLATE and so is skipped by `chezmoi apply --exclude=templates` - the very
-  # command this runner is plain in order to run under. Create the manifest's parent
-  # ourselves rather than fail the apply and leave the host with no manifest at all.
+  # Fresh host: /var/osquery is created by the osquery setup script, which may not
+  # have run yet on the first apply. Create the manifest's parent ourselves rather
+  # than fail the apply and leave the host with no manifest at all.
   # Only when it is actually missing, so a normal apply performs no extra privileged
   # call, and idempotent either way.
   refresh_manifest_dir="$(dirname "$refresh_manifest_dest")"

--- a/.chezmoitemplates/global-agent-rules.md
+++ b/.chezmoitemplates/global-agent-rules.md
@@ -52,7 +52,7 @@ Require per-invocation confirmation. Blanket "yes" doesn't carry over.
   `git clean -fd`, `git branch -D`, `git checkout .`
 - Dropping DB tables/schemas; `killall`; `shutdown`; `dd`
 - Bypassing checks: `--no-verify`, `--no-gpg-sign`, `--no-hooks`, `--skip-checks`
-- `chezmoi apply` from automation on template files (agents use `--exclude=templates`)
+- `chezmoi apply` in any form: the operator runs applies, agents propose changes
 
 ## Code discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,19 +120,25 @@ picked up automatically.
 ### Chezmoi operations
 
 ```bash
-just d                                      # chezmoi diff --exclude=templates
-just a                                      # chezmoi apply --exclude=templates --force
+just d                                      # chezmoi diff
+just a                                      # chezmoi apply
 chezmoi status                              # show pending changes
-chezmoi diff                                # diff all (including templates)
 chezmoi edit <file>                         # edit a template (prefer over direct edit of .tmpl)
 ```
 
-**`--exclude=templates` does not make an apply vault-free.** It skips `.tmpl` entries, but it does NOT
-skip a `modify_` template (measured 2026-08-02), and two modify-templates call `keepassxc`:
-`modify_private_dot_claude.json` (target `~/.claude.json`) and
-`Library/Application Support/Claude/modify_private_claude_desktop_config.json`. So `just a` and `just d`
-still reach the vault: run them from an interactive terminal with KeePassXC unlocked. To stay off the
-vault entirely, apply specific files by name:
+**THE OPERATOR RUNS APPLIES. Agents do not.** Both recipes above reach templates, so both need KeePassXC
+unlocked and an interactive terminal. An agent proposes changes and lets the operator apply them. This
+holds until the vault is replaced with a password manager an agent can unlock.
+
+**Why `--exclude=templates` was retired** (it was the mandated agent apply until 2026-08-10). It left the
+deployed copy of a templated target behind its source, while the osquery known-good manifest derives its
+hashes from the SOURCE. The two then disagree, and the pipeline audit reads that as tampering: a FALSE
+CRIT page on every tick until a full apply catches up, across ten manifested templated targets (seven
+osquery LaunchAgent plists, `posture-controls.json`, and the two osquery staging files). It also never
+delivered what it was for: it does NOT skip a `modify_` template (measured 2026-08-02), and two of those
+call `keepassxc`, so the excluded apply reached the vault anyway.
+
+To stay off the vault entirely, apply specific files by name:
 
 ```bash
 chezmoi apply ~/.fzf_bindings               # specific non-template, non-modify file

--- a/docs/runbooks/claude-code-settings.md
+++ b/docs/runbooks/claude-code-settings.md
@@ -5,8 +5,8 @@ chezmoi convention) that selectively enforces a fixed set of stable fields in `~
 On every `chezmoi apply`, the script reads the current target file, overlays the stable fields below via
 `setValueAtPath`, and writes the merged result back.
 
-`--exclude=templates` does not skip a modify-template (measured 2026-08-02), so this path runs on every
-`just a`, not only on a full apply.
+The retired `--exclude=templates` did not skip a modify-template (measured 2026-08-02), so this path runs
+on every `just a`, not only on a full apply.
 
 Fields fall into **three** categories, not two.
 

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -326,10 +326,8 @@ if [[ $- == *i* ]]; then
 
   {{ if eq .chezmoi.os "darwin" -}}
   # Brew shellenv cache self-heal. THIS IS THE ONLY AUTOMATIC WRITER of the cache
-  # sourced above: `chezmoi apply --exclude=templates` (what `just a` runs, and
-  # what CLAUDE.md requires of automation) does not run templated scripts, so the
-  # apply-time regen script only ever fired on a rare full interactive apply and
-  # was deleted. Two named predicates below answer the two separate questions:
+  # sourced above: the apply-time regen script fired only on a full interactive
+  # apply and was deleted, so nothing else writes the cache. Two named predicates below answer the two separate questions:
   # does anything need repairing, and are we allowed to try again yet.
   #
   # WHAT COUNTS AS NEEDING REPAIR (__brew_shellenv_cache_needs_repair):

--- a/dot_local/libexec/executable_brew-shellenv-cache-refresh.sh
+++ b/dot_local/libexec/executable_brew-shellenv-cache-refresh.sh
@@ -6,7 +6,7 @@
 #
 #   - ~/.bashrc's self-heal guard, detached, whenever the cache is unusable or
 #     stale. That guard is the only AUTOMATIC writer, because
-#     `chezmoi apply --exclude=templates` (what `just a` and every agent runs)
+#     the retired excluded apply (`just a` and every agent, until 2026-08-10)
 #     skips templated scripts, so an apply-time regen script could not be relied
 #     on and was removed.
 #   - `just brew-cache-refresh`, on demand. That is also the supported way to

--- a/dot_local/libexec/osquery/posture-controls.json.tmpl
+++ b/dot_local/libexec/osquery/posture-controls.json.tmpl
@@ -5,7 +5,7 @@ pipeline-integrity watch and the known-good manifest cover it: this file
 decides WHAT the posture poller monitors, so it is part of the monitor's body.
 
 NOTE for agents: this is a template, so the mandated agent apply
-(`chezmoi apply --exclude=templates`) skips it; a posture_controls data change
+(the retired excluded apply) skipped it; a posture_controls data change
 reaches the machine at the next interactive apply, the same lag every
 macos_defaults / macos_system_setup data change already has.
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ alias j := lint-json
 alias y := lint-yaml
 alias T := test
 alias d := diff
-alias a := apply-no-auth
+alias a := apply
 alias c := lint-check
 alias D := defaults-drift
 
@@ -66,11 +66,16 @@ lint-actions-syntax:
 lint-actions-security:
   zizmor --offline .github/workflows
 
+# Both reach templates, so both need KeePassXC unlocked and an interactive
+# terminal. That is deliberate: excluding templates left the deployed copy of a
+# templated target behind its source, which the osquery known-good manifest
+# reads as tampering. The operator runs these until the vault is replaced by
+# something an agent can unlock.
 diff:
-  chezmoi diff --exclude=templates
+  chezmoi diff
 
-apply-no-auth:
-  chezmoi apply --exclude=templates --force
+apply:
+  chezmoi apply
 
 # Test suites: test/unit (single component, stub-driven, fast), then
 # test/integration and test/e2e. Rust tests live in each plugin's own crate,

--- a/private_dot_claude/agents/chezmoi-apply.md
+++ b/private_dot_claude/agents/chezmoi-apply.md
@@ -1,46 +1,40 @@
 ---
 name: chezmoi-apply
-description: Safely run `chezmoi apply --exclude=templates --force` and report which template files still require interactive (KeePassXC-unlocked) apply.
+description: Report what a chezmoi apply would change, as a checklist for the operator to apply. Never applies anything itself.
 tools: Bash, Read
 ---
 
-You are the chezmoi-apply agent. Your job: apply chezmoi source state to `$HOME` without triggering
-KeePassXC password prompts, then enumerate the templates the user still needs to apply interactively.
+You are the chezmoi-apply agent. Your job is to REPORT, never to apply. The operator runs applies,
+because a full apply reaches KeePassXC-backed templates and needs an unlocked vault in an
+interactive terminal.
+
+Do not run `chezmoi apply` in any form, with or without flags, on any path. If you believe an apply
+is needed, say so and hand the command to the operator.
 
 ## Process
 
-1. Run `chezmoi status --exclude=templates` and show any pending non-template changes.
-2. Run `chezmoi diff --exclude=templates` and summarize the diff. If the diff is large, show only
-   the list of changed files plus a brief per-file summary.
-3. If the user approves (or in auto-apply mode), run `chezmoi apply --exclude=templates --force`.
-4. Then run `chezmoi status` (NOT excluding templates) and list every template file still requiring
-   apply. Format as a numbered checklist so the user can tick them off during an interactive session.
-5. Do NOT attempt `chezmoi apply` on template files, those need the user's interactive terminal
-   with KeePassXC unlocked.
+1. Run `chezmoi status` and show every pending change.
+2. Run `chezmoi diff` and summarize it. If the diff is large, list the changed files with a brief
+   per-file summary rather than the full text.
+3. Flag anything that looks unintended, for example a target that changed outside this session's
+   work, or a change to a file the operator did not ask about.
+4. End with the command for the operator to run.
 
 ## Output format
 
 ```
-## Non-template changes applied
+## Pending changes
 
-- path/to/file1
-- path/to/file2
+- path/to/file1: what changes and why
+- path/to/file2: what changes and why
 
-## Templates requiring interactive apply
-
-1. ~/.bashrc
-2. ~/.gitconfig
-3. ~/Library/Application Support/espanso/match/identity.yml
-...
-
-Run from an interactive terminal with KeePassXC unlocked:
+## Run this from an interactive terminal with KeePassXC unlocked
 
     chezmoi apply
 ```
 
 ## Error handling
 
-- If `chezmoi apply --exclude=templates --force` exits non-zero, show the error and stop. Do not
-  proceed to template enumeration until the non-template apply succeeds.
-- If KeePassXC prompts appear during a non-template apply, something is wrong, report it and stop.
-  A non-template apply should never hit KeePassXC.
+- If `chezmoi diff` or `chezmoi status` prompts for the vault, that is expected on templated
+  targets: report which ones prompted and stop rather than trying to work around it.
+- If either command exits non-zero, show the error and stop.

--- a/private_dot_hermes/private_dot_env.tmpl
+++ b/private_dot_hermes/private_dot_env.tmpl
@@ -8,7 +8,7 @@
   APPLY CAUTION: this OVERWRITES the entire live ~/.hermes/.env. Every KeePassXC entry below must exist and be
   populated before `chezmoi apply ~/.hermes/.env`, or the rendered file drops that secret and breaks Hermes
   (an empty DISCORD_BOT_TOKEN takes the Discord platform down). Because it calls keepassxc it is a TTY-only
-  template -- `chezmoi apply --exclude=templates` skips it, so apply it interactively with KeePassXC unlocked.
+  template, so apply it interactively with KeePassXC unlocked.
   .env values are bare (no quoting).
 */ -}}
 # --- Webhook gateway activation (the platform switch) ---

--- a/test/fixtures/osquery-manifest-lib.bash
+++ b/test/fixtures/osquery-manifest-lib.bash
@@ -94,14 +94,11 @@ manifest_fixture_chezmoi() {
     --source "$MF_SRC" --destination "$MF_HOME" "$@"
 }
 
-# manifest_fixture_apply: deploy the fixture source, mirroring the mandated agent
-# apply path (templates excluded).
+# manifest_fixture_apply: deploy the fixture source the way the operator applies,
+# which is every entry type. The mode split this replaced existed only to pass an
+# entry-type exclusion, and nothing excludes entry types any more.
 manifest_fixture_apply() {
-  manifest_fixture_apply_mode --exclude=templates
-}
-
-manifest_fixture_apply_mode() {
-  manifest_fixture_chezmoi apply "$@" --force >/dev/null 2>&1
+  manifest_fixture_chezmoi apply --force >/dev/null 2>&1
 }
 
 # manifest_fixture_run_runner: run the manifest runner exactly as chezmoi would

--- a/test/unit/bashrc-brew-cache-self-heal.sh
+++ b/test/unit/bashrc-brew-cache-self-heal.sh
@@ -3,7 +3,7 @@
 # The brew-shellenv cache self-heal in the rendered ~/.bashrc.
 #
 # This block is the ONLY automatic writer of the cache that ~/.bashrc sources for
-# Homebrew's PATH. `chezmoi apply --exclude=templates` (what `just a` runs, and
+# Homebrew's PATH. The retired excluded apply (`just a` until 2026-08-10, which
 # what CLAUDE.md requires of automation) does not run templated scripts, so the
 # old apply-time regen script only fired on a rare full interactive apply and was
 # removed. Deleting or weakening this block therefore has no backstop.

--- a/test/unit/brew-shellenv-cache-writer.sh
+++ b/test/unit/brew-shellenv-cache-writer.sh
@@ -5,7 +5,7 @@
 #
 # This script is the ONE implementation of the cache write. Both callers use it:
 # ~/.bashrc's self-heal guard (the only automatic writer, since
-# `chezmoi apply --exclude=templates` skips every templated script) and
+# skipped every templated script) and
 # `just brew-cache-refresh`. Everything ~/.bashrc sources at startup comes out of
 # here, so its failure modes are pinned individually:
 #


### PR DESCRIPTION
## Context

Applies have used `chezmoi apply --exclude=templates` as the mandated path for automation. That
exclusion causes a false alarm in the osquery pipeline: the known-good manifest derives its hashes
from the SOURCE, but an excluded apply does not rewrite templated targets on disk. After editing one,
the manifest and the deployed file disagree, and the pipeline audit reads the gap as tampering,
paging CRIT on every tick until a full apply catches up. Ten manifested targets are templated: seven
osquery LaunchAgent plists, `posture-controls.json`, and the two osquery staging files an in-flight
branch adds.

The exclusion also never did what it was for. It existed to keep an apply off KeePassXC, but it does
not skip a `modify_` template, and two of those call `keepassxc`, so an excluded apply reached the
vault anyway.

## Summary

- `justfile`: `diff` and `apply` (renamed from `apply-no-auth`, alias `a` follows) drop the
  exclusion and the `--force`. Both now reach templates, so both need the vault unlocked.
- `CLAUDE.md`: the chezmoi operations section states that the operator runs applies and agents
  propose changes, and records why the exclusion was retired.
- `.chezmoitemplates/global-agent-rules.md`: the destructive-action gate changes from "agents use
  `--exclude=templates`" to "agents do not apply at all", which reaches both `~/.claude/CLAUDE.md`
  and `~/.codex/AGENTS.md` through the shared partial.
- `private_dot_claude/agents/chezmoi-apply.md`: the agent becomes a REPORTER. It runs `status` and
  `diff`, summarizes what would change, and hands the operator the command; it never applies.
- `test/fixtures/osquery-manifest-lib.bash`: the fixture applies every entry type, and its
  apply-mode split is collapsed since nothing passes an exclusion any more.
- Comments in `dot_bashrc.tmpl`, `run_after_05-osquery-known-good-manifests.sh`,
  `brew-shellenv-cache-refresh.sh`, `posture-controls.json.tmpl`, two unit tests, the hermes env
  template and the Claude settings runbook drop their references to the retired flag.

## How it was verified

- `just ship` exits 0: `treefmt --no-cache --fail-on-change` reports no drift, the three shell
  suites and the Rust tests pass, and `zizmor` reports no findings.
- The fixture change was caught by shellcheck through the drift gate (SC2119/SC2120 on the now
  argument-less mode function) and fixed by collapsing the split, then re-verified green.
- `grep` across the tree confirms no live reference to the flag remains. Dated plans and specs under
  `docs/superpowers/` keep theirs deliberately: they are records of what was true when written.

## Effect of merging

Merging changes no deployed file. It changes who applies and how: `just a` and `just d` now require
KeePassXC unlocked in an interactive terminal, so agents can no longer apply unattended, and the
next apply the operator runs deploys every entry type rather than skipping templates. The false
tamper page disappears once that apply lands, because the manifest and the deployed bytes are then
derived from the same source state.

## Review guide

Read the `justfile` recipes first, then the CLAUDE.md section, since together they define the new
contract. `.chezmoitemplates/global-agent-rules.md` is the one edit that reaches other harnesses.
The rewritten `chezmoi-apply` agent is worth a look for what it now refuses to do. Everything else
is comment text. A second pair of eyes helps most on whether any automation still assumes an
unattended apply exists.
