### PR TITLE
feat(pns): repoint the weekly jobs at the engine binary

### DIFF
--- a/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
+++ b/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
@@ -223,6 +223,19 @@ else
     "$UNATTENDED_LOG_LIB" >&2
 fi
 
+# The engine, resolved without depending on log-entries.sh: partial
+# deployment explicitly tolerates that helper being absent, and the engine
+# choice must survive it. The shared rule applies when the helper is there;
+# the bash engine is the terminal fallback either way.
+weekly_engine() {
+  if declare -F unattended_engine >/dev/null 2>&1; then
+    unattended_engine
+  else
+    printf '%s' "${HOME:-}/.local/libexec/pns/relay.sh"
+  fi
+}
+
+
 # The entry's opening lines (this run's timestamp and the gap to the previous
 # success), captured ONCE at start-up from ONE clock reading. Start-up because
 # the gap must be read BEFORE this run can overwrite the marker, or every
@@ -441,7 +454,7 @@ __update_skills_alert() {
     alerter --timeout 30 --title "update-skills" --message "$detail" --sound default >/dev/null 2>&1 || true
   fi
   local relay_script
-  relay_script="$(unattended_engine)"
+  relay_script="$(weekly_engine)"
   if [[ -x $relay_script ]]; then
     # 9>&- for the same reason relay_fork_advisory carries it: relay DETACHES
     # channels that outlive this run, a kernel flock on fd 9 is held until the
@@ -1980,7 +1993,7 @@ __gen_reset_failure_streaks() {
 # and leaves the live generation untouched; the next slot retries.
 __gen_weekly_attempt() {
   local relay_script
-  relay_script="$(unattended_engine)"
+  relay_script="$(weekly_engine)"
   local id candidate_home candidate_agents id_dir
   if [[ -n $GEN_REUSE_CANDIDATE ]] && __gen_validate_candidate "$GEN_REUSE_CANDIDATE"; then
     candidate_agents="$GEN_REUSE_CANDIDATE"
@@ -2631,7 +2644,7 @@ converge_hermes_skills() {
 assert_superpowers_routing() {
   local routing_script="$HOME/.local/libexec/unattended-upgrades/agent-skills/assert-hermes-superpowers-routing.sh"
   local relay_script
-  relay_script="$(unattended_engine)"
+  relay_script="$(weekly_engine)"
   local routing_output
   if [[ ! -x $routing_script ]]; then
     # A non-empty superpowersRouting table with no routing script is a REQUIRED
@@ -2685,7 +2698,7 @@ assert_superpowers_routing() {
 update_hermes_registry_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
   local relay_script
-  relay_script="$(unattended_engine)"
+  relay_script="$(weekly_engine)"
   if ! command -v hermes >/dev/null 2>&1; then
     # A non-empty hermesRegistry table with no hermes binary is a REQUIRED
     # failure: the hub-owned skills would silently go un-refreshed (item 4). An
@@ -3078,7 +3091,7 @@ GIT_CONFIG_PARAMETERS_NONE=""
 relay_fork_advisory() {
   local state="$1" fork="$2" detail="$3"
   local relay_script
-  relay_script="$(unattended_engine)"
+  relay_script="$(weekly_engine)"
   if [[ $DRYRUN == "--dry-run" ]]; then
     return 0
   fi

--- a/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
+++ b/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
@@ -440,7 +440,8 @@ __update_skills_alert() {
   if command -v alerter >/dev/null 2>&1; then
     alerter --timeout 30 --title "update-skills" --message "$detail" --sound default >/dev/null 2>&1 || true
   fi
-  local relay_script="$HOME/.local/libexec/pns/relay.sh"
+  local relay_script
+  relay_script="$(unattended_engine)"
   if [[ -x $relay_script ]]; then
     # 9>&- for the same reason relay_fork_advisory carries it: relay DETACHES
     # channels that outlive this run, a kernel flock on fd 9 is held until the
@@ -1978,7 +1979,8 @@ __gen_reset_failure_streaks() {
 # candidate (no partial promotion), records a required failure (loud + relay),
 # and leaves the live generation untouched; the next slot retries.
 __gen_weekly_attempt() {
-  local relay_script="$HOME/.local/libexec/pns/relay.sh"
+  local relay_script
+  relay_script="$(unattended_engine)"
   local id candidate_home candidate_agents id_dir
   if [[ -n $GEN_REUSE_CANDIDATE ]] && __gen_validate_candidate "$GEN_REUSE_CANDIDATE"; then
     candidate_agents="$GEN_REUSE_CANDIDATE"
@@ -2628,7 +2630,8 @@ converge_hermes_skills() {
 # half-provisioned machine skips silently), exactly like the relay.sh gate.
 assert_superpowers_routing() {
   local routing_script="$HOME/.local/libexec/unattended-upgrades/agent-skills/assert-hermes-superpowers-routing.sh"
-  local relay_script="$HOME/.local/libexec/pns/relay.sh"
+  local relay_script
+  relay_script="$(unattended_engine)"
   local routing_output
   if [[ ! -x $routing_script ]]; then
     # A non-empty superpowersRouting table with no routing script is a REQUIRED
@@ -2681,7 +2684,8 @@ assert_superpowers_routing() {
 # --install-only never reaches it; the weekly run is where it belongs.
 update_hermes_registry_skills() {
   [[ -f $CUSTOM_SKILL_LOCK ]] || return 0
-  local relay_script="$HOME/.local/libexec/pns/relay.sh"
+  local relay_script
+  relay_script="$(unattended_engine)"
   if ! command -v hermes >/dev/null 2>&1; then
     # A non-empty hermesRegistry table with no hermes binary is a REQUIRED
     # failure: the hub-owned skills would silently go un-refreshed (item 4). An
@@ -3073,7 +3077,8 @@ GIT_CONFIG_PARAMETERS_NONE=""
 # that fires up to fifteen times a run.
 relay_fork_advisory() {
   local state="$1" fork="$2" detail="$3"
-  local relay_script="$HOME/.local/libexec/pns/relay.sh"
+  local relay_script
+  relay_script="$(unattended_engine)"
   if [[ $DRYRUN == "--dry-run" ]]; then
     return 0
   fi

--- a/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
+++ b/dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh
@@ -235,7 +235,6 @@ weekly_engine() {
   fi
 }
 
-
 # The entry's opening lines (this run's timestamp and the gap to the previous
 # success), captured ONCE at start-up from ONE clock reading. Start-up because
 # the gap must be read BEFORE this run can overwrite the marker, or every

--- a/dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh
+++ b/dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh
@@ -68,7 +68,7 @@ LOG_WEEK_GUARD="$STATE_DIR/log-week-claims"
 # The relay script by ABSOLUTE path. A LaunchAgent's PATH carries no
 # ~/.local/bin, so a bare `relay.sh` would never be found under launchd and
 # every alert would vanish exactly when it mattered.
-RELAY="${REPORT_PLUGIN_UPDATES_RELAY:-$HOME/.local/libexec/pns/relay.sh}"
+RELAY="${REPORT_PLUGIN_UPDATES_RELAY:-$(UNATTENDED_LOG_RELAY="" unattended_engine)}"
 
 # jq by absolute path for the same reason, with the same env seam.
 JQ="${REPORT_PLUGIN_UPDATES_JQ:-/opt/homebrew/bin/jq}"
@@ -155,7 +155,7 @@ mark_success_or_exit() {
 alert() {
   local state="$1" detail="$2"
   if [[ ! -x $RELAY ]]; then
-    printf '%s: relay.sh is not executable at %s; this alert was NOT delivered\n' \
+    printf '%s: no executable pns engine at %s; this alert was NOT delivered\n' \
       "$AGENT_NAME" "$RELAY" >&2
     return 0
   fi

--- a/dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh
+++ b/dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh
@@ -65,11 +65,6 @@ SNAPSHOT_FILE="$STATE_DIR/installed-plugins.snapshot"
 LOG_SUCCESS_MARKER="$STATE_DIR/last-success-at"
 LOG_WEEK_GUARD="$STATE_DIR/log-week-claims"
 
-# The relay script by ABSOLUTE path. A LaunchAgent's PATH carries no
-# ~/.local/bin, so a bare `relay.sh` would never be found under launchd and
-# every alert would vanish exactly when it mattered.
-RELAY="${REPORT_PLUGIN_UPDATES_RELAY:-$(UNATTENDED_LOG_RELAY="" unattended_engine)}"
-
 # jq by absolute path for the same reason, with the same env seam.
 JQ="${REPORT_PLUGIN_UPDATES_JQ:-/opt/homebrew/bin/jq}"
 [[ -x $JQ ]] || JQ="$(command -v jq 2>/dev/null || printf 'jq')"
@@ -115,6 +110,23 @@ else
   printf '%s: WARNING %s is missing; no record will be posted (run chezmoi apply)\n' \
     "$AGENT_NAME" "$UNATTENDED_LOG_LIB" >&2
 fi
+
+# The engine, resolved without depending on log-entries.sh: partial
+# deployment explicitly tolerates that helper being absent, and the engine
+# choice must survive it. The shared rule applies when the helper is there;
+# the bash engine is the terminal fallback either way.
+weekly_engine() {
+  if declare -F unattended_engine >/dev/null 2>&1; then
+    unattended_engine
+  else
+    printf '%s' "${HOME:-}/.local/libexec/pns/relay.sh"
+  fi
+}
+
+# The engine by ABSOLUTE path, resolved AFTER the source above: a LaunchAgent's
+# PATH carries no ~/.local anything, and the resolution must not run before
+# the function it prefers can possibly exist.
+RELAY="${REPORT_PLUGIN_UPDATES_RELAY:-$(weekly_engine)}"
 
 # The entry's opening lines, from ONE clock reading captured at START-UP, before
 # this run can rewrite its own marker. Read later, the gap would be zero on every

--- a/dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh
@@ -100,7 +100,7 @@ read -r UPGRADE_RECORD_EPOCH UPGRADE_RECORD_ISO < <(date -u '+%s %Y-%m-%dT%H:%M:
 # /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin, with no
 # ~/.local/bin in it, so a bare `relay.sh` would never be found under launchd and
 # every alert would vanish exactly when it mattered.
-RELAY="${HOMEBREW_WEEKLY_RELAY:-$HOME/.local/libexec/pns/relay.sh}"
+RELAY="${HOMEBREW_WEEKLY_RELAY:-$(UNATTENDED_LOG_RELAY="" unattended_engine)}"
 
 # weekly_alert <state> <detail> -- the EXISTING relay route, so this lands in the
 # priority channel beside every other alert on this machine. Best effort: a
@@ -108,7 +108,7 @@ RELAY="${HOMEBREW_WEEKLY_RELAY:-$HOME/.local/libexec/pns/relay.sh}"
 weekly_alert() {
   local state="$1" detail="$2"
   if [[ ! -x $RELAY ]]; then
-    printf 'homebrew-weekly-upgrade: relay.sh is not executable at %s; this alert was NOT delivered\n' "$RELAY" >&2
+    printf 'homebrew-weekly-upgrade: no executable pns engine at %s; this alert was NOT delivered\n' "$RELAY" >&2
     return 0
   fi
   "$RELAY" --agent homebrew-weekly-upgrade --state "$state" \

--- a/dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh
+++ b/dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh
@@ -100,7 +100,18 @@ read -r UPGRADE_RECORD_EPOCH UPGRADE_RECORD_ISO < <(date -u '+%s %Y-%m-%dT%H:%M:
 # /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin, with no
 # ~/.local/bin in it, so a bare `relay.sh` would never be found under launchd and
 # every alert would vanish exactly when it mattered.
-RELAY="${HOMEBREW_WEEKLY_RELAY:-$(UNATTENDED_LOG_RELAY="" unattended_engine)}"
+# The engine, resolved without depending on log-entries.sh: partial
+# deployment explicitly tolerates that helper being absent, and the engine
+# choice must survive it. The shared rule applies when the helper is there;
+# the bash engine is the terminal fallback either way.
+weekly_engine() {
+  if declare -F unattended_engine >/dev/null 2>&1; then
+    unattended_engine
+  else
+    printf '%s' "${HOME:-}/.local/libexec/pns/relay.sh"
+  fi
+}
+RELAY="${HOMEBREW_WEEKLY_RELAY:-$(weekly_engine)}"
 
 # weekly_alert <state> <detail> -- the EXISTING relay route, so this lands in the
 # priority channel beside every other alert on this machine. Best effort: a

--- a/dot_local/libexec/unattended-upgrades/helpers/log-entries.sh
+++ b/dot_local/libexec/unattended-upgrades/helpers/log-entries.sh
@@ -463,11 +463,36 @@ unattended_log_change_section() {
 #
 # Never ABORTS the caller: a non-zero return is a fact to act on, and both
 # callers do, but neither treats it as fatal.
+# unattended_engine
+# WHICH ENGINE the weekly jobs post through. Every unattended job sources this
+# file, so the transitional preference lives here once rather than in each of
+# them: the Rust binary when an apply has installed it, the bash engine until
+# then. Degrades rather than aborting when the pns resolver is absent, because
+# a half-provisioned machine must still be able to post its record.
+#
+# When the retirement slice removes the bash engine this collapses to the
+# binary path and the resolver source goes with it.
+unattended_engine() {
+  local override="${UNATTENDED_LOG_RELAY:-}"
+  if [[ -n $override ]]; then
+    printf '%s' "$override"
+    return 0
+  fi
+  # shellcheck source=dot_local/libexec/pns/helpers/engine-path.sh
+  source "${PNS_HELPERS_DIR:-${HOME:-}/.local/libexec/pns/helpers}/engine-path.sh" 2>/dev/null || true
+  if declare -F pns_engine_path >/dev/null 2>&1; then
+    pns_engine_path
+    return 0
+  fi
+  printf '%s' "${HOME:-}/.local/libexec/pns/relay.sh"
+}
+
 unattended_log_post() {
   local agent="$1" state="$2" project="$3" detail="$4" outcome
-  local relay_script="${UNATTENDED_LOG_RELAY:-$HOME/.local/libexec/pns/relay.sh}"
+  local relay_script
+  relay_script="$(unattended_engine)"
   if [[ ! -x $relay_script ]]; then
-    printf 'unattended-log: relay.sh is not executable at %s; this entry was NOT delivered (run chezmoi apply)\n' "$relay_script"
+    printf 'unattended-log: no executable pns engine at %s; this entry was NOT delivered (run chezmoi apply)\n' "$relay_script"
     return 1
   fi
   # stdout captured (it is the outcome), stderr left alone so relay's own
@@ -504,9 +529,10 @@ unattended_log_post() {
 # observed -- so it covers exactly what is knowable, that an attempt was made.
 unattended_log_alert_delivery_failure() {
   local guard="$1" agent="$2"
-  local relay_script="${UNATTENDED_LOG_RELAY:-$HOME/.local/libexec/pns/relay.sh}"
+  local relay_script
+  relay_script="$(unattended_engine)"
   if [[ ! -x $relay_script ]]; then
-    printf 'unattended-log: relay.sh is not executable at %s; the broken-record-channel alert was NOT delivered either, and this week stays unclaimed so a later run retries it\n' "$relay_script"
+    printf 'unattended-log: no executable pns engine at %s; the broken-record-channel alert was NOT delivered either, and this week stays unclaimed so a later run retries it\n' "$relay_script"
     return 0
   fi
   unattended_log_claim_week "$guard" delivery-alert || return 0

--- a/test/unit/pns-weekly-engine-resolution.sh
+++ b/test/unit/pns-weekly-engine-resolution.sh
@@ -123,7 +123,6 @@ resolver_err="$(PNS_HELPERS_DIR="$scratch/absent" unattended_engine 2>&1 >/dev/n
 [[ -z $resolver_err ]] ||
   fail "resolution must not leak shell noise into the record, got: $resolver_err"
 
-
 # --- the resolution runs where its function exists --------------------------
 # The regression this pins: RELAY= called unattended_engine forty lines above
 # the source that defines it, so every scheduled run died 127 at load. The

--- a/test/unit/pns-weekly-engine-resolution.sh
+++ b/test/unit/pns-weekly-engine-resolution.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# The weekly jobs post their records through the engine, and they run under
+# launchd where nothing is on PATH and nobody is watching. Their resolution is
+# the same transitional rule the hooks use, held once in log-entries.sh, so
+# this pins the rule and the three jobs that read it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# A home with a space, because these paths are interpolated in several places.
+HOME="$scratch/home dir"
+export HOME
+mkdir -p "$HOME/.local/libexec/pns/helpers"
+cp "$REPO_ROOT/dot_local/libexec/pns/helpers/engine-path.sh" \
+  "$HOME/.local/libexec/pns/helpers/"
+
+binary="$HOME/.local/libexec/pns/pns"
+relay="$HOME/.local/libexec/pns/relay.sh"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+# shellcheck source=dot_local/libexec/unattended-upgrades/helpers/log-entries.sh
+source "$REPO_ROOT/dot_local/libexec/unattended-upgrades/helpers/log-entries.sh"
+
+# --- the rule --------------------------------------------------------------
+printf '#!/usr/bin/env bash\n' >"$relay"
+chmod +x "$relay"
+[[ "$(unattended_engine)" == "$relay" ]] ||
+  fail "before the binary exists the weekly jobs keep the bash engine, got: $(unattended_engine)"
+
+printf '#!/usr/bin/env bash\n' >"$binary"
+chmod +x "$binary"
+[[ "$(unattended_engine)" == "$binary" ]] ||
+  fail "once installed the binary carries the weekly records, got: $(unattended_engine)"
+
+[[ "$(UNATTENDED_LOG_RELAY=/custom/engine unattended_engine)" == /custom/engine ]] ||
+  fail "an explicit override must win outright"
+
+# A machine without the pns tree at all: the jobs still resolve something and
+# report it, rather than aborting mid-record.
+(
+  PNS_HELPERS_DIR="$scratch/absent"
+  export PNS_HELPERS_DIR
+  [[ "$(unattended_engine)" == "$relay" ]] ||
+    fail "a missing resolver degrades to the bash engine, got: $(unattended_engine)"
+)
+
+# --- the record actually goes to the resolved engine -----------------------
+# unattended_log_post is what every weekly job calls; it must hand the record
+# to the binary once that exists.
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@" >"%s/posted"\nprintf "relay: posted HTTP 200\\n"\n' \
+  "$scratch" >"$binary"
+chmod +x "$binary"
+UNATTENDED_LOG_STATE_DIR="$scratch/state" unattended_log_post \
+  weekly-test 'done' project 'a detail' >/dev/null 2>&1 || true
+[[ -f "$scratch/posted" ]] ||
+  fail "the record must reach the resolved engine"
+grep -qx -- '--remote-only' "$scratch/posted" ||
+  fail "the weekly record is the durable log path, so it must stay --remote-only"
+
+# --- the three jobs read the rule, none keeps its own default --------------
+for job in \
+  "dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh" \
+  "dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh" \
+  "dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh"; do
+  if grep -n 'relay\.sh"$' "$REPO_ROOT/$job" | grep -qv '^\s*#'; then
+    fail "$job still defaults to the bash engine directly instead of the shared rule"
+  fi
+done
+
+exit 0

--- a/test/unit/pns-weekly-engine-resolution.sh
+++ b/test/unit/pns-weekly-engine-resolution.sh
@@ -68,8 +68,9 @@ for job in \
   "dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh" \
   "dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh" \
   "dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh"; do
-  if grep -n 'relay\.sh"$' "$REPO_ROOT/$job" | grep -qv '^\s*#'; then
-    fail "$job still defaults to the bash engine directly instead of the shared rule"
+  # Any non-comment mention of the bash engine path is a default of its own.
+  if grep -v '^[[:space:]]*#' "$REPO_ROOT/$job" | grep -q 'libexec/pns/relay\.sh'; then
+    fail "$job still names the bash engine directly instead of the shared rule"
   fi
 done
 

--- a/test/unit/pns-weekly-engine-resolution.sh
+++ b/test/unit/pns-weekly-engine-resolution.sh
@@ -57,21 +57,93 @@ printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@" >"%s/posted"\nprintf "relay: p
   "$scratch" >"$binary"
 chmod +x "$binary"
 UNATTENDED_LOG_STATE_DIR="$scratch/state" unattended_log_post \
-  weekly-test 'done' project 'a detail' >/dev/null 2>&1 || true
+  weekly-test 'done' project 'a detail' >/dev/null 2>&1 ||
+  fail "an accepted post must return success"
 [[ -f "$scratch/posted" ]] ||
   fail "the record must reach the resolved engine"
 grep -qx -- '--remote-only' "$scratch/posted" ||
   fail "the weekly record is the durable log path, so it must stay --remote-only"
 
-# --- the three jobs read the rule, none keeps its own default --------------
+# --- the three jobs resolve through the guard, none keeps a default --------
+# The path may appear inside weekly_engine's terminal fallback and nowhere
+# else. grep -q is never placed downstream of a pipe: its early exit closes
+# the pipe, the upstream grep dies of SIGPIPE on any file larger than the
+# buffer, and under pipefail the whole check reads as "no match": a guard
+# that cannot fail on exactly the biggest file.
 for job in \
   "dot_local/libexec/unattended-upgrades/executable_homebrew-weekly-upgrade.sh" \
   "dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh" \
   "dot_local/libexec/unattended-upgrades/agent-skills/executable_update-skills.sh"; do
-  # Any non-comment mention of the bash engine path is a default of its own.
-  if grep -v '^[[:space:]]*#' "$REPO_ROOT/$job" | grep -q 'libexec/pns/relay\.sh'; then
-    fail "$job still names the bash engine directly instead of the shared rule"
+  grep -q 'weekly_engine()' "$REPO_ROOT/$job" ||
+    fail "$job must define the guarded resolution"
+  assignments="$(grep -nE '(RELAY|relay_script)=' "$REPO_ROOT/$job" | grep -v '^[0-9]*: *#' || true)"
+  if grep 'libexec/pns/relay\.sh' <<<"$assignments" >/dev/null; then
+    fail "$job assigns the bash engine directly instead of weekly_engine: $assignments"
   fi
 done
+
+# --- a present-but-not-executable engine is refused with the stated lines --
+# An interrupted install leaves exactly this; the refusal and its wording are
+# the operator's only clue in a launchd log.
+# BOTH candidates dead, because a non-executable binary alone correctly
+# falls back to the bash engine: the refusal is for the machine where the
+# terminal resolution itself cannot run.
+chmod -x "$binary" "$relay"
+set +e
+post_out="$(UNATTENDED_LOG_STATE_DIR="$scratch/state" unattended_log_post \
+  weekly-test 'done' project 'a detail' 2>&1)"
+post_rc=$?
+set -e
+[[ $post_rc -ne 0 ]] ||
+  fail "a not-executable engine must fail the post so the caller can react"
+grep -q 'no executable pns engine at .*NOT delivered' <<<"$post_out" ||
+  fail "the refusal must speak the stated line, got: $post_out"
+alert_out="$(unattended_log_alert_delivery_failure "$scratch/guard" weekly-test 2>&1)" ||
+  fail "the alert path never fails its caller"
+grep -q 'stays unclaimed so a later run retries it' <<<"$alert_out" ||
+  fail "the alert refusal must speak the stated line, got: $alert_out"
+chmod +x "$binary" "$relay"
+
+# --- the week claim releases for retry -------------------------------------
+# A claim without a delivery must not burn the week: the first failing slot
+# would otherwise leave no record and no retry for seven days.
+guard_dir="$scratch/claims"
+unattended_log_claim_week "$guard_dir" completed ||
+  fail "a fresh week must claim"
+unattended_log_claim_week "$guard_dir" completed &&
+  fail "a claimed week must refuse a second claim"
+unattended_log_release_week "$guard_dir" completed
+unattended_log_claim_week "$guard_dir" completed ||
+  fail "a released week must claim again, or a failed slot burns the week"
+
+# --- a missing resolver degrades in silence --------------------------------
+# The quiet-degrade promise: no raw shell errors in a launchd record on a
+# machine without the pns tree.
+resolver_err="$(PNS_HELPERS_DIR="$scratch/absent" unattended_engine 2>&1 >/dev/null)"
+[[ -z $resolver_err ]] ||
+  fail "resolution must not leak shell noise into the record, got: $resolver_err"
+
+
+# --- the resolution runs where its function exists --------------------------
+# The regression this pins: RELAY= called unattended_engine forty lines above
+# the source that defines it, so every scheduled run died 127 at load. The
+# seed run proves the script gets PAST resolution and into its real work (the
+# inventory stage), whatever that stage then says.
+seed_home="$scratch/seed home"
+mkdir -p "$seed_home/.claude/plugins"
+printf '{"plugins":{}}' >"$seed_home/.claude/plugins/installed_plugins.json"
+set +e
+seed_err="$(HOME="$seed_home" \
+  "$REPO_ROOT/dot_local/libexec/unattended-upgrades/claude/executable_report-plugin-updates.sh" \
+  --seed-baseline 2>&1)"
+seed_rc=$?
+set -e
+[[ $seed_rc -ne 127 ]] ||
+  fail "the job died before its resolution function existed: $seed_err"
+if grep -q 'command not found' <<<"$seed_err"; then
+  fail "the resolution ran before its function existed: $seed_err"
+fi
+grep -q 'installed-plugin inventory' <<<"$seed_err" ||
+  fail "the run must reach the inventory stage past the resolution: $seed_err"
 
 exit 0


### PR DESCRIPTION
## Context

Last of the producer repoints: the three weekly unattended jobs. They run under launchd with nobody watching, and their whole purpose is a durable record, so the failure that matters here is a record that silently stops posting or a week claimed without delivery.

## Summary

- `dot_local/libexec/unattended-upgrades/helpers/log-entries.sh` gains `unattended_engine`, the shared transitional rule: an explicit override wins, else the pns resolver's binary-over-bash preference, else the bash engine. Its own two posting functions resolve through it.
- Each of the three jobs carries a small guarded `weekly_engine` of its own, resolved after its helper source: partial deployment explicitly tolerates `log-entries.sh` being absent, so the engine choice cannot ride on it. The nine call sites all resolve through these functions; none keeps a hardcoded default.
- Two operator-facing refusal messages now name the engine generically, since either form can be the missing one.
- `test/unit/pns-weekly-engine-resolution.sh` pins the rule, an accepted post reaching the resolved engine on the durable log path, the stated refusal lines against a machine where nothing can run, a week-claim round trip so a failed slot cannot burn the week, silence from the resolver on a machine without the pns tree, and the load-order regression by its signature through a real seed run of the plugin reporter.

## How it was verified

- The new test and the full unit suite pass; fifteen mutations across two review rounds are each caught by a named assertion with green controls, including each job's sites individually reverted, the ordering regression, the weakened executable guard, the dropped claim release, the noisy resolver, and message drift.
- Two regressions found in review were reproduced before fixing: the plugin reporter resolved its engine forty lines above the source defining the resolver and died at load on every scheduled run, and a missing helper left jobs with no engine at all rather than the bash fallback they document tolerating.
- One test defect found by review was reproduced both ways and fixed: a `grep -q` downstream of a pipe under `pipefail` dies of SIGPIPE on any file larger than the pipe buffer, which made the roster check unable to fail on exactly the file holding five of the nine call sites.

## Effect of merging

The weekly jobs post through the engine binary once an apply installs it, and through the bash engine until then; a machine missing either helper still posts through whatever it has and says what it could not do. Nothing else changes. Every producer is now repointed, which makes the retirement slice next.

## Review guide

Read `unattended_engine` and one `weekly_engine` (they are short and the comments carry the partial-deployment reasoning), then the test, which is most of the diff and is organized by the failure it prevents. The SIGPIPE note in the roster check is worth the minute: it is a general shape to avoid in any `pipefail` script.
