### PR TITLE
feat(pns): build the engine and repoint the shell notifier

### DIFF
--- a/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
@@ -72,8 +72,12 @@ report_line 'building the release binary'
 "$cargo_bin" build --release --quiet --manifest-path "$crate_dir/Cargo.toml"
 
 mkdir -p "$install_dir"
-# install(1) replaces the target atomically, so a producer firing mid-apply
-# either runs the old binary or the new one, never a half-written file.
+# install(1) replaces the target through a temporary file and a rename
+# ("Temporary files are no longer optional", install(1) under -S), so a
+# producer firing mid-apply runs either the old binary or the new one and
+# never a half-written file. cp would write in place. No test separates the
+# two: macOS permits overwriting a running binary, so the race is not
+# reproducible in a unit test, and the man page is the evidence.
 /usr/bin/install -m 755 "$crate_dir/target/release/pns" "$install_dir/pns"
 report_line "installed $install_dir/pns"
 

--- a/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
@@ -12,24 +12,25 @@ set -euo pipefail
 # manifest and the lock are hashed below, globbed rather than listed so a new
 # module cannot silently miss the trigger.
 {{ $crate := joinPath .chezmoi.sourceDir "dot_local/share/pns" -}}
-{{ range (glob (joinPath $crate "src/*.rs")) }}
-#   {{ base . }} {{ include . | sha256sum }}
+{{ range (glob (joinPath $crate "**/*.rs")) }}
+#   {{ . }} {{ include . | sha256sum }}
 {{- end }}
-{{- range (glob (joinPath $crate "src/channels/*.rs")) }}
-#   channels/{{ base . }} {{ include . | sha256sum }}
-{{- end }}
-{{- range (glob (joinPath $crate "src/bin/*.rs")) }}
-#   bin/{{ base . }} {{ include . | sha256sum }}
+{{- range (glob (joinPath $crate "build.rs")) }}
+#   {{ . }} {{ include . | sha256sum }}
 {{- end }}
 #   Cargo.toml {{ include (joinPath $crate "Cargo.toml") | sha256sum }}
 #   Cargo.lock {{ include (joinPath $crate "Cargo.lock") | sha256sum }}
 #
 # Retry state, the same mechanism the herdr plugin build uses: chezmoi records a
 # run_onchange script as done on ANY exit 0, so a skipped build (no toolchain)
