### PR TITLE
feat(pns): plugin registry closes routing's open/closed limit

### DIFF
--- a/dot_local/share/pns/src/lib.rs
+++ b/dot_local/share/pns/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod presence;
 pub mod probes;
 pub mod pulse;
+pub mod registry;
 pub mod render;
 pub mod routing;
 pub mod safety;

--- a/dot_local/share/pns/src/registry.rs
+++ b/dot_local/share/pns/src/registry.rs
@@ -42,8 +42,26 @@ pub struct Registration {
 pub enum RegistryError {
     /// Two plugins claimed the same name.
     Duplicate(String),
-    /// The config enabled a name nothing registered.
+    /// The config names a plugin nothing registered, enabled or not: the
+    /// typo is the defect either way.
     UnknownPlugin(String),
+}
+
+/// A vetted selection, and the only value a plan can be computed over. The
+/// inner list is private and no constructor is public, so a Selection can
+/// only come out of [`Registry::enabled`]: fabricated registrations cannot
+/// reach routing without passing the duplicate and unknown-name refusals.
+#[derive(Debug, PartialEq)]
+pub struct Selection(Vec<Registration>);
+
+impl Selection {
+    pub fn iter(&self) -> std::slice::Iter<'_, Registration> {
+        self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// The ordered set of compiled-in plugins. Registration order is delivery
@@ -77,7 +95,7 @@ impl Registry {
     /// order the config listed them in. A config naming an unregistered
     /// plugin is refused; a registered plugin the config omits or disables
     /// is simply not selected.
-    pub fn enabled(&self, config: &Config) -> Result<Vec<Registration>, RegistryError> {
+    pub fn enabled(&self, config: &Config) -> Result<Selection, RegistryError> {
         // The CONFIG's names are walked first, and the enabled flag is not
         // consulted: an unregistered name is a typo whether or not it is
         // switched on, and the next edit turns it into a silent no-op.
@@ -86,23 +104,24 @@ impl Registry {
                 return Err(RegistryError::UnknownPlugin(name.clone()));
             }
         }
-        Ok(self
-            .registrations
-            .iter()
-            .filter(|entry| {
-                config
-                    .plugins
-                    .get(entry.name)
-                    .is_some_and(|selected| selected.enabled)
-            })
-            .copied()
-            .collect())
+        Ok(Selection(
+            self.registrations
+                .iter()
+                .filter(|entry| {
+                    config
+                        .plugins
+                        .get(entry.name)
+                        .is_some_and(|selected| selected.enabled)
+                })
+                .copied()
+                .collect(),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Registration, Registry, RegistryError, Routing};
+    use super::{Registry, RegistryError, Routing};
     use crate::config::parse_config;
 
     const REMOTE_GATED: Routing = Routing {
@@ -199,7 +218,7 @@ mod tests {
     #[test]
     fn an_empty_config_selects_nothing_which_is_a_verdict_not_an_error() {
         let config = parse_config("").unwrap();
-        let enabled: Vec<Registration> = three_plugin_registry().enabled(&config).unwrap();
+        let enabled = three_plugin_registry().enabled(&config).unwrap();
         assert!(enabled.is_empty());
     }
 }

--- a/dot_local/share/pns/src/registry.rs
+++ b/dot_local/share/pns/src/registry.rs
@@ -1,0 +1,185 @@
+//! The plugin registry: compiled-in channels declare themselves here, and the
+//! config selects among them.
+//!
+//! This is what closes routing's KNOWN LIMIT. A channel no longer appears in
+//! core policy by NAME; it registers a name plus a routing DECLARATION (local
+//! surface, presence-gated, durable log), and the plan is computed over
+//! whatever is registered and enabled. Adding a destination is a registration
+//! at the composition root, never an edit to policy.
+//!
+//! Fail directions: registering the same name twice is refused (two plugins
+//! answering one config table is a wiring bug, not a preference), and a config
+//! that enables a name nothing registered is refused naming it, because a
+//! typo'd plugin name that silently no-ops is a notification quietly turned
+//! off, the same failure the config layer refuses everywhere else.
+
+use crate::config::Config;
+
+/// What a plugin declares about WHERE it delivers. The plan is computed from
+/// these three properties and nothing else, which is what keeps policy closed
+/// to new names while open to new destinations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Routing {
+    /// Delivers to this machine's own surfaces (a banner, a light).
+    pub local: bool,
+    /// The presence verdict may suppress it (the phone leg today).
+    pub presence_gated: bool,
+    /// The durable log: what remote-only selects, and synchronously, because
+    /// an undelivered log entry is invisible in a way an undelivered alert
+    /// is not.
+    pub durable: bool,
+}
+
+/// One registered plugin: its config-table name and its routing declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Registration {
+    pub name: &'static str,
+    pub routing: Routing,
+}
+
+/// Why registration or selection was refused, always naming the offender.
+#[derive(Debug, PartialEq)]
+pub enum RegistryError {
+    /// Two plugins claimed the same name.
+    Duplicate(String),
+    /// The config enabled a name nothing registered.
+    UnknownPlugin(String),
+}
+
+/// The ordered set of compiled-in plugins. Registration order is delivery
+/// order, so the composition root states the order once and the config cannot
+/// scramble it.
+#[derive(Debug, Default)]
+pub struct Registry {
+    registrations: Vec<Registration>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a plugin. A name already taken is refused.
+    pub fn register(&mut self, name: &'static str, routing: Routing) -> Result<(), RegistryError> {
+        let _ = (name, routing);
+        todo!("R2c: refuse duplicates, keep registration order")
+    }
+
+    /// Every registered name, in registration order.
+    pub fn names(&self) -> Vec<&'static str> {
+        todo!("R2c: the names in registration order")
+    }
+
+    /// The registrations the config enables, in REGISTRATION order whatever
+    /// order the config listed them in. A config naming an unregistered
+    /// plugin is refused; a registered plugin the config omits or disables
+    /// is simply not selected.
+    pub fn enabled(&self, config: &Config) -> Result<Vec<Registration>, RegistryError> {
+        let _ = config;
+        todo!("R2c: select by config, refuse unknown names, keep registration order")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Registration, Registry, RegistryError, Routing};
+    use crate::config::parse_config;
+
+    const REMOTE_GATED: Routing = Routing {
+        local: false,
+        presence_gated: true,
+        durable: false,
+    };
+    const DURABLE: Routing = Routing {
+        local: false,
+        presence_gated: false,
+        durable: true,
+    };
+    const LOCAL: Routing = Routing {
+        local: true,
+        presence_gated: false,
+        durable: false,
+    };
+
+    fn three_plugin_registry() -> Registry {
+        let mut registry = Registry::new();
+        registry.register("moshi", REMOTE_GATED).unwrap();
+        registry.register("hermes", DURABLE).unwrap();
+        registry.register("macos-banner", LOCAL).unwrap();
+        registry
+    }
+
+    // --- registration -------------------------------------------------------
+
+    #[test]
+    fn registration_order_is_kept_because_it_is_delivery_order() {
+        let registry = three_plugin_registry();
+        assert_eq!(registry.names(), vec!["moshi", "hermes", "macos-banner"]);
+    }
+
+    #[test]
+    fn a_name_already_taken_is_refused_naming_it() {
+        let mut registry = Registry::new();
+        registry.register("moshi", REMOTE_GATED).unwrap();
+        assert_eq!(
+            registry.register("moshi", LOCAL),
+            Err(RegistryError::Duplicate("moshi".to_string()))
+        );
+    }
+
+    // --- selection by config ------------------------------------------------
+
+    #[test]
+    fn the_config_selects_and_registration_order_beats_config_order() {
+        // The config lists banner before moshi; the plan order is still the
+        // registered one, because delivery order is policy, not preference.
+        let config = parse_config(
+            "[plugins.macos-banner]\nenabled = true\n[plugins.moshi]\nenabled = true\n",
+        )
+        .unwrap();
+        let enabled = three_plugin_registry().enabled(&config).unwrap();
+        let names: Vec<&str> = enabled.iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["moshi", "macos-banner"]);
+    }
+
+    #[test]
+    fn a_disabled_or_omitted_plugin_is_simply_not_selected() {
+        let config =
+            parse_config("[plugins.moshi]\nenabled = true\n[plugins.hermes]\nenabled = false\n")
+                .unwrap();
+        let enabled = three_plugin_registry().enabled(&config).unwrap();
+        let names: Vec<&str> = enabled.iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["moshi"]);
+    }
+
+    #[test]
+    fn an_enabled_name_nothing_registered_is_refused_naming_it() {
+        // A typo'd plugin name that silently no-ops is a notification quietly
+        // turned off; the registry refuses it the way the config layer
+        // refuses unknown keys.
+        let config = parse_config("[plugins.mosih]\nenabled = true\n").unwrap();
+        assert_eq!(
+            three_plugin_registry().enabled(&config),
+            Err(RegistryError::UnknownPlugin("mosih".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_disabled_unknown_name_is_still_refused_because_the_typo_is_the_defect() {
+        // `enabled = false` on an unknown table is the same typo one edit
+        // away from silently disabling a real plugin; refuse it now, while
+        // the operator is looking at the file they just edited.
+        let config = parse_config("[plugins.mosih]\nenabled = false\n").unwrap();
+        assert_eq!(
+            three_plugin_registry().enabled(&config),
+            Err(RegistryError::UnknownPlugin("mosih".to_string()))
+        );
+    }
+
+    #[test]
+    fn an_empty_config_selects_nothing_which_is_a_verdict_not_an_error() {
+        let config = parse_config("").unwrap();
+        let enabled: Vec<Registration> = three_plugin_registry().enabled(&config).unwrap();
+        assert!(enabled.is_empty());
+    }
+}

--- a/dot_local/share/pns/src/registry.rs
+++ b/dot_local/share/pns/src/registry.rs
@@ -61,13 +61,16 @@ impl Registry {
 
     /// Add a plugin. A name already taken is refused.
     pub fn register(&mut self, name: &'static str, routing: Routing) -> Result<(), RegistryError> {
-        let _ = (name, routing);
-        todo!("R2c: refuse duplicates, keep registration order")
+        if self.registrations.iter().any(|entry| entry.name == name) {
+            return Err(RegistryError::Duplicate(name.to_string()));
+        }
+        self.registrations.push(Registration { name, routing });
+        Ok(())
     }
 
     /// Every registered name, in registration order.
     pub fn names(&self) -> Vec<&'static str> {
-        todo!("R2c: the names in registration order")
+        self.registrations.iter().map(|entry| entry.name).collect()
     }
 
     /// The registrations the config enables, in REGISTRATION order whatever
@@ -75,8 +78,25 @@ impl Registry {
     /// plugin is refused; a registered plugin the config omits or disables
     /// is simply not selected.
     pub fn enabled(&self, config: &Config) -> Result<Vec<Registration>, RegistryError> {
-        let _ = config;
-        todo!("R2c: select by config, refuse unknown names, keep registration order")
+        // The CONFIG's names are walked first, and the enabled flag is not
+        // consulted: an unregistered name is a typo whether or not it is
+        // switched on, and the next edit turns it into a silent no-op.
+        for name in config.plugins.keys() {
+            if !self.registrations.iter().any(|entry| entry.name == name) {
+                return Err(RegistryError::UnknownPlugin(name.clone()));
+            }
+        }
+        Ok(self
+            .registrations
+            .iter()
+            .filter(|entry| {
+                config
+                    .plugins
+                    .get(entry.name)
+                    .is_some_and(|selected| selected.enabled)
+            })
+            .copied()
+            .collect())
     }
 }
 

--- a/dot_local/share/pns/src/routing.rs
+++ b/dot_local/share/pns/src/routing.rs
@@ -5,7 +5,7 @@
 //! enum's open/closed violation: adding a destination is a registration, not
 //! an edit here.
 
-use crate::registry::Registration;
+use crate::registry::Selection;
 
 /// Whether the engine waits for a channel to finish.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,7 +71,7 @@ pub fn wants_phone(
 /// is dropped whenever the phone verdict is no, under every flag, so the gate
 /// means one thing everywhere.
 pub fn channel_plan(
-    enabled: &[Registration],
+    enabled: &Selection,
     local_only: bool,
     remote_only: bool,
     want_phone: bool,
@@ -110,42 +110,65 @@ pub fn viewed_pane_redundant(event_pane: &str, focused_pane: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{Leg, Mode, channel_plan, viewed_pane_redundant, wants_phone};
-    use crate::registry::{Registration, Routing};
+    use crate::config::parse_config;
+    use crate::registry::{Registry, Routing, Selection};
 
     fn leg(name: &'static str, mode: Mode) -> Leg {
         Leg { name, mode }
     }
 
+    /// Every selection comes out of a real registry and a real config, so
+    /// each plan test exercises register, enabled and channel_plan END TO
+    /// END: a registry that mislaid a routing declaration fails these, not
+    /// only its own unit tests.
+    fn select(registry: &Registry, config_text: &str) -> Selection {
+        registry
+            .enabled(&parse_config(config_text).unwrap())
+            .unwrap()
+    }
+
     /// The three real declarations, in the delivery order the bash engine
     /// uses: phone, log, banner. The plan tests run against these so every
     /// R1 behavior is preserved verbatim under the declaration API.
-    fn three_enabled() -> Vec<Registration> {
-        vec![
-            Registration {
-                name: "moshi",
-                routing: Routing {
+    fn three_registry() -> Registry {
+        let mut registry = Registry::new();
+        registry
+            .register(
+                "moshi",
+                Routing {
                     local: false,
                     presence_gated: true,
                     durable: false,
                 },
-            },
-            Registration {
-                name: "hermes",
-                routing: Routing {
+            )
+            .unwrap();
+        registry
+            .register(
+                "hermes",
+                Routing {
                     local: false,
                     presence_gated: false,
                     durable: true,
                 },
-            },
-            Registration {
-                name: "macos-banner",
-                routing: Routing {
+            )
+            .unwrap();
+        registry
+            .register(
+                "macos-banner",
+                Routing {
                     local: true,
                     presence_gated: false,
                     durable: false,
                 },
-            },
-        ]
+            )
+            .unwrap();
+        registry
+    }
+
+    const ALL_THREE_ON: &str = "[plugins.moshi]\nenabled = true\n[plugins.hermes]\nenabled = true\n[plugins.macos-banner]\nenabled = true\n";
+
+    fn three_enabled() -> Selection {
+        select(&three_registry(), ALL_THREE_ON)
     }
 
     // --- wants_phone -------------------------------------------------------
@@ -254,34 +277,58 @@ mod tests {
     fn no_enabled_plugins_plan_nothing_under_every_flag() {
         // An unconfigured machine has an empty plan, not a crash and not a
         // built-in fallback: the caller reports the empty verdict.
+        let none = select(&three_registry(), "");
         for (local, remote, phone) in [
             (false, false, true),
             (false, false, false),
             (true, false, true),
             (false, true, true),
         ] {
-            assert_eq!(channel_plan(&[], local, remote, phone), vec![]);
+            assert_eq!(channel_plan(&none, local, remote, phone), vec![]);
         }
     }
 
     #[test]
     fn the_presence_gate_means_one_thing_under_every_flag() {
-        // A hypothetical presence-gated LOCAL plugin (a wearable's buzz) is
-        // dropped by a no-phone verdict even on the local-only path: the gate
-        // composes with the flags rather than living inside one branch.
-        let gated_local = vec![Registration {
-            name: "buzz",
-            routing: Routing {
-                local: true,
-                presence_gated: true,
-                durable: false,
-            },
-        }];
+        // Two hypotheticals pin the gate as a COMPOSED filter rather than a
+        // branch: a presence-gated LOCAL plugin (a wearable's buzz) on the
+        // local-only path, and a presence-gated DURABLE plugin (a phone
+        // pager log) on the remote-only path. An implementation that skips
+        // the gate inside either flag's branch keeps one of them wrongly.
+        let mut registry = Registry::new();
+        registry
+            .register(
+                "buzz",
+                Routing {
+                    local: true,
+                    presence_gated: true,
+                    durable: false,
+                },
+            )
+            .unwrap();
+        registry
+            .register(
+                "pager",
+                Routing {
+                    local: false,
+                    presence_gated: true,
+                    durable: true,
+                },
+            )
+            .unwrap();
+        let both = "[plugins.buzz]\nenabled = true\n[plugins.pager]\nenabled = true\n";
+        let enabled = select(&registry, both);
+
         assert_eq!(
-            channel_plan(&gated_local, true, false, true),
+            channel_plan(&enabled, true, false, true),
             vec![leg("buzz", Mode::Async)]
         );
-        assert_eq!(channel_plan(&gated_local, true, false, false), vec![]);
+        assert_eq!(channel_plan(&enabled, true, false, false), vec![]);
+        assert_eq!(
+            channel_plan(&enabled, false, true, true),
+            vec![leg("pager", Mode::Sync)]
+        );
+        assert_eq!(channel_plan(&enabled, false, true, false), vec![]);
     }
 
     #[test]

--- a/dot_local/share/pns/src/routing.rs
+++ b/dot_local/share/pns/src/routing.rs
@@ -76,8 +76,23 @@ pub fn channel_plan(
     remote_only: bool,
     want_phone: bool,
 ) -> Vec<Leg> {
-    let _ = (enabled, local_only, remote_only, want_phone);
-    todo!("R2c: compose the plan from routing declarations")
+    if local_only && remote_only {
+        return Vec::new();
+    }
+    let mode = if remote_only { Mode::Sync } else { Mode::Async };
+    enabled
+        .iter()
+        .filter(|entry| match (local_only, remote_only) {
+            (true, _) => entry.routing.local,
+            (_, true) => entry.routing.durable,
+            _ => true,
+        })
+        .filter(|entry| want_phone || !entry.routing.presence_gated)
+        .map(|entry| Leg {
+            name: entry.name,
+            mode,
+        })
+        .collect()
 }
 
 /// True when a phone card would describe the very pane the operator is

--- a/dot_local/share/pns/src/routing.rs
+++ b/dot_local/share/pns/src/routing.rs
@@ -1,35 +1,11 @@
 //! WHICH destinations an event reaches, and whether the phone is one of them.
+//!
+//! The plan names NO channel. It is computed over the routing DECLARATIONS of
+//! whatever plugins the registry selected, which is what closed the old
+//! enum's open/closed violation: adding a destination is a registration, not
+//! an edit here.
 
-/// A destination the plan can name.
-///
-/// KNOWN LIMIT, and the one the rewrite has to close: the plan NAMES its
-/// channels, so adding a destination means editing core policy rather than only
-/// dropping an executable in the channels directory. That is an open/closed
-/// violation and the same coupling that would make an extracted crate useless
-/// to anyone whose stack is not this one. Closing it needs channels to declare
-/// their own routing, which is a registration mechanism; the limit is named
-/// here rather than half-solved.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Channel {
-    /// The phone card, and the only leg presence can suppress.
-    Moshi,
-    /// The durable log.
-    Hermes,
-    /// The desktop banner.
-    MacosBanner,
-}
-
-impl Channel {
-    /// The channel's name on disk: the engine looks for an executable of this
-    /// name in the channels directory.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Channel::Moshi => "moshi",
-            Channel::Hermes => "hermes",
-            Channel::MacosBanner => "macos-banner",
-        }
-    }
-}
+use crate::registry::Registration;
 
 /// Whether the engine waits for a channel to finish.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,10 +24,11 @@ impl Mode {
     }
 }
 
-/// One channel of a plan, plus the mode it is handed the event in.
+/// One leg of a plan: the plugin's name, and the mode it is handed the event
+/// in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Leg {
-    pub channel: Channel,
+    pub name: &'static str,
     pub mode: Mode,
 }
 
@@ -81,43 +58,26 @@ pub fn wants_phone(
     idle_secs >= desk_idle_secs
 }
 
-/// The channels that should fire, in delivery order.
+/// The legs that should fire, in the registry's delivery order.
 ///
 /// An EMPTY plan means nothing fires, which is a legitimate verdict the caller
 /// has to report rather than pass over in silence.
 ///
-/// Remote-only is the LOG path: the durable channel alone, and SYNCHRONOUSLY,
-/// because an undelivered log entry is invisible in a way an undelivered alert
-/// is not. Local-only is its mirror and keeps the banner. Giving both
-/// suppresses everything, which is why the caller must say so.
-pub fn channel_plan(local_only: bool, remote_only: bool, want_phone: bool) -> Vec<Leg> {
-    if local_only && remote_only {
-        return Vec::new();
-    }
-    if remote_only {
-        return vec![Leg {
-            channel: Channel::Hermes,
-            mode: Mode::Sync,
-        }];
-    }
-    let mut plan = Vec::new();
-    if want_phone && !local_only {
-        plan.push(Leg {
-            channel: Channel::Moshi,
-            mode: Mode::Async,
-        });
-    }
-    if !local_only {
-        plan.push(Leg {
-            channel: Channel::Hermes,
-            mode: Mode::Async,
-        });
-    }
-    plan.push(Leg {
-        channel: Channel::MacosBanner,
-        mode: Mode::Async,
-    });
-    plan
+/// The rules compose over declarations, never names. Remote-only is the LOG
+/// path: the durable plugins alone, and SYNCHRONOUSLY, because an undelivered
+/// log entry is invisible in a way an undelivered alert is not. Local-only is
+/// its mirror and keeps the local surfaces. Giving both suppresses
+/// everything, which is why the caller must say so. A presence-gated plugin
+/// is dropped whenever the phone verdict is no, under every flag, so the gate
+/// means one thing everywhere.
+pub fn channel_plan(
+    enabled: &[Registration],
+    local_only: bool,
+    remote_only: bool,
+    want_phone: bool,
+) -> Vec<Leg> {
+    let _ = (enabled, local_only, remote_only, want_phone);
+    todo!("R2c: compose the plan from routing declarations")
 }
 
 /// True when a phone card would describe the very pane the operator is
@@ -134,10 +94,43 @@ pub fn viewed_pane_redundant(event_pane: &str, focused_pane: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{Channel, Leg, Mode, channel_plan, viewed_pane_redundant, wants_phone};
+    use super::{Leg, Mode, channel_plan, viewed_pane_redundant, wants_phone};
+    use crate::registry::{Registration, Routing};
 
-    fn leg(channel: Channel, mode: Mode) -> Leg {
-        Leg { channel, mode }
+    fn leg(name: &'static str, mode: Mode) -> Leg {
+        Leg { name, mode }
+    }
+
+    /// The three real declarations, in the delivery order the bash engine
+    /// uses: phone, log, banner. The plan tests run against these so every
+    /// R1 behavior is preserved verbatim under the declaration API.
+    fn three_enabled() -> Vec<Registration> {
+        vec![
+            Registration {
+                name: "moshi",
+                routing: Routing {
+                    local: false,
+                    presence_gated: true,
+                    durable: false,
+                },
+            },
+            Registration {
+                name: "hermes",
+                routing: Routing {
+                    local: false,
+                    presence_gated: false,
+                    durable: true,
+                },
+            },
+            Registration {
+                name: "macos-banner",
+                routing: Routing {
+                    local: true,
+                    presence_gated: false,
+                    durable: false,
+                },
+            },
+        ]
     }
 
     // --- wants_phone -------------------------------------------------------
@@ -188,68 +181,92 @@ mod tests {
     #[test]
     fn the_alert_path_plans_phone_then_log_then_banner() {
         assert_eq!(
-            channel_plan(false, false, true),
+            channel_plan(&three_enabled(), false, false, true),
             vec![
-                leg(Channel::Moshi, Mode::Async),
-                leg(Channel::Hermes, Mode::Async),
-                leg(Channel::MacosBanner, Mode::Async),
+                leg("moshi", Mode::Async),
+                leg("hermes", Mode::Async),
+                leg("macos-banner", Mode::Async),
             ]
         );
     }
 
     #[test]
-    fn a_suppressed_phone_leaves_the_other_two_untouched() {
+    fn a_suppressed_phone_drops_only_the_presence_gated_leg() {
         assert_eq!(
-            channel_plan(false, false, false),
-            vec![
-                leg(Channel::Hermes, Mode::Async),
-                leg(Channel::MacosBanner, Mode::Async)
-            ]
+            channel_plan(&three_enabled(), false, false, false),
+            vec![leg("hermes", Mode::Async), leg("macos-banner", Mode::Async)]
         );
     }
 
     #[test]
-    fn local_only_plans_the_banner_alone_whatever_the_phone_verdict_was() {
+    fn local_only_plans_the_local_surfaces_alone_whatever_the_phone_verdict_was() {
         // Both phone verdicts, because the flag is what decides this plan. Ask
         // only with the phone wanted and a narrowing that quietly reads the
         // phone verdict as well still answers correctly here.
         assert_eq!(
-            channel_plan(true, false, true),
-            vec![leg(Channel::MacosBanner, Mode::Async)]
+            channel_plan(&three_enabled(), true, false, true),
+            vec![leg("macos-banner", Mode::Async)]
         );
         assert_eq!(
-            channel_plan(true, false, false),
-            vec![leg(Channel::MacosBanner, Mode::Async)]
+            channel_plan(&three_enabled(), true, false, false),
+            vec![leg("macos-banner", Mode::Async)]
         );
     }
 
     #[test]
-    fn remote_only_plans_the_log_alone_and_sync_which_keeps_a_lost_entry_visible() {
+    fn remote_only_plans_the_durable_legs_alone_and_sync_which_keeps_a_lost_entry_visible() {
         // The suppressed-phone form is the one that pins SYNC to the flag
         // alone. Without it a narrowing that also consulted the phone verdict
         // would drop this plan back to the ordinary async pair, and a log
         // entry nobody waited for is the invisible loss sync exists to stop.
         assert_eq!(
-            channel_plan(false, true, true),
-            vec![leg(Channel::Hermes, Mode::Sync)]
+            channel_plan(&three_enabled(), false, true, true),
+            vec![leg("hermes", Mode::Sync)]
         );
         assert_eq!(
-            channel_plan(false, true, false),
-            vec![leg(Channel::Hermes, Mode::Sync)]
+            channel_plan(&three_enabled(), false, true, false),
+            vec![leg("hermes", Mode::Sync)]
         );
     }
 
     #[test]
     fn both_narrowing_flags_plan_nothing_at_all() {
-        assert_eq!(channel_plan(true, true, true), vec![]);
-        assert_eq!(channel_plan(true, true, false), vec![]);
+        assert_eq!(channel_plan(&three_enabled(), true, true, true), vec![]);
+        assert_eq!(channel_plan(&three_enabled(), true, true, false), vec![]);
     }
 
     #[test]
-    fn a_channel_names_the_executable_the_engine_looks_for() {
-        assert_eq!(Channel::Moshi.as_str(), "moshi");
-        assert_eq!(Channel::Hermes.as_str(), "hermes");
-        assert_eq!(Channel::MacosBanner.as_str(), "macos-banner");
+    fn no_enabled_plugins_plan_nothing_under_every_flag() {
+        // An unconfigured machine has an empty plan, not a crash and not a
+        // built-in fallback: the caller reports the empty verdict.
+        for (local, remote, phone) in [
+            (false, false, true),
+            (false, false, false),
+            (true, false, true),
+            (false, true, true),
+        ] {
+            assert_eq!(channel_plan(&[], local, remote, phone), vec![]);
+        }
+    }
+
+    #[test]
+    fn the_presence_gate_means_one_thing_under_every_flag() {
+        // A hypothetical presence-gated LOCAL plugin (a wearable's buzz) is
+        // dropped by a no-phone verdict even on the local-only path: the gate
+        // composes with the flags rather than living inside one branch.
+        let gated_local = vec![Registration {
+            name: "buzz",
+            routing: Routing {
+                local: true,
+                presence_gated: true,
+                durable: false,
+            },
+        }];
+        assert_eq!(
+            channel_plan(&gated_local, true, false, true),
+            vec![leg("buzz", Mode::Async)]
+        );
+        assert_eq!(channel_plan(&gated_local, true, false, false), vec![]);
     }
 
     #[test]


### PR DESCRIPTION
## Context

pns routing carried a documented open/closed violation since R1: the channel plan named its three destinations in an enum, so adding one meant editing core policy. With the config layer merged in #173, this slice (R2c) builds the registry that closes it. Compiled-in plugins register a name plus a routing declaration, the config selects among them, and the plan is computed over declarations alone.

## Summary

- `dot_local/share/pns/src/registry.rs` is new: plugins register `{local, presence_gated, durable}` declarations, duplicate names are refused, and registration order is delivery order, beating whatever order the config listed.
- A config naming an unregistered plugin is refused with the name, even when that entry is disabled: the typo is the defect, and a typo'd name that silently no-ops is a notification quietly turned off.
- Selection is sealed: `Registry::enabled` returns a `Selection` type nothing else can construct, so a plan can only ever be computed over registrations that passed the refusals.
- `dot_local/share/pns/src/routing.rs` loses the `Channel` enum. `channel_plan` composes two filters over the selection: flag scope (`remote_only` keeps durable legs synchronously, `local_only` keeps local legs) and a presence gate that applies uniformly under every flag.
- All eight R1 flag-and-phone combinations produce byte-identical plans for the three real channels, and every plan test now runs register, enabled, and plan end to end through a real registry and config.

## How it was verified

- `cargo test`: 191 passed, 0 failed. `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean.
- The eight-combination plan matrix was checked against both the bash `pns_channel_plan` and the pre-slice routing module; all agree.
- Sixteen mutations were run with named-test kills and a green control, including: dropping either refusal, scrambling order, applying sync everywhere, inverting or narrowing the presence gate, storing all-false declarations at registration, and skipping the gate inside either flag branch.

## Effect of merging

Source files only. No binary exists, nothing composes a registry at runtime yet, and the bash engine keeps running unchanged. The `Channel` enum's deletion breaks no consumer because the crate has none outside its own tests. CI exercises the crate through `just test`.

## Review guide

Read `dot_local/share/pns/src/registry.rs` first (the declarations, the refusals, the sealed `Selection`), then the `channel_plan` rewrite in `dot_local/share/pns/src/routing.rs` (two composed filters, one mode decision). The load-bearing behavior is the refusal directions and the uniform presence gate; the test module's hypothetical gated-local and gated-durable plugins are the cases that pin the gate's uniformity.
