### PR TITLE
fix(pns): render the final pulse dim and deliver turn-end summaries

### DIFF
--- a/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
+++ b/dot_local/libexec/pns/hooks/claude/executable_stop-pulse.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Claude Code Stop hook: pulse Hue green if the session lasted > 5 min.
+# Claude Code Stop hook: pulse Hue green when a TURN of 5+ minutes ends. Per
+# turn, not per session: the marker is written at the prompt and removed here,
+# so the elapsed time below measures the turn that just finished.
 #
 # Hook input: JSON on stdin with { session_id, transcript_path, cwd,
 # permission_mode, hook_event_name }. Env vars do NOT carry the session ID.
 #
-# Paired with claude-user-prompt-start.sh which writes the session start marker.
+# Paired with claude-user-prompt-start.sh which writes the turn start marker.
 
 set -euo pipefail
 # shellcheck source=dot_local/libexec/pns/helpers/event.sh

--- a/dot_local/libexec/pns/hooks/claude/executable_user-prompt-start.sh
+++ b/dot_local/libexec/pns/hooks/claude/executable_user-prompt-start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Claude Code UserPromptSubmit hook: record session start time on first prompt.
+# Claude Code UserPromptSubmit hook: record the TURN start time. The marker is
+# keyed by session but written only when none is there and removed by the Stop
+# hook, so what it times is the turn just submitted, not the whole session.
 #
 # Hook input: JSON on stdin with { session_id, transcript_path, cwd,
 # permission_mode, hook_event_name, prompt }.

--- a/dot_local/libexec/pns/hooks/executable_relay-agent.sh
+++ b/dot_local/libexec/pns/hooks/executable_relay-agent.sh
@@ -26,17 +26,35 @@ codex_bin="${CODEX_BIN:-codex}"
 project="${cwd##*/}"
 branch=""
 [[ -n $cwd && -d $cwd ]] && branch="$(git -C "$cwd" branch --show-current 2>/dev/null || true)"
