### PR TITLE
feat(pns): repoint the harness hooks at the engine binary

### DIFF
--- a/dot_local/libexec/pns/helpers/engine-path.sh
+++ b/dot_local/libexec/pns/helpers/engine-path.sh
@@ -20,27 +20,30 @@ pns_engine_path() {
     printf '%s' "$override"
     return 0
   fi
-  local binary="${PNS_ENGINE_BIN:-$HOME/.local/libexec/pns/pns}"
-  if [[ -x $binary ]]; then
+  # A regular file, not merely something with the execute bit: a DIRECTORY at
+  # that path satisfies -x and would suppress the fallback entirely.
+  local binary="${PNS_ENGINE_BIN:-${HOME:-}/.local/libexec/pns/pns}"
+  if [[ -f $binary && -x $binary ]]; then
     printf '%s' "$binary"
     return 0
   fi
-  printf '%s' "$HOME/.local/libexec/pns/relay.sh"
+  printf '%s' "${HOME:-}/.local/libexec/pns/relay.sh"
 }
 
 # pns_pulse_command
-# The command that pulses the lights, as ARGUMENTS on stdout, one per line:
-# the binary carries a subcommand, and a flat string would word-split on a
-# home directory with a space. Prints nothing when neither form is available,
-# which the caller reads as "no lights on this machine".
+# The command that pulses the lights, as NUL-separated ARGUMENTS on stdout:
+# the binary carries a subcommand, a flat string would word-split on a home
+# directory with a space, and a newline separator would split a path that
+# contains one. Prints nothing when neither form is available, which the
+# caller reads as "no lights on this machine".
 pns_pulse_command() {
-  local binary="${PNS_ENGINE_BIN:-$HOME/.local/libexec/pns/pns}"
-  local config="${PNS_CONFIG_FILE:-$HOME/.config/pns/config.toml}"
-  if [[ -x $binary && -f $config ]]; then
-    printf '%s\n' "$binary" pulse
+  local binary="${PNS_ENGINE_BIN:-${HOME:-}/.local/libexec/pns/pns}"
+  local config="${PNS_CONFIG_FILE:-${HOME:-}/.config/pns/config.toml}"
+  if [[ -f $binary && -x $binary && -f $config ]]; then
+    printf '%s\0' "$binary" pulse
     return 0
   fi
-  local channel="${PNS_CHANNELS_DIR:-$HOME/.local/libexec/pns/channels}/hue-pulse.sh"
-  [[ -x $channel ]] && printf '%s\n' "$channel"
+  local channel="${PNS_CHANNELS_DIR:-${HOME:-}/.local/libexec/pns/channels}/hue-pulse.sh"
+  [[ -f $channel && -x $channel ]] && printf '%s\0' "$channel"
   return 0
 }

--- a/dot_local/libexec/pns/helpers/engine-path.sh
+++ b/dot_local/libexec/pns/helpers/engine-path.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+# WHICH ENGINE a producer should call, resolved in one place.
+#
+# TRANSITIONAL BY DESIGN. Every producer prefers the Rust binary and falls
+# back to the bash engine until an apply installs it, because a hook or a
+# LaunchAgent can fire in the window between the two. When the retirement
+# slice removes the bash engine this file goes with it and the call sites
+# name the binary directly.
+#
+# The pulse resolves SEPARATELY from the engine: the binary's pulse mode
+# needs an enabled [plugins.hue] carrying a bridge and key, so until that
+# config exists the bash channel is the only thing that can light the room.
+
+# pns_engine_path
+# The engine a producer should exec. An override wins outright, so a caller
+# with its own opinion (a test, a one-off) is never second-guessed.
+pns_engine_path() {
+  local override="${1:-}"
+  if [[ -n $override ]]; then
+    printf '%s' "$override"
+    return 0
+  fi
+  local binary="${PNS_ENGINE_BIN:-$HOME/.local/libexec/pns/pns}"
+  if [[ -x $binary ]]; then
+    printf '%s' "$binary"
+    return 0
+  fi
+  printf '%s' "$HOME/.local/libexec/pns/relay.sh"
+}
+
+# pns_pulse_command
+# The command that pulses the lights, as ARGUMENTS on stdout, one per line:
+# the binary carries a subcommand, and a flat string would word-split on a
+# home directory with a space. Prints nothing when neither form is available,
+# which the caller reads as "no lights on this machine".
+pns_pulse_command() {
+  local binary="${PNS_ENGINE_BIN:-$HOME/.local/libexec/pns/pns}"
+  local config="${PNS_CONFIG_FILE:-$HOME/.config/pns/config.toml}"
+  if [[ -x $binary && -f $config ]]; then
+    printf '%s\n' "$binary" pulse
+    return 0
+  fi
+  local channel="${PNS_CHANNELS_DIR:-$HOME/.local/libexec/pns/channels}/hue-pulse.sh"
+  [[ -x $channel ]] && printf '%s\n' "$channel"
+  return 0
+}

