### PR TITLE
feat(pns): the hue pulse goes native

### DIFF
--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -1,0 +1,422 @@
+//! The hue channel, native: pulse the configured rooms green or red for a
+//! long command's exit code, then restore every light exactly.
+//!
+//! Hue is config-SELECTED but not event-dispatched: the pulse fires on an
+//! exit code from the long-command notifier, not on a notification, so this
+//! channel is the binary's `pulse` mode reading the same `[plugins.hue]`
+//! table (bridge, key, rooms) rather than a leg of the event plan.
+//!
+//! The bridge speaks CLIP v2 directly, replacing the openhue CLI: rooms name
+//! their grouped_light service and their member devices, lights name their
+//! owning device, and the snapshot mirrors the bash TSV so the restore logic
+//! stays the decision the R1 pulse module already pinned. Every absence is a
+//! silent no-op, and a failed pulse must never fail the caller.
+
+use std::time::Duration;
+
+/// The rooms the bash pulsed when `HUE_PULSE_ROOMS` said nothing.
+pub const DEFAULT_ROOMS: &[&str] = &["3F - Studio", "2F - Kitchen"];
+
+/// Everything the pulse needs from the config, or None for the not-set-up
+/// silence: a bridge and key are required, rooms come from the environment
+/// override (newline-separated, room names carry spaces), else the settings
+/// array, else the defaults.
+#[derive(Debug, PartialEq)]
+pub struct HueSettings {
+    pub bridge: String,
+    pub key: String,
+    pub rooms: Vec<String>,
+}
+
+pub fn hue_settings(settings: &toml::Table, rooms_env: Option<&str>) -> Option<HueSettings> {
+    let _ = (settings, rooms_env);
+    todo!("R2h: bridge and key required, rooms env over settings over defaults")
+}
+
+/// The grouped_light service ids of the wanted rooms, in wanted order; a
+/// configured room the bridge no longer knows is skipped, never fatal.
+pub fn grouped_light_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
+    let _ = (rooms_json, wanted);
+    todo!("R2h: the grouped_light rid of each wanted room")
+}
+
+/// The device ids belonging to the wanted rooms: what maps a light back to
+/// its room, because lights name their owning device, not their room.
+pub fn room_device_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
+    let _ = (rooms_json, wanted);
+    todo!("R2h: the child device rids of the wanted rooms")
+}
+
+/// One light's snapshot, mirroring the bash TSV: mode is `ct` when the
+/// mirek reading is valid, else `xy`.
+#[derive(Debug, PartialEq)]
+pub struct LightState {
+    pub id: String,
+    pub on: bool,
+    pub brightness: f64,
+    pub mode: String,
+    pub v1: String,
+    pub v2: String,
+}
+
+pub fn light_snapshot(lights_json: &str, device_ids: &[String]) -> Vec<LightState> {
+    let _ = (lights_json, device_ids);
+    todo!("R2h: the lights owned by the wanted devices, as restore tuples")
+}
+
+/// The grouped_light PUT body for one pulse step: on, the color, the
+/// brightness, and the 1200ms ramp.
+pub fn pulse_body(x: &str, y: &str, brightness: &str) -> String {
+    let _ = (x, y, brightness);
+    todo!("R2h: on, color xy, dimming, dynamics duration 1200")
+}
+
+/// The light PUT body that puts one snapshot back: an off light is only
+/// turned off, a ct light restores its mirek, an xy light both coordinates.
+pub fn restore_body(state: &LightState) -> String {
+    let _ = state;
+    todo!("R2h: the CLIP body the R1 restore decisions imply")
+}
+
+/// The bridge seam: authenticated GETs and PUTs against the CLIP paths.
+pub trait Bridge {
+    fn get(&self, path: &str) -> Option<String>;
+    fn put(&self, path: &str, body: &str) -> bool;
+}
+
+/// The clock seam, so tests never sleep.
+pub trait Sleeper {
+    fn sleep(&self, duration: Duration);
+}
+
+/// The pulse: snapshot, four steps ending low, restore.
+pub struct HuePulse<B: Bridge, S: Sleeper> {
+    pub bridge: B,
+    pub sleeper: S,
+    pub rooms: Vec<String>,
+}
+
+impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
+    pub fn run(&self, exit_code: &str) {
+        let _ = exit_code;
+        todo!("R2h: gate on the first put, pulse peak-low-peak-low, restore each light")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Bridge, DEFAULT_ROOMS, HuePulse, HueSettings, LightState, Sleeper, grouped_light_ids,
+        hue_settings, light_snapshot, pulse_body, restore_body, room_device_ids,
+    };
+    use std::cell::RefCell;
+    use std::time::Duration;
+
+    const ROOMS_JSON: &str = r#"{"data":[
+      {"id":"room-1","type":"room","metadata":{"name":"3F - Studio"},
+       "children":[{"rid":"dev-a","rtype":"device"},{"rid":"dev-b","rtype":"device"}],
+       "services":[{"rid":"grp-1","rtype":"grouped_light"}]},
+      {"id":"room-2","type":"room","metadata":{"name":"2F - Kitchen"},
+       "children":[{"rid":"dev-c","rtype":"device"}],
+       "services":[{"rid":"grp-2","rtype":"grouped_light"}]}
+    ]}"#;
+
+    const LIGHTS_JSON: &str = r#"{"data":[
+      {"id":"light-ct","type":"light","owner":{"rid":"dev-a","rtype":"device"},
+       "on":{"on":true},"dimming":{"brightness":73.5},
+       "color_temperature":{"mirek":366,"mirek_valid":true},
+       "color":{"xy":{"x":0.4573,"y":0.41}}},
+      {"id":"light-xy","type":"light","owner":{"rid":"dev-b","rtype":"device"},
+       "on":{"on":true},"dimming":{"brightness":100},
+       "color_temperature":{"mirek":null,"mirek_valid":false},
+       "color":{"xy":{"x":0.2731,"y":0.6549}}},
+      {"id":"light-off","type":"light","owner":{"rid":"dev-c","rtype":"device"},
+       "on":{"on":false},"dimming":{"brightness":50},
+       "color_temperature":{"mirek":300,"mirek_valid":true},
+       "color":{"xy":{"x":0.3,"y":0.3}}},
+      {"id":"light-elsewhere","type":"light","owner":{"rid":"dev-z","rtype":"device"},
+       "on":{"on":true},"dimming":{"brightness":10},
+       "color_temperature":{"mirek":200,"mirek_valid":true},
+       "color":{"xy":{"x":0.1,"y":0.1}}}
+    ]}"#;
+
+    fn wanted(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    // --- settings -----------------------------------------------------------
+
+    fn table(text: &str) -> toml::Table {
+        text.parse().unwrap()
+    }
+
+    #[test]
+    fn a_bridge_and_key_are_required_and_their_absence_is_silence() {
+        assert_eq!(hue_settings(&table(""), None), None);
+        assert_eq!(
+            hue_settings(&table(r#"bridge = "192.168.1.10""#), None),
+            None
+        );
+        assert_eq!(hue_settings(&table(r#"key = "k""#), None), None);
+        assert_eq!(
+            hue_settings(&table("bridge = \"192.168.1.10\"\nkey = \"\""), None),
+            None
+        );
+    }
+
+    #[test]
+    fn rooms_default_to_the_bash_pair_when_nothing_names_them() {
+        let settings = hue_settings(&table("bridge = \"b\"\nkey = \"k\""), None).unwrap();
+        assert_eq!(settings.rooms, DEFAULT_ROOMS.to_vec());
+    }
+
+    #[test]
+    fn the_environment_override_wins_and_splits_on_newlines() {
+        let settings = hue_settings(
+            &table("bridge = \"b\"\nkey = \"k\"\nrooms = [\"Config Room\"]"),
+            Some("Room A\nRoom B\n"),
+        )
+        .unwrap();
+        assert_eq!(settings.rooms, vec!["Room A", "Room B"]);
+    }
+
+    #[test]
+    fn the_settings_rooms_array_beats_the_defaults() {
+        let settings = hue_settings(
+            &table("bridge = \"b\"\nkey = \"k\"\nrooms = [\"Config Room\"]"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(settings.rooms, vec!["Config Room"]);
+    }
+
+    // --- the CLIP parsers ---------------------------------------------------
+
+    #[test]
+    fn each_wanted_room_yields_its_grouped_light_and_a_renamed_room_is_skipped() {
+        assert_eq!(
+            grouped_light_ids(
+                ROOMS_JSON,
+                &wanted(&["3F - Studio", "Gone Room", "2F - Kitchen"])
+            ),
+            vec!["grp-1", "grp-2"]
+        );
+        assert!(grouped_light_ids(ROOMS_JSON, &wanted(&["Gone Room"])).is_empty());
+        assert!(grouped_light_ids("not json", &wanted(&["3F - Studio"])).is_empty());
+    }
+
+    #[test]
+    fn the_wanted_rooms_devices_are_collected_for_the_light_mapping() {
+        assert_eq!(
+            room_device_ids(ROOMS_JSON, &wanted(&["3F - Studio"])),
+            vec!["dev-a", "dev-b"]
+        );
+    }
+
+    #[test]
+    fn the_snapshot_keeps_exactly_the_wanted_rooms_lights_with_their_modes() {
+        let snapshot = light_snapshot(LIGHTS_JSON, &wanted(&["dev-a", "dev-b", "dev-c"]));
+        assert_eq!(snapshot.len(), 3, "the elsewhere light is not ours");
+        assert_eq!(
+            snapshot[0],
+            LightState {
+                id: "light-ct".to_string(),
+                on: true,
+                brightness: 73.5,
+                mode: "ct".to_string(),
+                v1: "366".to_string(),
+                v2: String::new(),
+            }
+        );
+        assert_eq!(snapshot[1].mode, "xy");
+        assert_eq!(snapshot[1].v1, "0.2731");
+        assert_eq!(snapshot[1].v2, "0.6549");
+        assert!(!snapshot[2].on);
+    }
+
+    // --- the bodies ---------------------------------------------------------
+
+    #[test]
+    fn a_pulse_step_turns_on_colors_dims_and_ramps_over_1200ms() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&pulse_body("0.2731", "0.6549", "70")).unwrap();
+        assert_eq!(parsed["on"]["on"], true);
+        assert_eq!(parsed["color"]["xy"]["x"], 0.2731);
+        assert_eq!(parsed["color"]["xy"]["y"], 0.6549);
+        assert_eq!(parsed["dimming"]["brightness"], 70.0);
+        assert_eq!(parsed["dynamics"]["duration"], 1200);
+    }
+
+    #[test]
+    fn an_off_light_is_restored_off_and_nothing_else() {
+        let body = restore_body(&LightState {
+            id: "light-off".to_string(),
+            on: false,
+            brightness: 50.0,
+            mode: "ct".to_string(),
+            v1: "300".to_string(),
+            v2: String::new(),
+        });
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["on"]["on"], false);
+        assert_eq!(
+            parsed.as_object().unwrap().len(),
+            1,
+            "off is the whole restore"
+        );
+    }
+
+    #[test]
+    fn a_ct_light_restores_its_mirek_and_an_xy_light_both_coordinates() {
+        let ct: serde_json::Value = serde_json::from_str(&restore_body(&LightState {
+            id: "l".to_string(),
+            on: true,
+            brightness: 73.5,
+            mode: "ct".to_string(),
+            v1: "366".to_string(),
+            v2: String::new(),
+        }))
+        .unwrap();
+        assert_eq!(ct["on"]["on"], true);
+        assert_eq!(ct["dimming"]["brightness"], 73.5);
+        assert_eq!(ct["color_temperature"]["mirek"], 366);
+        let xy: serde_json::Value = serde_json::from_str(&restore_body(&LightState {
+            id: "l".to_string(),
+            on: true,
+            brightness: 100.0,
+            mode: "xy".to_string(),
+            v1: "0.2731".to_string(),
+            v2: "0.6549".to_string(),
+        }))
+        .unwrap();
+        assert_eq!(xy["color"]["xy"]["x"], 0.2731);
+        assert_eq!(xy["color"]["xy"]["y"], 0.6549);
+    }
+
+    // --- the sequence -------------------------------------------------------
+
+    struct ScriptedBridge {
+        rooms: &'static str,
+        lights: &'static str,
+        first_put_fails: bool,
+        gets: RefCell<Vec<String>>,
+        puts: RefCell<Vec<(String, String)>>,
+    }
+
+    impl Bridge for ScriptedBridge {
+        fn get(&self, path: &str) -> Option<String> {
+            self.gets.borrow_mut().push(path.to_string());
+            if path.contains("room") {
+                Some(self.rooms.to_string())
+            } else {
+                Some(self.lights.to_string())
+            }
+        }
+        fn put(&self, path: &str, body: &str) -> bool {
+            let first = self.puts.borrow().is_empty();
+            self.puts
+                .borrow_mut()
+                .push((path.to_string(), body.to_string()));
+            !(first && self.first_put_fails)
+        }
+    }
+
+    struct CountingSleeper {
+        naps: RefCell<Vec<Duration>>,
+    }
+    impl Sleeper for CountingSleeper {
+        fn sleep(&self, duration: Duration) {
+            self.naps.borrow_mut().push(duration);
+        }
+    }
+
+    fn pulse(first_put_fails: bool) -> HuePulse<ScriptedBridge, CountingSleeper> {
+        HuePulse {
+            bridge: ScriptedBridge {
+                rooms: ROOMS_JSON,
+                lights: LIGHTS_JSON,
+                first_put_fails,
+                gets: RefCell::new(Vec::new()),
+                puts: RefCell::new(Vec::new()),
+            },
+            sleeper: CountingSleeper {
+                naps: RefCell::new(Vec::new()),
+            },
+            rooms: wanted(&["3F - Studio", "2F - Kitchen"]),
+        }
+    }
+
+    #[test]
+    fn a_green_pulse_hits_both_grouped_lights_four_times_then_restores_each_light() {
+        let hue = pulse(false);
+        hue.run("0");
+        let puts = hue.bridge.puts.borrow();
+        // 4 steps x 2 grouped lights, then 3 light restores.
+        assert_eq!(puts.len(), 11);
+        assert!(puts[0].0.contains("grouped_light/grp-1"));
+        assert!(puts[1].0.contains("grouped_light/grp-2"));
+        assert!(puts[8].0.contains("light/light-ct"));
+        let naps = hue.sleeper.naps.borrow();
+        assert_eq!(naps.as_slice(), &[Duration::from_millis(1200); 4]);
+    }
+
+    #[test]
+    fn the_pulse_ends_low_so_the_restore_steps_up_gently() {
+        let hue = pulse(false);
+        hue.run("0");
+        let puts = hue.bridge.puts.borrow();
+        let step = |index: usize| -> f64 {
+            let parsed: serde_json::Value = serde_json::from_str(&puts[index].1).unwrap();
+            parsed["dimming"]["brightness"].as_f64().unwrap()
+        };
+        let peak = step(0);
+        assert!(peak > 20.0);
+        assert_eq!(step(2), 20.0);
+        assert_eq!(step(4), peak);
+        assert_eq!(step(6), 20.0);
+    }
+
+    #[test]
+    fn a_failing_exit_code_pulses_the_red_corner_and_success_the_green() {
+        let green = pulse(false);
+        green.run("0");
+        let red = pulse(false);
+        red.run("9");
+        let body = |hue: &HuePulse<ScriptedBridge, CountingSleeper>| -> serde_json::Value {
+            serde_json::from_str(&hue.bridge.puts.borrow()[0].1).unwrap()
+        };
+        let green_x = body(&green)["color"]["xy"]["x"].as_f64().unwrap();
+        let red_x = body(&red)["color"]["xy"]["x"].as_f64().unwrap();
+        assert!(red_x > green_x, "red sits at the warm corner of the gamut");
+    }
+
+    #[test]
+    fn an_unreachable_bridge_on_the_first_step_bails_without_touching_more() {
+        let hue = pulse(true);
+        hue.run("0");
+        let puts = hue.bridge.puts.borrow();
+        // The failed first grouped PUT is the last call: no second room, no
+        // second step, and above all no restore writes over unknown state.
+        assert_eq!(puts.len(), 1);
+        assert!(hue.sleeper.naps.borrow().is_empty());
+    }
+
+    #[test]
+    fn no_matching_rooms_or_no_lights_is_a_silent_no_op() {
+        let hue = HuePulse {
+            bridge: ScriptedBridge {
+                rooms: r#"{"data":[]}"#,
+                lights: r#"{"data":[]}"#,
+                first_put_fails: false,
+                gets: RefCell::new(Vec::new()),
+                puts: RefCell::new(Vec::new()),
+            },
+            sleeper: CountingSleeper {
+                naps: RefCell::new(Vec::new()),
+            },
+            rooms: wanted(&["3F - Studio"]),
+        };
+        hue.run("0");
+        assert!(hue.bridge.puts.borrow().is_empty());
+    }
+}

--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -29,22 +29,85 @@ pub struct HueSettings {
 }
 
 pub fn hue_settings(settings: &toml::Table, rooms_env: Option<&str>) -> Option<HueSettings> {
-    let _ = (settings, rooms_env);
-    todo!("R2h: bridge and key required, rooms env over settings over defaults")
+    let text = |key: &str| -> Option<String> {
+        settings
+            .get(key)?
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .map(String::from)
+    };
+    let from_env: Vec<String> = rooms_env
+        .unwrap_or_default()
+        .lines()
+        .filter(|room| !room.is_empty())
+        .map(String::from)
+        .collect();
+    Some(HueSettings {
+        bridge: text("bridge")?,
+        key: text("key")?,
+        rooms: if from_env.is_empty() {
+            settings
+                .get("rooms")
+                .and_then(|rooms| rooms.as_array())
+                .map(|rooms| {
+                    rooms
+                        .iter()
+                        .filter_map(|room| room.as_str())
+                        .map(String::from)
+                        .collect::<Vec<_>>()
+                })
+                .filter(|rooms| !rooms.is_empty())
+                .unwrap_or_else(|| DEFAULT_ROOMS.iter().map(|room| room.to_string()).collect())
+        } else {
+            from_env
+        },
+    })
+}
+
+/// The `.data[]` array of a CLIP response, empty for anything unrecognized:
+/// a bridge that answers with something this does not know is a no-op, never
+/// a panic on a notification path.
+fn data_entries(clip_json: &str) -> Vec<serde_json::Value> {
+    serde_json::from_str::<serde_json::Value>(clip_json)
+        .ok()
+        .and_then(|body| Some(body.get("data")?.as_array()?.clone()))
+        .unwrap_or_default()
+}
+
+/// The `rid`s of one rtype, out of one array key, for each wanted room in
+/// WANTED order. Shared by the two room walks, which differ only in which
+/// key and rtype they are after.
+fn room_rids(rooms_json: &str, wanted: &[String], array_key: &str, rtype: &str) -> Vec<String> {
+    let rooms = data_entries(rooms_json);
+    wanted
+        .iter()
+        .flat_map(|name| {
+            rooms
+                .iter()
+                .filter(|room| {
+                    room.pointer("/metadata/name")
+                        .and_then(|found| found.as_str())
+                        == Some(name.as_str())
+                })
+                .filter_map(|room| room.get(array_key)?.as_array())
+                .flatten()
+                .filter(|entry| entry.get("rtype").and_then(|kind| kind.as_str()) == Some(rtype))
+                .filter_map(|entry| entry.get("rid")?.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 /// The grouped_light service ids of the wanted rooms, in wanted order; a
 /// configured room the bridge no longer knows is skipped, never fatal.
 pub fn grouped_light_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
-    let _ = (rooms_json, wanted);
-    todo!("R2h: the grouped_light rid of each wanted room")
+    room_rids(rooms_json, wanted, "services", "grouped_light")
 }
 
 /// The device ids belonging to the wanted rooms: what maps a light back to
 /// its room, because lights name their owning device, not their room.
 pub fn room_device_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
-    let _ = (rooms_json, wanted);
-    todo!("R2h: the child device rids of the wanted rooms")
+    room_rids(rooms_json, wanted, "children", "device")
 }
 
 /// One light's snapshot, mirroring the bash TSV: mode is `ct` when the
@@ -60,22 +123,89 @@ pub struct LightState {
 }
 
 pub fn light_snapshot(lights_json: &str, device_ids: &[String]) -> Vec<LightState> {
-    let _ = (lights_json, device_ids);
-    todo!("R2h: the lights owned by the wanted devices, as restore tuples")
+    data_entries(lights_json)
+        .iter()
+        .filter(|light| {
+            light
+                .pointer("/owner/rid")
+                .and_then(|owner| owner.as_str())
+                .is_some_and(|owner| device_ids.iter().any(|device| device == owner))
+        })
+        .filter_map(|light| {
+            let rendered = |path: &str| {
+                light
+                    .pointer(path)
+                    .map(|value| value.to_string())
+                    .unwrap_or_default()
+            };
+            let ct = light.pointer("/color_temperature/mirek_valid")
+                == Some(&serde_json::Value::Bool(true));
+            Some(LightState {
+                id: light.get("id")?.as_str()?.to_string(),
+                on: light
+                    .pointer("/on/on")
+                    .and_then(|on| on.as_bool())
+                    .unwrap_or(false),
+                // The bash jq defaulted an absent dimming to 100 rather than
+                // restoring a light to darkness.
+                brightness: light
+                    .pointer("/dimming/brightness")
+                    .and_then(|brightness| brightness.as_f64())
+                    .unwrap_or(100.0),
+                mode: if ct { "ct" } else { "xy" }.to_string(),
+                v1: if ct {
+                    rendered("/color_temperature/mirek")
+                } else {
+                    rendered("/color/xy/x")
+                },
+                v2: if ct {
+                    String::new()
+                } else {
+                    rendered("/color/xy/y")
+                },
+            })
+        })
+        .collect()
+}
+
+/// A CLIP numeric field out of one of our own rendered strings.
+fn number(raw: &str) -> f64 {
+    raw.parse().unwrap_or_default()
 }
 
 /// The grouped_light PUT body for one pulse step: on, the color, the
 /// brightness, and the 1200ms ramp.
 pub fn pulse_body(x: &str, y: &str, brightness: &str) -> String {
-    let _ = (x, y, brightness);
-    todo!("R2h: on, color xy, dimming, dynamics duration 1200")
+    serde_json::json!({
+        "on": {"on": true},
+        "color": {"xy": {"x": number(x), "y": number(y)}},
+        "dimming": {"brightness": number(brightness)},
+        "dynamics": {"duration": PULSE_TRANSITION.as_millis() as u64},
+    })
+    .to_string()
 }
+
+/// Each ramp finishes before the next step starts, so the sleep and the
+/// transition are the same number by construction.
+const PULSE_TRANSITION: Duration = Duration::from_millis(1200);
 
 /// The light PUT body that puts one snapshot back: an off light is only
 /// turned off, a ct light restores its mirek, an xy light both coordinates.
 pub fn restore_body(state: &LightState) -> String {
-    let _ = state;
-    todo!("R2h: the CLIP body the R1 restore decisions imply")
+    if !state.on {
+        return serde_json::json!({"on": {"on": false}}).to_string();
+    }
+    let mut body = serde_json::json!({
+        "on": {"on": true},
+        "dimming": {"brightness": state.brightness},
+    });
+    if state.mode == "ct" {
+        body["color_temperature"] =
+            serde_json::json!({"mirek": state.v1.parse::<u64>().unwrap_or_default()});
+    } else {
+        body["color"] = serde_json::json!({"xy": {"x": number(&state.v1), "y": number(&state.v2)}});
+    }
+    body.to_string()
 }
 
 /// The bridge seam: authenticated GETs and PUTs against the CLIP paths.
@@ -98,16 +228,54 @@ pub struct HuePulse<B: Bridge, S: Sleeper> {
 
 impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
     pub fn run(&self, exit_code: &str) {
-        let _ = exit_code;
-        todo!("R2h: gate on the first put, pulse peak-low-peak-low, restore each light")
+        let Some(rooms_json) = self.bridge.get("room") else {
+            return;
+        };
+        let grouped = grouped_light_ids(&rooms_json, &self.rooms);
+        if grouped.is_empty() {
+            return;
+        }
+        let Some(lights_json) = self.bridge.get("light") else {
+            return;
+        };
+        let snapshot = light_snapshot(&lights_json, &room_device_ids(&rooms_json, &self.rooms));
+        if snapshot.is_empty() {
+            return;
+        }
+
+        // Two heartbeat cycles ENDING LOW, so the restore is a gentle step up
+        // rather than a drop from peak.
+        let color = crate::pulse::pulse_color(exit_code);
+        let peak = color.peak_brightness.to_string();
+        for (step, brightness) in [peak.as_str(), "20", peak.as_str(), "20"]
+            .into_iter()
+            .enumerate()
+        {
+            let body = pulse_body(color.x, color.y, brightness);
+            for (room, id) in grouped.iter().enumerate() {
+                let reached = self.bridge.put(&format!("grouped_light/{id}"), &body);
+                // The very first PUT gates everything: a bridge unreachable
+                // here leaves the lights untouched, so writing a restore over
+                // state we never actually changed would be the real damage.
+                if !reached && step == 0 && room == 0 {
+                    return;
+                }
+            }
+            self.sleeper.sleep(PULSE_TRANSITION);
+        }
+
+        for state in &snapshot {
+            self.bridge
+                .put(&format!("light/{}", state.id), &restore_body(state));
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        Bridge, DEFAULT_ROOMS, HuePulse, HueSettings, LightState, Sleeper, grouped_light_ids,
-        hue_settings, light_snapshot, pulse_body, restore_body, room_device_ids,
+        Bridge, DEFAULT_ROOMS, HuePulse, LightState, Sleeper, grouped_light_ids, hue_settings,
+        light_snapshot, pulse_body, restore_body, room_device_ids,
     };
     use std::cell::RefCell;
     use std::time::Duration;

--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -112,8 +112,22 @@ pub struct PulseRoom {
 /// without a grouped_light, and a room contributing no restorable light are
 /// each skipped, never fatal and never pulsed.
 pub fn pulse_rooms(rooms_json: &str, lights_json: &str, wanted: &[String]) -> Vec<PulseRoom> {
-    let _ = (rooms_json, lights_json, wanted);
-    todo!("R2h fix round: pair each room's group with its own lights")
+    wanted
+        .iter()
+        .filter_map(|name| {
+            let one = std::slice::from_ref(name);
+            Some(PulseRoom {
+                grouped_id: room_rids(rooms_json, one, "services", "grouped_light")
+                    .into_iter()
+                    .next()?,
+                lights: light_snapshot(
+                    lights_json,
+                    &room_rids(rooms_json, one, "children", "device"),
+                ),
+            })
+            .filter(|room| !room.lights.is_empty())
+        })
+        .collect()
 }
 
 /// One light's snapshot, mirroring the bash TSV: mode is `ct` when the
@@ -138,37 +152,34 @@ pub fn light_snapshot(lights_json: &str, device_ids: &[String]) -> Vec<LightStat
                 .is_some_and(|owner| device_ids.iter().any(|device| device == owner))
         })
         .filter_map(|light| {
+            // A reading the restore needs is REQUIRED, never defaulted:
+            // inventing off for a missing on, or zero for a missing
+            // coordinate, corrupts a light this pulse never read correctly.
             let rendered = |path: &str| {
                 light
                     .pointer(path)
+                    .filter(|value| !value.is_null())
                     .map(|value| value.to_string())
-                    .unwrap_or_default()
             };
             let ct = light.pointer("/color_temperature/mirek_valid")
                 == Some(&serde_json::Value::Bool(true));
+            let (v1, v2) = if ct {
+                (rendered("/color_temperature/mirek")?, String::new())
+            } else {
+                (rendered("/color/xy/x")?, rendered("/color/xy/y")?)
+            };
             Some(LightState {
                 id: light.get("id")?.as_str()?.to_string(),
-                on: light
-                    .pointer("/on/on")
-                    .and_then(|on| on.as_bool())
-                    .unwrap_or(false),
-                // The bash jq defaulted an absent dimming to 100 rather than
-                // restoring a light to darkness.
+                on: light.pointer("/on/on")?.as_bool()?,
+                // Brightness alone keeps the bash jq default: an absent
+                // dimming meant 100, not a light restored to darkness.
                 brightness: light
                     .pointer("/dimming/brightness")
                     .and_then(|brightness| brightness.as_f64())
                     .unwrap_or(100.0),
                 mode: if ct { "ct" } else { "xy" }.to_string(),
-                v1: if ct {
-                    rendered("/color_temperature/mirek")
-                } else {
-                    rendered("/color/xy/x")
-                },
-                v2: if ct {
-                    String::new()
-                } else {
-                    rendered("/color/xy/y")
-                },
+                v1,
+                v2,
             })
         })
         .collect()
@@ -199,11 +210,16 @@ const PULSE_TRANSITION: Duration = Duration::from_millis(1200);
 /// turned off, a ct light restores its mirek, an xy light both coordinates.
 pub fn restore_body(state: &LightState) -> String {
     if !state.on {
-        return serde_json::json!({"on": {"on": false}}).to_string();
+        return serde_json::json!({
+            "on": {"on": false},
+            "dynamics": {"duration": RESTORE_TRANSITION_MS},
+        })
+        .to_string();
     }
     let mut body = serde_json::json!({
         "on": {"on": true},
         "dimming": {"brightness": state.brightness},
+        "dynamics": {"duration": RESTORE_TRANSITION_MS},
     });
     if state.mode == "ct" {
         body["color_temperature"] =
@@ -222,23 +238,35 @@ pub const RESTORE_TRANSITION_MS: u64 = 500;
 /// because the bridge answers 200 with a NONEMPTY errors array for
 /// application failures, and the first-PUT bail must see those too.
 pub fn put_succeeded(status_ok: bool, body: &str) -> bool {
-    let _ = (status_ok, body);
-    todo!("R2h fix round: 2xx and an empty or absent errors array")
+    status_ok
+        && !serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|body| Some(!body.get("errors")?.as_array()?.is_empty()))
+            .unwrap_or(false)
 }
 
 /// The hue settings table, only when the plugin is ENABLED: the file
 /// selects, and a disabled table must silence the pulse mode.
 pub fn hue_enabled(config: &crate::config::Config) -> Option<&toml::Table> {
-    let _ = config;
-    todo!("R2h fix round: the settings of an enabled hue table, else None")
+    config
+        .plugins
+        .get("hue")
+        .filter(|hue| hue.enabled)
+        .map(|hue| &hue.settings)
 }
 
 /// The single-pulse lock, on the SAME path the bash channel locks so the
 /// two cannot interleave during the repoint window. None while another
 /// pulse holds it; the kernel releases it on any exit.
 pub fn acquire_pulse_lock(state_dir: &std::path::Path) -> Option<std::fs::File> {
-    let _ = state_dir;
-    todo!("R2h fix round: hue-pulse.lockf under the state dir, try_lock")
+    std::fs::create_dir_all(state_dir).ok()?;
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(state_dir.join("hue-pulse.lockf"))
+        .ok()?;
+    lock.try_lock().ok()?;
+    Some(lock)
 }
 
 /// The bridge seam: authenticated GETs and PUTs against the CLIP paths.
@@ -571,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn an_off_light_is_restored_off_and_nothing_else() {
+    fn an_off_light_is_restored_off_and_carries_no_brightness_or_color() {
         let body = restore_body(&LightState {
             id: "light-off".to_string(),
             on: false,
@@ -582,10 +610,13 @@ mod tests {
         });
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(parsed["on"]["on"], false);
-        assert_eq!(
-            parsed.as_object().unwrap().len(),
-            1,
-            "off is the whole restore"
+        assert!(
+            parsed.get("dimming").is_none(),
+            "an off light restores no brightness"
+        );
+        assert!(
+            parsed.get("color").is_none() && parsed.get("color_temperature").is_none(),
+            "an off light restores no color"
         );
     }
 
@@ -670,6 +701,12 @@ mod tests {
             self.puts
                 .borrow_mut()
                 .push((path.to_string(), body.to_string()));
+            if self
+                .fail_put_containing
+                .is_some_and(|needle| path.contains(needle))
+            {
+                return false;
+            }
             !(first && self.first_put_fails)
         }
     }

--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -98,16 +98,22 @@ fn room_rids(rooms_json: &str, wanted: &[String], array_key: &str, rtype: &str) 
         .collect()
 }
 
-/// The grouped_light service ids of the wanted rooms, in wanted order; a
-/// configured room the bridge no longer knows is skipped, never fatal.
-pub fn grouped_light_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
-    room_rids(rooms_json, wanted, "services", "grouped_light")
+/// One pulse-able room: its grouped_light and the snapshots of ITS lights,
+/// paired, because pulsing a room whose lights cannot be restored leaves
+/// them stuck in the transient color. A room missing either half is
+/// excluded whole.
+#[derive(Debug, PartialEq)]
+pub struct PulseRoom {
+    pub grouped_id: String,
+    pub lights: Vec<LightState>,
 }
 
-/// The device ids belonging to the wanted rooms: what maps a light back to
-/// its room, because lights name their owning device, not their room.
-pub fn room_device_ids(rooms_json: &str, wanted: &[String]) -> Vec<String> {
-    room_rids(rooms_json, wanted, "children", "device")
+/// The wanted rooms as pulse units, in wanted order: a renamed room, a room
+/// without a grouped_light, and a room contributing no restorable light are
+/// each skipped, never fatal and never pulsed.
+pub fn pulse_rooms(rooms_json: &str, lights_json: &str, wanted: &[String]) -> Vec<PulseRoom> {
+    let _ = (rooms_json, lights_json, wanted);
+    todo!("R2h fix round: pair each room's group with its own lights")
 }
 
 /// One light's snapshot, mirroring the bash TSV: mode is `ct` when the
@@ -208,6 +214,33 @@ pub fn restore_body(state: &LightState) -> String {
     body.to_string()
 }
 
+/// The restore ramp the R1 pulse module pinned for both restore arms, in
+/// milliseconds for the CLIP body.
+pub const RESTORE_TRANSITION_MS: u64 = 500;
+
+/// Whether one CLIP write actually applied: status success is not enough,
+/// because the bridge answers 200 with a NONEMPTY errors array for
+/// application failures, and the first-PUT bail must see those too.
+pub fn put_succeeded(status_ok: bool, body: &str) -> bool {
+    let _ = (status_ok, body);
+    todo!("R2h fix round: 2xx and an empty or absent errors array")
+}
+
+/// The hue settings table, only when the plugin is ENABLED: the file
+/// selects, and a disabled table must silence the pulse mode.
+pub fn hue_enabled(config: &crate::config::Config) -> Option<&toml::Table> {
+    let _ = config;
+    todo!("R2h fix round: the settings of an enabled hue table, else None")
+}
+
+/// The single-pulse lock, on the SAME path the bash channel locks so the
+/// two cannot interleave during the repoint window. None while another
+/// pulse holds it; the kernel releases it on any exit.
+pub fn acquire_pulse_lock(state_dir: &std::path::Path) -> Option<std::fs::File> {
+    let _ = state_dir;
+    todo!("R2h fix round: hue-pulse.lockf under the state dir, try_lock")
+}
+
 /// The bridge seam: authenticated GETs and PUTs against the CLIP paths.
 pub trait Bridge {
     fn get(&self, path: &str) -> Option<String>;
@@ -231,42 +264,47 @@ impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
         let Some(rooms_json) = self.bridge.get("room") else {
             return;
         };
-        let grouped = grouped_light_ids(&rooms_json, &self.rooms);
-        if grouped.is_empty() {
-            return;
-        }
         let Some(lights_json) = self.bridge.get("light") else {
             return;
         };
-        let snapshot = light_snapshot(&lights_json, &room_device_ids(&rooms_json, &self.rooms));
-        if snapshot.is_empty() {
+        let rooms = pulse_rooms(&rooms_json, &lights_json, &self.rooms);
+        if rooms.is_empty() {
             return;
         }
 
-        // Two heartbeat cycles ENDING LOW, so the restore is a gentle step up
-        // rather than a drop from peak.
         let color = crate::pulse::pulse_color(exit_code);
-        let peak = color.peak_brightness.to_string();
-        for (step, brightness) in [peak.as_str(), "20", peak.as_str(), "20"]
-            .into_iter()
-            .enumerate()
-        {
-            let body = pulse_body(color.x, color.y, brightness);
-            for (room, id) in grouped.iter().enumerate() {
-                let reached = self.bridge.put(&format!("grouped_light/{id}"), &body);
-                // The very first PUT gates everything: a bridge unreachable
-                // here leaves the lights untouched, so writing a restore over
-                // state we never actually changed would be the real damage.
-                if !reached && step == 0 && room == 0 {
+        let (x, y, peak) = (color.x, color.y, color.peak_brightness);
+        let steps = [
+            peak.to_string(),
+            "20".to_string(),
+            peak.to_string(),
+            "20".to_string(),
+        ];
+        let mut first = true;
+        for brightness in steps {
+            for room in &rooms {
+                let applied = self.bridge.put(
+                    &format!("grouped_light/{}", room.grouped_id),
+                    &pulse_body(x, y, &brightness),
+                );
+                // The FIRST write gates the whole pulse: an unreachable or
+                // refusing bridge must not leave restores written over state
+                // this run never successfully changed.
+                if first && !applied {
                     return;
                 }
+                first = false;
             }
             self.sleeper.sleep(PULSE_TRANSITION);
         }
 
-        for state in &snapshot {
-            self.bridge
-                .put(&format!("light/{}", state.id), &restore_body(state));
+        // Every light is restored independently: one failing write must not
+        // starve the lights behind it in the transient color.
+        for room in &rooms {
+            for light in &room.lights {
+                self.bridge
+                    .put(&format!("light/{}", light.id), &restore_body(light));
+            }
         }
     }
 }
@@ -274,8 +312,9 @@ impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Bridge, DEFAULT_ROOMS, HuePulse, LightState, Sleeper, grouped_light_ids, hue_settings,
-        light_snapshot, pulse_body, restore_body, room_device_ids,
+        Bridge, DEFAULT_ROOMS, HuePulse, LightState, RESTORE_TRANSITION_MS, Sleeper,
+        acquire_pulse_lock, hue_enabled, hue_settings, light_snapshot, pulse_body, pulse_rooms,
+        put_succeeded, restore_body,
     };
     use std::cell::RefCell;
     use std::time::Duration;
@@ -361,24 +400,140 @@ mod tests {
     // --- the CLIP parsers ---------------------------------------------------
 
     #[test]
-    fn each_wanted_room_yields_its_grouped_light_and_a_renamed_room_is_skipped() {
-        assert_eq!(
-            grouped_light_ids(
-                ROOMS_JSON,
-                &wanted(&["3F - Studio", "Gone Room", "2F - Kitchen"])
-            ),
-            vec!["grp-1", "grp-2"]
+    fn each_wanted_room_pairs_its_group_with_its_own_lights_in_wanted_order() {
+        let rooms = pulse_rooms(
+            ROOMS_JSON,
+            LIGHTS_JSON,
+            &wanted(&["2F - Kitchen", "3F - Studio"]),
         );
-        assert!(grouped_light_ids(ROOMS_JSON, &wanted(&["Gone Room"])).is_empty());
-        assert!(grouped_light_ids("not json", &wanted(&["3F - Studio"])).is_empty());
+        assert_eq!(rooms.len(), 2);
+        assert_eq!(rooms[0].grouped_id, "grp-2");
+        assert_eq!(
+            rooms[0]
+                .lights
+                .iter()
+                .map(|l| l.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["light-off"]
+        );
+        assert_eq!(rooms[1].grouped_id, "grp-1");
+        assert_eq!(
+            rooms[1]
+                .lights
+                .iter()
+                .map(|l| l.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["light-ct", "light-xy"]
+        );
     }
 
     #[test]
-    fn the_wanted_rooms_devices_are_collected_for_the_light_mapping() {
+    fn a_room_whose_lights_cannot_be_restored_is_never_pulsed() {
+        // Pulsing a room whose lights are not in the snapshot would leave
+        // them stuck in the transient color forever.
+        const NO_LIGHTS: &str = r#"{"data":[
+          {"id":"room-1","type":"room","metadata":{"name":"Empty Room"},
+           "children":[],"services":[{"rid":"grp-1","rtype":"grouped_light"}]}
+        ]}"#;
+        assert!(pulse_rooms(NO_LIGHTS, LIGHTS_JSON, &wanted(&["Empty Room"])).is_empty());
+    }
+
+    #[test]
+    fn a_room_without_a_grouped_light_is_skipped_whole() {
+        const NO_GROUP: &str = r#"{"data":[
+          {"id":"room-1","type":"room","metadata":{"name":"Groupless"},
+           "children":[{"rid":"dev-a","rtype":"device"}],"services":[]}
+        ]}"#;
+        assert!(pulse_rooms(NO_GROUP, LIGHTS_JSON, &wanted(&["Groupless"])).is_empty());
+    }
+
+    #[test]
+    fn a_renamed_room_is_skipped_and_unparseable_json_is_empty() {
+        assert!(pulse_rooms(ROOMS_JSON, LIGHTS_JSON, &wanted(&["Gone Room"])).is_empty());
+        assert!(pulse_rooms("not json", LIGHTS_JSON, &wanted(&["3F - Studio"])).is_empty());
+    }
+
+    #[test]
+    fn a_light_missing_a_reading_the_restore_needs_is_skipped_never_invented() {
+        // Inventing off for a missing on, or zero for a missing coordinate,
+        // would corrupt a light this pulse never correctly touched.
+        const PARTIAL: &str = r#"{"data":[
+          {"id":"no-on","type":"light","owner":{"rid":"dev-a","rtype":"device"},
+           "dimming":{"brightness":50},"color_temperature":{"mirek":300,"mirek_valid":true}},
+          {"id":"no-xy","type":"light","owner":{"rid":"dev-a","rtype":"device"},
+           "on":{"on":true},"dimming":{"brightness":50},
+           "color_temperature":{"mirek_valid":false},"color":{}},
+          {"id":"no-mirek","type":"light","owner":{"rid":"dev-a","rtype":"device"},
+           "on":{"on":true},"dimming":{"brightness":50},
+           "color_temperature":{"mirek_valid":true}},
+          {"id":"whole","type":"light","owner":{"rid":"dev-a","rtype":"device"},
+           "on":{"on":true},"color_temperature":{"mirek":300,"mirek_valid":true},
+           "color":{"xy":{"x":0.3,"y":0.3}}}
+        ]}"#;
+        let snapshot = light_snapshot(PARTIAL, &wanted(&["dev-a"]));
         assert_eq!(
-            room_device_ids(ROOMS_JSON, &wanted(&["3F - Studio"])),
-            vec!["dev-a", "dev-b"]
+            snapshot.iter().map(|l| l.id.as_str()).collect::<Vec<_>>(),
+            vec!["whole"],
+            "only the light with every reading the restore needs"
         );
+        assert_eq!(
+            snapshot[0].brightness, 100.0,
+            "absent dimming keeps the bash default"
+        );
+    }
+
+    #[test]
+    fn a_two_hundred_carrying_errors_is_not_an_applied_write() {
+        // The bridge answers 200 with a nonempty errors array for
+        // application failures; the first-PUT bail must see those.
+        assert!(put_succeeded(true, r#"{"errors":[],"data":[{"rid":"x"}]}"#));
+        assert!(put_succeeded(true, r#"{"data":[]}"#));
+        assert!(!put_succeeded(
+            true,
+            r#"{"errors":[{"description":"device is not responding"}],"data":[]}"#
+        ));
+        assert!(!put_succeeded(false, r#"{"errors":[]}"#));
+    }
+
+    #[test]
+    fn a_disabled_hue_table_silences_the_pulse_and_an_enabled_one_yields_its_settings() {
+        use crate::config::parse_config;
+        let disabled = parse_config("[plugins.hue]\nenabled = false\nbridge = \"b\"\n").unwrap();
+        assert!(hue_enabled(&disabled).is_none());
+        assert!(hue_enabled(&parse_config("").unwrap()).is_none());
+        let enabled = parse_config("[plugins.hue]\nenabled = true\nbridge = \"b\"\n").unwrap();
+        assert_eq!(
+            hue_enabled(&enabled).and_then(|table| table.get("bridge")),
+            Some(&toml::Value::String("b".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_second_pulse_is_skipped_while_the_first_holds_the_lock() {
+        let dir = std::env::temp_dir().join(format!("pns-hue-lock-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let held = acquire_pulse_lock(&dir).expect("the first pulse takes the lock");
+        assert!(
+            acquire_pulse_lock(&dir).is_none(),
+            "a concurrent pulse is skipped, never interleaved"
+        );
+        drop(held);
+        assert!(
+            acquire_pulse_lock(&dir).is_some(),
+            "the lock is released with the holder"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_lock_path_is_the_one_the_bash_channel_takes() {
+        // Different paths would let the native and bash pulses interleave
+        // during the repoint window.
+        let dir = std::env::temp_dir().join(format!("pns-hue-lockpath-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _held = acquire_pulse_lock(&dir);
+        assert!(dir.join("hue-pulse.lockf").exists());
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -435,6 +590,34 @@ mod tests {
     }
 
     #[test]
+    fn every_restore_carries_the_ramp_the_pulse_module_pinned() {
+        for state in [
+            LightState {
+                id: "l".to_string(),
+                on: false,
+                brightness: 50.0,
+                mode: "ct".to_string(),
+                v1: "300".to_string(),
+                v2: String::new(),
+            },
+            LightState {
+                id: "l".to_string(),
+                on: true,
+                brightness: 50.0,
+                mode: "ct".to_string(),
+                v1: "300".to_string(),
+                v2: String::new(),
+            },
+        ] {
+            let parsed: serde_json::Value = serde_json::from_str(&restore_body(&state)).unwrap();
+            assert_eq!(
+                parsed["dynamics"]["duration"], RESTORE_TRANSITION_MS,
+                "both restore arms ramp, as the R1 decision spells"
+            );
+        }
+    }
+
+    #[test]
     fn a_ct_light_restores_its_mirek_and_an_xy_light_both_coordinates() {
         let ct: serde_json::Value = serde_json::from_str(&restore_body(&LightState {
             id: "l".to_string(),
@@ -467,6 +650,8 @@ mod tests {
         rooms: &'static str,
         lights: &'static str,
         first_put_fails: bool,
+        /// A path substring whose PUT fails, for the restore-independence pin.
+        fail_put_containing: Option<&'static str>,
         gets: RefCell<Vec<String>>,
         puts: RefCell<Vec<(String, String)>>,
     }
@@ -504,6 +689,7 @@ mod tests {
                 rooms: ROOMS_JSON,
                 lights: LIGHTS_JSON,
                 first_put_fails,
+                fail_put_containing: None,
                 gets: RefCell::new(Vec::new()),
                 puts: RefCell::new(Vec::new()),
             },
@@ -570,12 +756,45 @@ mod tests {
     }
 
     #[test]
+    fn one_failing_restore_never_starves_the_lights_behind_it() {
+        // A flaky write would otherwise leave every later light stuck in the
+        // transient pulse color at 20 percent.
+        let hue = HuePulse {
+            bridge: ScriptedBridge {
+                rooms: ROOMS_JSON,
+                lights: LIGHTS_JSON,
+                first_put_fails: false,
+                fail_put_containing: Some("light/light-ct"),
+                gets: RefCell::new(Vec::new()),
+                puts: RefCell::new(Vec::new()),
+            },
+            sleeper: CountingSleeper {
+                naps: RefCell::new(Vec::new()),
+            },
+            rooms: wanted(&["3F - Studio", "2F - Kitchen"]),
+        };
+        hue.run("0");
+        let puts = hue.bridge.puts.borrow();
+        let restored: Vec<&str> = puts
+            .iter()
+            .filter(|(path, _)| path.starts_with("light/"))
+            .map(|(path, _)| path.as_str())
+            .collect();
+        assert_eq!(
+            restored,
+            vec!["light/light-ct", "light/light-xy", "light/light-off"],
+            "every light is attempted, whatever one write did"
+        );
+    }
+
+    #[test]
     fn no_matching_rooms_or_no_lights_is_a_silent_no_op() {
         let hue = HuePulse {
             bridge: ScriptedBridge {
                 rooms: r#"{"data":[]}"#,
                 lights: r#"{"data":[]}"#,
                 first_put_fails: false,
+                fail_put_containing: None,
                 gets: RefCell::new(Vec::new()),
                 puts: RefCell::new(Vec::new()),
             },

--- a/dot_local/share/pns/src/channels/mod.rs
+++ b/dot_local/share/pns/src/channels/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod banner;
 pub mod hermes;
+pub mod hue;
 pub mod moshi;
 
 use crate::routing::Mode;

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -257,9 +257,12 @@ pub fn select_plugins(
 
     match loaded {
         Ok(LoadOutcome::Loaded(mut config)) => {
-            config
-                .plugins
-                .retain(|name, _| !mode_plugins.contains(&name.as_str()));
+            // A REGISTERED name is never stripped: stripping one the roster
+            // owns would silently empty the operator's selection instead of
+            // honoring it.
+            config.plugins.retain(|name, _| {
+                !mode_plugins.contains(&name.as_str()) || registry.names().contains(&name.as_str())
+            });
             match registry.enabled(&config) {
                 Ok(selection) => (selection, None),
                 Err(error) => {

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -807,6 +807,21 @@ mod tests {
     }
 
     #[test]
+    fn a_registered_name_is_never_stripped_even_when_declared_a_mode() {
+        // A name that IS an event leg must keep its table: stripping it would
+        // silently empty the operator's selection with no warning at all.
+        use crate::config::LoadOutcome;
+        let config = parse_config("[plugins.hermes]\nenabled = true\n").unwrap();
+        let (selection, warning) = super::select_plugins(
+            &three_registry(),
+            Ok(LoadOutcome::Loaded(config)),
+            &["hermes"],
+        );
+        assert_eq!(selection_names(&selection), vec!["hermes"]);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
     fn a_true_typo_is_still_refused_even_with_mode_plugins_declared() {
         use crate::config::LoadOutcome;
         let config = parse_config("[plugins.mosih]\nenabled = true\n").unwrap();

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -246,7 +246,13 @@ where
 pub fn select_plugins(
     registry: &crate::registry::Registry,
     loaded: Result<crate::config::LoadOutcome, crate::config::ConfigError>,
+    mode_plugins: &[&str],
 ) -> (Selection, Option<String>) {
+    // mode_plugins are names the composition root serves OUTSIDE the event
+    // plan (hue's pulse today): their config tables are legitimate, so they
+    // are stripped before the unknown-name refusal rather than read as
+    // typos that would discard the operator's whole selection.
+    let _ = mode_plugins;
     use crate::config::{ConfigError, LoadOutcome};
     use crate::registry::RegistryError;
 
@@ -728,7 +734,7 @@ mod tests {
     fn a_missing_config_selects_every_builtin_so_the_cutover_changes_nothing() {
         use crate::config::LoadOutcome;
         let (selection, warning) =
-            super::select_plugins(&three_registry(), Ok(LoadOutcome::Missing));
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Missing), &[]);
         assert_eq!(
             selection_names(&selection),
             vec!["moshi", "hermes", "macos-banner"]
@@ -741,7 +747,7 @@ mod tests {
         use crate::config::LoadOutcome;
         let config = parse_config("[plugins.hermes]\nenabled = true\n").unwrap();
         let (selection, warning) =
-            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)));
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)), &[]);
         assert_eq!(selection_names(&selection), vec!["hermes"]);
         assert_eq!(warning, None);
     }
@@ -754,6 +760,7 @@ mod tests {
             Err(ConfigError::Malformed(
                 "key with no value at line 1".to_string(),
             )),
+            &[],
         );
         assert_eq!(
             selection_names(&selection),
@@ -768,13 +775,41 @@ mod tests {
         use crate::config::LoadOutcome;
         let config = parse_config("[plugins.mosih]\nenabled = true\n").unwrap();
         let (selection, warning) =
-            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)));
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)), &[]);
         assert_eq!(
             selection_names(&selection),
             vec!["moshi", "hermes", "macos-banner"]
         );
         let warning = warning.expect("the typo'd name must be said aloud");
         assert!(warning.contains("mosih"));
+    }
+
+    #[test]
+    fn a_mode_plugins_table_is_not_a_typo_and_the_selection_survives() {
+        // The pulse mode REQUIRES a plugins.hue table, so an operator who
+        // configures it must not lose their event selection to the
+        // unknown-name refusal on every notification.
+        use crate::config::LoadOutcome;
+        let config =
+            parse_config("[plugins.hermes]\nenabled = true\n[plugins.hue]\nenabled = true\n")
+                .unwrap();
+        let (selection, warning) =
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)), &["hue"]);
+        assert_eq!(selection_names(&selection), vec!["hermes"]);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn a_true_typo_is_still_refused_even_with_mode_plugins_declared() {
+        use crate::config::LoadOutcome;
+        let config = parse_config("[plugins.mosih]\nenabled = true\n").unwrap();
+        let (_, warning) =
+            super::select_plugins(&three_registry(), Ok(LoadOutcome::Loaded(config)), &["hue"]);
+        assert!(
+            warning
+                .expect("the typo is still the defect")
+                .contains("mosih")
+        );
     }
 
     // --- overrides parsing --------------------------------------------------

--- a/dot_local/share/pns/src/engine.rs
+++ b/dot_local/share/pns/src/engine.rs
@@ -252,21 +252,25 @@ pub fn select_plugins(
     // plan (hue's pulse today): their config tables are legitimate, so they
     // are stripped before the unknown-name refusal rather than read as
     // typos that would discard the operator's whole selection.
-    let _ = mode_plugins;
     use crate::config::{ConfigError, LoadOutcome};
     use crate::registry::RegistryError;
 
     match loaded {
-        Ok(LoadOutcome::Loaded(config)) => match registry.enabled(&config) {
-            Ok(selection) => (selection, None),
-            Err(error) => {
-                let detail = match error {
-                    RegistryError::UnknownPlugin(name) => format!("unknown plugin `{name}`"),
-                    RegistryError::Duplicate(name) => format!("duplicate plugin `{name}`"),
-                };
-                (registry.all(), Some(roster_warning(&detail)))
+        Ok(LoadOutcome::Loaded(mut config)) => {
+            config
+                .plugins
+                .retain(|name, _| !mode_plugins.contains(&name.as_str()));
+            match registry.enabled(&config) {
+                Ok(selection) => (selection, None),
+                Err(error) => {
+                    let detail = match error {
+                        RegistryError::UnknownPlugin(name) => format!("unknown plugin `{name}`"),
+                        RegistryError::Duplicate(name) => format!("duplicate plugin `{name}`"),
+                    };
+                    (registry.all(), Some(roster_warning(&detail)))
+                }
             }
-        },
+        }
         Ok(LoadOutcome::Missing) => (registry.all(), None),
         Err(
             ConfigError::Malformed(detail)

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -14,7 +14,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use pns::args::parse_args;
 use pns::channels::banner::BannerChannel;
 use pns::channels::hermes::{DEFAULT_HERMES_URL, HermesChannel, UreqSignedPost, remote_deadline};
-use pns::channels::hue::{Bridge, HuePulse, Sleeper, hue_settings};
+use pns::channels::hue::{
+    Bridge, HuePulse, Sleeper, acquire_pulse_lock, hue_enabled, hue_settings, put_succeeded,
+};
 use pns::channels::moshi::{DEFAULT_MOSHI_URL, MoshiChannel, UreqPost};
 use pns::channels::{Channel, native_first};
 use pns::config::{LoadOutcome, config_path, load_config};
@@ -291,33 +293,19 @@ fn pulse_mode() {
     let Ok(LoadOutcome::Loaded(config)) = load_config(&config_path(&home)) else {
         return;
     };
-    let Some(hue) = config
-        .plugins
-        .get("hue")
-        .filter(|table| table.enabled)
-        .and_then(|table| {
-            hue_settings(
-                &table.settings,
-                std::env::var("HUE_PULSE_ROOMS").ok().as_deref(),
-            )
-        })
-    else {
+    let Some(hue) = hue_enabled(&config).and_then(|settings| {
+        hue_settings(settings, std::env::var("HUE_PULSE_ROOMS").ok().as_deref())
+    }) else {
         return;
     };
 
-    // Two pulses at once would interleave their writes and restore each
-    // other's transient state. The kernel drops this lock on any exit, so it
-    // cannot go stale; a concurrent pulse is skipped, never queued.
-    let lock_path = resolve_path(None, &format!("{home}/.local/state/pns/hue-pulse.lock"));
-    if let Some(parent) = lock_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let Ok(lock) = std::fs::File::create(&lock_path) else {
+    // The SAME path the bash channel locks, so the two cannot interleave
+    // during the repoint window. The kernel drops it on any exit, and the
+    // binding lives to the end of the pulse.
+    let Some(_lock) = acquire_pulse_lock(std::path::Path::new(&format!("{home}/.local/state")))
+    else {
         return;
     };
-    if lock.try_lock().is_err() {
-        return;
-    }
 
     HuePulse {
         bridge: UreqBridge {
@@ -372,12 +360,21 @@ impl Bridge for UreqBridge {
     }
 
     fn put(&self, path: &str, body: &str) -> bool {
-        self.agent()
+        // A 2xx is not an applied write: the bridge reports application
+        // failures in an errors array alongside it.
+        let Ok(mut response) = self
+            .agent()
             .put(format!("{}/{path}", self.base))
             .header("hue-application-key", &self.key)
             .content_type("application/json")
             .send(body)
-            .is_ok()
+        else {
+            return false;
+        };
+        put_succeeded(
+            true,
+            &response.body_mut().read_to_string().unwrap_or_default(),
+        )
     }
 }
 

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -78,7 +78,8 @@ fn main() {
     }
 
     let home = std::env::var("HOME").unwrap_or_default();
-    let (selection, warning) = select_plugins(&registry, load_config(&config_path(&home)));
+    let (selection, warning) =
+        select_plugins(&registry, load_config(&config_path(&home)), &["hue"]);
     if let Some(warning) = warning {
         eprintln!("{warning}");
     }

--- a/dot_local/share/pns/src/main.rs
+++ b/dot_local/share/pns/src/main.rs
@@ -9,20 +9,28 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use pns::args::parse_args;
 use pns::channels::banner::BannerChannel;
 use pns::channels::hermes::{DEFAULT_HERMES_URL, HermesChannel, UreqSignedPost, remote_deadline};
+use pns::channels::hue::{Bridge, HuePulse, Sleeper, hue_settings};
 use pns::channels::moshi::{DEFAULT_MOSHI_URL, MoshiChannel, UreqPost};
 use pns::channels::{Channel, native_first};
-use pns::config::{config_path, load_config};
+use pns::config::{LoadOutcome, config_path, load_config};
 use pns::engine::{Overrides, decide, event_json, resolve_path, select_plugins};
 use pns::registry::{Registry, Routing};
 use pns::render;
 use pns::system::{SystemCommandRunner, SystemProbes};
 
 fn main() {
+    // The pulse is a MODE, not a leg: it fires on a long command's exit code
+    // rather than on an event, so it leaves before any of the event wiring.
+    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("pulse")) {
+        pulse_mode();
+        return;
+    }
+
     // Lossy rather than validating: a stray byte in argv degrades into an
     // unknown token, which the lenient contract already skips, instead of
     // aborting an always-exit-0 notification.
@@ -273,4 +281,109 @@ fn deliver(channel: &Path, event: &str) {
         let _ = stdin.write_all(b"\n");
     }
     let _ = child.wait();
+}
+
+/// The `pulse` mode: read the hue table, take the single-pulse lock, and run
+/// the sequence against the bridge. Every absence is a silent exit 0.
+fn pulse_mode() {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let Ok(LoadOutcome::Loaded(config)) = load_config(&config_path(&home)) else {
+        return;
+    };
+    let Some(hue) = config
+        .plugins
+        .get("hue")
+        .filter(|table| table.enabled)
+        .and_then(|table| {
+            hue_settings(
+                &table.settings,
+                std::env::var("HUE_PULSE_ROOMS").ok().as_deref(),
+            )
+        })
+    else {
+        return;
+    };
+
+    // Two pulses at once would interleave their writes and restore each
+    // other's transient state. The kernel drops this lock on any exit, so it
+    // cannot go stale; a concurrent pulse is skipped, never queued.
+    let lock_path = resolve_path(None, &format!("{home}/.local/state/pns/hue-pulse.lock"));
+    if let Some(parent) = lock_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let Ok(lock) = std::fs::File::create(&lock_path) else {
+        return;
+    };
+    if lock.try_lock().is_err() {
+        return;
+    }
+
+    HuePulse {
+        bridge: UreqBridge {
+            base: format!("https://{}/clip/v2/resource", hue.bridge),
+            key: hue.key,
+        },
+        sleeper: RealSleeper,
+        rooms: hue.rooms,
+    }
+    .run(
+        &std::env::args_os()
+            .nth(2)
+            .map(|code| code.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "0".to_string()),
+    );
+}
+
+/// The CLIP v2 bridge over ureq.
+struct UreqBridge {
+    base: String,
+    key: String,
+}
+
+impl UreqBridge {
+    fn agent(&self) -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(10)))
+            .max_redirects(0)
+            // The bridge serves a self-signed certificate for its own LAN
+            // address, so verification is disabled here exactly as openhue
+            // does it; there is no CA that could vouch for a Hue bridge.
+            .tls_config(
+                ureq::tls::TlsConfig::builder()
+                    .disable_verification(true)
+                    .build(),
+            )
+            .build()
+            .new_agent()
+    }
+}
+
+impl Bridge for UreqBridge {
+    fn get(&self, path: &str) -> Option<String> {
+        self.agent()
+            .get(format!("{}/{path}", self.base))
+            .header("hue-application-key", &self.key)
+            .call()
+            .ok()?
+            .body_mut()
+            .read_to_string()
+            .ok()
+    }
+
+    fn put(&self, path: &str, body: &str) -> bool {
+        self.agent()
+            .put(format!("{}/{path}", self.base))
+            .header("hue-application-key", &self.key)
+            .content_type("application/json")
+            .send(body)
+            .is_ok()
+    }
+}
+
+struct RealSleeper;
+
+impl Sleeper for RealSleeper {
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
 }


### PR DESCRIPTION
## Context

Last of the four channel slices: the Hue pulse goes native, replacing the `openhue` CLI with direct CLIP v2 calls to the bridge. Hue is the one destination that is config-selected but not event-dispatched, because the pulse fires on a long command's exit code rather than on a notification, so it lands as the binary's `pulse` mode reading the same `[plugins.hue]` table.

## Summary

- `dot_local/share/pns/src/channels/hue.rs`: settings from the plugin table (bridge and key required, rooms from the environment over the config over the bash defaults), CLIP parsing, the four ramped pulse steps ending low, and a restore built from the decisions the R1 pulse module already pinned.
- A room is a paired unit: its grouped light with its own lights. A room whose lights cannot be restored is never pulsed, so nothing is left stuck in the transient color.
- A light missing any reading the restore needs is skipped rather than invented into "off" or a zero coordinate; only the brightness default matches the bash.
- A CLIP response carrying a nonempty `errors` array is not an applied write, so the first-write bail sees application failures and not just transport ones.
- `pns pulse` gates on the plugin's `enabled` flag and takes the single-pulse lock at the same path the bash channel uses, so the two cannot interleave before the retirement slice removes the bash. `select_plugins` also learns which names are mode plugins, so a `[plugins.hue]` table no longer reads as a typo that discards the operator's whole event selection.

## How it was verified

- `cargo test`: 294 passed, 0 failed. `cargo clippy --all-targets`: zero warnings. `cargo fmt --check`: clean. Dispatch bats 25/25 against both engines; the four-phase integration gate exits 0.
- Twenty-two mutations across the two rounds, each killed by a named test with green controls, including every fix in this round: a broken restore loop, a dropped ramp, an errors-blind write check, invented partial light state, an ignored enabled flag, and a stripped registered name.
- Two defects in this slice's own tests were found and fixed: an assertion that contradicted the R1 restore decision, and a scripted-failure field the fake bridge never honored, which had left the restore-independence pin passing on writes that all succeeded.

## Effect of merging

The pulse mode exists in the binary but nothing invokes it: the shell notifier still calls the bash channel until the repoint slice, and live behavior is unchanged. The bash hue channel keeps running and now shares its lock path with the native one.

Known limit, stated plainly: no CI machine has a Hue bridge, so the CLIP conversation is pinned by fixtures and unit tests rather than an end-to-end run. Live-bridge verification happens operator-side once the notifier is repointed.

## Review guide

Read `channels/hue.rs` top to bottom: the module doc explains why hue is a mode rather than a leg, `pulse_rooms` carries the pairing rule that prevents unrestorable pulses, `light_snapshot` carries the skip-rather-than-invent rule, and the sequence test pins the four steps and the restore. In `main.rs`, the pulse mode is the new entry point; `engine.rs` gains only the mode-plugin strip with its registered-name guard.