+# The assistant text of the transcript's last turn, or empty for anything this
+# cannot read. Only the TAIL is read: the extraction needs the last user turn
+# and what follows, never the whole file, and a long session grows the
+# transcript past 200MB. Measured 2026-08-05: each slurp of the full file held
+# ~33MB resident and minutes of CPU, and a stop-hook loop piled up 33
+# concurrent jq processes. 4MB of tail parses in well under a second (a cut
+# first line is dropped by fromjson? by design).
+reply_from_transcript() {
+  tail -c 4000000 "$1" | jq -rs -R '[ split("\n")[] | select(length > 0) | fromjson? | select(type=="object") ] as $a
+    | ([ $a | to_entries[] | select(.value.type=="user" and ((.value.message.content|type)=="string" or ((.value.message.content[0]?.type)=="text"))) | .key ] | last // -1) as $s
+    | [ $a[$s+1:][] | select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text ] | join("\n\n")' 2>/dev/null || true
+}
+# The harness has not always flushed the assistant's final text by the time the
+# Stop hook runs. Live capture 2026-08-12: the single read came back empty, the
+# summarizer was skipped, and the notification shipped with no --detail at all.
+# So an empty read is RE-READ inside a bounded window, and only a window that
+# expires means the turn really said nothing. The bound is what keeps a
+# transcript that is legitimately empty from delaying every notification.
+reply_reread_attempts=4
+reply_reread_interval=0.15
 detail=""
 if [[ $state == "done" && -n $transcript && -f $transcript ]]; then
-  # Read only the transcript TAIL. The reply extraction needs the last user turn
-  # and what follows, never the whole file, and a long session grows the
-  # transcript past 200MB. Measured 2026-08-05: each slurp of the full file held
-  # ~33MB resident and minutes of CPU, and a stop-hook loop piled up 33
-  # concurrent jq processes. 4MB of tail parses in well under a second (a cut
-  # first line is dropped by fromjson? by design).
-  reply="$(tail -c 4000000 "$transcript" | jq -rs -R '[ split("\n")[] | select(length > 0) | fromjson? | select(type=="object") ] as $a
-    | ([ $a | to_entries[] | select(.value.type=="user" and ((.value.message.content|type)=="string" or ((.value.message.content[0]?.type)=="text"))) | .key ] | last // -1) as $s
-    | [ $a[$s+1:][] | select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text ] | join("\n\n")' 2>/dev/null || true)"
+  reply="$(reply_from_transcript "$transcript")"
+  attempt=0
+  while [[ -z $reply && $attempt -lt $reply_reread_attempts ]]; do
+    sleep "$reply_reread_interval"
+    reply="$(reply_from_transcript "$transcript")"
+    attempt=$((attempt + 1))
+  done
   reply="$(pns_flatten_reply "$reply")" # one line, trimmed, last 8000 chars at most
   used_codex=""
   # Codex-primary: one cheap `codex exec` summarizes the whole turn + classifies it as "STATE|SUMMARY";

--- a/dot_local/libexec/pns/hooks/executable_relay-agent.sh
+++ b/dot_local/libexec/pns/hooks/executable_relay-agent.sh
@@ -41,21 +41,38 @@ reply_from_transcript() {
 # The harness has not always flushed the assistant's final text by the time the
 # Stop hook runs. Live capture 2026-08-12: the single read came back empty, the
 # summarizer was skipped, and the notification shipped with no --detail at all.
-# So an empty read is RE-READ inside a bounded window, and only a window that
-# expires means the turn really said nothing. The bound is what keeps a
-# transcript that is legitimately empty from delaying every notification.
+# So an empty result is RE-READ inside a bounded window. What an expired window
+# proves is only that nothing readable arrived in time: a turn that really said
+# nothing, a transcript that could not be read, and one that would not parse all
+# leave the same empty string, and all three are reported the same way. The
+# bound is what keeps those cases from delaying every notification.
+#
+# The window is measured on the FLATTENED reply, not the raw extraction: an
+# assistant block carrying only whitespace is non-empty raw and empty once
+# flattened, which is the same missing-summary symptom through another door.
+#
+# The attempt count is VALIDATED before it is believed, and falls back to the
+# default rather than to no retries. Measured 2026-08-12: `[[ $attempt -lt abc ]]`
+# evaluates `abc` as a variable name in arithmetic context, which under `set -u`
+# is an unbound-variable error and exits the hook 1, on the one path whose whole
+# contract is exiting 0. The INTERVAL needs no such guard: a value sleep refuses
+# fails the sleep, and the guarded sleep below breaks the loop and carries on.
 reply_reread_attempts=4
-reply_reread_interval=0.15
+[[ ${PNS_REPLY_REREAD_ATTEMPTS:-} =~ ^[0-9]+$ ]] && reply_reread_attempts="$PNS_REPLY_REREAD_ATTEMPTS"
+reply_reread_interval="${PNS_REPLY_REREAD_INTERVAL:-0.15}"
 detail=""
 if [[ $state == "done" && -n $transcript && -f $transcript ]]; then
-  reply="$(reply_from_transcript "$transcript")"
+  # one line, trimmed, last 8000 chars at most
+  reply="$(pns_flatten_reply "$(reply_from_transcript "$transcript")")"
   attempt=0
   while [[ -z $reply && $attempt -lt $reply_reread_attempts ]]; do
-    sleep "$reply_reread_interval"
-    reply="$(reply_from_transcript "$transcript")"
+    # A sleep that FAILS must not fail the hook: bare, `set -e` turns a killed
+    # or refused sleep into a non-zero exit on the one path whose whole
+    # contract is exiting 0.
+    sleep "$reply_reread_interval" || break
+    reply="$(pns_flatten_reply "$(reply_from_transcript "$transcript")")"
     attempt=$((attempt + 1))
   done
-  reply="$(pns_flatten_reply "$reply")" # one line, trimmed, last 8000 chars at most
   used_codex=""
   # Codex-primary: one cheap `codex exec` summarizes the whole turn + classifies it as "STATE|SUMMARY";
   # STATE may override 'done' (e.g. asking). It runs in a stripped, dedicated CODEX_HOME (minimal config:

--- a/dot_local/libexec/pns/hooks/executable_relay-agent.sh
+++ b/dot_local/libexec/pns/hooks/executable_relay-agent.sh
@@ -60,19 +60,29 @@ reply_from_transcript() {
 reply_reread_attempts=4
 [[ ${PNS_REPLY_REREAD_ATTEMPTS:-} =~ ^[0-9]+$ ]] && reply_reread_attempts="$PNS_REPLY_REREAD_ATTEMPTS"
 reply_reread_interval="${PNS_REPLY_REREAD_INTERVAL:-0.15}"
+# The harness's OWN copy of the final text, which is why the transcript read
+# above is the fallback rather than the source. Claude Code documents that a
+# Stop hook can fire before the transcript write completes, and recommends this
+# field instead; version 2.1.226 builds the Stop payload with it, carrying the
+# last assistant message joined and trimmed, and omits it when there is none.
+# Absent, or present and empty, falls through to the file.
+payload_reply="$(printf '%s' "$input" | jq -r '.last_assistant_message // empty' 2>/dev/null || true)"
 detail=""
-if [[ $state == "done" && -n $transcript && -f $transcript ]]; then
+if [[ $state == "done" ]] && [[ -n $payload_reply || (-n $transcript && -f $transcript) ]]; then
   # one line, trimmed, last 8000 chars at most
-  reply="$(pns_flatten_reply "$(reply_from_transcript "$transcript")")"
-  attempt=0
-  while [[ -z $reply && $attempt -lt $reply_reread_attempts ]]; do
-    # A sleep that FAILS must not fail the hook: bare, `set -e` turns a killed
-    # or refused sleep into a non-zero exit on the one path whose whole
-    # contract is exiting 0.
-    sleep "$reply_reread_interval" || break
+  reply="$(pns_flatten_reply "$payload_reply")"
+  if [[ -z $reply && -n $transcript && -f $transcript ]]; then
     reply="$(pns_flatten_reply "$(reply_from_transcript "$transcript")")"
-    attempt=$((attempt + 1))
-  done
+    attempt=0
+    while [[ -z $reply && $attempt -lt $reply_reread_attempts ]]; do
+      # A sleep that FAILS must not fail the hook: bare, `set -e` turns a
+      # killed or refused sleep into a non-zero exit on the one path whose
+      # whole contract is exiting 0.
+      sleep "$reply_reread_interval" || break
+      reply="$(pns_flatten_reply "$(reply_from_transcript "$transcript")")"
+      attempt=$((attempt + 1))
+    done
+  fi
   used_codex=""
   # Codex-primary: one cheap `codex exec` summarizes the whole turn + classifies it as "STATE|SUMMARY";
   # STATE may override 'done' (e.g. asking). It runs in a stripped, dedicated CODEX_HOME (minimal config:

--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -210,6 +210,11 @@ const PULSE_TRANSITION: Duration = Duration::from_millis(1200);
 /// finding 2026-08-11: the restore fired the instant the fourth ramp's sleep
 /// returned and overrode the final dim before the bridge rendered it, so the
 /// pulse read as three phases, not four.
+///
+/// The VALUE is empirical padding for bridge-side render latency, chosen as
+/// half a `PULSE_TRANSITION` and nothing more principled than that: the ramp
+/// it follows had already been given its full transition time, so the gap it
+/// covers is unexplained and unmeasured. Retune after the first live pulse.
 const FINAL_DIM_HOLD: Duration = Duration::from_millis(600);
 
 /// The light PUT body that puts one snapshot back: an off light is only
@@ -347,9 +352,9 @@ impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Bridge, DEFAULT_ROOMS, FINAL_DIM_HOLD, HuePulse, LightState, RESTORE_TRANSITION_MS,
-        Sleeper, acquire_pulse_lock, hue_enabled, hue_settings, light_snapshot, pulse_body,
-        pulse_rooms, put_succeeded, restore_body,
+        Bridge, DEFAULT_ROOMS, HuePulse, LightState, RESTORE_TRANSITION_MS, Sleeper,
+        acquire_pulse_lock, hue_enabled, hue_settings, light_snapshot, pulse_body, pulse_rooms,
+        put_succeeded, restore_body,
     };
     use std::cell::RefCell;
     use std::time::Duration;
@@ -762,7 +767,10 @@ mod tests {
                 Duration::from_millis(1200),
                 Duration::from_millis(1200),
                 Duration::from_millis(1200),
-                FINAL_DIM_HOLD,
+                // The literal, not the constant: comparing the hold against
+                // itself would pass for any value, including one too short
+                // for the bridge to render.
+                Duration::from_millis(600),
             ],
             "four ramps, then the hold that lets the last dim render"
         );

--- a/dot_local/share/pns/src/channels/hue.rs
+++ b/dot_local/share/pns/src/channels/hue.rs
@@ -206,6 +206,12 @@ pub fn pulse_body(x: &str, y: &str, brightness: &str) -> String {
 /// transition are the same number by construction.
 const PULSE_TRANSITION: Duration = Duration::from_millis(1200);
 
+/// The last dim is HELD before the restore ramps the lights back up. Live
+/// finding 2026-08-11: the restore fired the instant the fourth ramp's sleep
+/// returned and overrode the final dim before the bridge rendered it, so the
+/// pulse read as three phases, not four.
+const FINAL_DIM_HOLD: Duration = Duration::from_millis(600);
+
 /// The light PUT body that puts one snapshot back: an off light is only
 /// turned off, a ct light restores its mirek, an xy light both coordinates.
 pub fn restore_body(state: &LightState) -> String {
@@ -325,6 +331,7 @@ impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
             }
             self.sleeper.sleep(PULSE_TRANSITION);
         }
+        self.sleeper.sleep(FINAL_DIM_HOLD);
 
         // Every light is restored independently: one failing write must not
         // starve the lights behind it in the transient color.
@@ -340,9 +347,9 @@ impl<B: Bridge, S: Sleeper> HuePulse<B, S> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Bridge, DEFAULT_ROOMS, HuePulse, LightState, RESTORE_TRANSITION_MS, Sleeper,
-        acquire_pulse_lock, hue_enabled, hue_settings, light_snapshot, pulse_body, pulse_rooms,
-        put_succeeded, restore_body,
+        Bridge, DEFAULT_ROOMS, FINAL_DIM_HOLD, HuePulse, LightState, RESTORE_TRANSITION_MS,
+        Sleeper, acquire_pulse_lock, hue_enabled, hue_settings, light_snapshot, pulse_body,
+        pulse_rooms, put_succeeded, restore_body,
     };
     use std::cell::RefCell;
     use std::time::Duration;
@@ -748,7 +755,89 @@ mod tests {
         assert!(puts[1].0.contains("grouped_light/grp-2"));
         assert!(puts[8].0.contains("light/light-ct"));
         let naps = hue.sleeper.naps.borrow();
-        assert_eq!(naps.as_slice(), &[Duration::from_millis(1200); 4]);
+        assert_eq!(
+            naps.as_slice(),
+            &[
+                Duration::from_millis(1200),
+                Duration::from_millis(1200),
+                Duration::from_millis(1200),
+                Duration::from_millis(1200),
+                FINAL_DIM_HOLD,
+            ],
+            "four ramps, then the hold that lets the last dim render"
+        );
+    }
+
+    /// One shared, ordered log across bridge and sleeper: the hold's PLACE
+    /// in the sequence is the behavior under test, and the two separate
+    /// recorders above cannot see cross-seam order.
+    struct SequencedBridge {
+        log: std::rc::Rc<RefCell<Vec<String>>>,
+    }
+    impl Bridge for SequencedBridge {
+        fn get(&self, path: &str) -> Option<String> {
+            Some(match path {
+                "room" => ROOMS_JSON.to_string(),
+                _ => LIGHTS_JSON.to_string(),
+            })
+        }
+        fn put(&self, path: &str, _body: &str) -> bool {
+            self.log.borrow_mut().push(format!("put {path}"));
+            true
+        }
+    }
+    struct SequencedSleeper {
+        log: std::rc::Rc<RefCell<Vec<String>>>,
+    }
+    impl Sleeper for SequencedSleeper {
+        fn sleep(&self, duration: Duration) {
+            self.log
+                .borrow_mut()
+                .push(format!("nap {}", duration.as_millis()));
+        }
+    }
+
+    #[test]
+    fn the_final_dim_is_held_before_any_restore_write_so_it_renders() {
+        // Live finding 2026-08-11: the restore fired the instant the fourth
+        // ramp's sleep returned, and the physical bridge never rendered the
+        // second dim. The contract is peak, dim, peak, dim, EACH phase
+        // visible, then restore: five naps, and the fifth sits between the
+        // last grouped-light write and the first light restore.
+        let log = std::rc::Rc::new(RefCell::new(Vec::new()));
+        let hue = HuePulse {
+            bridge: SequencedBridge {
+                log: std::rc::Rc::clone(&log),
+            },
+            sleeper: SequencedSleeper {
+                log: std::rc::Rc::clone(&log),
+            },
+            rooms: wanted(&["3F - Studio", "2F - Kitchen"]),
+        };
+        hue.run("1");
+        let log = log.borrow();
+        let naps: Vec<usize> = (0..log.len())
+            .filter(|index| log[*index].starts_with("nap"))
+            .collect();
+        assert_eq!(
+            naps.len(),
+            5,
+            "four ramps plus the final hold, got: {log:?}"
+        );
+        let first_restore = log
+            .iter()
+            .position(|entry| entry.starts_with("put light/"))
+            .expect("the restores must still run");
+        assert!(
+            naps[4] < first_restore,
+            "the hold must precede every restore write: {log:?}"
+        );
+        let hold = log[naps[4]]
+            .strip_prefix("nap ")
+            .unwrap()
+            .parse::<u64>()
+            .unwrap();
+        assert!(hold > 0, "a zero-length hold is the live bug itself");
     }
 
     #[test]

--- a/test/unit/pns-relay-agent.bats
+++ b/test/unit/pns-relay-agent.bats
@@ -118,6 +118,21 @@ TRANSCRIPT
     capture whitespace_first 'done' "$(payload_with "$BATS_FILE_TMPDIR/whitespace-first.jsonl")"
   ) &
   capture cut_first_line 'done' "$(payload_with "$BATS_FILE_TMPDIR/cut-first-line.jsonl")" &
