### PR TITLE
feat(pns): the banner channel goes native

### DIFF
--- a/dot_local/share/pns/src/channels/banner.rs
+++ b/dot_local/share/pns/src/channels/banner.rs
@@ -18,6 +18,10 @@ use crate::system::CommandRunner;
 /// The bundle id the click activates when the pane's terminal is unknown.
 pub const DEFAULT_TERMINAL_BUNDLE_ID: &str = "com.mitchellh.ghostty";
 
+/// Absolute, like the other system readers: a channel must not resolve a
+/// system binary through a PATH it does not control.
+const LSAPPINFO_PATH: &str = "/usr/bin/lsappinfo";
+
 /// True when the operator is demonstrably watching this pane RIGHT NOW, the
 /// one case the banner may be dropped. Pure: every reading arrives as an
 /// argument, every unknown is an `Option::None` or empty string, and any
@@ -30,15 +34,16 @@ pub fn operator_is_watching(
     focused_pane: Option<&str>,
     pane: &str,
 ) -> bool {
-    let _ = (
-        idle_secs,
-        desk_idle_secs,
-        terminal_id,
-        front_bundle_id,
-        focused_pane,
-        pane,
-    );
-    todo!("R2e: all three must hold; any unknown fires the banner")
+    if pane.is_empty() {
+        return false;
+    }
+    let (Some(idle_secs), Some(desk_idle_secs)) = (idle_secs, desk_idle_secs) else {
+        return false;
+    };
+    idle_secs < desk_idle_secs
+        && !terminal_id.is_empty()
+        && front_bundle_id == Some(terminal_id)
+        && focused_pane == Some(pane)
 }
 
 /// The shell string the click runs: focus the pane's WORKSPACE (the pane id