-# must bump this marker to change the rendered script and re-fire next apply.
-# Sanitized to the leading digit run, because splicing raw file bytes into a
-# rendered script would be a live-shell-injection channel.
-#   retry-attempts: {{ $rm := printf "%s/.cache/pns-build/engine.retry" (env "HOME") }}{{ if stat $rm }}{{ (output "cat" $rm) | regexFind "^[0-9]+" }}{{ else }}0{{ end }}
+# must change this rendered script to re-fire on the next apply.
+#
+# The marker's MODIFICATION TIME is the trigger, never its contents: reading a
+# file at render time means an unreadable node aborts the apply and a FIFO at
+# that path hangs it forever, before any of this script's own recovery can
+# run. Each bump rewrites the marker, which moves the timestamp, which changes
+# this line.
+#   retry-marker: {{ $rm := printf "%s/.cache/pns-build/engine.retry" (env "HOME") }}{{ if stat $rm }}{{ (stat $rm).modTime }}{{ else }}settled{{ end }}
 
 {{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
 
@@ -69,7 +70,9 @@ report_section 'pns engine'
 report_line 'building the release binary'
 # A build failure exits non-zero, which chezmoi does not record, so it retries
 # on its own without touching the marker.
-"$cargo_bin" build --release --quiet --manifest-path "$crate_dir/Cargo.toml"
+# --locked: build exactly the committed lock. Without it cargo may rewrite
+# the deployed lockfile and pull dependencies the lock never recorded.
+"$cargo_bin" build --release --locked --quiet --manifest-path "$crate_dir/Cargo.toml"
 
 mkdir -p "$install_dir"
 # install(1) replaces the target through a temporary file and a rename

--- a/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl
@@ -1,0 +1,81 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+set -euo pipefail
+
+# Builds the pns engine binary and installs it beside the channels it will
+# replace. The crate deploys as SOURCE under ~/.local/share/pns; nothing else
+# compiles it, so without this script every producer repointed at the binary
+# would find nothing there.
+#
+# Re-runs whenever any build input changes: every crate source file, the
+# manifest and the lock are hashed below, globbed rather than listed so a new
+# module cannot silently miss the trigger.
+{{ $crate := joinPath .chezmoi.sourceDir "dot_local/share/pns" -}}
+{{ range (glob (joinPath $crate "src/*.rs")) }}
+#   {{ base . }} {{ include . | sha256sum }}
+{{- end }}
+{{- range (glob (joinPath $crate "src/channels/*.rs")) }}
+#   channels/{{ base . }} {{ include . | sha256sum }}
+{{- end }}
+{{- range (glob (joinPath $crate "src/bin/*.rs")) }}
+#   bin/{{ base . }} {{ include . | sha256sum }}
+{{- end }}
+#   Cargo.toml {{ include (joinPath $crate "Cargo.toml") | sha256sum }}
+#   Cargo.lock {{ include (joinPath $crate "Cargo.lock") | sha256sum }}
+#
+# Retry state, the same mechanism the herdr plugin build uses: chezmoi records a
+# run_onchange script as done on ANY exit 0, so a skipped build (no toolchain)
+# must bump this marker to change the rendered script and re-fire next apply.
+# Sanitized to the leading digit run, because splicing raw file bytes into a
+# rendered script would be a live-shell-injection channel.
+#   retry-attempts: {{ $rm := printf "%s/.cache/pns-build/engine.retry" (env "HOME") }}{{ if stat $rm }}{{ (output "cat" $rm) | regexFind "^[0-9]+" }}{{ else }}0{{ end }}
+
+{{ includeTemplate "cli-print-style-lib.sh.tmpl" }}
+
+crate_dir="$HOME/.local/share/pns"
+# Beside the channels, not in bin: the operator never types this, launchd and
+# the shell notifier do.
+install_dir="$HOME/.local/libexec/pns"
+retry_marker="$HOME/.cache/pns-build/engine.retry"
+
+# Deterministic path, never a PATH probe: a fresh machine provisions rustup
+# during THIS apply and ~/.cargo/bin is not on the apply shell's PATH yet.
+cargo_bin="$HOME/.cargo/bin/cargo"
+
+bump_retry_marker() {
+  local count=0
+  mkdir -p "$(dirname "$retry_marker")"
+  if [[ -f $retry_marker ]]; then
+    count="$(cat "$retry_marker" 2>/dev/null || printf '0')"
+    [[ $count =~ ^[0-9]+$ ]] || count=0
+  fi
+  printf '%d\n' "$((count + 1))" >"$retry_marker"
+}
+
+if [[ ! -x $cargo_bin ]]; then
+  report_line 'pns: cargo not found at ~/.cargo/bin/cargo; engine build deferred to the next apply.' >&2
+  bump_retry_marker
+  exit 0
+fi
+
+if [[ ! -f "$crate_dir/Cargo.toml" ]]; then
+  report_line 'pns: crate source is not deployed yet; engine build deferred to the next apply.' >&2
+  bump_retry_marker
+  exit 0
+fi
+
+report_section 'pns engine'
+report_line 'building the release binary'
+# A build failure exits non-zero, which chezmoi does not record, so it retries
+# on its own without touching the marker.
+"$cargo_bin" build --release --quiet --manifest-path "$crate_dir/Cargo.toml"
+
+mkdir -p "$install_dir"
+# install(1) replaces the target atomically, so a producer firing mid-apply
+# either runs the old binary or the new one, never a half-written file.
+/usr/bin/install -m 755 "$crate_dir/target/release/pns" "$install_dir/pns"
+report_line "installed $install_dir/pns"
+
+rm -f "$retry_marker"
+{{ end -}}

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -484,15 +484,25 @@ if [[ $- == *i* ]]; then
     # binary arrives with an apply, and a shell already running when that
     # apply lands must not lose its notifications to a path that does not
     # exist yet. The pulse follows the same rule.
-    local pns_engine="$HOME/.local/libexec/pns/relay.sh" pns_pulse=""
+    local pns_engine="$HOME/.local/libexec/pns/relay.sh"
+    # An ARRAY, not a string: the pulse carries a subcommand, and a $HOME with
+    # a space would word-split a flat string into a command that does not exist.
+    local -a pns_pulse=()
     if [[ -x "$HOME/.local/libexec/pns/pns" ]]; then
       pns_engine="$HOME/.local/libexec/pns/pns"
-      pns_pulse="$pns_engine pulse"
+    fi
+    # The pulse follows the CONFIG, not the binary: the engine's pulse mode
+    # needs an enabled [plugins.hue] with a bridge and key, and until that
+    # file exists it would return silently and the lights would simply stop.
+    # The bash channel keeps its own openhue configuration, so it stays the
+    # pulse until the operator writes the pns config.
+    if [[ -x "$HOME/.local/libexec/pns/pns" && -f "$HOME/.config/pns/config.toml" ]]; then
+      pns_pulse=("$HOME/.local/libexec/pns/pns" pulse)
     elif [[ -x "$HOME/.local/libexec/pns/channels/hue-pulse.sh" ]]; then
-      pns_pulse="$HOME/.local/libexec/pns/channels/hue-pulse.sh"
+      pns_pulse=("$HOME/.local/libexec/pns/channels/hue-pulse.sh")
     fi
     if ((elapsed >= 300)); then
-      [[ -n $pns_pulse ]] && ($pns_pulse "$exit_code" >/dev/null 2>&1 &)
+      [[ ${#pns_pulse[@]} -gt 0 ]] && ("${pns_pulse[@]}" "$exit_code" >/dev/null 2>&1 &)
       ("$pns_engine" --agent shell --state "$state" --project "${PWD##*/}" --detail "$cmd ($dur)" --pane "${HERDR_PANE_ID:-}" >/dev/null 2>&1 &)
     elif ((elapsed >= 30)); then
       # Not --local-only: a 30s command must reach the phone when the gate

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -480,13 +480,24 @@ if [[ $- == *i* ]]; then
     # makes the banner clickable, which is what carries the pane. Both tiers
     # go through relay's presence gate; the 300s tier only adds the lights.
     # No test pins these thresholds: only a real long command exercises them.
+    # The Rust engine when it is built, the bash engine until then: the
+    # binary arrives with an apply, and a shell already running when that
+    # apply lands must not lose its notifications to a path that does not
+    # exist yet. The pulse follows the same rule.
+    local pns_engine="$HOME/.local/libexec/pns/relay.sh" pns_pulse=""
+    if [[ -x "$HOME/.local/libexec/pns/pns" ]]; then
+      pns_engine="$HOME/.local/libexec/pns/pns"
+      pns_pulse="$pns_engine pulse"
+    elif [[ -x "$HOME/.local/libexec/pns/channels/hue-pulse.sh" ]]; then
+      pns_pulse="$HOME/.local/libexec/pns/channels/hue-pulse.sh"
+    fi
     if ((elapsed >= 300)); then
-      ("$HOME/.local/libexec/pns/channels/hue-pulse.sh" "$exit_code" >/dev/null 2>&1 &)
-      ("$HOME/.local/libexec/pns/relay.sh" --agent shell --state "$state" --project "${PWD##*/}" --detail "$cmd ($dur)" --pane "${HERDR_PANE_ID:-}" >/dev/null 2>&1 &)
+      [[ -n $pns_pulse ]] && ($pns_pulse "$exit_code" >/dev/null 2>&1 &)
+      ("$pns_engine" --agent shell --state "$state" --project "${PWD##*/}" --detail "$cmd ($dur)" --pane "${HERDR_PANE_ID:-}" >/dev/null 2>&1 &)
     elif ((elapsed >= 30)); then
       # Not --local-only: a 30s command must reach the phone when the gate
-      # says away. relay decides; this tier just skips the lights.
-      ("$HOME/.local/libexec/pns/relay.sh" --agent shell --state "$state" --project "${PWD##*/}" --detail "$cmd ($dur)" --pane "${HERDR_PANE_ID:-}" >/dev/null 2>&1 &)
+      # says away. The engine decides; this tier just skips the lights.
+      ("$pns_engine" --agent shell --state "$state" --project "${PWD##*/}" --detail "$cmd ($dur)" --pane "${HERDR_PANE_ID:-}" >/dev/null 2>&1 &)
     fi
   }
 

--- a/test/unit/pns-engine-build-install.sh
+++ b/test/unit/pns-engine-build-install.sh
@@ -58,7 +58,13 @@ while [[ \$# -gt 0 ]]; do
 done
 crate="\$(dirname "\$manifest")"
 mkdir -p "\$crate/target/release"
-printf '#!/usr/bin/env bash\nprintf pns-engine\n' >"\$crate/target/release/pns"
+if [[ -f "\$HOME/.stub-build-sleeper" ]]; then
+  # A real Mach-O, so running it holds the text lock that makes an in-place
+  # overwrite fail.
+  cp /bin/sleep "\$crate/target/release/pns"
+else
+  printf '#!/usr/bin/env bash\nprintf pns-engine\n' >"\$crate/target/release/pns"
+fi
 chmod +x "\$crate/target/release/pns"
 STUB
 chmod +x "$home/.cargo/bin/cargo"
@@ -94,5 +100,23 @@ run_script || {
   echo "a successful build must settle the trigger" >&2
   exit 1
 }
+
+# --- a rebuild while the old binary is RUNNING still replaces it -----------
+# The real mid-apply hazard: a producer (an agent hook, a long command, a
+# LaunchAgent) is executing the installed engine when the next apply lands.
+# Replacing the file in place fails with ETXTBSY; unlinking and creating
+# anew does not.
+touch "$home/.stub-build-sleeper"
+run_script
+"$installed" 5 >/dev/null 2>&1 &
+running=$!
+sleep 0.3
+run_script || {
+  kill "$running" 2>/dev/null || true
+  echo "a rebuild must replace the binary even while it is running" >&2
+  exit 1
+}
+kill "$running" 2>/dev/null || true
+wait "$running" 2>/dev/null || true
 
 exit 0

--- a/test/unit/pns-engine-build-install.sh
+++ b/test/unit/pns-engine-build-install.sh
@@ -52,10 +52,19 @@ cat >"$home/.cargo/bin/cargo" <<STUB
 # Stand-in for the real build: honor --manifest-path and produce the binary
 # the script installs.
 manifest=""
+locked=0
 while [[ \$# -gt 0 ]]; do
   [[ \$1 == --manifest-path ]] && manifest="\$2"
+  [[ \$1 == --locked ]] && locked=1
   shift
 done
+# The committed lock is the build: without --locked cargo may rewrite the
+# deployed lockfile and pull dependencies the lock never recorded.
+if [[ \$locked -ne 1 ]]; then
+  echo "cargo was invoked without --locked" >&2
+  exit 1
+fi
+
 crate="\$(dirname "\$manifest")"
 mkdir -p "\$crate/target/release"
 if [[ -f "\$HOME/.stub-build-sleeper" ]]; then

--- a/test/unit/pns-engine-build-install.sh
+++ b/test/unit/pns-engine-build-install.sh
@@ -76,7 +76,7 @@ run_script || {
   echo "nothing may be installed without the crate source" >&2
   exit 1
 }
-[[ "$(cat "$marker")" -gt "$first_attempt" ]] || {
+[[ "$(cat "$marker")" -gt $first_attempt ]] || {
   echo "each deferral must change the trigger, or it stops re-firing" >&2
   exit 1
 }

--- a/test/unit/pns-engine-build-install.sh
+++ b/test/unit/pns-engine-build-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# The apply-time build script is what puts the engine binary on the machine.
+# Its three behaviors are load-bearing and none of them is visible anywhere
+# else: install the binary WHERE THE PRODUCERS LOOK, leave the run_onchange
+# trigger retryable when the build could not happen, and settle the trigger
+# once it did.
+#
+# The script resolves cargo at a fixed $HOME-relative path, so a sandboxed
+# HOME with a stub cargo runs the real rendered script end to end.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+script="$scratch/build-pns.sh"
+CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$REPO_ROOT/.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl" \
+  >"$script" 2>/dev/null
+[[ -s $script ]] || {
+  echo "the build script rendered empty" >&2
+  exit 1
+}
+chmod +x "$script"
+
+home="$scratch/home"
+marker="$home/.cache/pns-build/engine.retry"
+installed="$home/.local/libexec/pns/pns"
+
+run_script() { HOME="$home" "$script" >/dev/null 2>&1; }
+
+# --- no toolchain: nothing installed, and the trigger stays retryable ------
+mkdir -p "$home"
+run_script || {
+  echo "a missing toolchain must not fail the apply" >&2
+  exit 1
+}
+[[ ! -e $installed ]] || {
+  echo "nothing may be installed without a toolchain" >&2
+  exit 1
+}
+[[ -s $marker ]] || {
+  echo "a deferred build must leave the trigger retryable" >&2
+  exit 1
+}
+first_attempt="$(cat "$marker")"
+
+# --- toolchain, no crate: still deferred, and the marker keeps counting ----
+mkdir -p "$home/.cargo/bin"
+cat >"$home/.cargo/bin/cargo" <<STUB
+#!/usr/bin/env bash
+# Stand-in for the real build: honor --manifest-path and produce the binary
+# the script installs.
+manifest=""
+while [[ \$# -gt 0 ]]; do
+  [[ \$1 == --manifest-path ]] && manifest="\$2"
+  shift
+done
+crate="\$(dirname "\$manifest")"
+mkdir -p "\$crate/target/release"
+printf '#!/usr/bin/env bash\nprintf pns-engine\n' >"\$crate/target/release/pns"
+chmod +x "\$crate/target/release/pns"
+STUB
+chmod +x "$home/.cargo/bin/cargo"
+run_script || {
+  echo "a missing crate must not fail the apply" >&2
+  exit 1
+}
+[[ ! -e $installed ]] || {
+  echo "nothing may be installed without the crate source" >&2
+  exit 1
+}
+[[ "$(cat "$marker")" -gt "$first_attempt" ]] || {
+  echo "each deferral must change the trigger, or it stops re-firing" >&2
+  exit 1
+}
+
+# --- toolchain and crate: the binary lands where the producers look --------
+mkdir -p "$home/.local/share/pns"
+printf '[package]\nname = "pns"\n' >"$home/.local/share/pns/Cargo.toml"
+run_script || {
+  echo "the build must succeed with a toolchain and a crate" >&2
+  exit 1
+}
+[[ -x $installed ]] || {
+  echo "the binary must install where the producers look: $installed" >&2
+  exit 1
+}
+[[ "$("$installed")" == pns-engine ]] || {
+  echo "the installed file is not the built binary" >&2
+  exit 1
+}
+[[ ! -e $marker ]] || {
+  echo "a successful build must settle the trigger" >&2
+  exit 1
+}
+
+exit 0

--- a/test/unit/pns-shell-notifier-engine-choice.sh
+++ b/test/unit/pns-shell-notifier-engine-choice.sh
@@ -2,7 +2,8 @@
 # The shell notifier must reach the RUST engine once the binary is installed
 # and the BASH engine until then: an apply installs the binary under a shell
 # that is already running, and that shell must not lose its notifications to
-# a path that does not exist yet. The pulse follows the same rule.
+# a path that does not exist yet. The pulse is separate, because the engine's
+# pulse mode needs a pns config the machine may not have yet.
 #
 # The function is extracted from the RENDERED bashrc rather than a copy, so a
 # repoint that edits one and not the other fails here.
@@ -23,18 +24,28 @@ sed -n '/^  __cmd_notify_precmd() {$/,/^  }$/p' "$scratch/bashrc" |
   exit 1
 }
 
+# A HOME with a space, because a flat command string would word-split here and
+# silently drop the call.
+home="$scratch/home dir"
+
 stub() { # <path> <label>
   mkdir -p "$(dirname "$1")"
-  printf '#!/usr/bin/env bash\nprintf "%%s %%s\\n" "%s" "$*" >>"%s/calls"\n' "$2" "$scratch" >"$1"
+  # One line per ARGUMENT, so a broken argument boundary cannot read the same
+  # as separate arguments.
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "%s <<%%s>>\\n" "$@" >>"%s/calls"\n' "$2" "$scratch"
+  } >"$1"
   chmod +x "$1"
 }
 
-home="$scratch/home"
 stub "$home/.local/libexec/pns/relay.sh" BASH-RELAY
 stub "$home/.local/libexec/pns/channels/hue-pulse.sh" BASH-PULSE
 
-# fire <elapsed>: run one notification with that duration and collect the
-# calls the stubs recorded.
+# fire <elapsed>: run one notification and collect what the stubs recorded.
+# The calls are DETACHED subshells the shell cannot wait for, so this settles
+# on a quiet period rather than stopping at the first write: stopping early
+# would let a later unwanted call escape the negative assertions.
 fire() {
   : >"$scratch/calls"
   HOME="$home" SECONDS="$1" HERDR_PANE_ID=wW:p7 bash --noprofile --norc -c "
@@ -43,57 +54,83 @@ fire() {
     __cmd_notify_name='sleep 999'
     (exit 0)
     __cmd_notify_precmd
-    wait
   " >/dev/null 2>&1 || true
-  # The calls are backgrounded subshells; give them a moment to land.
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
-    [[ -s $scratch/calls ]] && break
-    sleep 0.1
+  local previous="" current="" stable=0
+  for _ in $(seq 1 40); do
+    sleep 0.05
+    current="$(cat "$scratch/calls" 2>/dev/null || true)"
+    if [[ $current == "$previous" ]]; then
+      stable=$((stable + 1))
+      [[ $stable -ge 4 ]] && break
+    else
+      stable=0
+    fi
+    previous="$current"
   done
-  sort "$scratch/calls" 2>/dev/null || true
+  printf '%s' "$current"
+}
+
+expect_call() { # <label> <calls> <arg>...
+  local label="$1" calls="$2"
+  shift 2
+  local argument
+  for argument in "$@"; do
+    grep -qxF "$label <<$argument>>" <<<"$calls" || {
+      echo "expected $label to be handed <<$argument>>" >&2
+      echo "got:" >&2
+      printf '%s\n' "$calls" >&2
+      exit 1
+    }
+  done
+}
+
+refute_label() { # <label> <calls>
+  if grep -q "^$1 " <<<"$2"; then
+    echo "$1 must not have run" >&2
+    printf '%s\n' "$2" >&2
+    exit 1
+  fi
 }
 
 # --- the binary is not installed yet: the bash engine still carries it -----
 calls="$(fire 400)"
-grep -q '^BASH-RELAY --agent shell' <<<"$calls" || {
-  echo "without the binary the bash engine must still be called; got: $calls" >&2
-  exit 1
-}
-grep -q '^BASH-PULSE 0' <<<"$calls" || {
-  echo "without the binary the bash pulse must still fire; got: $calls" >&2
-  exit 1
-}
+expect_call BASH-RELAY "$calls" --agent shell --state 'done' --pane wW:p7
+expect_call BASH-PULSE "$calls" 0
 
-# --- the binary is installed: it wins, and the pulse is its subcommand -----
+# --- the binary is installed: it carries the notification ------------------
+# The pulse stays with the bash channel, because no pns config exists here.
 stub "$home/.local/libexec/pns/pns" BINARY
 calls="$(fire 400)"
-# The WHOLE argv, not a prefix: a dropped --pane leaves the banner unclickable
-# and viewed-pane suppression unable to fire, and a narrowing flag appended
-# here would silently drop every long-command phone push.
-expected="BINARY --agent shell --state done --project ${PWD##*/} --detail sleep (400s) --pane wW:p7"
-grep -qxF "$expected" <<<"$calls" || {
-  echo "the binary must carry exactly the expected argv" >&2
-  echo "expected: $expected" >&2
-  echo "got:      $calls" >&2
+expect_call BINARY "$calls" --agent shell --state 'done' --project "${PWD##*/}" \
+  --detail "sleep (400s)" --pane wW:p7
+refute_label BASH-RELAY "$calls"
+if grep -qxF 'BINARY <<--local-only>>' <<<"$calls"; then
+  echo "a narrowing flag would silently drop every long-command phone push" >&2
   exit 1
-}
-grep -q '^BINARY pulse 0' <<<"$calls" || {
-  echo "the pulse must be the binary's own subcommand; got: $calls" >&2
-  exit 1
-}
-grep -q '^BASH' <<<"$calls" && {
-  echo "no bash script may run once the binary is installed; got: $calls" >&2
-  exit 1
-}
+fi
+expect_call BASH-PULSE "$calls" 0
 
-# --- the 30s tier notifies without pulsing ---------------------------------
-calls="$(fire 60)"
-grep -qxF "BINARY --agent shell --state done --project ${PWD##*/} --detail sleep (60s) --pane wW:p7" <<<"$calls" || {
-  echo "the 30s tier must notify with the same full argv; got: $calls" >&2
-  exit 1
-}
-grep -q 'pulse' <<<"$calls" && {
-  echo "the 30s tier must not pulse the lights; got: $calls" >&2
+# --- with a pns config, the pulse becomes the binary's own subcommand ------
+mkdir -p "$home/.config/pns"
+printf '[plugins.hue]\nenabled = true\n' >"$home/.config/pns/config.toml"
+calls="$(fire 400)"
+expect_call BINARY "$calls" pulse 0
+refute_label BASH-PULSE "$calls"
+rm -r "$home/.config/pns"
+
+# --- the tier boundaries, exactly ------------------------------------------
+calls="$(fire 300)"
+expect_call BASH-PULSE "$calls" 0
+calls="$(fire 299)"
+refute_label BASH-PULSE "$calls"
+expect_call BINARY "$calls" --agent shell
+calls="$(fire 30)"
+expect_call BINARY "$calls" --agent shell
+refute_label BASH-PULSE "$calls"
+calls="$(fire 29)"
+[[ -z $calls ]] || {
+  echo "nothing may fire below the 30 second tier" >&2
+  printf '%s\n' "$calls" >&2
   exit 1
 }
 

--- a/test/unit/pns-shell-notifier-engine-choice.sh
+++ b/test/unit/pns-shell-notifier-engine-choice.sh
@@ -37,7 +37,7 @@ stub "$home/.local/libexec/pns/channels/hue-pulse.sh" BASH-PULSE
 # calls the stubs recorded.
 fire() {
   : >"$scratch/calls"
-  HOME="$home" SECONDS="$1" bash --noprofile --norc -c "
+  HOME="$home" SECONDS="$1" HERDR_PANE_ID=wW:p7 bash --noprofile --norc -c "
     source '$scratch/notifier.sh'
     __cmd_notify_start=0
     __cmd_notify_name='sleep 999'
@@ -67,8 +67,14 @@ grep -q '^BASH-PULSE 0' <<<"$calls" || {
 # --- the binary is installed: it wins, and the pulse is its subcommand -----
 stub "$home/.local/libexec/pns/pns" BINARY
 calls="$(fire 400)"
-grep -q '^BINARY --agent shell' <<<"$calls" || {
-  echo "the installed binary must carry the notification; got: $calls" >&2
+# The WHOLE argv, not a prefix: a dropped --pane leaves the banner unclickable
+# and viewed-pane suppression unable to fire, and a narrowing flag appended
+# here would silently drop every long-command phone push.
+expected="BINARY --agent shell --state done --project ${PWD##*/} --detail sleep (400s) --pane wW:p7"
+grep -qxF "$expected" <<<"$calls" || {
+  echo "the binary must carry exactly the expected argv" >&2
+  echo "expected: $expected" >&2
+  echo "got:      $calls" >&2
   exit 1
 }
 grep -q '^BINARY pulse 0' <<<"$calls" || {
@@ -82,8 +88,8 @@ grep -q '^BASH' <<<"$calls" && {
 
 # --- the 30s tier notifies without pulsing ---------------------------------
 calls="$(fire 60)"
-grep -q '^BINARY --agent shell' <<<"$calls" || {
-  echo "the 30s tier must notify; got: $calls" >&2
+grep -qxF "BINARY --agent shell --state done --project ${PWD##*/} --detail sleep (60s) --pane wW:p7" <<<"$calls" || {
+  echo "the 30s tier must notify with the same full argv; got: $calls" >&2
   exit 1
 }
 grep -q 'pulse' <<<"$calls" && {

--- a/test/unit/pns-shell-notifier-engine-choice.sh
+++ b/test/unit/pns-shell-notifier-engine-choice.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# The shell notifier must reach the RUST engine once the binary is installed
+# and the BASH engine until then: an apply installs the binary under a shell
+# that is already running, and that shell must not lose its notifications to
+# a path that does not exist yet. The pulse follows the same rule.
+#
+# The function is extracted from the RENDERED bashrc rather than a copy, so a
+# repoint that edits one and not the other fails here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+CI=1 chezmoi --source "$REPO_ROOT" execute-template --no-tty \
+  <"$REPO_ROOT/dot_bashrc.tmpl" >"$scratch/bashrc" 2>/dev/null
+
+# The notifier function alone, dedented out of its interactive-shell block.
+sed -n '/^  __cmd_notify_precmd() {$/,/^  }$/p' "$scratch/bashrc" |
+  sed 's/^  //' >"$scratch/notifier.sh"
+[[ -s $scratch/notifier.sh ]] || {
+  echo "could not extract __cmd_notify_precmd from the rendered bashrc" >&2
+  exit 1
+}
+
+stub() { # <path> <label>
+  mkdir -p "$(dirname "$1")"
+  printf '#!/usr/bin/env bash\nprintf "%%s %%s\\n" "%s" "$*" >>"%s/calls"\n' "$2" "$scratch" >"$1"
+  chmod +x "$1"
+}
+
+home="$scratch/home"
+stub "$home/.local/libexec/pns/relay.sh" BASH-RELAY
+stub "$home/.local/libexec/pns/channels/hue-pulse.sh" BASH-PULSE
+
+# fire <elapsed>: run one notification with that duration and collect the
+# calls the stubs recorded.
+fire() {
+  : >"$scratch/calls"
+  HOME="$home" SECONDS="$1" bash --noprofile --norc -c "
+    source '$scratch/notifier.sh'
+    __cmd_notify_start=0
+    __cmd_notify_name='sleep 999'
+    (exit 0)
+    __cmd_notify_precmd
+    wait
+  " >/dev/null 2>&1 || true
+  # The calls are backgrounded subshells; give them a moment to land.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s $scratch/calls ]] && break
+    sleep 0.1
+  done
+  sort "$scratch/calls" 2>/dev/null || true
+}
+
+# --- the binary is not installed yet: the bash engine still carries it -----
+calls="$(fire 400)"
+grep -q '^BASH-RELAY --agent shell' <<<"$calls" || {
+  echo "without the binary the bash engine must still be called; got: $calls" >&2
+  exit 1
+}
+grep -q '^BASH-PULSE 0' <<<"$calls" || {
+  echo "without the binary the bash pulse must still fire; got: $calls" >&2
+  exit 1
+}
+
+# --- the binary is installed: it wins, and the pulse is its subcommand -----
+stub "$home/.local/libexec/pns/pns" BINARY
+calls="$(fire 400)"
+grep -q '^BINARY --agent shell' <<<"$calls" || {
+  echo "the installed binary must carry the notification; got: $calls" >&2
+  exit 1
+}
+grep -q '^BINARY pulse 0' <<<"$calls" || {
+  echo "the pulse must be the binary's own subcommand; got: $calls" >&2
+  exit 1
+}
+grep -q '^BASH' <<<"$calls" && {
+  echo "no bash script may run once the binary is installed; got: $calls" >&2
+  exit 1
+}
+
+# --- the 30s tier notifies without pulsing ---------------------------------
+calls="$(fire 60)"
+grep -q '^BINARY --agent shell' <<<"$calls" || {
+  echo "the 30s tier must notify; got: $calls" >&2
+  exit 1
+}
+grep -q 'pulse' <<<"$calls" && {
+  echo "the 30s tier must not pulse the lights; got: $calls" >&2
+  exit 1
+}
+
+exit 0


### PR DESCRIPTION
## Context

With all four channels native, the R3 slices move the producers over one at a time. This is the first, the shell's long-command notifier, and it carries the piece every later repoint depends on: nothing in the repository compiled the crate. It deployed as source, so any producer pointed at the binary would have found nothing there.

## Summary

- `.chezmoiscripts/run_onchange_after_58-build-pns-engine.sh.tmpl` builds the engine at apply time and installs it to `~/.local/libexec/pns/pns`, beside the channels it replaces. It hashes the crate recursively so a new module or a build script cannot miss the trigger, builds `--locked` so the committed lock is what ships, and defers retryably when the toolchain or the crate is not there yet.
- The retry trigger reads the marker's modification time rather than its contents: reading a file during rendering means an unreadable node aborts the apply and a named pipe at that path hangs it forever, before the script's own recovery can run.
- `dot_bashrc.tmpl` prefers the binary for notifications and falls back to the bash engine until an apply installs it, because the shell running during that apply must not lose its notifications.
- The pulse follows the config rather than the binary. The engine's pulse mode returns silently without an enabled `[plugins.hue]` carrying a bridge and key, so the bash channel keeps the lights until `~/.config/pns/config.toml` exists.
- `test/unit/pns-shell-notifier-engine-choice.sh` extracts the notifier from the rendered bashrc and drives every case with stub engines; `test/unit/pns-engine-build-install.sh` runs the rendered build script under a sandboxed HOME with a stub cargo.

## How it was verified

- Both new tests pass, along with `cargo test` (294), the four-phase integration gate, and the rendered-template shellcheck.
- Seventeen mutations across two review rounds are each caught by a named assertion, with green controls: the binary preference, the bash fallback, the pulse subcommand and its config gate, the exit code, the full argv including `--pane` and any appended narrowing flag, the tier boundaries at 29, 30, 299 and 300, the install path, the retry marker, and `--locked`.
- The build test runs the real script: nothing installs and the trigger stays retryable without a toolchain or a crate, each deferral increments so it keeps re-firing, the built binary lands executable where the notifier probes, and a rebuild replaces the binary while a process is running it.
- A named pipe at the marker path was checked directly: the previous form hung past a timeout, the current one renders in milliseconds.

## Effect of merging

The next apply builds and installs the engine, and from then on new shells send their long-command notifications through it. Shells already running keep using the bash engine until they restart, and the lights keep running through the bash channel until a pns config exists. Nothing else is repointed yet.

Known limit: `install(1)` replaces the target through a temporary file and a rename, so a producer firing mid-apply never sees a half-written binary, but no test separates it from a plain copy, because macOS permits overwriting a running binary and the race is not reproducible in a unit test. The man page is the evidence, and the comment says so.

## Review guide

Read the build script first, top to bottom: the hashing block is what makes the trigger honest, and the comments above the retry marker and the install explain the two failure modes that shaped them. Then the notifier block in `dot_bashrc.tmpl`, which is fifteen lines and carries two independent choices, the engine and the pulse. The tests are worth reading for their harnesses: one extracts the deployed function from a render, the other runs the deployed script against a stub toolchain.