+
+  # The harness's own copy of the final text. Claude Code 2.1.226 builds the
+  # Stop payload with `last_assistant_message`, the last assistant message
+  # joined and trimmed, and omits it when there is none. Its transcript here
+  # NEVER flushes an assistant turn, so anything the hook delivers had to come
+  # from the payload, and the sleep marker stays absent only if no re-read
+  # window was paid at all.
+  printf '{"type":"user","message":{"content":"q"}}\n' >"$BATS_FILE_TMPDIR/payload-primary.jsonl"
+  (
+    export RELAY_SLEEP_MARKER="$BATS_FILE_TMPDIR/payload.marker"
+    capture payload_primary 'done' \
+      "$(payload_with "$BATS_FILE_TMPDIR/payload-primary.jsonl" '' 'The payload carried it.')"
+  ) &
+  capture payload_beats_transcript 'done' \
+    "$(payload_with "$BATS_FILE_TMPDIR/two-turns.jsonl" '' 'From the payload, not the file.')" &
   capture done_turn 'done' "$(payload_with "$BATS_FILE_TMPDIR/two-turns.jsonl")" &
   capture blocked_state 'blocked' "$(payload_with '' 'permission to run brew')" &
   capture asked_state 'asked' "$(payload_with '' 'which of the two?')" &
