### PR TITLE
feat(pns): the hermes channel goes native

### DIFF
--- a/dot_local/share/pns/Cargo.lock
+++ b/dot_local/share/pns/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +38,57 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
 
 [[package]]
 name = "equivalent"
@@ -60,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +143,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -125,7 +203,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "pns"
 version = "0.1.0"
 dependencies = [
+ "hmac",
  "serde_json",
+ "sha2",
  "toml",
  "ureq",
 ]
@@ -249,6 +329,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +400,12 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/dot_local/share/pns/Cargo.toml
+++ b/dot_local/share/pns/Cargo.toml
@@ -11,7 +11,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+hmac = "0.13.0"
 serde_json = "1.0.151"
+sha2 = "0.11.0"
 # Parse only: the default `display` feature pulls toml_writer, and nothing here
 # ever writes TOML back out. `serde` stays because `toml::Table` and
 # `toml::Value` are gated behind it.

--- a/dot_local/share/pns/src/bin/http-capture.rs
+++ b/dot_local/share/pns/src/bin/http-capture.rs
@@ -14,9 +14,14 @@ use std::time::{Duration, Instant};
 fn main() {
     let mut arguments = std::env::args().skip(1);
     let (Some(port_path), Some(capture_path)) = (arguments.next(), arguments.next()) else {
-        eprintln!("usage: http-capture <port-file> <capture-file>");
+        eprintln!("usage: http-capture <port-file> <capture-file> [status]");
         std::process::exit(2);
     };
+    // An optional status lets the gate play an unhappy gateway.
+    let status: u16 = arguments
+        .next()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(200);
 
     let listener = TcpListener::bind("127.0.0.1:0").expect("loopback bind");
     let port = listener.local_addr().expect("local addr").port();
@@ -77,5 +82,6 @@ fn main() {
     }
 
     std::fs::write(&capture_path, &raw).expect("write capture");
-    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    let _ =
+        stream.write_all(format!("HTTP/1.1 {status} X\r\nContent-Length: 0\r\n\r\n").as_bytes());
 }

--- a/dot_local/share/pns/src/channels/hermes.rs
+++ b/dot_local/share/pns/src/channels/hermes.rs
@@ -23,13 +23,25 @@ pub const DEFAULT_HERMES_URL: &str = "http://127.0.0.1:8644/webhooks/relay";
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PostOutcome {
     Status(u16),
+    /// A request that went out and got no HTTP status back: curl's 000.
     NoResponse,
+    /// A request that could not even be attempted (a malformed URL): curl's
+    /// empty status, reported with its own wording.
+    NoStatus,
 }
 
 /// The POST seam: body plus signature header in, outcome out. The production
 /// impl honors the deadline; a fake records everything.
 pub trait SignedPost {
-    fn post(&self, url: &str, body: &str, signature_hex: &str, deadline: Duration) -> PostOutcome;
+    /// `deadline` None means NO deadline, curl's `-m 0`: explicit caller
+    /// intent, not a default.
+    fn post(
+        &self,
+        url: &str,
+        body: &str,
+        signature_hex: &str,
+        deadline: Option<Duration>,
+    ) -> PostOutcome;
 }
 
 /// The gateway body: agent, state, project, and the FULL message as the
@@ -80,6 +92,7 @@ pub fn outcome_line(outcome: PostOutcome) -> String {
             format!("relay: posted HTTP {code}")
         }
         PostOutcome::Status(code) => format!("relay: post FAILED HTTP {code}"),
+        PostOutcome::NoStatus => todo!("R2g fix round: the empty-status wording"),
         PostOutcome::NoResponse => {
             "relay: post FAILED HTTP 000 (no response; is the hermes gateway up?)".to_string()
         }