@@ -46,23 +51,47 @@ pub fn operator_is_watching(
 /// herdr path because the click runs in a bare launchd context. No pane or
 /// no herdr leaves the no-op `:` so `-activate` still raises the terminal.
 pub fn click_command(herdr_path: Option<&str>, pane: &str) -> String {
-    let _ = (herdr_path, pane);
-    todo!("R2e: workspace focus then agent focus, or the no-op")
+    match herdr_path {
+        Some(herdr) if !pane.is_empty() => {
+            let workspace = pane.split(':').next().unwrap_or(pane);
+            format!("{herdr} workspace focus {workspace}; {herdr} agent focus {pane}")
+        }
+        _ => ":".to_string(),
+    }
 }
 
 /// The frontmost app's bundle id, parsed out of `lsappinfo info -only
 /// bundleid` output: the value of the quoted CFBundleIdentifier pair, from
 /// the first line carrying one. Anything else is unknown.
 pub fn parse_front_bundle_id(lsappinfo_output: &str) -> Option<String> {
-    let _ = lsappinfo_output;
-    todo!("R2e: the quoted CFBundleIdentifier value")
+    let line = lsappinfo_output
+        .lines()
+        .find(|line| line.contains("CFBundleIdentifier"))?;
+    // The pair AFTER the key, so a line carrying an earlier `=` cannot
+    // mislead the split, matching the sed this ports.
+    let value = line.split_once("CFBundleIdentifier")?.1.split_once('=')?.1;
+    let value = value.trim_start().strip_prefix('"')?;
+    Some(value[..value.find('"')?].to_string())
 }
 
 /// The exact terminal-notifier argv, order pinned: title, message, sound,
 /// activate, execute.
 pub fn notifier_args(title: &str, preview: &str, activate: &str, exec_cmd: &str) -> Vec<String> {
-    let _ = (title, preview, activate, exec_cmd);
-    todo!("R2e: the five flag pairs in the bash order")
+    [
+        "-title",
+        title,
+        "-message",
+        preview,
+        "-sound",
+        "default",
+        "-activate",
+        activate,
+        "-execute",
+        exec_cmd,
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
 }
 
 /// The native banner plugin. The runner spawns `lsappinfo` and
@@ -80,9 +109,49 @@ pub struct BannerChannel<R: CommandRunner, P> {
 }
 
 impl<R: CommandRunner, P: IdleProbe + FocusedPaneProbe> Channel for BannerChannel<R, P> {
-    fn deliver(&self, event: &Event, mode: Mode) {
-        let _ = (event, mode);
-        todo!("R2e: suppress only when watching, else spawn the notifier")
+    fn deliver(&self, event: &Event, _mode: Mode) {
+        // Two steps, as the bash runs them: the frontmost app's ASN, then its
+        // bundle id. Either step unreadable leaves the id unknown, which fires.
+        let front_bundle_id = self
+            .runner
+            .run(LSAPPINFO_PATH, &["front"])
+            .map(|asn| asn.trim().to_string())
+            .filter(|asn| !asn.is_empty())
+            .and_then(|asn| {
+                self.runner
+                    .run(LSAPPINFO_PATH, &["info", "-only", "bundleid", &asn])
+            })
+            .and_then(|output| parse_front_bundle_id(&output));
+        let focused_pane = self.probes.focused_pane();
+
+        if operator_is_watching(
+            self.probes.idle_secs(),
+            self.desk_idle_secs,
+            &self.terminal_id,
+            front_bundle_id.as_deref(),
+            focused_pane.as_deref(),
+            &event.pane,
+        ) {
+            return;
+        }
+
+        let activate = if self.terminal_id.is_empty() {
+            DEFAULT_TERMINAL_BUNDLE_ID
+        } else {
+            &self.terminal_id
+        };
+        let args = notifier_args(
+            &event.title,
+            &event.preview,
+            activate,
+            &click_command(self.herdr_path.as_deref(), &event.pane),
+        );
+        // By NAME, not an absolute path: parity with the bash's `command -v`
+        // guard, and a runner that cannot find it is silently fine.
+        self.runner.run(
+            "terminal-notifier",
+            &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
     }
 }
 

--- a/dot_local/share/pns/src/channels/banner.rs
+++ b/dot_local/share/pns/src/channels/banner.rs
@@ -1,0 +1,400 @@
+//! The clickable macOS banner, native. Clicking focuses the exact herdr pane
+//! the event came from, which is the whole reason this channel beats a plain
+//! notification. Delivery spawns `terminal-notifier`, the one binary that can
+//! post a banner without a signed app bundle; everything around that spawn is
+//! pure and pinned.
+//!
+//! SUPPRESSION FAILS OPEN. The banner is suppressed only when all three hold
+//! at once: the Mac was touched recently, the pane's terminal is the
+//! frontmost app, and the pane is herdr's focused pane. Anything false,
+//! unreadable or unknown FIRES the banner: a spare banner is spam, a dropped
+//! one is a lost notification.
+
+use super::{Channel, Event};
+use crate::probes::{FocusedPaneProbe, IdleProbe};
+use crate::routing::Mode;
+use crate::system::CommandRunner;
+
+/// The bundle id the click activates when the pane's terminal is unknown.
+pub const DEFAULT_TERMINAL_BUNDLE_ID: &str = "com.mitchellh.ghostty";
+
+/// True when the operator is demonstrably watching this pane RIGHT NOW, the
+/// one case the banner may be dropped. Pure: every reading arrives as an
+/// argument, every unknown is an `Option::None` or empty string, and any
+/// unknown answer is false, which fires.
+pub fn operator_is_watching(
+    idle_secs: Option<u64>,
+    desk_idle_secs: Option<u64>,
+    terminal_id: &str,
+    front_bundle_id: Option<&str>,
+    focused_pane: Option<&str>,
+    pane: &str,
+) -> bool {
+    let _ = (
+        idle_secs,
+        desk_idle_secs,
+        terminal_id,
+        front_bundle_id,
+        focused_pane,
+        pane,
+    );
+    todo!("R2e: all three must hold; any unknown fires the banner")
+}
+
+/// The shell string the click runs: focus the pane's WORKSPACE (the pane id
+/// prefix before the first colon), then the pane, both through an absolute
+/// herdr path because the click runs in a bare launchd context. No pane or
+/// no herdr leaves the no-op `:` so `-activate` still raises the terminal.
+pub fn click_command(herdr_path: Option<&str>, pane: &str) -> String {
+    let _ = (herdr_path, pane);
+    todo!("R2e: workspace focus then agent focus, or the no-op")
+}
+
+/// The frontmost app's bundle id, parsed out of `lsappinfo info -only
+/// bundleid` output: the value of the quoted CFBundleIdentifier pair, from
+/// the first line carrying one. Anything else is unknown.
+pub fn parse_front_bundle_id(lsappinfo_output: &str) -> Option<String> {
+    let _ = lsappinfo_output;
+    todo!("R2e: the quoted CFBundleIdentifier value")
+}
+
+/// The exact terminal-notifier argv, order pinned: title, message, sound,
+/// activate, execute.
+pub fn notifier_args(title: &str, preview: &str, activate: &str, exec_cmd: &str) -> Vec<String> {
+    let _ = (title, preview, activate, exec_cmd);
+    todo!("R2e: the five flag pairs in the bash order")
+}
+
+/// The native banner plugin. The runner spawns `lsappinfo` and
+/// `terminal-notifier`; the probes are the same seams the engine reads.
+pub struct BannerChannel<R: CommandRunner, P> {
+    pub runner: R,
+    pub probes: P,
+    /// `PNS_TERMINAL_BUNDLE_ID` override, else the inherited
+    /// `__CFBundleIdentifier`, else empty (unknown never suppresses).
+    pub terminal_id: String,
+    pub desk_idle_secs: Option<u64>,
+    /// Absolute herdr path resolved at composition time, `None` when PATH
+    /// has none.
+    pub herdr_path: Option<String>,
+}
+
+impl<R: CommandRunner, P: IdleProbe + FocusedPaneProbe> Channel for BannerChannel<R, P> {
+    fn deliver(&self, event: &Event, mode: Mode) {
+        let _ = (event, mode);
+        todo!("R2e: suppress only when watching, else spawn the notifier")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BannerChannel, DEFAULT_TERMINAL_BUNDLE_ID, click_command, notifier_args,
+        operator_is_watching, parse_front_bundle_id,
+    };
+    use crate::channels::{Channel, Event};
+    use crate::probes::{FocusedPaneProbe, IdleProbe, MoshRateProbe, PhoneMarkerProbe};
+    use crate::routing::Mode;
+    use crate::system::CommandRunner;
+    use std::cell::RefCell;
+
+    // --- suppression: all three, fail open ----------------------------------
+
+    const WATCHING: (&str, &str) = ("com.term", "com.term");
+
+    fn watching_case(
+        idle: Option<u64>,
+        terminal: &str,
+        front: Option<&str>,
+        focused: Option<&str>,
+        pane: &str,
+    ) -> bool {
+        operator_is_watching(idle, Some(120), terminal, front, focused, pane)
+    }
+
+    #[test]
+    fn all_three_holding_at_once_suppresses_the_banner() {
+        assert!(watching_case(
+            Some(5),
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+    }
+
+    #[test]
+    fn a_stale_keyboard_fires_even_with_the_pane_front_and_focused() {
+        assert!(!watching_case(
+            Some(900),
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+    }
+
+    #[test]
+    fn a_buried_terminal_fires_even_with_the_pane_focused() {
+        assert!(!watching_case(
+            Some(5),
+            "com.term",
+            Some("com.browser"),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+    }
+
+    #[test]
+    fn an_unfocused_pane_fires_even_with_the_terminal_front() {
+        assert!(!watching_case(
+            Some(5),
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p2"),
+            "wW:p1"
+        ));
+    }
+
+    #[test]
+    fn every_unknown_reading_fires_because_a_dropped_banner_costs_the_event() {
+        // Unknown idle, unknown terminal, unknown front app, unknown focused
+        // pane, and a pane-less event each refuse to suppress.
+        assert!(!watching_case(
+            None,
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+        assert!(!watching_case(
+            Some(5),
+            "",
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+        assert!(!watching_case(
+            Some(5),
+            WATCHING.0,
+            None,
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+        assert!(!watching_case(
+            Some(5),
+            WATCHING.0,
+            Some(WATCHING.1),
+            None,
+            "wW:p1"
+        ));
+        assert!(!watching_case(
+            Some(5),
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            ""
+        ));
+    }
+
+    #[test]
+    fn an_unreadable_desk_threshold_fires_too() {
+        assert!(!operator_is_watching(
+            Some(5),
+            None,
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+    }
+
+    // --- the click string ----------------------------------------------------
+
+    #[test]
+    fn the_click_focuses_the_workspace_then_the_pane_through_the_absolute_path() {
+        assert_eq!(
+            click_command(Some("/Users/o/.local/bin/herdr"), "wW:p21"),
+            "/Users/o/.local/bin/herdr workspace focus wW; /Users/o/.local/bin/herdr agent focus wW:p21"
+        );
+    }
+
+    #[test]
+    fn no_pane_or_no_herdr_leaves_the_noop_so_activate_still_raises_the_terminal() {
+        assert_eq!(click_command(Some("/bin/herdr"), ""), ":");
+        assert_eq!(click_command(None, "wW:p21"), ":");
+    }
+
+    // --- the lsappinfo parser -------------------------------------------------
+
+    #[test]
+    fn the_front_bundle_id_is_the_quoted_identifier_value() {
+        let output = "\"CFBundleIdentifier\"=\"com.mitchellh.ghostty\"\n";
+        assert_eq!(
+            parse_front_bundle_id(output),
+            Some("com.mitchellh.ghostty".to_string())
+        );
+    }
+
+    #[test]
+    fn unrecognisable_lsappinfo_output_reads_as_unknown_which_fires() {
+        assert_eq!(parse_front_bundle_id(""), None);
+        assert_eq!(parse_front_bundle_id("no identifier here"), None);
+    }
+
+    // --- the notifier argv ----------------------------------------------------
+
+    #[test]
+    fn the_notifier_argv_carries_the_five_flag_pairs_in_the_bash_order() {
+        assert_eq!(
+            notifier_args("a title", "a preview", "com.term", ": "),
+            vec![
+                "-title",
+                "a title",
+                "-message",
+                "a preview",
+                "-sound",
+                "default",
+                "-activate",
+                "com.term",
+                "-execute",
+                ": ",
+            ]
+        );
+    }
+
+    // --- the plugin end to end, through fakes ---------------------------------
+
+    struct ScriptedRunner {
+        lsappinfo: Option<String>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl CommandRunner for ScriptedRunner {
+        fn run(&self, program: &str, args: &[&str]) -> Option<String> {
+            self.calls
+                .borrow_mut()
+                .push(format!("{program} {}", args.join(" ")));
+            if program.contains("lsappinfo") {
+                self.lsappinfo.clone()
+            } else {
+                Some(String::new())
+            }
+        }
+    }
+
+    struct FixedProbes {
+        idle: Option<u64>,
+        focused: Option<String>,
+    }
+    impl IdleProbe for FixedProbes {
+        fn idle_secs(&self) -> Option<u64> {
+            self.idle
+        }
+    }
+    impl PhoneMarkerProbe for FixedProbes {
+        fn marker_mtime_secs(&self) -> Option<u64> {
+            None
+        }
+    }
+    impl MoshRateProbe for FixedProbes {
+        fn sample_csv(&self) -> Option<String> {
+            None
+        }
+    }
+    impl FocusedPaneProbe for FixedProbes {
+        fn focused_pane(&self) -> Option<String> {
+            self.focused.clone()
+        }
+    }
+
+    fn event_with_pane(pane: &str) -> Event {
+        Event {
+            title: "claude done: dotfiles".to_string(),
+            preview: "a preview".to_string(),
+            pane: pane.to_string(),
+            ..Event::default()
+        }
+    }
+
+    #[test]
+    fn a_watched_pane_spawns_no_notifier_at_all() {
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("\"CFBundleIdentifier\"=\"com.term\"\n".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: "com.term".to_string(),
+            desk_idle_secs: Some(120),
+            herdr_path: Some("/x/herdr".to_string()),
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        assert!(
+            !calls.iter().any(|call| call.contains("terminal-notifier")),
+            "suppressed delivery must not spawn the notifier: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn an_unwatched_pane_fires_the_notifier_with_the_click_baked_in() {
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("\"CFBundleIdentifier\"=\"com.browser\"\n".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: "com.term".to_string(),
+            desk_idle_secs: Some(120),
+            herdr_path: Some("/x/herdr".to_string()),
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        let notifier = calls
+            .iter()
+            .find(|call| call.contains("terminal-notifier"))
+            .expect("an unwatched pane must fire the banner");
+        assert!(notifier.contains("-title claude done: dotfiles"));
+        assert!(notifier.contains("-activate com.term"));
+        assert!(notifier.contains("/x/herdr workspace focus wW; /x/herdr agent focus wW:p1"));
+    }
+
+    #[test]
+    fn an_unknown_terminal_activates_the_default_and_never_suppresses() {
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("\"CFBundleIdentifier\"=\"com.term\"\n".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: String::new(),
+            desk_idle_secs: Some(120),
+            herdr_path: None,
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        let notifier = calls
+            .iter()
+            .find(|call| call.contains("terminal-notifier"))
+            .expect("unknown terminal fires");
+        assert!(notifier.contains(&format!("-activate {DEFAULT_TERMINAL_BUNDLE_ID}")));
+    }
+
+    // --- dispatch precedence --------------------------------------------------
+
+    #[test]
+    fn an_explicit_channels_dir_means_executables_win() {
+        assert!(!crate::channels::native_first(true));
+        assert!(crate::channels::native_first(false));
+    }
+}

--- a/dot_local/share/pns/src/channels/banner.rs
+++ b/dot_local/share/pns/src/channels/banner.rs
@@ -64,13 +64,12 @@ pub fn click_command(herdr_path: Option<&str>, pane: &str) -> String {
 /// bundleid` output: the value of the quoted CFBundleIdentifier pair, from
 /// the first line carrying one. Anything else is unknown.
 pub fn parse_front_bundle_id(lsappinfo_output: &str) -> Option<String> {
-    let line = lsappinfo_output
-        .lines()
-        .find(|line| line.contains("CFBundleIdentifier"))?;
-    // The pair AFTER the key, so a line carrying an earlier `=` cannot
-    // mislead the split, matching the sed this ports.
-    let value = line.split_once("CFBundleIdentifier")?.1.split_once('=')?.1;
-    let value = value.trim_start().strip_prefix('"')?;
+    // The QUOTED key exactly, as the bash sed requires: an unquoted lookalike
+    // must not produce a confident id that wrongly suppresses.
+    let value = lsappinfo_output
+        .split_once("\"CFBundleIdentifier\"=")?
+        .1
+        .strip_prefix('"')?;
     Some(value[..value.find('"')?].to_string())
 }
 
@@ -127,10 +126,19 @@ impl<R: CommandRunner, P: IdleProbe + FocusedPaneProbe> Channel for BannerChanne
                     .run(LSAPPINFO_PATH, &["info", "-only", "bundleid", &asn])
             })
             .and_then(|output| parse_front_bundle_id(&output));
-        let focused_pane = self.probes.focused_pane();
+        // A caller-supplied reading IS the reading, so the probe under it is
+        // never consulted.
+        let idle_secs = match self.idle_override {
+            Some(secs) => Some(secs),
+            None => self.probes.idle_secs(),
+        };
+        let focused_pane = match &self.focused_override {
+            Some(pane) => Some(pane.clone()),
+            None => self.probes.focused_pane(),
+        };
 
         if operator_is_watching(
-            self.probes.idle_secs(),
+            idle_secs,
             self.desk_idle_secs,
             &self.terminal_id,
             front_bundle_id.as_deref(),

--- a/dot_local/share/pns/src/channels/banner.rs
+++ b/dot_local/share/pns/src/channels/banner.rs
@@ -106,6 +106,11 @@ pub struct BannerChannel<R: CommandRunner, P> {
     /// Absolute herdr path resolved at composition time, `None` when PATH
     /// has none.
     pub herdr_path: Option<String>,
+    /// `RELAY_IDLE_SECS`: a caller-supplied idle beats the probe, and the
+    /// probe is not read when it is present.
+    pub idle_override: Option<u64>,
+    /// `RELAY_HERDR_FOCUSED_PANE`: same, for the focused pane.
+    pub focused_override: Option<String>,
 }
 
 impl<R: CommandRunner, P: IdleProbe + FocusedPaneProbe> Channel for BannerChannel<R, P> {
@@ -400,6 +405,8 @@ mod tests {
             terminal_id: "com.term".to_string(),
             desk_idle_secs: Some(120),
             herdr_path: Some("/x/herdr".to_string()),
+            idle_override: None,
+            focused_override: None,
         };
         channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
         let calls = channel.runner.calls.borrow();
@@ -423,6 +430,8 @@ mod tests {
             terminal_id: "com.term".to_string(),
             desk_idle_secs: Some(120),
             herdr_path: Some("/x/herdr".to_string()),
+            idle_override: None,
+            focused_override: None,
         };
         channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
         let calls = channel.runner.calls.borrow();
@@ -449,6 +458,8 @@ mod tests {
             terminal_id: String::new(),
             desk_idle_secs: Some(120),
             herdr_path: None,
+            idle_override: None,
+            focused_override: None,
         };
         channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
         let calls = channel.runner.calls.borrow();
@@ -457,6 +468,111 @@ mod tests {
             .find(|call| call.contains("terminal-notifier"))
             .expect("unknown terminal fires");
         assert!(notifier.contains(&format!("-activate {DEFAULT_TERMINAL_BUNDLE_ID}")));
+    }
+
+    #[test]
+    fn idle_exactly_at_the_threshold_is_already_away_so_the_banner_fires() {
+        // The same boundary the engine uses: at the threshold the operator
+        // counts as away, and the two verdicts must not disagree by one
+        // second.
+        assert!(!watching_case(
+            Some(120),
+            WATCHING.0,
+            Some(WATCHING.1),
+            Some("wW:p1"),
+            "wW:p1"
+        ));
+    }
+
+    #[test]
+    fn an_unquoted_identifier_key_reads_as_unknown_like_the_bash_sed() {
+        // The bash pattern requires the QUOTED key; a lookalike line must not
+        // produce a confident id that wrongly suppresses.
+        assert_eq!(
+            super::parse_front_bundle_id("CFBundleIdentifier=\"com.term\"\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_caller_supplied_idle_beats_the_probe_and_spares_the_read() {
+        // RELAY_IDLE_SECS=900 with a live idle of 5: the bash fires because
+        // the override IS the reading; consulting the probe instead would
+        // suppress a banner the caller asked to judge as away.
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("\"CFBundleIdentifier\"=\"com.term\"\n".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: "com.term".to_string(),
+            desk_idle_secs: Some(120),
+            herdr_path: None,
+            idle_override: Some(900),
+            focused_override: None,
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        assert!(
+            calls.iter().any(|call| call.contains("terminal-notifier")),
+            "the override says away, so the banner fires: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_caller_supplied_focused_pane_beats_the_probe() {
+        // RELAY_HERDR_FOCUSED_PANE=wW:p2 with live focus on the event's own
+        // pane: the caller's reading wins, the panes differ, the banner fires.
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("\"CFBundleIdentifier\"=\"com.term\"\n".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: "com.term".to_string(),
+            desk_idle_secs: Some(120),
+            herdr_path: None,
+            idle_override: None,
+            focused_override: Some("wW:p2".to_string()),
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        assert!(
+            calls.iter().any(|call| call.contains("terminal-notifier")),
+            "the caller's focus reading wins: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn the_front_app_is_read_in_the_bash_two_step_and_nothing_else() {
+        // `lsappinfo front` for the ASN, then `info -only bundleid` ON that
+        // ASN: a collapsed call reads an ARBITRARY app and can wrongly
+        // suppress with the terminal buried.
+        let channel = BannerChannel {
+            runner: ScriptedRunner {
+                lsappinfo: Some("ASN-42".to_string()),
+                calls: RefCell::new(Vec::new()),
+            },
+            probes: FixedProbes {
+                idle: Some(5),
+                focused: Some("wW:p1".to_string()),
+            },
+            terminal_id: "com.term".to_string(),
+            desk_idle_secs: Some(120),
+            herdr_path: None,
+            idle_override: None,
+            focused_override: None,
+        };
+        channel.deliver(&event_with_pane("wW:p1"), Mode::Async);
+        let calls = channel.runner.calls.borrow();
+        assert_eq!(calls[0], "/usr/bin/lsappinfo front");
+        assert_eq!(calls[1], "/usr/bin/lsappinfo info -only bundleid ASN-42");
     }
 
     // --- dispatch precedence --------------------------------------------------

--- a/dot_local/share/pns/src/channels/mod.rs
+++ b/dot_local/share/pns/src/channels/mod.rs
@@ -36,6 +36,5 @@ pub trait Channel {
 /// True when native plugins take precedence for dispatch: only when the
 /// channels directory was NOT explicitly overridden.
 pub fn native_first(channels_dir_overridden: bool) -> bool {
-    let _ = channels_dir_overridden;
-    todo!("R2e: an explicit channels dir means executables win")
+    !channels_dir_overridden
 }

--- a/dot_local/share/pns/src/channels/mod.rs
+++ b/dot_local/share/pns/src/channels/mod.rs
@@ -1,0 +1,41 @@
+//! Native channel plugins: the compiled-in delivery half of a registration.
+//!
+//! DISPATCH PRECEDENCE, decided here once: with `PNS_CHANNELS_DIR` explicitly
+//! set, executables win for every name, which is the test seam and the
+//! operator's escape hatch. With it unset, a native plugin wins and the
+//! executable fallback serves only names that have no native implementation
+//! yet. That rule is what lets each channel slice go native without touching
+//! the dispatch bats: the stubs keep winning wherever the suite points the
+//! engine at a stub directory.
+
+pub mod banner;
+
+use crate::routing::Mode;
+
+/// One rendered event, the structured form of the channel contract's JSON
+/// object. The pane is the SANITIZED one.
+#[derive(Debug, Default, PartialEq)]
+pub struct Event {
+    pub agent: String,
+    pub state: String,
+    pub project: String,
+    pub branch: String,
+    pub detail: String,
+    pub title: String,
+    pub message: String,
+    pub preview: String,
+    pub pane: String,
+}
+
+/// A native channel: it decides HOW to deliver and whether it can, never
+/// WHETHER it should fire, and it must never fail the caller.
+pub trait Channel {
+    fn deliver(&self, event: &Event, mode: Mode);
+}
+
+/// True when native plugins take precedence for dispatch: only when the
+/// channels directory was NOT explicitly overridden.
+pub fn native_first(channels_dir_overridden: bool) -> bool {
+    let _ = channels_dir_overridden;
+    todo!("R2e: an explicit channels dir means executables win")
+}

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -23,7 +23,7 @@ use crate::routing::Leg;
 
 /// The idle threshold the bash defaults to when `RELAY_DESK_IDLE_SECS` says
 /// nothing: past this the operator counts as away from the desk.
-const DEFAULT_DESK_IDLE_SECS: u64 = 120;
+pub const DEFAULT_DESK_IDLE_SECS: u64 = 120;
 
 /// Everything the environment may override, parsed once at the edge.
 /// Garbage numeric values read as absent, never as zero.

--- a/dot_local/share/pns/src/lib.rs
+++ b/dot_local/share/pns/src/lib.rs
@@ -13,6 +13,7 @@
 //! wiring lives.
 
 pub mod args;
+pub mod channels;
 pub mod config;
 pub mod engine;
 pub mod presence;

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -12,6 +12,8 @@ use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use pns::args::parse_args;
+use pns::channels::banner::BannerChannel;
+use pns::channels::{Channel, native_first};
 use pns::config::{config_path, load_config};
 use pns::engine::{Overrides, decide, event_json, resolve_path, select_plugins};
 use pns::registry::{Registry, Routing};
@@ -131,12 +133,48 @@ fn main() {
     let title = render::title(&event.agent, &event.state, &event.project);
     let message = render::message(&event.branch, &event.detail, &event.state);
     let preview = render::preview(&message);
+    let channels_dir_override = std::env::var("PNS_CHANNELS_DIR")
+        .ok()
+        .filter(|dir| !dir.is_empty());
     let channels_dir = resolve_path(
-        std::env::var("PNS_CHANNELS_DIR").ok().as_deref(),
+        channels_dir_override.as_deref(),
         &format!("{home}/.local/libexec/pns/channels"),
     );
 
+    let banner = BannerChannel {
+        runner: SystemCommandRunner,
+        probes: SystemProbes::new(SystemCommandRunner, String::new()),
+        terminal_id: std::env::var("PNS_TERMINAL_BUNDLE_ID")
+            .or_else(|_| std::env::var("__CFBundleIdentifier"))
+            .unwrap_or_default(),
+        desk_idle_secs: if overrides.desk_invalid {
+            None
+        } else {
+            Some(
+                overrides
+                    .desk_idle_secs
+                    .unwrap_or(pns::engine::DEFAULT_DESK_IDLE_SECS),
+            )
+        },
+        herdr_path: executable_in_path("herdr"),
+    };
+    let native = pns::channels::Event {
+        agent: event.agent.clone(),
+        state: event.state.clone(),
+        project: event.project.clone(),
+        branch: event.branch.clone(),
+        detail: event.detail.clone(),
+        title: title.clone(),
+        message: message.clone(),
+        preview: preview.clone(),
+        pane: pane.to_string(),
+    };
+
     for leg in &decision.legs {
+        if native_first(channels_dir_override.is_some()) && leg.name == "macos-banner" {
+            banner.deliver(&native, leg.mode);
+            continue;
+        }
         deliver(
             &channels_dir.join(format!("{}.sh", leg.name)),
             &event_json(
@@ -153,6 +191,20 @@ fn main() {
             ),
         );
     }
+}
+
+/// The first executable of that name on PATH, absolute, or None. The click
+/// string bakes it in because the click runs in a bare launchd context whose
+/// PATH cannot find `~/.local/bin`.
+fn executable_in_path(name: &str) -> Option<String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|directory| directory.join(name))
+        .find(|candidate| {
+            std::fs::metadata(candidate)
+                .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        })
+        .map(|path| path.to_string_lossy().into_owned())
 }
 
 /// Hand one channel its event on stdin. A channel that is missing, is not

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -157,6 +157,9 @@ fn main() {
             )
         },
         herdr_path: executable_in_path("herdr"),
+        // Red-state placeholders: the fix round wires these from overrides.
+        idle_override: None,
+        focused_override: None,
     };
     let native = pns::channels::Event {
         agent: event.agent.clone(),

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -144,10 +144,22 @@ fn main() {
     let banner = BannerChannel {
         runner: SystemCommandRunner,
         probes: SystemProbes::new(SystemCommandRunner, String::new()),
+        // An EMPTY override falls through, so an exported-but-blank variable
+        // cannot shadow the inherited bundle id.
         terminal_id: std::env::var("PNS_TERMINAL_BUNDLE_ID")
-            .or_else(|_| std::env::var("__CFBundleIdentifier"))
+            .ok()
+            .filter(|id| !id.is_empty())
+            .or_else(|| {
+                std::env::var("__CFBundleIdentifier")
+                    .ok()
+                    .filter(|id| !id.is_empty())
+            })
             .unwrap_or_default(),
-        desk_idle_secs: if overrides.desk_invalid {
+        // A garbled idle override leaves the THRESHOLD unknown, which is what
+        // makes the banner unsuppressable without a third override state: the
+        // bash keeps the garbled string, fails its numeric test and fires, so
+        // consulting the live probe here could drop a banner instead.
+        desk_idle_secs: if overrides.desk_invalid || overrides.idle_invalid {
             None
         } else {
             Some(
@@ -157,9 +169,8 @@ fn main() {
             )
         },
         herdr_path: executable_in_path("herdr"),
-        // Red-state placeholders: the fix round wires these from overrides.
-        idle_override: None,
-        focused_override: None,
+        idle_override: overrides.idle_secs,
+        focused_override: overrides.focused_pane.clone(),
     };
     let native = pns::channels::Event {
         agent: event.agent.clone(),

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -15,3 +15,34 @@ cargo build --quiet --manifest-path "$REPO_ROOT/dot_local/share/pns/Cargo.toml"
 
 HOME="$scratch" PNS_RELAY_BIN="$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
   bats "$REPO_ROOT/test/unit/pns-channel-dispatch.bats"
+
+# Phase 2: native dispatch reachability. With no channels-dir override, the
+# banner leg must deliver NATIVELY: the PATH-stubbed terminal-notifier records
+# the spawn and a decoy executable channel must stay silent. This is the one
+# branch the stub-driven bats above can never reach, because they set
+# PNS_CHANNELS_DIR, the exact condition under which executables win by design.
+stub_bin="$scratch/bin"
+decoy_dir="$scratch/.local/libexec/pns/channels"
+mkdir -p "$stub_bin" "$decoy_dir"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >"%s/notifier.args"\n' "$scratch" \
+  >"$stub_bin/terminal-notifier"
+printf '#!/usr/bin/env bash\ncat >"%s/decoy.event"\n' "$scratch" \
+  >"$decoy_dir/macos-banner.sh"
+chmod +x "$stub_bin/terminal-notifier" "$decoy_dir/macos-banner.sh"
+
+env -u PNS_CHANNELS_DIR HOME="$scratch" PATH="$stub_bin:$PATH" RELAY_IDLE_SECS=99999 \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent claude --state 'done' --detail x --local-only
+
+[[ -f "$scratch/notifier.args" ]] || {
+  echo "native banner did not spawn the notifier" >&2
+  exit 1
+}
+grep -q -- '-title' "$scratch/notifier.args" || {
+  echo "the notifier spawn carried no title" >&2
+  exit 1
+}
+[[ ! -f "$scratch/decoy.event" ]] || {
+  echo "the decoy executable channel fired; native did not win" >&2
+  exit 1
+}


### PR DESCRIPTION
## Context

With the engine binary merged (#175), the four channel slices replace one executable spawn each with native delivery through the registry. This slice (R2e) is the first: the macOS banner, the channel whose click focuses the exact herdr pane the event came from.

## Summary

- `dot_local/share/pns/src/channels/` is new: the `Event` struct, the `Channel` trait, and the dispatch precedence rule in one place. An explicitly set `PNS_CHANNELS_DIR` means executables win, which is the test seam and the operator escape hatch; unset (or empty, matching the crate's empty-means-unset rule) means native plugins win, with executables as the fallback for names that have no native implementation yet.
- `channels/banner.rs` ports the bash channel: suppression only when a recent touch, a frontmost terminal, and a focused pane all hold at once, with every unknown firing; the click string focusing workspace then pane through an absolute herdr path; the `lsappinfo` two-step and its quoted-key parser; and the notifier argv in the bash order.
- Caller-supplied readings (`RELAY_IDLE_SECS`, `RELAY_HERDR_FOCUSED_PANE`) beat the probes, and a garbled idle folds into an unknown threshold so it fires exactly as bash does.
- `test/integration/pns-engine-binary-dispatch.sh` gains a second phase pinning native dispatch itself: with no channels-dir override, a PATH-stubbed `terminal-notifier` must record the spawn and a decoy executable channel must stay silent. That branch is unreachable from the stub-driven bats by design, and it is the branch the R3d retirement depends on.
- Two deliberate deviations from the bash, both argued in code comments: delivery reads its three inputs eagerly so the policy stays in one pure predicate, and an octal-looking desk threshold reads as unknown (fires) rather than reproducing bash's octal arithmetic.

## How it was verified

- `cargo test`: 238 passed, 0 failed. `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean.
- The dispatch bats pass 25/25 against both engines; the two-phase integration gate exits 0.
- Nineteen mutations were run across the two review rounds with named-test kills and green controls; the five that survived the first round (idle boundary, collapsed lsappinfo two-step, ignored overrides, loosened parser, disabled native branch) are each now caught, the last by the integration gate itself.
- Both fixes unreachable from bats were exercised against the real binary with stubbed delivery and recorded argv.

## Effect of merging

The banner leg delivers natively wherever `PNS_CHANNELS_DIR` is not overridden once a producer invokes the binary; today nothing does, so live behavior is unchanged and the bash engine keeps running. The bash banner channel remains on disk as the engine's own delivery until R3 repoints producers and R3d retires it. CI's integration gate now also proves native dispatch on every run.

## Review guide

Read `channels/banner.rs` top to bottom: the suppression predicate and its fail-open doc carry the slice's policy, the plugin impl below is composition, and the test module pins both plus the argv of every spawn. `channels/mod.rs` is small but load-bearing for the precedence rule. The main.rs changes are wiring plus the terminal-id fallback chain. The integration gate's phase 2 is the piece to read if you only read one thing: it is what makes "native actually runs in production shape" a checked claim.