@@ -140,12 +155,15 @@ setup() {
   source "$BATS_TEST_DIRNAME/../../dot_local/libexec/pns/helpers/event.sh"
 }
 
-# payload_with <transcript_path> [message]: one harness hook payload.
+# payload_with <transcript_path> [message] [last_assistant_message]: one
+# harness hook payload. Each field is omitted when empty, because absent and
+# present-but-empty are different inputs to the hook.
 payload_with() {
-  jq -cn --arg t "${1:-}" --arg m "${2:-}" \
+  jq -cn --arg t "${1:-}" --arg m "${2:-}" --arg a "${3:-}" \
     '{cwd: "/nowhere/webdavis/dotfiles"}
      + (if $t == "" then {} else {transcript_path: $t} end)
-     + (if $m == "" then {} else {message: $m} end)'
+     + (if $m == "" then {} else {message: $m} end)
+     + (if $a == "" then {} else {last_assistant_message: $a} end)'
 }
 
 # capture <name> <state> <payload>: run the hook once, keep its argv and status.
@@ -199,6 +217,19 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
 
 @test "a transcript still flushing at hook time is re-read until the reply lands" {
   [ "$(flag lagging_transcript --detail)" = "The late-flushed reply." ]
+}
+
+@test "the payload's own final text is used, and the transcript is never waited on" {
+  # The docs are explicit that a Stop hook can fire before the transcript write
+  # completes, so the file is the FALLBACK and the payload is the primary. The
+  # transcript behind this run never got its assistant turn, so the text can
+  # only have come from the payload.
+  [ "$(flag payload_primary --detail)" = "The payload carried it." ]
+  [ ! -e "$BATS_FILE_TMPDIR/payload.marker" ]
+}
+
+@test "the payload's text beats a transcript that carries its own" {
+  [ "$(flag payload_beats_transcript --detail)" = "From the payload, not the file." ]
 }
 
 @test "a reply that is only whitespace is waited out like an absent one" {

--- a/test/unit/pns-relay-agent.bats
+++ b/test/unit/pns-relay-agent.bats
@@ -5,17 +5,43 @@
 # harness payload into the argument list relay.sh takes.
 #
 # WHAT THIS COSTS AND WHY IT IS SHAPED THIS WAY. Every behavior about ARGUMENT
-# ASSEMBLY needs the real process, and one run costs 35-60ms depending on
-# whether there is a transcript to parse, which is more than a unit test may
-# spend. So the runs happen ONCE in setup_file, CONCURRENTLY (they share
-# nothing but a tmpdir, and each writes its own files), and a test reads a
-# recording instead of spawning anything. The reply-shaping behaviors need no
-# process at all: pns_flatten_reply lives in the decision core, so those tests
-# source it, exactly as pns-event.bats does for relay.sh's decisions.
+# ASSEMBLY needs the real process. A run with a reply already in the transcript
+# costs 35-60ms, but a `done` run that finds NO reply pays the hook's re-read
+# window on top, ~600ms of it, and the three no-reply fixtures below are exactly
+# that case. Either way it is more than a unit test may spend. So the runs
+# happen ONCE in setup_file, CONCURRENTLY (they share nothing but a tmpdir, and
+# each writes its own files, so the window is paid once wall-clock rather than
+# per fixture), and a test reads a recording instead of spawning anything. The
+# reply-shaping behaviors need no process at all: pns_flatten_reply lives in the
+# decision core, so those tests source it, exactly as pns-event.bats does for
+# relay.sh's decisions.
 #
 # RELAY_SUMMARIZING is set for every run. It is the hook's own re-entry guard,
 # and it keeps the optional `codex exec` summarizer out of a unit test, which
 # would otherwise be a network round trip on any machine that has codex.
+
+# The sync seam, in two halves. The hook side is a `sleep` the hook inherits as
+# an exported function: it announces the wait by dropping RELAY_SLEEP_MARKER,
+# then does the real wait. Only the two race captures set that variable, so
+# every other run delegates and behaves exactly as before.
+sleep() {
+  [[ -n ${RELAY_SLEEP_MARKER:-} ]] && : >"$RELAY_SLEEP_MARKER"
+  command sleep "$@"
+}
+export -f sleep
+
+# flush_when_hook_waits <marker> <transcript> <line>: the fixture side. Append
+# <line> as soon as the hook is inside its re-read window, or after a 0.5s
+# fallback if the hook never waits at all, which is what makes a no-retry
+# regression fail rather than pass late.
+flush_when_hook_waits() {
+  local marker="$1" transcript="$2" line="$3" waited=0
+  while [[ ! -e $marker && $waited -lt 50 ]]; do
+    command sleep 0.01
+    waited=$((waited + 1))
+  done
+  printf '%s\n' "$line" >>"$transcript"
+}
 
 setup_file() {
   export HOOK="$BATS_TEST_DIRNAME/../../dot_local/libexec/pns/hooks/executable_relay-agent.sh"
@@ -34,12 +60,23 @@ setup_file() {
   printf '#!/usr/bin/env bash\nexit 9\n' >"$BATS_FILE_TMPDIR/failing-relay.sh"
   chmod +x "$BATS_FILE_TMPDIR/failing-relay.sh"
 
-  # Two turns, so "the LAST turn" is a claim the fixture can falsify.
+  # Two turns, so "the LAST turn" is a claim the fixture can falsify, and the
+  # last turn speaks in TWO text blocks, so the blank line the extraction joins
+  # them with is a claim too: a run of whitespace is what the flatten collapses
+  # back to one space, and a join that dropped it would read as one word.
   cat >"$BATS_FILE_TMPDIR/two-turns.jsonl" <<'TRANSCRIPT'
 {"type":"user","message":{"content":"the first question"}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"STALE, from the previous turn."}]}}
 {"type":"user","message":{"content":"the second question"}}