--- a/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
+++ b/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
@@ -35,6 +35,15 @@ rm -f "$start_file"
 [[ $started =~ ^[0-9]+$ ]] || exit 0
 elapsed=$(($(date +%s) - started))
 
-pns_session_was_long "$elapsed" "${PNS_PULSE_THRESHOLD_SECS:-300}" &&
-  exec "${PNS_CHANNELS_DIR:-$HOME/.local/libexec/pns/channels}/hue-pulse.sh" 0
-exit 0
+pns_session_was_long "$elapsed" "${PNS_PULSE_THRESHOLD_SECS:-300}" || exit 0
+
+# shellcheck source=dot_local/libexec/pns/helpers/engine-path.sh
+source "${PNS_HELPERS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/helpers}/engine-path.sh" || exit 0
+# An ARRAY: the binary form carries a subcommand, and a home directory with a
+# space would word-split a flat string into a command that does not exist.
+pulse=()
+while IFS= read -r argument; do
+  [[ -n $argument ]] && pulse+=("$argument")
+done < <(pns_pulse_command)
+[[ ${#pulse[@]} -gt 0 ]] || exit 0
+exec "${pulse[@]}" 0

--- a/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
+++ b/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
@@ -42,8 +42,8 @@ source "${PNS_HELPERS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/h
 # An ARRAY: the binary form carries a subcommand, and a home directory with a
 # space would word-split a flat string into a command that does not exist.
 pulse=()
-while IFS= read -r argument; do
-  [[ -n $argument ]] && pulse+=("$argument")
+while IFS= read -r -d '' argument; do
+  pulse+=("$argument")
 done < <(pns_pulse_command)
 [[ ${#pulse[@]} -gt 0 ]] || exit 0
 exec "${pulse[@]}" 0

--- a/dot_local/libexec/pns/hooks/executable_relay-agent.sh
+++ b/dot_local/libexec/pns/hooks/executable_relay-agent.sh
@@ -16,7 +16,9 @@ set -euo pipefail
 # shellcheck source=dot_local/libexec/pns/helpers/event.sh
 source "${PNS_HELPERS_DIR:-${BASH_SOURCE[0]%/*}/../helpers}/event.sh" || exit 0
 state="${1:-done}"
-relay="${RELAY_BIN:-$HOME/.local/libexec/pns/relay.sh}"
+# shellcheck source=dot_local/libexec/pns/helpers/engine-path.sh
+source "${PNS_HELPERS_DIR:-${BASH_SOURCE[0]%/*}/../helpers}/engine-path.sh" || exit 0
+relay="$(pns_engine_path "${RELAY_BIN:-}")"
 input="$(cat 2>/dev/null || true)"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)"
 transcript="$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || true)"

--- a/dot_local/libexec/pns/hooks/executable_relay-agent.sh
+++ b/dot_local/libexec/pns/hooks/executable_relay-agent.sh
@@ -16,9 +16,16 @@ set -euo pipefail
 # shellcheck source=dot_local/libexec/pns/helpers/event.sh
 source "${PNS_HELPERS_DIR:-${BASH_SOURCE[0]%/*}/../helpers}/event.sh" || exit 0
 state="${1:-done}"
+# NOT `|| exit 0`: everything below this line still has to run, above all the
+# blocked-event handoff, whose exit code IS the operator's approval decision.
+# A resolver that cannot be sourced degrades to the bash engine instead.
 # shellcheck source=dot_local/libexec/pns/helpers/engine-path.sh
-source "${PNS_HELPERS_DIR:-${BASH_SOURCE[0]%/*}/../helpers}/engine-path.sh" || exit 0
-relay="$(pns_engine_path "${RELAY_BIN:-}")"
+source "${PNS_HELPERS_DIR:-${BASH_SOURCE[0]%/*}/../helpers}/engine-path.sh" 2>/dev/null || true
+if declare -F pns_engine_path >/dev/null 2>&1; then
+  relay="$(pns_engine_path "${RELAY_BIN:-}")"
+else
+  relay="${RELAY_BIN:-$HOME/.local/libexec/pns/relay.sh}"
+fi
 input="$(cat 2>/dev/null || true)"
 cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)"
 transcript="$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || true)"

--- a/test/unit/pns-engine-path-resolution.sh
+++ b/test/unit/pns-engine-path-resolution.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Every producer resolves its engine through one function, so the transition
+# window is decided once rather than copied per call site. Two rules:
+#
+#   the ENGINE prefers the binary and falls back to the bash relay, because a
+#   hook can fire between the apply that installs the binary and the retirement
+#   that removes the bash;
+#
+#   the PULSE follows the CONFIG, not the binary, because the binary's pulse
+#   mode returns silently without an enabled [plugins.hue] and the lights would
+#   simply stop.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# A home with a space, because a flat command string would word-split here.
+HOME="$scratch/home dir"
+export HOME
+mkdir -p "$HOME/.local/libexec/pns/channels" "$HOME/.config/pns"
+
+# shellcheck source=dot_local/libexec/pns/helpers/engine-path.sh
+source "$REPO_ROOT/dot_local/libexec/pns/helpers/engine-path.sh"
+
+binary="$HOME/.local/libexec/pns/pns"
+relay="$HOME/.local/libexec/pns/relay.sh"
+channel="$HOME/.local/libexec/pns/channels/hue-pulse.sh"
+config="$HOME/.config/pns/config.toml"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+pulse_line() { pns_pulse_command | tr '\n' '|'; }
+
+# --- the engine ------------------------------------------------------------
+printf '#!/usr/bin/env bash\n' >"$relay"
+chmod +x "$relay"
+[[ "$(pns_engine_path)" == "$relay" ]] ||
+  fail "without the binary the bash relay must carry it, got: $(pns_engine_path)"
+
+printf '#!/usr/bin/env bash\n' >"$binary"
+chmod +x "$binary"
+[[ "$(pns_engine_path)" == "$binary" ]] ||
+  fail "the installed binary must win, got: $(pns_engine_path)"
+
+# A binary that is present but NOT executable is not an engine: a partial
+# install must fall back rather than produce a call that cannot run.
+chmod -x "$binary"
+[[ "$(pns_engine_path)" == "$relay" ]] ||
+  fail "a non-executable binary must fall back, got: $(pns_engine_path)"
+chmod +x "$binary"
+
+[[ "$(pns_engine_path /custom/engine)" == /custom/engine ]] ||
+  fail "an explicit override must win outright"
+
+# --- the pulse -------------------------------------------------------------
+[[ "$(pulse_line)" == "" ]] ||
+  fail "with no channel and no config there are no lights, got: $(pulse_line)"
+
+printf '#!/usr/bin/env bash\n' >"$channel"
+chmod +x "$channel"
+[[ "$(pulse_line)" == "$channel|" ]] ||
+  fail "without a config the bash channel keeps the lights, got: $(pulse_line)"
+
+printf '[plugins.hue]\nenabled = true\n' >"$config"
+[[ "$(pulse_line)" == "$binary|pulse|" ]] ||
+  fail "with a config the binary's pulse mode wins, got: $(pulse_line)"
+
+# The subcommand must survive a home with a space: reading the command back
+# as separate lines is what makes that possible.
+mapfile -t parts < <(pns_pulse_command)
+[[ ${#parts[@]} -eq 2 && ${parts[0]} == "$binary" && ${parts[1]} == pulse ]] ||
+  fail "the pulse command must be two arguments, got: ${parts[*]}"
+
+rm "$config"
+[[ "$(pulse_line)" == "$channel|" ]] ||
+  fail "removing the config returns the lights to the bash channel"
+
+exit 0

--- a/test/unit/pns-engine-path-resolution.sh
+++ b/test/unit/pns-engine-path-resolution.sh
@@ -106,8 +106,11 @@ chmod +x "$channel"
 # --- a stripped environment with explicit overrides still resolves ---------
 # Hooks run with HOME sometimes absent; the overrides are what such a caller
 # has, and expanding an unset HOME under set -u would abort the hook.
-( set -u; unset HOME
-  PNS_CHANNELS_DIR="$(dirname "$channel")" pns_pulse_command >/dev/null ) ||
+(
+  set -u
+  unset HOME
+  PNS_CHANNELS_DIR="$(dirname "$channel")" pns_pulse_command >/dev/null
+) ||
   fail "an unset HOME with an explicit channels dir must still resolve"
 
 exit 0

--- a/test/unit/pns-engine-path-resolution.sh
+++ b/test/unit/pns-engine-path-resolution.sh
@@ -33,7 +33,7 @@ fail() {
   exit 1
 }
 
-pulse_line() { pns_pulse_command | tr '\n' '|'; }
+pulse_line() { pns_pulse_command | tr '\0' '|'; }
 
 # --- the engine ------------------------------------------------------------
 printf '#!/usr/bin/env bash\n' >"$relay"
@@ -71,12 +71,43 @@ printf '[plugins.hue]\nenabled = true\n' >"$config"
 
 # The subcommand must survive a home with a space: reading the command back
 # as separate lines is what makes that possible.
-mapfile -t parts < <(pns_pulse_command)
+mapfile -t -d '' parts < <(pns_pulse_command)
 [[ ${#parts[@]} -eq 2 && ${parts[0]} == "$binary" && ${parts[1]} == pulse ]] ||
   fail "the pulse command must be two arguments, got: ${parts[*]}"
 
 rm "$config"
 [[ "$(pulse_line)" == "$channel|" ]] ||
   fail "removing the config returns the lights to the bash channel"
+
+# --- neither candidate may be a directory or a non-executable file ---------
+# -x alone accepts a searchable DIRECTORY, which would suppress every
+# fallback and leave the caller trying to execute it.
+printf '[plugins.hue]\nenabled = true\n' >"$config"
+chmod -x "$binary"
+[[ "$(pulse_line)" == "$channel|" ]] ||
+  fail "a non-executable binary must not claim the pulse, got: $(pulse_line)"
+chmod +x "$binary"
+
+mv "$binary" "$binary.real"
+mkdir -p "$binary"
+[[ "$(pulse_line)" == "$channel|" ]] ||
+  fail "a DIRECTORY at the binary path must not claim the pulse, got: $(pulse_line)"
+[[ "$(pns_engine_path)" == "$relay" ]] ||
+  fail "a DIRECTORY at the binary path must not claim the engine either"
+rmdir "$binary"
+mv "$binary.real" "$binary"
+rm "$config"
+
+chmod -x "$channel"
+[[ "$(pulse_line)" == "" ]] ||
+  fail "a non-executable channel is no pulse at all, got: $(pulse_line)"
+chmod +x "$channel"
+
+# --- a stripped environment with explicit overrides still resolves ---------
+# Hooks run with HOME sometimes absent; the overrides are what such a caller
+# has, and expanding an unset HOME under set -u would abort the hook.
+( set -u; unset HOME
+  PNS_CHANNELS_DIR="$(dirname "$channel")" pns_pulse_command >/dev/null ) ||
+  fail "an unset HOME with an explicit channels dir must still resolve"
 
 exit 0

--- a/test/unit/pns-hooks.bats
+++ b/test/unit/pns-hooks.bats
@@ -21,6 +21,9 @@ setup() {
 payload() { jq -cn --arg s "$1" '{session_id: $s}'; }
 marker() { printf '%s/session-%s.start' "$PNS_STATE_DIR" "$1"; }
 pulsed() { [[ -f "$BATS_TEST_TMPDIR/pulsed" ]]; }
+# A plain refute, because a bare `! cmd` only fails the test when it happens
+# to be the body's LAST command.
+refute() { if "$@"; then return 1; fi; }
 
 @test "the first prompt writes a session marker" {
   payload abc123 | "$START"
@@ -109,4 +112,62 @@ pulsed() { [[ -f "$BATS_TEST_TMPDIR/pulsed" ]]; }
   printf 'not-a-timestamp' >"$(marker abc123)"
   run bash -c "printf '%s' '$(payload abc123)' | $(printf '%q' "$STOP")"
   [ ! -f "$(marker abc123)" ]
+}
+
+# --- the engine binary form -------------------------------------------------
+# The bash channel above is a ONE-element pulse, so it cannot see the binary
+# form's subcommand at all. These pin the branch the repoint exists to add.
+
+binary_pulse_setup() { # the binary and a config exist, so the binary wins
+  export PNS_ENGINE_BIN="$BATS_TEST_TMPDIR/pns"
+  export PNS_CONFIG_FILE="$BATS_TEST_TMPDIR/config.toml"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@" >"%s/binary-argv"\n' "$BATS_TEST_TMPDIR" \
+    >"$PNS_ENGINE_BIN"
+  chmod +x "$PNS_ENGINE_BIN"
+  printf '[plugins.hue]\nenabled = true\n' >"$PNS_CONFIG_FILE"
+}
+
+@test "a long session pulses through the binary's own subcommand, exit code included" {
+  binary_pulse_setup
+  payload bin1 | "$START"
+  printf '%s' "$(($(date +%s) - 400))" >"$(marker bin1)"
+  payload bin1 | "$STOP"
+  # Three arguments, in order: dropping the subcommand would run the ENGINE
+  # with a bare "0" instead of pulsing anything.
+  run cat "$BATS_TEST_TMPDIR/binary-argv"
+  [ "$output" = "pulse
+0" ]
+}
+
+@test "the binary form never falls back to the bash channel" {
+  binary_pulse_setup
+  payload bin2 | "$START"
+  printf '%s' "$(($(date +%s) - 400))" >"$(marker bin2)"
+  payload bin2 | "$STOP"
+  refute pulsed
+}
+
+@test "with no pulse available at all the hook is still a silent exit 0" {
+  # The mid-cutover state: no binary, and the bash channel not installed
+  # either. A hook that exits non-zero here is the one thing it must never do.
+  rm -f "$PNS_CHANNELS_DIR/hue-pulse.sh"
+  payload none1 | "$START"
+  printf '%s' "$(($(date +%s) - 400))" >"$(marker none1)"
+  run "$STOP" <<<"$(payload none1)"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "an unreadable engine-path helper still exits 0" {
+  # The resolution the repoint ADDED must not be able to make the hook noisy:
+  # a helpers dir that carries the decision core but not the engine resolver
+  # is a silent no-pulse. (The decision core's own source predates this and
+  # is not what this pins.)
+  mkdir -p "$PNS_STATE_DIR" "$BATS_TEST_TMPDIR/partial-helpers"
+  cp "$PNS/helpers/event.sh" "$BATS_TEST_TMPDIR/partial-helpers/event.sh"
+  printf '%s' "$(($(date +%s) - 400))" >"$(marker none2)"
+  # Only the STOP hook sees the broken helpers dir; the marker is written
+  # directly so the start hook is not the thing under test here.
+  run env PNS_HELPERS_DIR="$BATS_TEST_TMPDIR/partial-helpers" "$STOP" <<<"$(payload none2)"
+  [ "$status" -eq 0 ]
 }

--- a/test/unit/pns-relay-agent.bats
+++ b/test/unit/pns-relay-agent.bats
@@ -207,3 +207,25 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
   [ ! -f "$sandbox/bash-ran" ]
   grep -qx -- '--agent' "$sandbox/binary-argv"
 }
+
+@test "a missing engine resolver never answers the approval prompt for the operator" {
+  # Everything above the handoff is a notification, and a notification that
+  # cannot be delivered must not fail the turn. The BLOCKED path is the one
+  # exception: its exit code IS the operator's decision, so a helper that
+  # cannot be sourced must degrade to the bash engine rather than short
+  # circuit the hook and report success in their place.
+  local sandbox="$BATS_TEST_TMPDIR/no-resolver"
+  mkdir -p "$sandbox/helpers" "$sandbox/bin"
+  # The decision core is present; the engine resolver deliberately is not.
+  cp "$BATS_TEST_DIRNAME/../../dot_local/libexec/pns/helpers/event.sh" "$sandbox/helpers/"
+  printf '#!/usr/bin/env bash\nexit 7\n' >"$sandbox/bin/gate.sh"
+  printf '#!/usr/bin/env bash\nexit 7\n' >"$sandbox/bin/moshi-hook"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$sandbox/bin/relay.sh"
+  chmod +x "$sandbox/bin/gate.sh" "$sandbox/bin/moshi-hook" "$sandbox/bin/relay.sh"
+
+  run env PNS_HELPERS_DIR="$sandbox/helpers" PNS_MOSHI_GATE="$sandbox/bin/gate.sh" \
+    MOSHI_HOOK_BIN="$sandbox/bin/moshi-hook" RELAY_BIN="$sandbox/bin/relay.sh" \
+    RELAY_SUMMARIZING=1 RELAY_IDLE_SECS=99999 \
+    "$HOOK" blocked <<<'{"cwd":"/tmp/p","message":"needs approval"}'
+  [ "$status" -eq 7 ]
+}

--- a/test/unit/pns-relay-agent.bats
+++ b/test/unit/pns-relay-agent.bats
@@ -186,3 +186,24 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
   [ "$(pns_flatten_reply 'short enough' 8000)" = "short enough" ]
   [ "$(pns_flatten_reply 'abcdefghij' 4)" = ghij ]
 }
+
+@test "an installed engine binary is what the hook calls, with no override set" {
+  # Both the harness suites above set RELAY_BIN, which the resolver honors as
+  # an explicit override, so nothing there can tell the repoint from the old
+  # hardcoded bash path. This is the slice's whole point: after the binary is
+  # installed the hook must stop calling the bash engine, or the retirement
+  # turns every agent notification into a missing-file no-op.
+  local sandbox="$BATS_TEST_TMPDIR/repoint"
+  mkdir -p "$sandbox/.local/libexec/pns"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@" >"%s/binary-argv"\n' "$sandbox" \
+    >"$sandbox/.local/libexec/pns/pns"
+  printf '#!/usr/bin/env bash\nprintf bash-engine >"%s/bash-ran"\n' "$sandbox" \
+    >"$sandbox/.local/libexec/pns/relay.sh"
+  chmod +x "$sandbox/.local/libexec/pns/pns" "$sandbox/.local/libexec/pns/relay.sh"
+
+  run env -u RELAY_BIN HOME="$sandbox" RELAY_SUMMARIZING=1 \
+    "$HOOK" done <<<'{"cwd":"/tmp/project","message":"a detail"}'
+  [ "$status" -eq 0 ]
+  [ ! -f "$sandbox/bash-ran" ]
+  grep -qx -- '--agent' "$sandbox/binary-argv"
+}


### PR DESCRIPTION
## Context

Second of the producer repoints: the harness hooks. Claude Code fires `relay-agent.sh` for agent state and `stop-pulse.sh` when a session ends, and both still called the bash engine directly.

Seven producers across this slice and the next need the same two rules, so the resolution lives in one helper rather than a copy per call site. The helper is transitional and is removed with the bash engine.

## Summary

- `dot_local/libexec/pns/helpers/engine-path.sh` resolves both questions: `pns_engine_path` prefers the installed binary and falls back to the bash relay, since a hook can fire between the apply that installs the binary and the retirement that removes the bash; `pns_pulse_command` returns the binary's pulse subcommand only when a pns config exists, because that mode returns silently without an enabled `[plugins.hue]` and the lights would simply stop.
- Both resolvers require a regular executable file. A directory satisfies `-x` on its own and would suppress every fallback, leaving the caller trying to execute it.
- The pulse command is returned as NUL-separated arguments, so neither a home directory with a space nor a path containing a newline can split the subcommand away.
- `relay-agent.sh` degrades to the bash engine when the helper cannot be sourced rather than exiting. Everything below that line still has to run, above all the blocked-event handoff, whose exit code is the operator's approval decision; the earlier form answered that prompt with success in their place.
- `stop-pulse.sh` reads the resolved command into an array and keeps its `exec`, its threshold, and its silent exit 0 on every path where no pulse is available.

## How it was verified

- `just test-unit` passes with no failures, including the extended hook suites and the new resolver test.
- Eighteen mutations across two review rounds are each caught by a named assertion with green controls: the binary preference, the executable and regular-file checks, the override, the config gate, the flat-string pulse, the collapsed array, the empty-pulse guard, the threshold, the repoint itself, and the exit-code contracts.
- The approval regression was reproduced end to end before and after: with the resolver absent and a gate returning 7, the earlier form returned 0 and the current one returns 7.
- Existing suites pinned these hooks entirely against the bash world, so the binary branch this slice adds was invisible to all of them; the hook suites now run the binary form directly, asserting the argv is `<binary> pulse 0` and that no fallback fires behind it.

## Effect of merging

Agent notifications and the end-of-session pulse go through the engine binary once an apply has installed it, and through the bash engine until then. The lights stay with the bash channel until a pns config exists. The weekly jobs are the last producers still calling the bash engine directly.

## Review guide

Read `helpers/engine-path.sh` first, it is forty lines and holds every rule. Then the two call sites: `relay-agent.sh` for the degrade-rather-than-exit reasoning above the handoff, and `stop-pulse.sh` for the array read. The tests worth reading are the new resolver script and the two hook cases that exercise the binary form, since those are the branch the existing suites could not see.
