### PR TITLE
feat(pns): the moshi channel goes native

### DIFF
--- a/dot_local/share/pns/Cargo.lock
+++ b/dot_local/share/pns/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,15 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,16 +41,6 @@ name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "getrandom"
@@ -133,16 +108,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "once_cell"
@@ -290,12 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,7 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
  "base64",
- "flate2",
  "log",
  "percent-encoding",
  "rustls",

--- a/dot_local/share/pns/Cargo.lock
+++ b/dot_local/share/pns/Cargo.lock
@@ -3,16 +3,102 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "indexmap"
@@ -31,10 +117,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pns"
@@ -42,6 +162,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -60,6 +181,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -112,6 +282,24 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -170,10 +358,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -1,9 +1,9 @@
 # pns: the decision core, its edges, and the engine binary.
 #
-# TWO DEPENDENCIES, each taken where a format demands it: the config edge
-# parses TOML and the event contract is JSON. The decision core and the
-# probe edge run on std alone, and that split is the property to keep: a
-# new dependency needs a layer whose format genuinely requires one.
+# Every dependency is taken where a format demands it and nowhere else:
+# TOML for the config edge, JSON for the event contract, TLS for the phone
+# webhook. The decision core and the probe edge run on std alone, and that
+# split is the property to keep.
 
 [package]
 name = "pns"
@@ -20,4 +20,4 @@ toml = { version = "1.1.4", default-features = false, features = [
   "serde",
   "std",
 ] }
-ureq = "3.4.0"
+ureq = { version = "3.4.0", default-features = false, features = ["rustls"] }

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -20,3 +20,4 @@ toml = { version = "1.1.4", default-features = false, features = [
   "serde",
   "std",
 ] }
+ureq = "3.4.0"