-{"type":"assistant","message":{"content":[{"type":"text","text":"Ran the suite and it passed."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Ran the suite and it passed."},{"type":"text","text":"The lint gate is green too."}]}}
+TRANSCRIPT
+  # A tail cut mid-line is the NORMAL shape of a long transcript: the hook reads
+  # the last 4MB, so the first line it sees is usually a fragment. The reply
+  # must survive it rather than the whole parse dying on one broken line.
+  cat >"$BATS_FILE_TMPDIR/cut-first-line.jsonl" <<'TRANSCRIPT'
+{"type":"assistant","message":{"content":[{"type":"text","tex
+{"type":"user","message":{"content":"q"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Survived the cut."}]}}
 TRANSCRIPT
   printf 'this is not json\nand neither is this\n' >"$BATS_FILE_TMPDIR/not-json.jsonl"
   : >"$BATS_FILE_TMPDIR/empty.jsonl"
@@ -47,23 +84,40 @@ TRANSCRIPT
   chmod 000 "$BATS_FILE_TMPDIR/unreadable.jsonl"
 
   # The live 2026-08-12 capture: at Stop-hook time the harness had not yet
-  # flushed the assistant's final text, so a single read found no reply and
-  # the notification went out with no summary at all. The fixture reproduces
-  # the race: only the user turn exists when the hook starts, and the
-  # assistant entry lands ~150ms later. The hook must re-read within a
-  # BOUNDED window (total well under the one-second rule, and the wait may
-  # run only on the done-with-a-transcript path, so the static fixtures
-  # below stay fast).
+  # flushed the assistant's final text, so a single read found no reply and the
+  # notification went out with no summary at all. Two fixtures reproduce it,
+  # one per door into the same symptom: nothing there yet, and an assistant
+  # block carrying only whitespace, which is non-empty until it is flattened.
+  #
+  # Both are SYNCHRONIZED rather than timed. A fixture that just slept 150ms
+  # before appending could let a descheduled hook read the finished file on its
+  # FIRST try, and then the unfixed code passes: a false negative, in the one
+  # direction a race fixture must never fail. So `sleep` is exported as a shell
+  # function into the hook's environment, where it drops a marker the instant
+  # the hook first waits, and the appender holds its write until that marker
+  # appears. The late text therefore lands inside the re-read window on any
+  # machine, however loaded. A hook that never re-reads never drops a marker,
+  # so the 0.5s fallback flushes far too late for it, and the unfixed code
+  # fails every run instead of most runs.
   printf '{"type":"user","message":{"content":"q"}}\n' >"$BATS_FILE_TMPDIR/lagging.jsonl"
-  (
-    sleep 0.15
-    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"The late-flushed reply."}]}}\n' \
-      >>"$BATS_FILE_TMPDIR/lagging.jsonl"
-  ) &
+  flush_when_hook_waits "$BATS_FILE_TMPDIR/lagging.marker" "$BATS_FILE_TMPDIR/lagging.jsonl" \
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"The late-flushed reply."}]}}' &
+  printf '{"type":"user","message":{"content":"q"}}\n{"type":"assistant","message":{"content":[{"type":"text","text":"   "}]}}\n' \
+    >"$BATS_FILE_TMPDIR/whitespace-first.jsonl"
+  flush_when_hook_waits "$BATS_FILE_TMPDIR/whitespace.marker" "$BATS_FILE_TMPDIR/whitespace-first.jsonl" \
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"The real text, late."}]}}' &
 
   # cwd is a path that does NOT exist on purpose: the project name is derived
   # from the string, and a real directory would fork git for a branch as well.
