### PR TITLE
fix(claude): move the Stop-entry comment out of the hooks dict action

### DIFF
--- a/private_dot_claude/modify_settings.json
+++ b/private_dot_claude/modify_settings.json
@@ -185,16 +185,17 @@
      then the prompt appears and Notification fires), so this is one seam per
      harness, matching Codex's PermissionRequest entry in
      hooks/codex/install-hooks.sh. alerter keeps the Notification slot: it is a
-     local sound, not a notification pns routes.  --- */ -}}
+     local sound, not a notification pns routes.
+
+     ONE Stop entry: the engine measures the turn and reports it in the same
+     pass, where a separate pulse hook used to decide the tier again on its
+     own.  --- */ -}}
 {{- $home := .chezmoi.homeDir -}}
 {{- $hooks := dict
     "UserPromptSubmit" (list (dict
       "hooks" (list (dict
         "type" "command"
         "command" (printf "%s/.local/libexec/pns/pns hook prompt" $home)))))
-    {{- /* ONE Stop entry: the engine measures the turn and reports it in the
-           same pass, where a separate pulse hook used to decide the tier
-           again on its own. */ -}}
     "Stop" (list (dict
       "hooks" (list (dict
         "type" "command"


### PR DESCRIPTION
## Context

PR #185 added a `{{- /* ... */ -}}` comment inside the still-open `$hooks := dict` action in the Claude settings modify-template. A Go template action cannot contain another action, so every `chezmoi apply` failed at parse time on `.claude/settings.json`. No lint gate renders this template, so the first live apply was what caught it.

## Summary

- Move the Stop-entry rationale into the header comment above the action, where a comment is legal, and delete the nested one.

## How it was verified

- `chezmoi cat ~/.claude/settings.json` renders cleanly and `jq` confirms valid JSON with all five hook events pointing at the engine.
