### PR TITLE
fix(claude): keep the ELI5 edits in source, and stop diffing the generated map

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 # configured (CI, other machines), git falls back to a normal merge conflict,
 # resolvable by regenerating the map (`graphify update .`).
 graphify-out/graph.json merge=graphify-union
+
+# The map is generated: a rebuild rewrites nearly every line, so a textual diff of it
+# is noise in `git diff`, `git log -p` and any prompt that summarizes the worktree.
+graphify-out/graph.json -diff

--- a/private_dot_claude/output-styles/ELI5.md
+++ b/private_dot_claude/output-styles/ELI5.md
@@ -7,7 +7,8 @@ keep-coding-instructions: true
 It's been a long day and my brain is fried, talk to me like I'm 5.
 
 Small words, short sentences, short paragraphs. If you have to use a big word, explain it right after.
-Only return what's actually necessary.
+Only return what's actually necessary. No essays, no multi-section answers, no restating context you
+already know.
 
 Just tell me what you did, did it work, what do I do now.
 
@@ -15,3 +16,5 @@ If I have to decide something: 2 options max, the context I need to pick fast, a
 with.
 
 Keep paths and commands exact. I have no brain cells left for the rest.
+
+Don't speak in litotes and don't use any irony.


### PR DESCRIPTION
## Context

Two small corrections found while running an apply.

The ELI5 output style was edited in the deployed copy at `~/.claude/output-styles/ELI5.md`, which chezmoi owns. The next apply restored the source version and the edits vanished.

Separately, a graphify rebuild rewrites nearly every line of `graphify-out/graph.json`, so every prompt and every diff paid to compare a generated file line by line.

## Summary

- `private_dot_claude/output-styles/ELI5.md` gains the two edits that were lost: the stronger brevity rule and the no-litotes line.
- `.gitattributes` marks `graphify-out/graph.json` as `-diff`, so git reports it as changed without computing a textual diff. It stays tracked and its union merge driver is unaffected.

## How it was verified

Measured with the map genuinely dirty, same file both ways:

| | git_metrics | prompt shows |
|---|---|---|
| without the attribute | 60ms | `+81566 -81567` |
| with the attribute | 40ms | nothing |

A first attempt at this comparison was invalid (the attribute was active in both runs, so it measured itself against itself) and was redone.

`just ship` passed on the ELI5 commit; the attribute change touches no code path a suite covers.

## Effect of merging

The next apply deploys the corrected ELI5 style, so the two rules take effect in new sessions. The attribute takes effect immediately for anyone on this checkout: quieter diffs and a cheaper prompt.

## Review guide

Two files, both small. Worth confirming that `-diff` does not disturb the `merge=graphify-union` attribute on the same path.