-  capture lagging_transcript 'done' "$(payload_with "$BATS_FILE_TMPDIR/lagging.jsonl")" &
+  (
+    export RELAY_SLEEP_MARKER="$BATS_FILE_TMPDIR/lagging.marker"
+    capture lagging_transcript 'done' "$(payload_with "$BATS_FILE_TMPDIR/lagging.jsonl")"
+  ) &
+  (
+    export RELAY_SLEEP_MARKER="$BATS_FILE_TMPDIR/whitespace.marker"
+    capture whitespace_first 'done' "$(payload_with "$BATS_FILE_TMPDIR/whitespace-first.jsonl")"
+  ) &
+  capture cut_first_line 'done' "$(payload_with "$BATS_FILE_TMPDIR/cut-first-line.jsonl")" &
   capture done_turn 'done' "$(payload_with "$BATS_FILE_TMPDIR/two-turns.jsonl")" &
   capture blocked_state 'blocked' "$(payload_with '' 'permission to run brew')" &
   capture asked_state 'asked' "$(payload_with '' 'which of the two?')" &
@@ -147,8 +201,24 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
   [ "$(flag lagging_transcript --detail)" = "The late-flushed reply." ]
 }
 
+@test "a reply that is only whitespace is waited out like an absent one" {
+  # The same missing-summary symptom through another door: whitespace text is
+  # non-empty as extracted and empty once flattened, so a window measured on
+  # the RAW read would stop early and ship the notification with no summary.
+  [ "$(flag whitespace_first --detail)" = "The real text, late." ]
+}
+
 @test "the summary is the assistant text of the transcript's LAST turn" {
-  [ "$(flag done_turn --detail)" = "Ran the suite and it passed." ]
+  # Both text blocks of that turn, in order: the extraction joins them on a
+  # blank line, which the flatten then collapses to the single space asserted
+  # here. A join that dropped the separator would run the two into one word.
+  [ "$(flag done_turn --detail)" = "Ran the suite and it passed. The lint gate is green too." ]
+}
+
+@test "a transcript whose first line was cut mid-JSON still yields its reply" {
+  # The hook reads a 4MB tail, so the first line it sees is routinely a
+  # fragment. Only that line may be dropped; the turn behind it must survive.
+  [ "$(flag cut_first_line --detail)" = "Survived the cut." ]
 }
 
 @test "the project name is the last segment of the payload's cwd" {
@@ -185,6 +255,13 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
   # notification is not worth a red turn in the harness that asked for it.
   [ "$(exit_status relay_failed)" = 0 ]
   [ "$(exit_status no_core)" = 0 ]
+  # And the third end: a re-read window that EXPIRES. These three fixtures are
+  # the only runs that reach the end of the retry loop empty-handed, so without
+  # them the contract is unguarded on the path the retry added.
+  local name
+  for name in not_json empty_transcript unreadable; do
+    [ "$(exit_status "$name")" = 0 ]
+  done
 }
 
 # --- pns_flatten_reply, the reply shaping, called directly -------------------