@@ -96,8 +109,8 @@ pub fn skipped_line(auth_path: &std::path::Path) -> String {
 
 /// The sync deadline: `RELAY_REMOTE_TIMEOUT` validated as a count, else 5
 /// seconds, because a garbled deadline must not become zero or forever.
-pub fn remote_deadline(env_value: Option<&str>) -> Duration {
-    Duration::from_secs(env_value.and_then(crate::parse_count).unwrap_or(5))
+pub fn remote_deadline(env_value: Option<&str>) -> Option<Duration> {
+    Some({ Duration::from_secs(env_value.and_then(crate::parse_count).unwrap_or(5)) })
 }
 
 /// The native hermes plugin.
@@ -107,8 +120,9 @@ pub struct HermesChannel<P: SignedPost> {
     pub auth_path: PathBuf,
     /// `RELAY_HERMES_URL` override, else the default.
     pub url: String,
-    /// The sync deadline, already validated at the edge.
-    pub sync_deadline: Duration,
+    /// The sync deadline, already validated at the edge; None is curl's
+    /// explicit no-deadline.
+    pub sync_deadline: Option<Duration>,
 }
 
 impl<P: SignedPost> Channel for HermesChannel<P> {
@@ -130,7 +144,7 @@ impl<P: SignedPost> Channel for HermesChannel<P> {
 
         let deadline = match mode {
             Mode::Sync => self.sync_deadline,
-            Mode::Async => Duration::from_secs(10),
+            Mode::Async => Some(Duration::from_secs(10)),
         };
         let outcome = self.post.post(&self.url, &body, &signature, deadline);
         if mode == Mode::Sync {
@@ -146,7 +160,16 @@ impl<P: SignedPost> Channel for HermesChannel<P> {
 pub struct UreqSignedPost;
 
 impl SignedPost for UreqSignedPost {
-    fn post(&self, url: &str, body: &str, signature_hex: &str, deadline: Duration) -> PostOutcome {
+    fn post(
+        &self,
+        url: &str,
+        body: &str,
+        signature_hex: &str,
+        deadline: Option<Duration>,
+    ) -> PostOutcome {
+        // Red-state shim: the fix round teaches this the None (no deadline)
+        // and clamp semantics.
+        let deadline = deadline.unwrap_or(Duration::from_secs(10));
         let sent = ureq::Agent::config_builder()
             .timeout_global(Some(deadline))
             .max_redirects(0)
@@ -177,7 +200,7 @@ mod tests {
 
     struct RecordingPost {
         outcome: PostOutcome,
-        posts: RefCell<Vec<(String, String, String, Duration)>>,
+        posts: RefCell<Vec<(String, String, String, Option<Duration>)>>,
     }
 
     impl SignedPost for RecordingPost {
@@ -186,7 +209,7 @@ mod tests {
             url: &str,
             body: &str,
             signature_hex: &str,
-            deadline: Duration,
+            deadline: Option<Duration>,
         ) -> PostOutcome {
             self.posts.borrow_mut().push((
                 url.to_string(),
@@ -231,7 +254,7 @@ mod tests {
                 },
                 auth_path: path.clone(),
                 url: "http://127.0.0.1:9/test".to_string(),
-                sync_deadline: Duration::from_secs(5),
+                sync_deadline: Some(Duration::from_secs(5)),
             },
             path,
         )
@@ -309,10 +332,123 @@ mod tests {
 
     #[test]
     fn the_sync_deadline_validates_and_defaults_to_five() {
-        assert_eq!(remote_deadline(None), Duration::from_secs(5));
-        assert_eq!(remote_deadline(Some("garbage")), Duration::from_secs(5));
-        assert_eq!(remote_deadline(Some("012")), Duration::from_secs(5));
-        assert_eq!(remote_deadline(Some("30")), Duration::from_secs(30));
+        assert_eq!(remote_deadline(None), Some(Duration::from_secs(5)));
+        assert_eq!(
+            remote_deadline(Some("garbage")),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(remote_deadline(Some("012")), Some(Duration::from_secs(5)));
+        assert_eq!(remote_deadline(Some("30")), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn an_explicit_zero_deadline_is_no_deadline_like_curls_dash_m_zero() {
+        assert_eq!(remote_deadline(Some("0")), None);
+    }
+
+    #[test]
+    fn an_absurd_deadline_clamps_to_a_day_instead_of_panicking_the_edge() {
+        assert_eq!(
+            remote_deadline(Some("9223372036854775807")),
+            Some(Duration::from_secs(86_400))
+        );
+    }
+
+    #[test]
+    fn a_redirect_is_the_final_answer_so_3xx_reads_failed() {
+        assert_eq!(
+            outcome_line(PostOutcome::Status(301)),
+            "relay: post FAILED HTTP 301"
+        );
+    }
+
+    #[test]
+    fn the_never_attempted_case_has_its_own_bash_wording() {
+        assert_eq!(
+            outcome_line(PostOutcome::NoStatus),
+            "relay: post FAILED (curl reported no HTTP status at all)"
+        );
+    }
+
+    #[test]
+    fn the_empty_and_unicode_bodies_match_openssls_own_hmac() {
+        assert_eq!(
+            sign("key", "").as_deref(),
+            Some("5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")
+        );
+        assert_eq!(
+            sign("key", "\u{17c}\u{f3}\u{142}\u{107} \u{fc}ber \u{1f6a8}").as_deref(),
+            Some("2ce40f95a8377ebe61896f8eeb03cd9150b1ed7fbf16c47483ee58f86976d6c5")
+        );
+    }
+
+    #[test]
+    fn the_key_never_rides_in_the_body_the_url_or_the_signature() {
+        let (channel, path) = channel_with_auth(
+            r#"{"hermes_secret":"sekrit-key-9"}"#,
+            PostOutcome::Status(200),
+        );
+        channel.deliver(&event(), Mode::Async);
+        std::fs::remove_file(&path).ok();
+        let posts = channel.post.posts.borrow();
+        assert!(!posts[0].0.contains("sekrit-key-9"));
+        assert!(!posts[0].1.contains("sekrit-key-9"));
+        assert!(!posts[0].2.contains("sekrit-key-9"));
+    }
+
+    // --- the production post, against real sockets ---------------------------
+
+    use super::UreqSignedPost;
+
+    #[test]
+    fn a_malformed_url_is_never_attempted_which_is_its_own_outcome() {
+        assert_eq!(
+            UreqSignedPost.post("http://[::1", "{}", "sig", Some(Duration::from_secs(2))),
+            PostOutcome::NoStatus
+        );
+    }
+
+    #[test]
+    fn a_closed_port_is_no_response() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", listener.local_addr().unwrap());
+        drop(listener);
+        assert_eq!(
+            UreqSignedPost.post(&url, "{}", "sig", Some(Duration::from_secs(2))),
+            PostOutcome::NoResponse
+        );
+    }
+
+    #[test]
+    fn a_redirecting_gateway_is_the_final_answer_and_the_signed_body_stays_home() {
+        use std::io::{Read, Write};
+        let decoy = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let decoy_addr = decoy.local_addr().unwrap();
+        decoy.set_nonblocking(true).unwrap();
+        let redirector = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/hook", redirector.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = redirector.accept() {
+                let mut request = [0u8; 2048];
+                let _ = stream.read(&mut request);
+                let _ = stream.write_all(
+                    format!(
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://{decoy_addr}/\r\nContent-Length: 0\r\n\r\n"
+                    )
+                    .as_bytes(),
+                );
+            }
+        });
+        let outcome = UreqSignedPost.post(
+            &url,
+            "{\"signed\":true}",
+            "sig",
+            Some(Duration::from_secs(2)),
+        );
+        server.join().unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(decoy.accept().is_err(), "the signed body must stay home");
+        assert_eq!(outcome, PostOutcome::Status(307));
     }
 
     // --- delivery ------------------------------------------------------------
@@ -333,7 +469,7 @@ mod tests {
         );
         assert_eq!(
             posts[0].3,
-            Duration::from_secs(10),
+            Some(Duration::from_secs(10)),
             "async carries the ten second deadline"
         );
     }
@@ -344,7 +480,10 @@ mod tests {
             channel_with_auth(r#"{"hermes_secret":"key"}"#, PostOutcome::Status(200));
         channel.deliver(&event(), Mode::Sync);
         std::fs::remove_file(&path).ok();
-        assert_eq!(channel.post.posts.borrow()[0].3, Duration::from_secs(5));
+        assert_eq!(
+            channel.post.posts.borrow()[0].3,
+            Some(Duration::from_secs(5))
+        );
     }
 
     #[test]

--- a/dot_local/share/pns/src/channels/hermes.rs
+++ b/dot_local/share/pns/src/channels/hermes.rs
@@ -35,41 +35,69 @@ pub trait SignedPost {
 /// The gateway body: agent, state, project, and the FULL message as the
 /// detail, because Discord has no length ceiling for the preview to serve.
 pub fn hermes_body(event: &Event) -> String {
-    let _ = event;
-    todo!("R2g: the four-field body, detail carrying the full message")
+    serde_json::json!({
+        "agent": event.agent,
+        "state": event.state,
+        "project": event.project,
+        "detail": event.message,
+    })
+    .to_string()
 }
 
 /// The lowercase hex HMAC-SHA256 of the body under the signing key, or None
 /// when the key is empty, which is the not-set-up case.
 pub fn sign(secret: &str, body: &str) -> Option<String> {
-    let _ = (secret, body);
-    todo!("R2g: hmac-sha256 through the RustCrypto crates, never hand-rolled")
+    use hmac::{Hmac, KeyInit, Mac};
+    if secret.is_empty() {
+        return None;
+    }
+    let mut mac = Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    mac.update(body.as_bytes());
+    Some(
+        mac.finalize()
+            .into_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect(),
+    )
 }
 
 /// The hermes signing key out of the auth JSON: `.hermes_secret`, non-empty,
 /// else None. Silent, like every not-set-up reading.
 pub fn hermes_secret(auth_json: &str) -> Option<String> {
-    let _ = auth_json;
-    todo!("R2g: the non-empty hermes key")
+    let key = serde_json::from_str::<serde_json::Value>(auth_json)
+        .ok()?
+        .get("hermes_secret")?
+        .as_str()?
+        .to_string();
+    (!key.is_empty()).then_some(key)
 }
 
 /// The line sync mode prints for one outcome, exactly as the bash spells it.
 pub fn outcome_line(outcome: PostOutcome) -> String {
-    let _ = outcome;
-    todo!("R2g: posted for 2xx, FAILED HTTP for the rest, the 000 wording for no response")
+    match outcome {
+        PostOutcome::Status(code) if (200..300).contains(&code) => {
+            format!("relay: posted HTTP {code}")
+        }
+        PostOutcome::Status(code) => format!("relay: post FAILED HTTP {code}"),
+        PostOutcome::NoResponse => {
+            "relay: post FAILED HTTP 000 (no response; is the hermes gateway up?)".to_string()
+        }
+    }
 }
 
 /// The line sync mode prints when there is no signing key.
 pub fn skipped_line(auth_path: &std::path::Path) -> String {
-    let _ = auth_path;
-    todo!("R2g: the SKIPPED line naming the auth file")
+    format!(
+        "relay: post SKIPPED -- no hermes signing key in {}; nothing was sent",
+        auth_path.display()
+    )
 }
 
 /// The sync deadline: `RELAY_REMOTE_TIMEOUT` validated as a count, else 5
 /// seconds, because a garbled deadline must not become zero or forever.
 pub fn remote_deadline(env_value: Option<&str>) -> Duration {
-    let _ = env_value;
-    todo!("R2g: validated seconds, defaulting to five")
+    Duration::from_secs(env_value.and_then(crate::parse_count).unwrap_or(5))
 }
 
 /// The native hermes plugin.
@@ -85,8 +113,54 @@ pub struct HermesChannel<P: SignedPost> {
 
 impl<P: SignedPost> Channel for HermesChannel<P> {
     fn deliver(&self, event: &Event, mode: Mode) {
-        let _ = (event, mode);
-        todo!("R2g: sign and post; sync says what happened, async stays silent")
+        let body = hermes_body(event);
+        let signature = std::fs::read_to_string(&self.auth_path)
+            .ok()
+            .as_deref()
+            .and_then(hermes_secret)
+            .and_then(|key| sign(&key, &body));
+        let Some(signature) = signature else {
+            // No key is unavailable, not a failure. Sync callers are told,
+            // because an empty Discord channel looks like the jobs stopped.
+            if mode == Mode::Sync {
+                println!("{}", skipped_line(&self.auth_path));
+            }
+            return;
+        };
+
+        let deadline = match mode {
+            Mode::Sync => self.sync_deadline,
+            Mode::Async => Duration::from_secs(10),
+        };
+        let outcome = self.post.post(&self.url, &body, &signature, deadline);
+        if mode == Mode::Sync {
+            println!("{}", outcome_line(outcome));
+        }
+    }
+}
+
+/// The production POST: one agent, no redirects (following one would send the
+/// signed body to whatever host the gateway names), the deadline per call.
+/// An HTTP error status IS the answer sync mode prints, so a status-carrying
+/// error is unwrapped rather than collapsed, matching the bash's missing -f.
+pub struct UreqSignedPost;
+
+impl SignedPost for UreqSignedPost {
+    fn post(&self, url: &str, body: &str, signature_hex: &str, deadline: Duration) -> PostOutcome {
+        let sent = ureq::Agent::config_builder()
+            .timeout_global(Some(deadline))
+            .max_redirects(0)
+            .build()
+            .new_agent()
+            .post(url)
+            .content_type("application/json")
+            .header("X-Webhook-Signature", signature_hex)
+            .send(body);
+        match sent {
+            Ok(response) => PostOutcome::Status(response.status().as_u16()),
+            Err(ureq::Error::StatusCode(code)) => PostOutcome::Status(code),
+            Err(_) => PostOutcome::NoResponse,
+        }
     }
 }
 
@@ -139,10 +213,14 @@ mod tests {
         auth: &str,
         outcome: PostOutcome,
     ) -> (HermesChannel<RecordingPost>, std::path::PathBuf) {
+        // A process-wide counter, because two tests handing in the SAME auth
+        // string must never share a path: parallel runs would race on the
+        // cleanup and one test would read the other's deleted file.
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
         let path = std::env::temp_dir().join(format!(
             "pns-hermes-auth-{}-{}",
             std::process::id(),
-            auth.len()
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         std::fs::write(&path, auth).unwrap();
         (

--- a/dot_local/share/pns/src/channels/hermes.rs
+++ b/dot_local/share/pns/src/channels/hermes.rs
@@ -92,7 +92,9 @@ pub fn outcome_line(outcome: PostOutcome) -> String {
             format!("relay: posted HTTP {code}")
         }
         PostOutcome::Status(code) => format!("relay: post FAILED HTTP {code}"),
-        PostOutcome::NoStatus => todo!("R2g fix round: the empty-status wording"),
+        PostOutcome::NoStatus => {
+            "relay: post FAILED (curl reported no HTTP status at all)".to_string()
+        }
         PostOutcome::NoResponse => {
             "relay: post FAILED HTTP 000 (no response; is the hermes gateway up?)".to_string()
         }
@@ -110,7 +112,11 @@ pub fn skipped_line(auth_path: &std::path::Path) -> String {
 /// The sync deadline: `RELAY_REMOTE_TIMEOUT` validated as a count, else 5
 /// seconds, because a garbled deadline must not become zero or forever.
 pub fn remote_deadline(env_value: Option<&str>) -> Option<Duration> {
-    Some({ Duration::from_secs(env_value.and_then(crate::parse_count).unwrap_or(5)) })
+    let seconds = env_value.and_then(crate::parse_count).unwrap_or(5);
+    // Zero is curl's `-m 0`: no deadline at all, and caller intent rather
+    // than a default. The clamp keeps an absurd value out of ureq's deadline
+    // arithmetic; a day is already longer than any notification can matter.
+    (seconds != 0).then(|| Duration::from_secs(seconds.min(86_400)))
 }
 
 /// The native hermes plugin.
@@ -167,11 +173,10 @@ impl SignedPost for UreqSignedPost {
         signature_hex: &str,
         deadline: Option<Duration>,
     ) -> PostOutcome {
-        // Red-state shim: the fix round teaches this the None (no deadline)
-        // and clamp semantics.
-        let deadline = deadline.unwrap_or(Duration::from_secs(10));
         let sent = ureq::Agent::config_builder()
-            .timeout_global(Some(deadline))
+            // None is no deadline at all, so the option passes straight
+            // through rather than being defaulted back into one.
+            .timeout_global(deadline)
             .max_redirects(0)
             .build()
             .new_agent()
@@ -182,6 +187,11 @@ impl SignedPost for UreqSignedPost {
         match sent {
             Ok(response) => PostOutcome::Status(response.status().as_u16()),
             Err(ureq::Error::StatusCode(code)) => PostOutcome::Status(code),
+            // The request was never put on the wire: a URI ureq refuses, or a
+            // header the http crate refuses to build. Curl prints no status
+            // at all for these, which is a different report from a silent
+            // gateway.
+            Err(ureq::Error::BadUri(_) | ureq::Error::Http(_)) => PostOutcome::NoStatus,
             Err(_) => PostOutcome::NoResponse,
         }
     }
@@ -198,9 +208,12 @@ mod tests {
     use std::cell::RefCell;
     use std::time::Duration;
 
+    /// url, body, signature, deadline: one recorded post.
+    type RecordedPost = (String, String, String, Option<Duration>);
+
     struct RecordingPost {
         outcome: PostOutcome,
-        posts: RefCell<Vec<(String, String, String, Option<Duration>)>>,
+        posts: RefCell<Vec<RecordedPost>>,
     }
 
     impl SignedPost for RecordingPost {

--- a/dot_local/share/pns/src/channels/hermes.rs
+++ b/dot_local/share/pns/src/channels/hermes.rs
@@ -1,0 +1,286 @@
+//! The hermes channel, native: the durable Discord log, one signed POST to
+//! the local gateway.
+//!
+//! SYNC MODE EXISTS TO BE SEEN. The weekly job records must be able to see a
+//! delivery failure: a 401 swallowed silently leaves the Discord channel
+//! empty, and an empty channel looks like the jobs stopped running. So sync
+//! posts print the HTTP status and the no-key case says so aloud, while
+//! async stays silent like every other leg. The signing key never reaches
+//! argv, a child environment, or any printed line; the signature is computed
+//! in-process over the exact body bytes.
+
+use super::{Channel, Event};
+use crate::routing::Mode;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// The gateway when `RELAY_HERMES_URL` says nothing: the local hermes
+/// webhook route.
+pub const DEFAULT_HERMES_URL: &str = "http://127.0.0.1:8644/webhooks/relay";
+
+/// What one signed POST came back with: a status code, or no response at
+/// all, which sync mode reports as its own distinct failure.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PostOutcome {
+    Status(u16),
+    NoResponse,
+}
+
+/// The POST seam: body plus signature header in, outcome out. The production
+/// impl honors the deadline; a fake records everything.
+pub trait SignedPost {
+    fn post(&self, url: &str, body: &str, signature_hex: &str, deadline: Duration) -> PostOutcome;
+}
+
+/// The gateway body: agent, state, project, and the FULL message as the
+/// detail, because Discord has no length ceiling for the preview to serve.
+pub fn hermes_body(event: &Event) -> String {
+    let _ = event;
+    todo!("R2g: the four-field body, detail carrying the full message")
+}
+
+/// The lowercase hex HMAC-SHA256 of the body under the signing key, or None
+/// when the key is empty, which is the not-set-up case.
+pub fn sign(secret: &str, body: &str) -> Option<String> {
+    let _ = (secret, body);
+    todo!("R2g: hmac-sha256 through the RustCrypto crates, never hand-rolled")
+}
+
+/// The hermes signing key out of the auth JSON: `.hermes_secret`, non-empty,
+/// else None. Silent, like every not-set-up reading.
+pub fn hermes_secret(auth_json: &str) -> Option<String> {
+    let _ = auth_json;
+    todo!("R2g: the non-empty hermes key")
+}
+
+/// The line sync mode prints for one outcome, exactly as the bash spells it.
+pub fn outcome_line(outcome: PostOutcome) -> String {
+    let _ = outcome;
+    todo!("R2g: posted for 2xx, FAILED HTTP for the rest, the 000 wording for no response")
+}
+
+/// The line sync mode prints when there is no signing key.
+pub fn skipped_line(auth_path: &std::path::Path) -> String {
+    let _ = auth_path;
+    todo!("R2g: the SKIPPED line naming the auth file")
+}
+
+/// The sync deadline: `RELAY_REMOTE_TIMEOUT` validated as a count, else 5
+/// seconds, because a garbled deadline must not become zero or forever.
+pub fn remote_deadline(env_value: Option<&str>) -> Duration {
+    let _ = env_value;
+    todo!("R2g: validated seconds, defaulting to five")
+}
+
+/// The native hermes plugin.
+pub struct HermesChannel<P: SignedPost> {
+    pub post: P,
+    /// `RELAY_AUTH_FILE` override, else `~/.config/relay/auth.json`.
+    pub auth_path: PathBuf,
+    /// `RELAY_HERMES_URL` override, else the default.
+    pub url: String,
+    /// The sync deadline, already validated at the edge.
+    pub sync_deadline: Duration,
+}
+
+impl<P: SignedPost> Channel for HermesChannel<P> {
+    fn deliver(&self, event: &Event, mode: Mode) {
+        let _ = (event, mode);
+        todo!("R2g: sign and post; sync says what happened, async stays silent")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_HERMES_URL, HermesChannel, PostOutcome, SignedPost, hermes_body, hermes_secret,
+        outcome_line, remote_deadline, sign, skipped_line,
+    };
+    use crate::channels::{Channel, Event};
+    use crate::routing::Mode;
+    use std::cell::RefCell;
+    use std::time::Duration;
+
+    struct RecordingPost {
+        outcome: PostOutcome,
+        posts: RefCell<Vec<(String, String, String, Duration)>>,
+    }
+
+    impl SignedPost for RecordingPost {
+        fn post(
+            &self,
+            url: &str,
+            body: &str,
+            signature_hex: &str,
+            deadline: Duration,
+        ) -> PostOutcome {
+            self.posts.borrow_mut().push((
+                url.to_string(),
+                body.to_string(),
+                signature_hex.to_string(),
+                deadline,
+            ));
+            self.outcome
+        }
+    }
+
+    fn event() -> Event {
+        Event {
+            agent: "claude".to_string(),
+            state: "done".to_string(),
+            project: "dotfiles".to_string(),
+            message: "the full message".to_string(),
+            preview: "a preview".to_string(),
+            ..Event::default()
+        }
+    }
+
+    fn channel_with_auth(
+        auth: &str,
+        outcome: PostOutcome,
+    ) -> (HermesChannel<RecordingPost>, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "pns-hermes-auth-{}-{}",
+            std::process::id(),
+            auth.len()
+        ));
+        std::fs::write(&path, auth).unwrap();
+        (
+            HermesChannel {
+                post: RecordingPost {
+                    outcome,
+                    posts: RefCell::new(Vec::new()),
+                },
+                auth_path: path.clone(),
+                url: "http://127.0.0.1:9/test".to_string(),
+                sync_deadline: Duration::from_secs(5),
+            },
+            path,
+        )
+    }
+
+    // --- the body ------------------------------------------------------------
+
+    #[test]
+    fn the_body_carries_the_full_message_because_discord_has_no_ceiling() {
+        let body = hermes_body(&event());
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["agent"], "claude");
+        assert_eq!(parsed["state"], "done");
+        assert_eq!(parsed["project"], "dotfiles");
+        assert_eq!(parsed["detail"], "the full message");
+        assert_eq!(parsed.as_object().unwrap().len(), 4);
+    }
+
+    // --- the signature -------------------------------------------------------
+
+    #[test]
+    fn the_signature_matches_the_published_hmac_sha256_vector() {
+        // RFC-known vector: HMAC-SHA256("key", "The quick brown fox jumps
+        // over the lazy dog").
+        assert_eq!(
+            sign("key", "The quick brown fox jumps over the lazy dog").as_deref(),
+            Some("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8")
+        );
+    }
+
+    #[test]
+    fn an_empty_key_signs_nothing_which_is_the_not_set_up_case() {
+        assert_eq!(sign("", "anything"), None);
+    }
+
+    #[test]
+    fn every_way_the_auth_can_fail_to_provide_a_key_reads_not_set_up() {
+        assert_eq!(hermes_secret(""), None);
+        assert_eq!(hermes_secret("not json"), None);
+        assert_eq!(hermes_secret(r#"{"moshi_secret":"x"}"#), None);
+        assert_eq!(hermes_secret(r#"{"hermes_secret":""}"#), None);
+    }
+
+    // --- the sync voice ------------------------------------------------------
+
+    #[test]
+    fn sync_outcomes_are_spelled_exactly_as_the_bash_spells_them() {
+        assert_eq!(
+            outcome_line(PostOutcome::Status(200)),
+            "relay: posted HTTP 200"
+        );
+        assert_eq!(
+            outcome_line(PostOutcome::Status(204)),
+            "relay: posted HTTP 204"
+        );
+        assert_eq!(
+            outcome_line(PostOutcome::Status(404)),
+            "relay: post FAILED HTTP 404"
+        );
+        assert_eq!(
+            outcome_line(PostOutcome::NoResponse),
+            "relay: post FAILED HTTP 000 (no response; is the hermes gateway up?)"
+        );
+    }
+
+    #[test]
+    fn the_no_key_line_names_the_auth_file_the_operator_must_fix() {
+        assert_eq!(
+            skipped_line(std::path::Path::new("/x/auth.json")),
+            "relay: post SKIPPED -- no hermes signing key in /x/auth.json; nothing was sent"
+        );
+    }
+
+    // --- the deadline --------------------------------------------------------
+
+    #[test]
+    fn the_sync_deadline_validates_and_defaults_to_five() {
+        assert_eq!(remote_deadline(None), Duration::from_secs(5));
+        assert_eq!(remote_deadline(Some("garbage")), Duration::from_secs(5));
+        assert_eq!(remote_deadline(Some("012")), Duration::from_secs(5));
+        assert_eq!(remote_deadline(Some("30")), Duration::from_secs(30));
+    }
+
+    // --- delivery ------------------------------------------------------------
+
+    #[test]
+    fn a_key_posts_once_with_the_signature_of_the_exact_body_bytes() {
+        let (channel, path) =
+            channel_with_auth(r#"{"hermes_secret":"key"}"#, PostOutcome::Status(200));
+        channel.deliver(&event(), Mode::Async);
+        std::fs::remove_file(&path).ok();
+        let posts = channel.post.posts.borrow();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].0, "http://127.0.0.1:9/test");
+        assert_eq!(
+            Some(posts[0].2.as_str()),
+            super::sign("key", &posts[0].1).as_deref(),
+            "the signature covers the body that was actually posted"
+        );
+        assert_eq!(
+            posts[0].3,
+            Duration::from_secs(10),
+            "async carries the ten second deadline"
+        );
+    }
+
+    #[test]
+    fn sync_carries_the_validated_sync_deadline() {
+        let (channel, path) =
+            channel_with_auth(r#"{"hermes_secret":"key"}"#, PostOutcome::Status(200));
+        channel.deliver(&event(), Mode::Sync);
+        std::fs::remove_file(&path).ok();
+        assert_eq!(channel.post.posts.borrow()[0].3, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn no_key_means_no_post_in_either_mode() {
+        for mode in [Mode::Async, Mode::Sync] {
+            let (channel, path) = channel_with_auth(r#"{}"#, PostOutcome::Status(200));
+            channel.deliver(&event(), mode);
+            std::fs::remove_file(&path).ok();
+            assert!(channel.post.posts.borrow().is_empty());
+        }
+    }
+
+    #[test]
+    fn the_default_url_is_the_local_gateway_route() {
+        assert_eq!(DEFAULT_HERMES_URL, "http://127.0.0.1:8644/webhooks/relay");
+    }
+}

--- a/dot_local/share/pns/src/channels/hermes.rs
+++ b/dot_local/share/pns/src/channels/hermes.rs
@@ -442,14 +442,45 @@ mod tests {
         let url = format!("http://{}/hook", redirector.local_addr().unwrap());
         let server = std::thread::spawn(move || {
             if let Ok((mut stream, _)) = redirector.accept() {
-                let mut request = [0u8; 2048];
-                let _ = stream.read(&mut request);
+                // Consume the WHOLE request (headers plus Content-Length body)
+                // before answering: responding after one read can reset the
+                // socket under a client still writing, which turns the
+                // outcome into NoResponse on a slow runner.
+                let mut raw = Vec::new();
+                let mut chunk = [0u8; 2048];
+                let header_end = loop {
+                    let read = stream.read(&mut chunk).unwrap_or(0);
+                    if read == 0 {
+                        break raw.len();
+                    }
+                    raw.extend_from_slice(&chunk[..read]);
+                    if let Some(position) = raw.windows(4).position(|window| window == b"\r\n\r\n")
+                    {
+                        break position + 4;
+                    }
+                };
+                let content_length = String::from_utf8_lossy(&raw[..header_end])
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())?
+                    })
+                    .unwrap_or(0);
+                while raw.len() < header_end + content_length {
+                    let read = stream.read(&mut chunk).unwrap_or(0);
+                    if read == 0 {
+                        break;
+                    }
+                    raw.extend_from_slice(&chunk[..read]);
+                }
                 let _ = stream.write_all(
                     format!(
                         "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://{decoy_addr}/\r\nContent-Length: 0\r\n\r\n"
                     )
                     .as_bytes(),
                 );
+                let _ = stream.flush();
             }
         });
         let outcome = UreqSignedPost.post(

--- a/dot_local/share/pns/src/channels/mod.rs
+++ b/dot_local/share/pns/src/channels/mod.rs
@@ -9,6 +9,7 @@
 //! engine at a stub directory.
 
 pub mod banner;
+pub mod hermes;
 pub mod moshi;
 
 use crate::routing::Mode;

--- a/dot_local/share/pns/src/channels/moshi.rs
+++ b/dot_local/share/pns/src/channels/moshi.rs
@@ -120,10 +120,14 @@ mod tests {
     }
 
     fn channel_with_auth(auth: &str) -> (MoshiChannel<RecordingHttp>, std::path::PathBuf) {
+        // A process-wide counter, because two tests handing in the SAME auth
+        // string must never share a path: parallel runs would race on the
+        // cleanup and one test would read the other's deleted file.
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
         let path = std::env::temp_dir().join(format!(
             "pns-moshi-auth-{}-{}",
             std::process::id(),
-            auth.len()
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         std::fs::write(&path, auth).unwrap();
         (

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use pns::args::parse_args;
 use pns::channels::banner::BannerChannel;
+use pns::channels::hermes::{DEFAULT_HERMES_URL, HermesChannel, UreqSignedPost, remote_deadline};
 use pns::channels::moshi::{DEFAULT_MOSHI_URL, MoshiChannel, UreqPost};
 use pns::channels::{Channel, native_first};
 use pns::config::{config_path, load_config};
@@ -185,16 +186,27 @@ fn main() {
         pane: pane.to_string(),
     };
 
+    let auth_path = resolve_path(
+        std::env::var("RELAY_AUTH_FILE").ok().as_deref(),
+        &format!("{home}/.config/relay/auth.json"),
+    );
     let moshi = MoshiChannel {
         http: UreqPost::default(),
-        auth_path: resolve_path(
-            std::env::var("RELAY_AUTH_FILE").ok().as_deref(),
-            &format!("{home}/.config/relay/auth.json"),
-        ),
+        auth_path: auth_path.clone(),
         url: std::env::var("RELAY_MOSHI_URL")
             .ok()
             .filter(|url| !url.is_empty())
             .unwrap_or_else(|| DEFAULT_MOSHI_URL.to_string()),
+    };
+
+    let hermes = HermesChannel {
+        post: UreqSignedPost,
+        auth_path,
+        url: std::env::var("RELAY_HERMES_URL")
+            .ok()
+            .filter(|url| !url.is_empty())
+            .unwrap_or_else(|| DEFAULT_HERMES_URL.to_string()),
+        sync_deadline: remote_deadline(std::env::var("RELAY_REMOTE_TIMEOUT").ok().as_deref()),
     };
 
     for leg in &decision.legs {
@@ -206,6 +218,10 @@ fn main() {
                 }
                 "moshi" => {
                     moshi.deliver(&native, leg.mode);
+                    continue;
+                }
+                "hermes" => {
+                    hermes.deliver(&native, leg.mode);
                     continue;
                 }
                 _ => {}

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -116,3 +116,48 @@ env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROX
   echo "a failed post said something; the failure path must be silent" >&2
   exit 1
 }
+
+# Phase 4: native hermes. The capture binary again, this time on the log
+# path: --remote-only makes hermes the whole plan, sync, so the engine must
+# print the posted line, and the captured X-Webhook-Signature must equal
+# openssl's own HMAC of the captured body, proving the signature covers the
+# exact bytes that were sent.
+printf '{"hermes_secret":"gate-signing-key"}\n' >"$scratch/auth.json"
+: >"$scratch/port"
+"$REPO_ROOT/dot_local/share/pns/target/debug/http-capture" \
+  "$scratch/port" "$scratch/hermes.capture" 2>"$scratch/server.err" &
+server_pid=$!
+for _ in $(seq 1 60); do
+  [[ -s "$scratch/port" ]] && break
+  sleep 0.5
+done
+[[ -s "$scratch/port" ]] || {
+  echo "hermes capture server never bound; its stderr:" >&2
+  cat "$scratch/server.err" >&2 || true
+  exit 1
+}
+
+env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
+  -u ALL_PROXY -u NO_PROXY \
+  HOME="$scratch" PATH="$stub_bin:$PATH" \
+  RELAY_AUTH_FILE="$scratch/auth.json" \
+  RELAY_HERMES_URL="http://127.0.0.1:$(cat "$scratch/port")" \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent weekly --state 'done' --detail ran --remote-only \
+  >"$scratch/hermes.out" 2>"$scratch/hermes.err"
+
+wait "$server_pid" 2>/dev/null || true
+grep -q 'relay: posted HTTP 200' "$scratch/hermes.out" || {
+  echo "sync hermes did not report its posted status" >&2
+  exit 1
+}
+body="$(tr -d '\r' <"$scratch/hermes.capture" | sed -n '/^$/,$p' | sed '1d')"
+sent_signature="$(tr -d '\r' <"$scratch/hermes.capture" |
+  sed -n 's/^[Xx]-[Ww]ebhook-[Ss]ignature: //p' | head -1)"
+expected_signature="$(printf '%s' "$body" |
+  openssl dgst -sha256 -hmac 'gate-signing-key' | sed 's/^.*= //')"
+[[ -n $sent_signature && $sent_signature == "$expected_signature" ]] || {
+  echo "the signature does not match openssl's HMAC of the captured body" >&2
+  echo "sent: $sent_signature expected: $expected_signature" >&2
+  exit 1
+}

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -196,3 +196,20 @@ wait "$server_pid" 2>/dev/null || true
   cat "$scratch/hermes-401.out" >&2
   exit 1
 }
+
+# Phase 4c: async hermes with a real key must be SILENT even when the post
+# fails. The alert-path silence check in phase 3 cannot see this: its auth
+# carries no hermes key, so that run returns before any outcome exists.
+env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
+  -u ALL_PROXY -u NO_PROXY \
+  HOME="$scratch" PATH="$stub_bin:$PATH" \
+  RELAY_IDLE_SECS=99999 RELAY_AUTH_FILE="$scratch/auth.json" \
+  RELAY_HERMES_URL="http://127.0.0.1:1" RELAY_MOSHI_URL="http://127.0.0.1:1" \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent claude --state 'done' --detail x \
+  >"$scratch/async-keyed.out" 2>/dev/null
+[[ ! -s "$scratch/async-keyed.out" ]] || {
+  echo "an async delivery printed an outcome; async legs must be silent:" >&2
+  cat "$scratch/async-keyed.out" >&2
+  exit 1
+}

--- a/test/integration/pns-engine-binary-dispatch.sh
+++ b/test/integration/pns-engine-binary-dispatch.sh
@@ -101,6 +101,10 @@ if grep -qf "$scratch/token.pattern" "$scratch/pns.out" "$scratch/pns.err" 2>/de
   echo "the token leaked into the engine's own output" >&2
   exit 1
 fi
+[[ ! -s "$scratch/pns.out" ]] || {
+  echo "the alert path printed to stdout; async legs must be silent" >&2
+  exit 1
+}
 
 # The same path against a dead endpoint: exit 0 and SILENCE, because the only
 # thing worth reporting would carry the token.
@@ -147,8 +151,9 @@ env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROX
   >"$scratch/hermes.out" 2>"$scratch/hermes.err"
 
 wait "$server_pid" 2>/dev/null || true
-grep -q 'relay: posted HTTP 200' "$scratch/hermes.out" || {
-  echo "sync hermes did not report its posted status" >&2
+[[ "$(cat "$scratch/hermes.out")" == "relay: posted HTTP 200" ]] || {
+  echo "sync hermes stdout is not exactly the posted line:" >&2
+  cat "$scratch/hermes.out" >&2
   exit 1
 }
 body="$(tr -d '\r' <"$scratch/hermes.capture" | sed -n '/^$/,$p' | sed '1d')"
@@ -159,5 +164,35 @@ expected_signature="$(printf '%s' "$body" |
 [[ -n $sent_signature && $sent_signature == "$expected_signature" ]] || {
   echo "the signature does not match openssl's HMAC of the captured body" >&2
   echo "sent: $sent_signature expected: $expected_signature" >&2
+  exit 1
+}
+
+# Phase 4b: the gateway answers 401 (a rotated signing key). Sync must name
+# the status, because "no response" would send the operator to restart a
+# healthy gateway instead of fixing the key.
+: >"$scratch/port"
+"$REPO_ROOT/dot_local/share/pns/target/debug/http-capture" \
+  "$scratch/port" "$scratch/hermes-401.capture" 401 2>"$scratch/server.err" &
+server_pid=$!
+for _ in $(seq 1 60); do
+  [[ -s "$scratch/port" ]] && break
+  sleep 0.5
+done
+[[ -s "$scratch/port" ]] || {
+  echo "the 401 capture server never bound" >&2
+  exit 1
+}
+env -u PNS_CHANNELS_DIR -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
+  -u ALL_PROXY -u NO_PROXY \
+  HOME="$scratch" PATH="$stub_bin:$PATH" \
+  RELAY_AUTH_FILE="$scratch/auth.json" \
+  RELAY_HERMES_URL="http://127.0.0.1:$(cat "$scratch/port")" \
+  "$REPO_ROOT/dot_local/share/pns/target/debug/pns" \
+  --agent weekly --state 'done' --detail ran --remote-only \
+  >"$scratch/hermes-401.out" 2>/dev/null
+wait "$server_pid" 2>/dev/null || true
+[[ "$(cat "$scratch/hermes-401.out")" == "relay: post FAILED HTTP 401" ]] || {
+  echo "a 401 must read as HTTP 401, not as a downed gateway:" >&2
+  cat "$scratch/hermes-401.out" >&2
   exit 1
 }


### PR DESCRIPTION
## Context

Third of the four channel slices: hermes, the durable Discord log, goes native. The bash channel signed its body through an embedded python HMAC and reported sync outcomes so the weekly job records could see a delivery failure; both properties carry over with an independent check standing behind each.

## Summary

- `dot_local/share/pns/src/channels/hermes.rs`: the four-field body carrying the full message, the signature as lowercase-hex HMAC-SHA256 over the exact posted bytes through the `hmac` and `sha2` crates, and the signing key never touching argv, output, or any error path.
- Sync mode speaks the bash's exact lines: `posted HTTP 2xx`, `FAILED HTTP <code>` for everything else including 3xx (with redirects refused, a redirect is the final answer), the 000 no-response wording, the never-attempted wording for requests that could not go on the wire, and the no-key SKIPPED line naming the auth file. Async is silent on every path.
- Deadline semantics match curl: `RELAY_REMOTE_TIMEOUT` validated with a 5-second default, an explicit `0` meaning no deadline, and absurd values clamping to a day instead of panicking the always-exit-0 edge.
- Error statuses are answers, not failures: a 401 from a rotated key reads `FAILED HTTP 401`, never "is the gateway up", preserving the bash's curl-without-`-f` semantics.
- The integration gate gains three hermes phases: the captured signature must equal openssl's own HMAC of the captured body, a 401 gateway must be named as such, and a keyed async run against a dead endpoint must print nothing.

## How it was verified

- `cargo test`: 267 passed, 0 failed, across repeated parallel runs (a temp-file race in two test helpers was found by the implementation round and fixed with counter-based naming).
- Signature vectors: the published fox vector plus empty-body and unicode vectors minted from openssl; the gate cross-checks the live signature against openssl on every CI run.
- Real-socket pins: closed port, malformed URL, and a redirecting gateway whose decoy target must never see the signed body.
- Twenty-one mutations across the two rounds, each killed by a named test or gate assertion with green controls; one silence pin was itself proven incomplete by its mutation run and completed before landing.
- `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean. Dispatch bats 25/25 both engines; the full gate exits 0.

## Effect of merging

The hermes leg delivers natively wherever the channels directory is not overridden once a producer invokes the binary; nothing does yet, so live behavior is unchanged. The embedded python HMAC remains only in the bash channel R3d retires. CI now proves the signature, the status voice, and async silence on every run.

## Review guide

Read `channels/hermes.rs` in one pass: the module doc states the sync-visibility rationale, the pure functions carry the wire contract, and `UreqSignedPost`'s three-way error classification is the subtle part (status is an answer, never-attempted has its own wording, everything else is no-response). The gate's hermes phases are the independent evidence: openssl agreeing on the signature bytes is the strongest claim in the slice.
