### PR TITLE
docs(chezmoi): retire the by-name apply, which skips the manifest refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,11 +138,14 @@ osquery LaunchAgent plists, `posture-controls.json`, and the two osquery staging
 delivered what it was for: it does NOT skip a `modify_` template (measured 2026-08-02), and two of those
 call `keepassxc`, so the excluded apply reached the vault anyway.
 
-To stay off the vault entirely, apply specific files by name:
-
-```bash
-chezmoi apply ~/.fzf_bindings               # specific non-template, non-modify file
-```
+**A by-name apply is NOT a supported shortcut.** `chezmoi apply <path>` deploys that path without running
+the `run_` scripts, so `run_after_05-osquery-known-good-manifests.sh` never refreshes the known-good
+manifests. Deploy a MANIFESTED file that way and its hash no longer matches the manifest, which the
+pipeline audit reads as tampering and pages CRIT on every tick until a full apply. The manifested set is
+the osquery pipeline under `~/.local/libexec/osquery/`, the managed scripts under `~/.local/bin` and
+`~/.local/libexec`, and the osquery LaunchAgents. Use a full `chezmoi apply`; it is what keeps the
+deployed state and the manifests derived from the same source state. The by-name form existed to dodge
+the vault, which is no longer a goal now that the operator applies with it unlocked.
 
 Twelve targets pull secrets through `keepassxc` and need KeePassXC unlocked: `~/.gitconfig`,
 `~/.aws/credentials`, `~/.claude.json`, `~/.composio/user_data.json`, `~/.config/atuin/config.toml`,

--- a/private_dot_hermes/private_dot_env.tmpl
+++ b/private_dot_hermes/private_dot_env.tmpl
@@ -8,7 +8,9 @@
   APPLY CAUTION: this OVERWRITES the entire live ~/.hermes/.env. Every KeePassXC entry below must exist and be
   populated before `chezmoi apply ~/.hermes/.env`, or the rendered file drops that secret and breaks Hermes
   (an empty DISCORD_BOT_TOKEN takes the Discord platform down). Because it calls keepassxc it is a TTY-only
-  template, so apply it interactively with KeePassXC unlocked.
+  template, so apply it interactively with KeePassXC unlocked. A by-name apply is safe HERE only because this
+  target is not in a known-good manifest; a by-name apply of a manifested file skips the manifest refresh and
+  pages a false tamper CRIT (see CLAUDE.md).
   .env values are bare (no quoting).
 */ -}}
 # --- Webhook gateway activation (the platform switch) ---


### PR DESCRIPTION
## Context

PR #168 stopped applies from excluding templates, which closed the main path to a false tamper page:
the osquery known-good manifest derives its hashes from the source, and an excluded apply left the
deployed copy behind. One narrower path survived it.

`chezmoi apply <path>` deploys that path without running the `run_` scripts, so
`run_after_05-osquery-known-good-manifests.sh` never refreshes the manifests. Deploy a MANIFESTED
file that way and its hash no longer matches, which the pipeline audit reads as tampering: a CRIT
page on every tick until a full apply. CLAUDE.md recommended exactly that form as a way to stay off
the vault.

## Summary

- `CLAUDE.md` replaces the by-name apply recommendation with the hazard it carries, and names the
  manifested set: the osquery pipeline under `~/.local/libexec/osquery/`, the managed scripts under
  `~/.local/bin` and `~/.local/libexec`, and the osquery LaunchAgents.
- The recommendation had one purpose, dodging the vault, which stopped being a goal in #168 now that
  the operator applies with it unlocked.
- `private_dot_hermes/private_dot_env.tmpl` keeps its by-name instruction and gains the reason it is
  safe: that target sits in no manifest. Verified against both live manifests.

## How it was verified

- Read both live manifests to confirm what is covered. `~/.hermes/.env` is absent from each; the two
  hermes-named entries are pns and skills scripts, not that target.
- `just ship` exits 0: no drift, all suites pass, zizmor clean.
- Searched the tree for other live recommendations of the by-name form; the hermes template was the
  only one, and dated plans under `docs/superpowers/` keep theirs as historical record.

## Effect of merging

Documentation only. No deployed file changes and no behavior changes. It removes a documented
shortcut that could produce a false security alert, and states why the one remaining by-name
instruction is safe.

## Review guide

One paragraph in `CLAUDE.md` carries the change; the hermes template edit is a single sentence. Worth
checking: whether the manifested set as described matches what `run_after_05` actually manifests, and
whether any automation still relies on a by-name apply.