@@ -205,6 +282,18 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
 @test "only an over-long reply is cut, and it is cut to its TAIL" {
   [ "$(pns_flatten_reply 'short enough' 8000)" = "short enough" ]
   [ "$(pns_flatten_reply 'abcdefghij' 4)" = ghij ]
+}
+
+@test "a garbage re-read knob still notifies and still exits 0" {
+  # Both knobs are set to something unusable at once. The attempt count is the
+  # dangerous one: bash evaluates a bare word in [[ -lt ]] as a variable name in
+  # arithmetic context, so under `set -u` an unvalidated value exits the hook 1
+  # (measured) and the harness turn goes red over a notification setting.
+  run env PNS_REPLY_REREAD_ATTEMPTS=abc PNS_REPLY_REREAD_INTERVAL=abc \
+    RELAY_ARGV_OUT="$BATS_TEST_TMPDIR/knobs.argv" \
+    "$HOOK" done <<<"$(payload_with "$BATS_FILE_TMPDIR/empty.jsonl")"
+  [ "$status" -eq 0 ]
+  tr '\0' '\n' <"$BATS_TEST_TMPDIR/knobs.argv" | grep -qx -- '--state'
 }
 
 @test "an installed engine binary is what the hook calls, with no override set" {

--- a/test/unit/pns-relay-agent.bats
+++ b/test/unit/pns-relay-agent.bats
@@ -46,8 +46,24 @@ TRANSCRIPT
   printf '{"type":"user","message":{"content":"q"}}\n' >"$BATS_FILE_TMPDIR/unreadable.jsonl"
   chmod 000 "$BATS_FILE_TMPDIR/unreadable.jsonl"
 
+  # The live 2026-08-12 capture: at Stop-hook time the harness had not yet
+  # flushed the assistant's final text, so a single read found no reply and
+  # the notification went out with no summary at all. The fixture reproduces
+  # the race: only the user turn exists when the hook starts, and the
+  # assistant entry lands ~150ms later. The hook must re-read within a
+  # BOUNDED window (total well under the one-second rule, and the wait may
+  # run only on the done-with-a-transcript path, so the static fixtures
+  # below stay fast).
+  printf '{"type":"user","message":{"content":"q"}}\n' >"$BATS_FILE_TMPDIR/lagging.jsonl"
+  (
+    sleep 0.15
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"The late-flushed reply."}]}}\n' \
+      >>"$BATS_FILE_TMPDIR/lagging.jsonl"
+  ) &
+
   # cwd is a path that does NOT exist on purpose: the project name is derived
   # from the string, and a real directory would fork git for a branch as well.