--- a/dot_local/share/pns/src/bin/http-capture.rs
+++ b/dot_local/share/pns/src/bin/http-capture.rs
@@ -1,0 +1,81 @@
+//! Test support: a one-shot HTTP capture server for the integration gate.
+//!
+//! Binds an ephemeral loopback port, writes the port number to argv[1],
+//! accepts ONE request, writes its raw bytes (headers and body) to argv[2],
+//! answers 200, and exits. std only, built alongside the engine, so the gate
+//! depends on nothing with an interpreter cold start to diagnose. Exits
+//! non-zero if no request arrives within thirty seconds, so a wedged gate
+//! fails instead of hanging.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+fn main() {
+    let mut arguments = std::env::args().skip(1);
+    let (Some(port_path), Some(capture_path)) = (arguments.next(), arguments.next()) else {
+        eprintln!("usage: http-capture <port-file> <capture-file>");
+        std::process::exit(2);
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("loopback bind");
+    let port = listener.local_addr().expect("local addr").port();
+    std::fs::write(&port_path, port.to_string()).expect("write port file");
+
+    listener.set_nonblocking(true).expect("nonblocking");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut stream = loop {
+        match listener.accept() {
+            Ok((stream, _)) => break stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() > deadline {
+                    eprintln!("http-capture: no request within the deadline");
+                    std::process::exit(1);
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => {
+                eprintln!("http-capture: accept failed: {error}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    stream.set_nonblocking(false).expect("blocking stream");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("read timeout");
+
+    // Read headers, then exactly Content-Length body bytes: reading to EOF
+    // would deadlock against a client that waits for the response.
+    let mut raw = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).unwrap_or(0);
+        if read == 0 {
+            break raw.len();
+        }
+        raw.extend_from_slice(&chunk[..read]);
+        if let Some(position) = raw.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let content_length = String::from_utf8_lossy(&raw[..header_end])
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0);
+    while raw.len() < header_end + content_length {
+        let read = stream.read(&mut chunk).unwrap_or(0);
+        if read == 0 {
+            break;
+        }
+        raw.extend_from_slice(&chunk[..read]);
+    }
+
+    std::fs::write(&capture_path, &raw).expect("write capture");
+    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+}

--- a/dot_local/share/pns/src/channels/mod.rs
+++ b/dot_local/share/pns/src/channels/mod.rs
@@ -9,6 +9,7 @@
 //! engine at a stub directory.
 
 pub mod banner;
+pub mod moshi;
 
 use crate::routing::Mode;
 

--- a/dot_local/share/pns/src/channels/moshi.rs
+++ b/dot_local/share/pns/src/channels/moshi.rs
@@ -68,7 +68,19 @@ impl<H: HttpPost> Channel for MoshiChannel<H> {
 /// The production POST: one agent, one deadline, no retry. Every failure is
 /// `false` and nothing is logged, because the only thing worth reporting
 /// would be the request that carries the token.
-pub struct UreqPost;
+pub struct UreqPost {
+    /// The whole-request deadline. Production uses the default; tests hand
+    /// in a short one to prove the deadline actually fires.
+    pub timeout: std::time::Duration,
+}
+
+impl Default for UreqPost {
+    fn default() -> Self {
+        Self {
+            timeout: std::time::Duration::from_secs(10),
+        }
+    }
+}
 
 impl HttpPost for UreqPost {
     fn post_json(&self, url: &str, body: &str) -> bool {
@@ -116,7 +128,7 @@ mod tests {
                     posts: RefCell::new(Vec::new()),
                 },
                 auth_path: path.clone(),
-                url: DEFAULT_MOSHI_URL.to_string(),
+                url: "https://example.invalid/hook".to_string(),
             },
             path,
         )
@@ -183,7 +195,10 @@ mod tests {
         std::fs::remove_file(&path).ok();
         let posts = channel.http.posts.borrow();
         assert_eq!(posts.len(), 1);
-        assert_eq!(posts[0].0, DEFAULT_MOSHI_URL);
+        assert_eq!(
+            posts[0].0, "https://example.invalid/hook",
+            "the configured url is the one posted to, never the constant"
+        );
         assert!(posts[0].1.contains("a preview"));
         assert!(
             !posts[0].1.contains("longer than the preview"),
@@ -202,5 +217,81 @@ mod tests {
         };
         channel.deliver(&event(), Mode::Async);
         assert!(channel.http.posts.borrow().is_empty());
+    }
+
+    // --- the production post, against real sockets ---------------------------
+
+    use super::UreqPost;
+    use std::time::Duration;
+
+    #[test]
+    fn the_deadline_fires_instead_of_parking_the_notification_path() {
+        // A bound socket that never accepts: the connection black-holes, and
+        // the deadline is what keeps the hermes and banner legs from queuing
+        // behind a dead network for minutes.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", listener.local_addr().unwrap());
+        let post = UreqPost {
+            timeout: Duration::from_millis(100),
+        };
+        let started = std::time::Instant::now();
+        assert!(!post.post_json(&url, "{}"), "a dead endpoint is a false");
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "the deadline fired, not the OS timeout"
+        );
+    }
+
+    #[test]
+    fn a_closed_port_is_a_quiet_false_never_a_report() {
+        // The only thing worth reporting would be the request that carries
+        // the token, so failure returns false and says nothing. The stderr
+        // half is held by the integration gate, which runs this same path
+        // against a closed port and asserts empty output.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", listener.local_addr().unwrap());
+        drop(listener);
+        assert!(!UreqPost::default().post_json(&url, "{}"));
+    }
+
+    #[test]
+    fn a_redirecting_endpoint_is_never_followed() {
+        // The bash curl carried no -L: a compromised endpoint must not turn
+        // the channel into a blind request against a target it names. The
+        // decoy listener proves no second request happens.
+        use std::io::{Read, Write};
+        let decoy = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let decoy_addr = decoy.local_addr().unwrap();
+        let hit = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let decoy_hit = hit.clone();
+        decoy.set_nonblocking(true).unwrap();
+
+        let redirector = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", redirector.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = redirector.accept() {
+                let mut request = [0u8; 1024];
+                let _ = stream.read(&mut request);
+                let _ = stream.write_all(
+                    format!(
+                        "HTTP/1.1 302 Found\r\nLocation: http://{decoy_addr}/\r\nContent-Length: 0\r\n\r\n"
+                    )
+                    .as_bytes(),
+                );
+            }
+        });
+        let post = UreqPost {
+            timeout: Duration::from_secs(2),
+        };
+        post.post_json(&url, "{}");
+        server.join().unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        if decoy.accept().is_ok() {
+            decoy_hit.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        assert!(
+            !hit.load(std::sync::atomic::Ordering::SeqCst),
+            "the redirect target must never be contacted"
+        );
     }
 }

--- a/dot_local/share/pns/src/channels/moshi.rs
+++ b/dot_local/share/pns/src/channels/moshi.rs
@@ -1,0 +1,181 @@
+//! The moshi channel, native: the phone push, a single HTTPS POST.
+//!
+//! THE SECRET'S PATH IS THE POINT. The token is read from the auth file,
+//! placed in the request BODY, and never touches argv, the environment of a
+//! child, or an error string: the bash put it on stdin for the same reason
+//! (the process table is world-readable), and in-process is the stronger
+//! form of the same rule. An absent auth file or key is the
+//! silent-unavailable case: the channel is simply not set up, which is not
+//! an error and must not say anything.
+
+use super::{Channel, Event};
+use crate::routing::Mode;
+use std::path::Path;
+
+/// Where the push goes when `RELAY_MOSHI_URL` says nothing.
+pub const DEFAULT_MOSHI_URL: &str = "https://api.getmoshi.app/api/webhook";
+
+/// The POST seam: one call, a URL and a JSON body in, success or not out.
+/// The production impl carries the 10 second deadline; a fake records.
+pub trait HttpPost {
+    fn post_json(&self, url: &str, body: &str) -> bool;
+}
+
+/// The moshi token, or None for every way the auth file can fail to provide
+/// one: absent, unreadable, not JSON, no key, or an empty value. All of
+/// them mean "not set up", never an error.
+pub fn moshi_secret(auth_json: &str) -> Option<String> {
+    let _ = auth_json;
+    todo!("R2f: .moshi_secret, non-empty, else None")
+}
+
+/// The webhook body: token, title, and the PREVIEW as the message, because
+/// the phone card has a length ceiling the full message ignores.
+pub fn webhook_body(token: &str, title: &str, preview: &str) -> String {
+    let _ = (token, title, preview);
+    todo!("R2f: the three-field JSON object")
+}
+
+/// Read the auth file quietly: any failure is None, the not-set-up case.
+pub fn read_auth(path: &Path) -> Option<String> {
+    let _ = path;
+    todo!("R2f: read to string, silently None on any failure")
+}
+
+/// The native moshi plugin.
+pub struct MoshiChannel<H: HttpPost> {
+    pub http: H,
+    /// `RELAY_AUTH_FILE` override, else `~/.config/relay/auth.json`.
+    pub auth_path: std::path::PathBuf,
+    /// `RELAY_MOSHI_URL` override, else the default.
+    pub url: String,
+}
+
+impl<H: HttpPost> Channel for MoshiChannel<H> {
+    fn deliver(&self, event: &Event, mode: Mode) {
+        let _ = (event, mode);
+        todo!("R2f: no secret means no post; one post otherwise, failure ignored")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_MOSHI_URL, HttpPost, MoshiChannel, moshi_secret, webhook_body};
+    use crate::channels::{Channel, Event};
+    use crate::routing::Mode;
+    use std::cell::RefCell;
+
+    struct RecordingHttp {
+        posts: RefCell<Vec<(String, String)>>,
+    }
+
+    impl HttpPost for RecordingHttp {
+        fn post_json(&self, url: &str, body: &str) -> bool {
+            self.posts
+                .borrow_mut()
+                .push((url.to_string(), body.to_string()));
+            true
+        }
+    }
+
+    fn channel_with_auth(auth: &str) -> (MoshiChannel<RecordingHttp>, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "pns-moshi-auth-{}-{}",
+            std::process::id(),
+            auth.len()
+        ));
+        std::fs::write(&path, auth).unwrap();
+        (
+            MoshiChannel {
+                http: RecordingHttp {
+                    posts: RefCell::new(Vec::new()),
+                },
+                auth_path: path.clone(),
+                url: DEFAULT_MOSHI_URL.to_string(),
+            },
+            path,
+        )
+    }
+
+    fn event() -> Event {
+        Event {
+            title: "claude done: dotfiles".to_string(),
+            preview: "a preview".to_string(),
+            message: "the full message, longer than the preview".to_string(),
+            ..Event::default()
+        }
+    }
+
+    // --- the secret ---------------------------------------------------------
+
+    #[test]
+    fn the_secret_is_the_non_empty_moshi_key() {
+        assert_eq!(
+            moshi_secret(r#"{"moshi_secret":"tok-1","other":"x"}"#),
+            Some("tok-1".to_string())
+        );
+    }
+
+    #[test]
+    fn every_way_the_auth_can_fail_to_provide_a_token_reads_not_set_up() {
+        assert_eq!(moshi_secret(""), None);
+        assert_eq!(moshi_secret("not json"), None);
+        assert_eq!(moshi_secret(r#"{"other":"x"}"#), None);
+        assert_eq!(moshi_secret(r#"{"moshi_secret":""}"#), None);
+        assert_eq!(moshi_secret(r#"{"moshi_secret":42}"#), None);
+    }
+
+    // --- the body -----------------------------------------------------------
+
+    #[test]
+    fn the_body_carries_token_title_and_the_preview_as_the_message() {
+        let body = webhook_body("tok-1", "a title", "a preview");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["token"], "tok-1");
+        assert_eq!(parsed["title"], "a title");
+        assert_eq!(parsed["message"], "a preview");
+        assert_eq!(
+            parsed.as_object().unwrap().len(),
+            3,
+            "nothing else rides along with the secret"
+        );
+    }
+
+    // --- delivery -----------------------------------------------------------
+
+    #[test]
+    fn no_token_means_no_post_and_no_sound() {
+        let (channel, path) = channel_with_auth(r#"{"other":"x"}"#);
+        channel.deliver(&event(), Mode::Async);
+        std::fs::remove_file(&path).ok();
+        assert!(channel.http.posts.borrow().is_empty());
+    }
+
+    #[test]
+    fn a_token_posts_once_to_the_url_with_the_preview_never_the_message() {
+        let (channel, path) = channel_with_auth(r#"{"moshi_secret":"tok-1"}"#);
+        channel.deliver(&event(), Mode::Async);
+        std::fs::remove_file(&path).ok();
+        let posts = channel.http.posts.borrow();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].0, DEFAULT_MOSHI_URL);
+        assert!(posts[0].1.contains("a preview"));
+        assert!(
+            !posts[0].1.contains("longer than the preview"),
+            "the phone gets the ceiling-safe preview"
+        );
+    }
+
+    #[test]
+    fn an_absent_auth_file_is_silently_not_set_up() {
+        let channel = MoshiChannel {
+            http: RecordingHttp {
+                posts: RefCell::new(Vec::new()),
+            },
+            auth_path: std::path::PathBuf::from("/nonexistent/pns-moshi-auth"),
+            url: DEFAULT_MOSHI_URL.to_string(),
+        };
+        channel.deliver(&event(), Mode::Async);
+        assert!(channel.http.posts.borrow().is_empty());
+    }
+}

--- a/dot_local/share/pns/src/channels/moshi.rs
+++ b/dot_local/share/pns/src/channels/moshi.rs
@@ -85,7 +85,11 @@ impl Default for UreqPost {
 impl HttpPost for UreqPost {
     fn post_json(&self, url: &str, body: &str) -> bool {
         ureq::Agent::config_builder()
-            .timeout_global(Some(std::time::Duration::from_secs(10)))
+            .timeout_global(Some(self.timeout))
+            // The bash curl carried no -L, and following one would send the
+            // token to whatever host the endpoint names. Zero returns the 3xx
+            // as the response rather than an error, so the post simply ends.
+            .max_redirects(0)
             .build()
             .new_agent()
             .post(url)

--- a/dot_local/share/pns/src/channels/moshi.rs
+++ b/dot_local/share/pns/src/channels/moshi.rs
@@ -25,21 +25,23 @@ pub trait HttpPost {
 /// one: absent, unreadable, not JSON, no key, or an empty value. All of
 /// them mean "not set up", never an error.
 pub fn moshi_secret(auth_json: &str) -> Option<String> {
-    let _ = auth_json;
-    todo!("R2f: .moshi_secret, non-empty, else None")
+    let token = serde_json::from_str::<serde_json::Value>(auth_json)
+        .ok()?
+        .get("moshi_secret")?
+        .as_str()?
+        .to_string();
+    (!token.is_empty()).then_some(token)
 }
 
 /// The webhook body: token, title, and the PREVIEW as the message, because
 /// the phone card has a length ceiling the full message ignores.
 pub fn webhook_body(token: &str, title: &str, preview: &str) -> String {
-    let _ = (token, title, preview);
-    todo!("R2f: the three-field JSON object")
+    serde_json::json!({ "token": token, "title": title, "message": preview }).to_string()
 }
 
 /// Read the auth file quietly: any failure is None, the not-set-up case.
 pub fn read_auth(path: &Path) -> Option<String> {
-    let _ = path;
-    todo!("R2f: read to string, silently None on any failure")
+    std::fs::read_to_string(path).ok()
 }
 
 /// The native moshi plugin.
@@ -52,9 +54,32 @@ pub struct MoshiChannel<H: HttpPost> {
 }
 
 impl<H: HttpPost> Channel for MoshiChannel<H> {
-    fn deliver(&self, event: &Event, mode: Mode) {
-        let _ = (event, mode);
-        todo!("R2f: no secret means no post; one post otherwise, failure ignored")
+    fn deliver(&self, event: &Event, _mode: Mode) {
+        let Some(token) = read_auth(&self.auth_path).as_deref().and_then(moshi_secret) else {
+            return;
+        };
+        self.http.post_json(
+            &self.url,
+            &webhook_body(&token, &event.title, &event.preview),
+        );
+    }
+}
+
+/// The production POST: one agent, one deadline, no retry. Every failure is
+/// `false` and nothing is logged, because the only thing worth reporting
+/// would be the request that carries the token.
+pub struct UreqPost;
+
+impl HttpPost for UreqPost {
+    fn post_json(&self, url: &str, body: &str) -> bool {
+        ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(10)))
+            .build()
+            .new_agent()
+            .post(url)
+            .content_type("application/json")
+            .send(body)
+            .is_ok()
     }
 }
 

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use pns::args::parse_args;
 use pns::channels::banner::BannerChannel;
+use pns::channels::moshi::{DEFAULT_MOSHI_URL, MoshiChannel, UreqPost};
 use pns::channels::{Channel, native_first};
 use pns::config::{config_path, load_config};
 use pns::engine::{Overrides, decide, event_json, resolve_path, select_plugins};
@@ -184,10 +185,31 @@ fn main() {
         pane: pane.to_string(),
     };
 
+    let moshi = MoshiChannel {
+        http: UreqPost,
+        auth_path: resolve_path(
+            std::env::var("RELAY_AUTH_FILE").ok().as_deref(),
+            &format!("{home}/.config/relay/auth.json"),
+        ),
+        url: std::env::var("RELAY_MOSHI_URL")
+            .ok()
+            .filter(|url| !url.is_empty())
+            .unwrap_or_else(|| DEFAULT_MOSHI_URL.to_string()),
+    };
+
     for leg in &decision.legs {
-        if native_first(channels_dir_override.is_some()) && leg.name == "macos-banner" {
-            banner.deliver(&native, leg.mode);
-            continue;
+        if native_first(channels_dir_override.is_some()) {
+            match leg.name {
+                "macos-banner" => {
+                    banner.deliver(&native, leg.mode);
+                    continue;
+                }
+                "moshi" => {
+                    moshi.deliver(&native, leg.mode);
+                    continue;
+                }
+                _ => {}
+            }
         }
         deliver(
             &channels_dir.join(format!("{}.sh", leg.name)),

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -186,7 +186,7 @@ fn main() {
     };
 
     let moshi = MoshiChannel {
-        http: UreqPost,
+        http: UreqPost::default(),
         auth_path: resolve_path(
             std::env::var("RELAY_AUTH_FILE").ok().as_deref(),
             &format!("{home}/.config/relay/auth.json"),

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -53,12 +53,20 @@ grep -q -- '-title' "$scratch/notifier.args" || {
 # in the body and never on argv.
 printf '{"moshi_secret":"tok-integration"}\n' >"$scratch/auth.json"
 python3 - "$scratch/port" "$scratch/capture" <<'PYEOF' &
+import json
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
         body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        if self.headers.get('Content-Type') != 'application/json':
+            body = b'WRONG-CONTENT-TYPE'
+        else:
+            try:
+                json.loads(body)
+            except ValueError:
+                body = b'NOT-JSON'
         with open(sys.argv[2], 'wb') as capture:
             capture.write(body)
         self.send_response(200)
@@ -83,18 +91,45 @@ done
   exit 1
 }
 
-env -u PNS_CHANNELS_DIR HOME="$scratch" PATH="$stub_bin:$PATH" \
+# Proxy-hermetic, and the binary's own output is captured: the token must
+# reach the capture server and NOTHING else, including this engine's stdout
+# and stderr. The token is matched through a pattern file so it never rides
+# an argv of this script's own children either.
+printf 'tok-integration\n' >"$scratch/token.pattern"
+env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
+  -u ALL_PROXY -u NO_PROXY \
+  HOME="$scratch" PATH="$stub_bin:$PATH" \
   RELAY_IDLE_SECS=99999 RELAY_AUTH_FILE="$scratch/auth.json" \
   RELAY_MOSHI_URL="http://127.0.0.1:$(cat "$scratch/port")" \
   "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
-  --agent claude --state 'done' --detail x
+  --agent claude --state 'done' --detail x \
+  >"$scratch/pns.out" 2>"$scratch/pns.err"
 
 wait "$server_pid" 2>/dev/null || true
-grep -q 'tok-integration' "$scratch/capture" 2>/dev/null || {
+grep -qf "$scratch/token.pattern" "$scratch/capture" 2>/dev/null || {
   echo "native moshi did not post the token" >&2
   exit 1
 }
 grep -q 'claude' "$scratch/capture" || {
   echo "the post carried no title" >&2
+  exit 1
+}
+if grep -qf "$scratch/token.pattern" "$scratch/pns.out" "$scratch/pns.err" 2>/dev/null; then
+  echo "the token leaked into the engine's own output" >&2
+  exit 1
+fi
+
+# The same path against a dead endpoint: exit 0 and SILENCE, because the only
+# thing worth reporting would carry the token.
+env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
+  -u ALL_PROXY -u NO_PROXY \
+  HOME="$scratch" PATH="$stub_bin:$PATH" \
+  RELAY_IDLE_SECS=99999 RELAY_AUTH_FILE="$scratch/auth.json" \
+  RELAY_MOSHI_URL="http://127.0.0.1:1" \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent claude --state 'done' --detail x \
+  >"$scratch/pns-dead.out" 2>"$scratch/pns-dead.err"
+[[ ! -s "$scratch/pns-dead.err" ]] || {
+  echo "a failed post said something; the failure path must be silent" >&2
   exit 1
 }

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -52,7 +52,11 @@ grep -q -- '-title' "$scratch/notifier.args" || {
 # carry that token and the title: the moshi leg went native, with the secret
 # in the body and never on argv.
 printf '{"moshi_secret":"tok-integration"}\n' >"$scratch/auth.json"
-python3 - "$scratch/port" "$scratch/capture" <<'PYEOF' &
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required for the capture phase" >&2
+  exit 1
+}
+python3 - "$scratch/port" "$scratch/capture" <<'PYEOF' 2>"$scratch/server.err" &
 import json
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -82,12 +86,15 @@ with open(sys.argv[1], 'w') as port_file:
 server.handle_request()
 PYEOF
 server_pid=$!
-for _ in $(seq 1 50); do
+# A cold CI runner can take several seconds to start python; the wait is
+# generous because it only costs time when something is already slow.
+for _ in $(seq 1 60); do
   [[ -s "$scratch/port" ]] && break
-  sleep 0.1
+  sleep 0.5
 done
 [[ -s "$scratch/port" ]] || {
-  echo "capture server never bound" >&2
+  echo "capture server never bound; its stderr:" >&2
+  cat "$scratch/server.err" >&2 || true
   exit 1
 }
 

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -46,3 +46,55 @@ grep -q -- '-title' "$scratch/notifier.args" || {
   echo "the decoy executable channel fired; native did not win" >&2
   exit 1
 }
+
+# Phase 3: native moshi. RELAY_MOSHI_URL points at a one-shot local capture
+# server, the isolated HOME carries an auth token, and the delivered body must
+# carry that token and the title: the moshi leg went native, with the secret
+# in the body and never on argv.
+printf '{"moshi_secret":"tok-integration"}\n' >"$scratch/auth.json"
+python3 - "$scratch/port" "$scratch/capture" <<'PYEOF' &
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        with open(sys.argv[2], 'wb') as capture:
+            capture.write(body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+server = HTTPServer(('127.0.0.1', 0), Handler)
+server.timeout = 10
+with open(sys.argv[1], 'w') as port_file:
+    port_file.write(str(server.server_address[1]))
+server.handle_request()
+PYEOF
+server_pid=$!
+for _ in $(seq 1 50); do
+  [[ -s "$scratch/port" ]] && break
+  sleep 0.1
+done
+[[ -s "$scratch/port" ]] || {
+  echo "capture server never bound" >&2
+  exit 1
+}
+
+env -u PNS_CHANNELS_DIR HOME="$scratch" PATH="$stub_bin:$PATH" \
+  RELAY_IDLE_SECS=99999 RELAY_AUTH_FILE="$scratch/auth.json" \
+  RELAY_MOSHI_URL="http://127.0.0.1:$(cat "$scratch/port")" \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent claude --state 'done' --detail x
+
+wait "$server_pid" 2>/dev/null || true
+grep -q 'tok-integration' "$scratch/capture" 2>/dev/null || {
+  echo "native moshi did not post the token" >&2
+  exit 1
+}
+grep -q 'claude' "$scratch/capture" || {
+  echo "the post carried no title" >&2
+  exit 1
+}

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -47,47 +47,15 @@ grep -q -- '-title' "$scratch/notifier.args" || {
   exit 1
 }
 
-# Phase 3: native moshi. RELAY_MOSHI_URL points at a one-shot local capture
-# server, the isolated HOME carries an auth token, and the delivered body must
-# carry that token and the title: the moshi leg went native, with the secret
-# in the body and never on argv.
+# Phase 3: native moshi. RELAY_MOSHI_URL points at the crate's own one-shot
+# capture binary (std only, built by the same cargo build), and the captured
+# raw request must carry the JSON content type, a valid JSON body, the token
+# and the title: the moshi leg went native, with the secret in the body and
+# never on argv. No interpreter, so there is no cold start to diagnose.
 printf '{"moshi_secret":"tok-integration"}\n' >"$scratch/auth.json"
-command -v python3 >/dev/null 2>&1 || {
-  echo "python3 is required for the capture phase" >&2
-  exit 1
-}
-python3 - "$scratch/port" "$scratch/capture" <<'PYEOF' 2>"$scratch/server.err" &
-import json
-import sys
-from http.server import BaseHTTPRequestHandler, HTTPServer
-
-class Handler(BaseHTTPRequestHandler):
-    def do_POST(self):
-        body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
-        if self.headers.get('Content-Type') != 'application/json':
-            body = b'WRONG-CONTENT-TYPE'
-        else:
-            try:
-                json.loads(body)
-            except ValueError:
-                body = b'NOT-JSON'
-        with open(sys.argv[2], 'wb') as capture:
-            capture.write(body)
-        self.send_response(200)
-        self.end_headers()
-
-    def log_message(self, *args):
-        pass
-
-server = HTTPServer(('127.0.0.1', 0), Handler)
-server.timeout = 10
-with open(sys.argv[1], 'w') as port_file:
-    port_file.write(str(server.server_address[1]))
-server.handle_request()
-PYEOF
+"$REPO_ROOT/dot_local/share/pns/target/debug/http-capture" \
+  "$scratch/port" "$scratch/capture" 2>"$scratch/server.err" &
 server_pid=$!
-# A cold CI runner can take several seconds to start python; the wait is
-# generous because it only costs time when something is already slow.
 for _ in $(seq 1 60); do
   [[ -s "$scratch/port" ]] && break
   sleep 0.5
@@ -113,6 +81,14 @@ env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROX
   >"$scratch/pns.out" 2>"$scratch/pns.err"
 
 wait "$server_pid" 2>/dev/null || true
+grep -qi 'Content-Type: application/json' "$scratch/capture" 2>/dev/null || {
+  echo "the request carried no JSON content type" >&2
+  exit 1
+}
+tr -d '\r' <"$scratch/capture" | sed -n '/^$/,$p' | sed '1d' | jq -e . >/dev/null || {
+  echo "the posted body is not JSON" >&2
+  exit 1
+}
 grep -qf "$scratch/token.pattern" "$scratch/capture" 2>/dev/null || {
   echo "native moshi did not post the token" >&2
   exit 1


### PR DESCRIPTION
## Context

Second of the four channel slices: the moshi phone push goes native. The bash channel was one `curl` POST with the token deliberately kept off argv; the native form keeps the token in-process end to end, which is the stronger version of the same rule.

## Summary

- `dot_local/share/pns/src/channels/moshi.rs`: the token reads quietly from the auth file (`RELAY_AUTH_FILE`, default `~/.config/relay/auth.json`), every failure to obtain it is silent not-set-up, and the webhook body carries exactly token, title, and the ceiling-safe preview.
- The POST runs through an `HttpPost` seam; the production impl uses `ureq` with a ten-second whole-request deadline and `max_redirects(0)`, restoring the bash parity where no redirect was ever followed, so a compromised endpoint cannot direct a blind request at a target it names.
- Failure is a quiet `false`: no error is formatted or printed anywhere, because the only thing worth reporting would be the request that carries the token.
- The integration gate's moshi phase posts to a local capture server that validates content type and JSON shape, asserts the token absent from the engine's own output, runs proxy-hermetic, and re-runs against a dead endpoint asserting exit 0 with empty stderr.
- `ureq` is trimmed to TLS only (its unused gzip tree is gone), and the crate header now states the dependency rule without a count.

## How it was verified

- `cargo test`: 247 passed, 0 failed, including three real-socket pins: the deadline fires against a never-accepting socket instead of parking the delivery sequence, a redirecting endpoint's decoy target sees zero connections, and a closed port is a quiet false.
- `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean. Dispatch bats 25/25 against both engines; the three-phase integration gate exits 0.
- Thirteen mutations across the two rounds, each killed by a named test or a named gate assertion, with green controls; the redirect semantics of `max_redirects(0)` were verified against the vendored ureq source rather than assumed.
- rustls and its webpki are at versions covered by the current advisories.

## Effect of merging

The moshi leg delivers natively wherever the channels directory is not overridden once a producer invokes the binary; nothing does yet, so live behavior is unchanged and the bash engine keeps running. CI's integration gate now proves the native POST, the URL and auth overrides, and the silent failure path on every run.

## Review guide

Read `channels/moshi.rs` in one pass: the module doc states the secret's path, the three pure functions carry the policy, and the socket tests at the bottom are the operational pins. The gate's moshi phase in `test/integration/pns-engine-binary-dispatch.sh` is the second thing to read: it is what makes "the token reaches the server and nothing else" a checked claim on every CI run.
