### PR TITLE
feat(pns): add the TOML config layer that selects plugins

### DIFF
--- a/dot_local/share/pns/Cargo.lock
+++ b/dot_local/share/pns/Cargo.lock
@@ -3,5 +3,139 @@
 version = 4
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "pns"
 version = "0.1.0"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -9,3 +9,6 @@
 name = "pns"
 version = "0.1.0"
 edition = "2024"
+
+[dependencies]
+toml = "1.1.4"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -1,9 +1,10 @@
 # The pns decision core plus its probe edge. Library only: the engine binary
 # and dispatch arrive with later slices.
 #
-# NO DEPENDENCIES, and that is a property of this layer rather than a policy:
-# the decisions are pure, and the probe edge needs only std (spawning the
-# system readers, one fs mtime), so nothing here has anything to depend on.
+# ONE DEPENDENCY, taken where the format demands it: the config edge parses
+# TOML through the standard crate. The decision core and the probe edge run
+# on std alone, and that split is a property to keep: a new dependency needs
+# a layer whose format genuinely requires one.
 
 [package]
 name = "pns"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -12,4 +12,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-toml = "1.1.4"
+# Parse only: the default `display` feature pulls toml_writer, and nothing here
+# ever writes TOML back out. `serde` stays because `toml::Table` and
+# `toml::Value` are gated behind it.
+toml = { version = "1.1.4", default-features = false, features = [
+  "parse",
+  "serde",
+  "std",
+] }