+  capture lagging_transcript 'done' "$(payload_with "$BATS_FILE_TMPDIR/lagging.jsonl")" &
   capture done_turn 'done' "$(payload_with "$BATS_FILE_TMPDIR/two-turns.jsonl")" &
   capture blocked_state 'blocked' "$(payload_with '' 'permission to run brew')" &
   capture asked_state 'asked' "$(payload_with '' 'which of the two?')" &
@@ -126,6 +142,10 @@ exit_status() { cat "$BATS_FILE_TMPDIR/$1.status"; }
 }
 
 # --- what the notification says ---------------------------------------------
+
+@test "a transcript still flushing at hook time is re-read until the reply lands" {
+  [ "$(flag lagging_transcript --detail)" = "The late-flushed reply." ]
+}
 
 @test "the summary is the assistant text of the transcript's LAST turn" {
   [ "$(flag done_turn --detail)" = "Ran the suite and it passed." ]


### PR DESCRIPTION
## Context

The first live-testing round after the pns Rust cutover found two behavior defects. The Hue pulse's final dim never rendered: the restore fired the instant the last ramp's sleep returned and overwrote it. And turn-end notifications often arrived with no summary text, which traced to a documented Claude Code behavior: a Stop hook can fire before the transcript write completes, so a single read of the file finds no reply.

## Summary

- `dot_local/share/pns/src/channels/hue.rs` holds the final dim for 600ms (`FINAL_DIM_HOLD`) between the last pulse step and the restore, so the dim renders before the lights are put back. A sequenced-log test pins the nap count, the hold's placement before every restore write, and the literal value.
- `dot_local/libexec/pns/hooks/executable_relay-agent.sh` takes the reply from the Stop payload's `last_assistant_message` field first. Claude Code 2.1.226 populates it and its docs recommend it over reading the transcript. The transcript read survives as the fallback, wrapped in a bounded re-read (4 attempts, 150ms apart, env-overridable with validated values) for harnesses and versions without the field.
- The retry window measures the flattened reply, so a whitespace-only partial flush waits like an absent one; a failing sleep breaks the loop instead of failing the hook's exit-0 contract; a garbage attempts knob falls back to the default instead of dying under `set -u`.
- `test/unit/pns-relay-agent.bats` grows from 13 to 18 tests: a marker-synchronized race fixture that fails deterministically when the retry is missing, a cut-first-line fixture pinning the `fromjson?` guard, payload precedence and fallback pins, and exit-status pins over every no-reply fixture.
- The stop-pulse and user-prompt-start headers now say a turn of five or more minutes pulses, matching the built behavior.

## How it was verified

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (295 passing), `just test-unit` (211 ok), and `just s` all green, run by the implementer and re-run independently before this PR was opened.
- Two review passes on the initial diff: seventeen mutations against green controls (five survivors, each fixed in this PR or accepted with a written rationale in the slice log), and a second reviewer that reproduced a `set -e` exit-9 escape through the retry's bare sleep, fixed in-round.
- Every fix's kill was re-run afterward: a 1ms hold dies, the unguarded `fromjson` dies, a dropped join separator dies, exit 1 on the exhausted window dies, removal of the payload-first read dies, and payload-wins-when-empty dies against the fallback pins.
- Measured on the case that started the PR: a transcript that never flushes now delivers a summary in 0.074s where it previously spent 0.785s and delivered none.

## Effect of merging

Nothing changes on a live machine until the next full chezmoi apply. After one: long-command pulses render all four phases before restoring, and turn-end notifications carry their summary deterministically on current Claude Code, with the bounded re-read covering every other harness and version. The 600ms hold has no measured basis against a physical bridge yet and may need one retune after live observation; its doc comment says so.

## Review guide

Read the hook's done path first (`payload_reply`, then the fallback loop): it is the load-bearing change and its comments carry the contracts. The hue change is a constant and one sleep plus tests. The bats file is most of the diff; the sync-seam comment at its top explains the one non-obvious fixture. The place a second pair of eyes helps most is the widened done-path condition, which now admits a payload that carries text without a usable transcript path.