--- a/dot_local/share/pns/src/config.rs
+++ b/dot_local/share/pns/src/config.rs
@@ -1,0 +1,193 @@
+//! The config edge: `~/.config/pns/config.toml` decides which plugins run.
+//!
+//! The file SELECTS; it never defines. Every plugin is compiled in, disabled
+//! until its table says `enabled = true`, so a machine runs exactly what its
+//! config names and nothing else. The settings inside a plugin's table are
+//! free-form here: this layer proves the shape, the registry interprets the
+//! contents, and neither knows the other's plugin names.
+//!
+//! Failure directions, each pinned by a test: a MALFORMED file is a loud
+//! error and never a silent empty config, because a typo that turns every
+//! notification off must not pass quietly; a MISSING file is its own honest
+//! outcome, distinct from both error and emptiness, so the caller can say
+//! "unconfigured" instead of guessing; unknown top-level keys are refused,
+//! so `[plugin.hue]` cannot silently disable what `[plugins.hue]` enables.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// One plugin's slice of the config: the selection flag, and its settings
+/// with the flag itself removed, because `enabled` belongs to this layer and
+/// everything else belongs to the plugin.
+#[derive(Debug, PartialEq)]
+pub struct PluginEntry {
+    pub enabled: bool,
+    pub settings: toml::Table,
+}
+
+/// The whole parsed file. Ordered, so listings and errors are deterministic.
+#[derive(Debug, PartialEq, Default)]
+pub struct Config {
+    pub plugins: BTreeMap<String, PluginEntry>,
+}
+
+/// Why a config could not be used. Every variant carries the offender by
+/// name, because "config invalid" without a noun is a hunt.
+#[derive(Debug, PartialEq)]
+pub enum ConfigError {
+    /// The file exists but is not TOML.
+    Malformed(String),
+    /// The TOML is well-formed but violates the schema.
+    Invalid(String),
+    /// The file exists and could not be read.
+    Unreadable(String),
+}
+
+/// What loading found at the path. `Missing` is deliberately not an error:
+/// an unconfigured machine is a state to report, not a fault to diagnose.
+#[derive(Debug, PartialEq)]
+pub enum LoadOutcome {
+    Missing,
+    Loaded(Config),
+}
+
+/// Where the config lives for a given home directory. Pure, so the path rule
+/// is testable without an environment.
+pub fn config_path(home: &str) -> PathBuf {
+    let _ = home;
+    todo!("R2b: home/.config/pns/config.toml")
+}
+
+/// The pure half: text in, config or a named refusal out.
+pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
+    let _ = text;
+    todo!("R2b: parse the TOML, validate the schema, split enabled from settings")
+}
+
+/// The IO edge: read the file at `path` and hand its text to the parser.
+pub fn load_config(path: &Path) -> Result<LoadOutcome, ConfigError> {
+    let _ = path;
+    todo!("R2b: absent file is Missing; present file goes through parse_config")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigError, LoadOutcome, config_path, load_config, parse_config};
+
+    // --- path resolution ----------------------------------------------------
+
+    #[test]
+    fn the_config_lives_under_the_homes_dot_config_pns() {
+        assert_eq!(
+            config_path("/Users/operator"),
+            std::path::PathBuf::from("/Users/operator/.config/pns/config.toml")
+        );
+    }
+
+    // --- parsing and the schema ---------------------------------------------
+
+    #[test]
+    fn a_plugin_table_with_enabled_true_is_selected_and_keeps_its_settings() {
+        let config = parse_config("[plugins.hue]\nenabled = true\nroom = \"office\"\n").unwrap();
+        let hue = &config.plugins["hue"];
+        assert!(hue.enabled);
+        assert_eq!(
+            hue.settings.get("room").and_then(|v| v.as_str()),
+            Some("office")
+        );
+        assert!(
+            !hue.settings.contains_key("enabled"),
+            "the selection flag is this layer's, not a setting"
+        );
+    }
+
+    #[test]
+    fn an_absent_enabled_flag_reads_disabled_because_selection_is_explicit() {
+        let config = parse_config("[plugins.hue]\nroom = \"office\"\n").unwrap();
+        assert!(!config.plugins["hue"].enabled);
+    }
+
+    #[test]
+    fn an_empty_config_is_valid_and_selects_nothing() {
+        let config = parse_config("").unwrap();
+        assert!(config.plugins.is_empty());
+    }
+
+    #[test]
+    fn a_non_boolean_enabled_flag_is_refused_naming_the_plugin() {
+        let err = parse_config("[plugins.hue]\nenabled = \"yes\"\n").unwrap_err();
+        match err {
+            ConfigError::Invalid(message) => {
+                assert!(message.contains("hue"), "the offender is named: {message}")
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_top_level_key_is_refused_so_a_typo_cannot_disable_a_channel() {
+        // [plugin.hue] instead of [plugins.hue] must be a loud refusal, never
+        // a quietly ignored table that leaves hue disabled.
+        let err = parse_config("[plugin.hue]\nenabled = true\n").unwrap_err();
+        match err {
+            ConfigError::Invalid(message) => {
+                assert!(
+                    message.contains("plugin"),
+                    "the offender is named: {message}"
+                )
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_plugin_entry_that_is_not_a_table_is_refused_naming_the_plugin() {
+        let err = parse_config("[plugins]\nhue = true\n").unwrap_err();
+        match err {
+            ConfigError::Invalid(message) => {
+                assert!(message.contains("hue"), "the offender is named: {message}")
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_toml_is_a_loud_error_never_a_silent_empty_config() {
+        // A config that fails to parse and quietly becomes "nothing enabled"
+        // would turn every notification off with no trace.
+        assert!(matches!(
+            parse_config("not [ toml"),
+            Err(ConfigError::Malformed(_))
+        ));
+    }
+
+    // --- the IO edge --------------------------------------------------------
+
+    #[test]
+    fn a_missing_file_is_its_own_outcome_not_an_error_and_not_empty() {
+        let outcome = load_config(std::path::Path::new("/nonexistent/pns-config-test.toml"));
+        assert_eq!(outcome, Ok(LoadOutcome::Missing));
+    }
+
+    #[test]
+    fn a_present_file_loads_through_the_parser() {
+        let path = std::env::temp_dir().join(format!("pns-config-test-{}", std::process::id()));
+        std::fs::write(&path, "[plugins.hue]\nenabled = true\n").unwrap();
+        let outcome = load_config(&path);
+        std::fs::remove_file(&path).ok();
+        match outcome {
+            Ok(LoadOutcome::Loaded(config)) => assert!(config.plugins["hue"].enabled),
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_present_malformed_file_is_a_loud_error() {
+        let path =
+            std::env::temp_dir().join(format!("pns-config-malformed-{}", std::process::id()));
+        std::fs::write(&path, "corrupt [").unwrap();
+        let outcome = load_config(&path);
+        std::fs::remove_file(&path).ok();
+        assert!(matches!(outcome, Err(ConfigError::Malformed(_))));
+    }
+}

--- a/dot_local/share/pns/src/config.rs
+++ b/dot_local/share/pns/src/config.rs
@@ -54,20 +54,60 @@ pub enum LoadOutcome {
 /// Where the config lives for a given home directory. Pure, so the path rule
 /// is testable without an environment.
 pub fn config_path(home: &str) -> PathBuf {
-    let _ = home;
-    todo!("R2b: home/.config/pns/config.toml")
+    Path::new(home).join(".config/pns/config.toml")
 }
 
 /// The pure half: text in, config or a named refusal out.
 pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
-    let _ = text;
-    todo!("R2b: parse the TOML, validate the schema, split enabled from settings")
+    let document: toml::Table = text
+        .parse()
+        .map_err(|error: toml::de::Error| ConfigError::Malformed(error.to_string()))?;
+
+    let mut config = Config::default();
+    for (key, value) in document {
+        if key != "plugins" {
+            return Err(ConfigError::Invalid(format!(
+                "unknown top-level key `{key}`"
+            )));
+        }
+        let plugins = value
+            .as_table()
+            .ok_or_else(|| ConfigError::Invalid("`plugins` is not a table".to_string()))?;
+
+        for (name, entry) in plugins {
+            // The copy is what `enabled` is removed FROM, so the flag reaches
+            // this layer and everything left over reaches the plugin untouched.
+            let mut settings = entry
+                .as_table()
+                .cloned()
+                .ok_or_else(|| ConfigError::Invalid(format!("plugin `{name}` is not a table")))?;
+            let enabled = match settings.remove("enabled") {
+                None => false,
+                Some(toml::Value::Boolean(flag)) => flag,
+                Some(_) => {
+                    return Err(ConfigError::Invalid(format!(
+                        "plugin `{name}` has a non-boolean `enabled`"
+                    )));
+                }
+            };
+            config
+                .plugins
+                .insert(name.clone(), PluginEntry { enabled, settings });
+        }
+    }
+    Ok(config)
 }
 
 /// The IO edge: read the file at `path` and hand its text to the parser.
 pub fn load_config(path: &Path) -> Result<LoadOutcome, ConfigError> {
-    let _ = path;
-    todo!("R2b: absent file is Missing; present file goes through parse_config")
+    match std::fs::read_to_string(path) {
+        Ok(text) => parse_config(&text).map(LoadOutcome::Loaded),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(LoadOutcome::Missing),
+        Err(error) => Err(ConfigError::Unreadable(format!(
+            "{}: {error}",
+            path.display()
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -178,6 +218,20 @@ mod tests {
         match outcome {
             Ok(LoadOutcome::Loaded(config)) => assert!(config.plugins["hue"].enabled),
             other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unreadable_path_is_an_error_never_a_silent_unconfigured() {
+        // A directory at the config path is the deterministic unreadable
+        // case: it exists, so reporting Missing here would make a broken
+        // path read as "unconfigured" and silently disable everything.
+        let outcome = load_config(std::env::temp_dir().as_path());
+        match outcome {
+            Err(ConfigError::Unreadable(message)) => {
+                assert!(!message.is_empty(), "the path and cause are named")
+            }
+            other => panic!("expected Unreadable, got {other:?}"),
         }
     }
 

--- a/dot_local/share/pns/src/config.rs
+++ b/dot_local/share/pns/src/config.rs
@@ -192,6 +192,39 @@ mod tests {
     }
 
     #[test]
+    fn a_non_table_plugins_value_is_refused_naming_the_key() {
+        // `plugins = 5` at the one key the whole file hangs off must refuse,
+        // never parse to an empty config with everything silently disabled.
+        let err = parse_config("plugins = 5\n").unwrap_err();
+        match err {
+            ConfigError::Invalid(message) => {
+                assert!(
+                    message.contains("plugins"),
+                    "the offender is named: {message}"
+                )
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_malformed_line_is_reported_without_echoing_its_value() {
+        // The config carries plugin secrets, and error strings travel to
+        // logs: the refusal names where and why, never the line's contents.
+        let err = parse_config("[plugins.moshi]\ntoken = \"SUPERSECRET\" trailing\n").unwrap_err();
+        match err {
+            ConfigError::Malformed(message) => {
+                assert!(!message.is_empty(), "the cause is still named");
+                assert!(
+                    !message.contains("SUPERSECRET"),
+                    "the offending line's value must not be echoed: {message}"
+                );
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn malformed_toml_is_a_loud_error_never_a_silent_empty_config() {
         // A config that fails to parse and quietly becomes "nothing enabled"
         // would turn every notification off with no trace.
@@ -218,6 +251,25 @@ mod tests {
         match outcome {
             Ok(LoadOutcome::Loaded(config)) => assert!(config.plugins["hue"].enabled),
             other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_dangling_config_symlink_is_an_error_never_missing() {
+        // chezmoi deploys configs as symlinks: a broken link is a PRESENT
+        // entry whose target is wrong, and reading it as "unconfigured"
+        // would silently disable everything. Only a truly absent entry is
+        // Missing.
+        let link = std::env::temp_dir().join(format!("pns-config-dangling-{}", std::process::id()));
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink("pns-absent-target", &link).unwrap();
+        let outcome = load_config(&link);
+        std::fs::remove_file(&link).ok();
+        match outcome {
+            Err(ConfigError::Unreadable(message)) => {
+                assert!(!message.is_empty(), "the path and cause are named")
+            }
+            other => panic!("expected Unreadable, got {other:?}"),
         }
     }
 

--- a/dot_local/share/pns/src/config.rs
+++ b/dot_local/share/pns/src/config.rs
@@ -59,9 +59,18 @@ pub fn config_path(home: &str) -> PathBuf {
 
 /// The pure half: text in, config or a named refusal out.
 pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
-    let document: toml::Table = text
-        .parse()
-        .map_err(|error: toml::de::Error| ConfigError::Malformed(error.to_string()))?;
+    // The parser's Display echoes the offending source line, and this file
+    // carries plugin secrets into log lines, so the refusal is rebuilt from
+    // the cause and the location alone.
+    let document: toml::Table = text.parse().map_err(|error: toml::de::Error| {
+        let line = error
+            .span()
+            .map(|span| text[..span.start].matches('\n').count() + 1);
+        ConfigError::Malformed(match line {
+            Some(line) => format!("{} at line {line}", error.message()),
+            None => error.message().to_string(),
+        })
+    })?;
 
     let mut config = Config::default();
     for (key, value) in document {
@@ -70,17 +79,18 @@ pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
                 "unknown top-level key `{key}`"
             )));
         }
-        let plugins = value
-            .as_table()
-            .ok_or_else(|| ConfigError::Invalid("`plugins` is not a table".to_string()))?;
+        let toml::Value::Table(plugins) = value else {
+            return Err(ConfigError::Invalid("`plugins` is not a table".to_string()));
+        };
 
         for (name, entry) in plugins {
-            // The copy is what `enabled` is removed FROM, so the flag reaches
-            // this layer and everything left over reaches the plugin untouched.
-            let mut settings = entry
-                .as_table()
-                .cloned()
-                .ok_or_else(|| ConfigError::Invalid(format!("plugin `{name}` is not a table")))?;
+            let toml::Value::Table(mut settings) = entry else {
+                return Err(ConfigError::Invalid(format!(
+                    "plugin `{name}` is not a table"
+                )));
+            };
+            // `enabled` is removed rather than read, so the flag reaches this
+            // layer and everything left over reaches the plugin untouched.
             let enabled = match settings.remove("enabled") {
                 None => false,
                 Some(toml::Value::Boolean(flag)) => flag,
@@ -92,7 +102,7 @@ pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
             };
             config
                 .plugins
-                .insert(name.clone(), PluginEntry { enabled, settings });
+                .insert(name, PluginEntry { enabled, settings });
         }
     }
     Ok(config)
@@ -102,7 +112,15 @@ pub fn parse_config(text: &str) -> Result<Config, ConfigError> {
 pub fn load_config(path: &Path) -> Result<LoadOutcome, ConfigError> {
     match std::fs::read_to_string(path) {
         Ok(text) => parse_config(&text).map(LoadOutcome::Loaded),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(LoadOutcome::Missing),
+        // A dangling symlink also reads NotFound, and chezmoi deploys configs
+        // as symlinks: the entry is PRESENT with a wrong target, so only an
+        // absent entry is Missing and the broken link is an error.
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && std::fs::symlink_metadata(path).is_err() =>
+        {
+            Ok(LoadOutcome::Missing)
+        }
         Err(error) => Err(ConfigError::Unreadable(format!(
             "{}: {error}",
             path.display()

--- a/dot_local/share/pns/src/lib.rs
+++ b/dot_local/share/pns/src/lib.rs
@@ -1,14 +1,16 @@
-//! pns decision core: the total functions the engine wraps with IO.
+//! pns: the decision core plus its thin edges.
 //!
-//! WHY THIS IS A LIBRARY OF ITS OWN. Everything here is a function of its
-//! arguments: no network, no files, no clock, no environment. That is what
-//! makes it testable one behavior at a time, in microseconds, without stubbing
-//! a subprocess. The binary keeps the impure half (reading the idle probe,
-//! spawning channels) and this keeps the decisions.
+//! THE SPLIT THAT MATTERS. The decision modules (`presence`, `routing`,
+//! `render`, `pulse`, `safety`) are total functions of their arguments: no
+//! network, no files, no clock, no environment. That is what makes them
+//! testable one behavior at a time, in microseconds, without stubbing a
+//! subprocess. The edges (`system` reads the machine, `config` reads the
+//! file) keep their IO one seam away from a pure parser, and the engine
+//! binary will own the wiring.
 //!
-//! Nothing here prints diagnostics or exits, and nothing here reads a variable
-//! out of the environment. A caller decides what to do with a verdict, and the
-//! composition root is where wiring lives.
+//! The decision modules never print, exit, or read the environment. A caller
+//! decides what to do with a verdict, and the composition root is where
+//! wiring lives.
 
 pub mod config;
 pub mod presence;

--- a/dot_local/share/pns/src/lib.rs
+++ b/dot_local/share/pns/src/lib.rs
@@ -10,6 +10,7 @@
 //! out of the environment. A caller decides what to do with a verdict, and the
 //! composition root is where wiring lives.
 
+pub mod config;
 pub mod presence;
 pub mod probes;
 pub mod pulse;


### PR DESCRIPTION
## Context

pns is growing a plugin architecture: every delivery channel is compiled in, and a config file selects which ones run on a given machine. This slice (R2b, following the probe edge in #172) builds that config layer. Nothing consumes it yet; the registry that interprets plugin settings is the next slice.

## Summary

- `dot_local/share/pns/src/config.rs` parses `~/.config/pns/config.toml`: one `[plugins.<name>]` table per plugin, an optional boolean `enabled` defaulting to false (selection is explicit opt-in), and every other key passing through untouched as that plugin's settings.
- Refusals are loud and name their offender: malformed TOML never becomes a silent empty config, unknown top-level keys are rejected so a `[plugin.hue]` typo cannot quietly disable a channel, and non-table values at either level error with the key's name.
- A missing file is its own `Missing` outcome, distinct from errors and from emptiness; a dangling symlink at the config path counts as present-and-broken and errors, since chezmoi deploys configs as symlinks.
- Parse errors are rebuilt from the parser's cause and line number, never its Display output, which echoes source lines that can carry plugin secrets into logs.
- `dot_local/share/pns/Cargo.toml` takes the crate's first dependency, `toml`, trimmed to parse-only features; the decision core and probe edge stay on std alone.

## How it was verified

- `cargo test`: 183 passed, 0 failed. `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean.
- Every load-bearing refusal was mutation-verified: removing the outer table check, the symlink guard, or the error rebuild each fails a named test, with a green unmutated control.
- Hostile inputs probed beyond the suite: dotted keys, duplicate tables, unicode keys, deep nesting, a 16 MiB setting value, and secret-bearing malformed lines (the error output was inspected and carries cause and line only).
- `cargo tree -e features` confirms the writer half of the toml crate is absent from the graph.

## Effect of merging

Source files only. A chezmoi apply deploys them under `~/.local/share/pns`; no binary exists, nothing reads the config yet, and no `~/.config/pns/config.toml` is shipped by this change. The bash engine keeps running unchanged. CI exercises the crate through `just test`.

## Review guide

Read `dot_local/share/pns/src/config.rs` top to bottom: the module doc states the failure directions, `parse_config` and `load_config` implement them, and the test module pins each one. `Cargo.toml` carries the dependency with its feature rationale in a comment. The load-bearing decisions are the fail directions (malformed is loud, missing is distinct, dangling symlinks are errors); the schema walk itself is mechanical.
